### PR TITLE
feat(mobile): 增加可信 Android 更新检查

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -37,6 +37,7 @@ import 'package:speakup/features/coaching/review/session_evaluation_page.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 import 'package:speakup/features/coaching/scenario/scenario_practice_session.dart';
+import 'package:speakup/features/update/app_update.dart';
 
 class SpeakUpApp extends StatelessWidget {
   const SpeakUpApp({
@@ -55,6 +56,7 @@ class SpeakUpApp extends StatelessWidget {
     this.sessionEvaluationController,
     this.speechFeedbackController,
     this.coachingProfileController,
+    this.appUpdateService,
     this.avatarControllerFactory,
     super.key,
   }) : _authentication = (controller: authController),
@@ -75,6 +77,7 @@ class SpeakUpApp extends StatelessWidget {
     this.sessionEvaluationController,
     this.speechFeedbackController,
     this.coachingProfileController,
+    this.appUpdateService,
     this.avatarControllerFactory,
     super.key,
   }) : _authentication = null,
@@ -95,6 +98,7 @@ class SpeakUpApp extends StatelessWidget {
   final SessionEvaluationController? sessionEvaluationController;
   final SpeechFeedbackController? speechFeedbackController;
   final CoachingProfileController? coachingProfileController;
+  final AppUpdateService? appUpdateService;
   final AvatarControllerFactory? avatarControllerFactory;
   final bool _allowFakePreview;
 
@@ -122,6 +126,7 @@ class SpeakUpApp extends StatelessWidget {
               sessionEvaluationController: sessionEvaluationController,
               speechFeedbackController: speechFeedbackController,
               coachingProfileController: coachingProfileController,
+              appUpdateService: appUpdateService,
               avatarControllerFactory: avatarControllerFactory,
               allowFakePreview: _allowFakePreview,
             )
@@ -145,6 +150,7 @@ class SpeakUpApp extends StatelessWidget {
                 sessionEvaluationController: sessionEvaluationController,
                 speechFeedbackController: speechFeedbackController,
                 coachingProfileController: coachingProfileController,
+                appUpdateService: appUpdateService,
                 avatarControllerFactory: avatarControllerFactory,
                 allowFakePreview: _allowFakePreview,
               ),
@@ -171,6 +177,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
     this.sessionEvaluationController,
     this.speechFeedbackController,
     this.coachingProfileController,
+    this.appUpdateService,
     this.avatarControllerFactory,
     required this.allowFakePreview,
   });
@@ -191,6 +198,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
   final SessionEvaluationController? sessionEvaluationController;
   final SpeechFeedbackController? speechFeedbackController;
   final CoachingProfileController? coachingProfileController;
+  final AppUpdateService? appUpdateService;
   final AvatarControllerFactory? avatarControllerFactory;
   final bool allowFakePreview;
 
@@ -397,6 +405,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             reviewHistoryController: widget.reviewHistoryController,
             speechFeedbackController: widget.speechFeedbackController,
             coachingProfileController: widget.coachingProfileController,
+            appUpdateService: widget.appUpdateService,
           ),
           AppRoutes.preparation => PreparationPage(
             showBackButton: true,
@@ -456,6 +465,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             reviewHistoryController: widget.reviewHistoryController,
             speechFeedbackController: widget.speechFeedbackController,
             coachingProfileController: widget.coachingProfileController,
+            appUpdateService: widget.appUpdateService,
           ),
           AppRoutes.review => ReviewPage(
             showBackButton: true,

--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -209,6 +209,7 @@ class _AuthenticatedNavigator extends StatefulWidget {
 
 class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
   final _navigatorKey = GlobalKey<NavigatorState>();
+  final _routeObserver = RouteObserver<ModalRoute<Object?>>();
   late final ConversationController _conversationController;
   late final ComposerController _composerController;
   late final AgentMessageAudioController? _messageAudioController;
@@ -384,6 +385,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
   Widget build(BuildContext context) {
     return Navigator(
       key: _navigatorKey,
+      observers: [_routeObserver],
       initialRoute: AppRoutes.home,
       onGenerateRoute: (settings) {
         final page = switch (settings.name) {
@@ -406,6 +408,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             speechFeedbackController: widget.speechFeedbackController,
             coachingProfileController: widget.coachingProfileController,
             appUpdateService: widget.appUpdateService,
+            routeObserver: _routeObserver,
           ),
           AppRoutes.preparation => PreparationPage(
             showBackButton: true,
@@ -466,6 +469,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
             speechFeedbackController: widget.speechFeedbackController,
             coachingProfileController: widget.coachingProfileController,
             appUpdateService: widget.appUpdateService,
+            routeObserver: _routeObserver,
           ),
           AppRoutes.review => ReviewPage(
             showBackButton: true,

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -35,6 +35,8 @@ import 'package:speakup/features/coaching/evaluation/agent_conversation_feedback
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 import 'package:speakup/features/profile/profile_page.dart';
 import 'package:speakup/features/profile/profile_avatar_view.dart';
+import 'package:speakup/features/update/app_update.dart';
+import 'package:speakup/features/update/app_update_ui.dart';
 
 class SpeakUpShell extends StatefulWidget {
   const SpeakUpShell({
@@ -50,6 +52,7 @@ class SpeakUpShell extends StatefulWidget {
     this.reviewHistoryController,
     this.speechFeedbackController,
     this.coachingProfileController,
+    this.appUpdateService,
     required this.conversationController,
     required this.composerController,
     this.messageAudioController,
@@ -75,12 +78,14 @@ class SpeakUpShell extends StatefulWidget {
   final ReviewHistoryController? reviewHistoryController;
   final SpeechFeedbackController? speechFeedbackController;
   final CoachingProfileController? coachingProfileController;
+  final AppUpdateService? appUpdateService;
 
   @override
   State<SpeakUpShell> createState() => _SpeakUpShellState();
 }
 
-class _SpeakUpShellState extends State<SpeakUpShell> {
+class _SpeakUpShellState extends State<SpeakUpShell>
+    with WidgetsBindingObserver {
   static const _destinations = [
     PlatformNavigationDestination(
       label: 'SpeakUp',
@@ -122,6 +127,11 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
   bool _practiceRouteInFlight = false;
   bool _clientActionInFlight = false;
   bool _conversationDrawerOpen = false;
+  bool _updateCheckInFlight = false;
+  bool _updateDialogVisible = false;
+  bool _updatePresentationScheduled = false;
+  ({InstalledAppVersion installedVersion, AppRelease release})?
+  _pendingAutomaticUpdate;
   int _navigationGeneration = 0;
 
   @override
@@ -132,6 +142,12 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
     widget.composerController.addListener(_handleAgentInteractionState);
     widget.practiceController.addListener(_handlePracticeState);
     _feedbackPresenter = _createFeedbackPresenter();
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        unawaited(_checkForUpdate(automatic: true));
+      }
+    });
   }
 
   @override
@@ -170,7 +186,15 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
     widget.composerController.removeListener(_handleAgentInteractionState);
     widget.practiceController.removeListener(_handlePracticeState);
     _feedbackPresenter?.dispose();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      unawaited(_checkForUpdate(automatic: true));
+    }
   }
 
   void _handleAuthState() {
@@ -271,6 +295,110 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _checkForUpdate({required bool automatic}) async {
+    final service = widget.appUpdateService;
+    if (service == null || _updateCheckInFlight) {
+      return;
+    }
+    if (!automatic) {
+      _pendingAutomaticUpdate = null;
+    }
+    setState(() => _updateCheckInFlight = true);
+    late final AppUpdateCheckResult result;
+    try {
+      result = await service.check(automatic: automatic);
+    } finally {
+      if (mounted) {
+        setState(() => _updateCheckInFlight = false);
+      }
+    }
+    if (!mounted) {
+      return;
+    }
+    switch (result.status) {
+      case AppUpdateCheckStatus.available:
+        final installedVersion = result.installedVersion!;
+        final release = result.release!;
+        if (automatic) {
+          _pendingAutomaticUpdate = (
+            installedVersion: installedVersion,
+            release: release,
+          );
+          _schedulePendingUpdatePresentation();
+        } else {
+          await _presentAvailableUpdate(installedVersion, release);
+        }
+      case AppUpdateCheckStatus.upToDate:
+        if (!automatic) {
+          _showMockNotice('已是最新版本 v${result.installedVersion!.version}');
+        }
+      case AppUpdateCheckStatus.failed:
+        if (!automatic) {
+          _showMockNotice('暂时无法检查更新，请检查网络后重试');
+        }
+      case AppUpdateCheckStatus.skipped:
+        break;
+    }
+  }
+
+  void _schedulePendingUpdatePresentation() {
+    if (_updatePresentationScheduled || _pendingAutomaticUpdate == null) {
+      return;
+    }
+    _updatePresentationScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _updatePresentationScheduled = false;
+      if (!mounted || !_canPresentAutomaticUpdate) {
+        return;
+      }
+      final pending = _pendingAutomaticUpdate;
+      if (pending == null) {
+        return;
+      }
+      _pendingAutomaticUpdate = null;
+      unawaited(
+        _presentAvailableUpdate(pending.installedVersion, pending.release),
+      );
+    });
+  }
+
+  bool get _canPresentAutomaticUpdate {
+    return !_updateDialogVisible &&
+        canPresentAutomaticAppUpdate(
+          routeCurrent: ModalRoute.of(context)?.isCurrent ?? false,
+          practiceRouteInFlight: _practiceRouteInFlight,
+          conversationBusy: widget.conversationController.isBusy,
+          composerActiveWorkflow: widget.composerController.hasActiveWorkflow,
+          practiceBusy: widget.practiceController.isBusy,
+          practiceRecordingIdle:
+              widget.practiceController.recordingState ==
+              PracticeRecordingState.idle,
+        );
+  }
+
+  Future<void> _presentAvailableUpdate(
+    InstalledAppVersion installedVersion,
+    AppRelease release,
+  ) async {
+    final service = widget.appUpdateService;
+    if (service == null || _updateDialogVisible || !mounted) {
+      return;
+    }
+    _updateDialogVisible = true;
+    final openDownload = await showAppUpdateDialog(
+      context,
+      installedVersion: installedVersion,
+      release: release,
+    );
+    _updateDialogVisible = false;
+    if (!mounted || openDownload != true) {
+      return;
+    }
+    if (!await service.openDownload(release) && mounted) {
+      _showMockNotice('无法打开下载页面，请稍后重试');
+    }
   }
 
   Future<void> _openPractice() => _openPracticeRoute();
@@ -457,6 +585,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       }
     } finally {
       _practiceRouteInFlight = false;
+      _schedulePendingUpdatePresentation();
     }
   }
 
@@ -465,6 +594,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       return;
     }
     setState(() {});
+    _schedulePendingUpdatePresentation();
   }
 
   void _handlePracticeState() {
@@ -472,6 +602,7 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
       return;
     }
     setState(() {});
+    _schedulePendingUpdatePresentation();
   }
 
   @override
@@ -605,6 +736,11 @@ class _SpeakUpShellState extends State<SpeakUpShell> {
         onLogout: widget.authController?.logout,
         reviewHistoryController: widget.reviewHistoryController,
         coachingProfileController: widget.coachingProfileController,
+        appUpdateService: widget.appUpdateService,
+        updateCheckInProgress: _updateCheckInFlight,
+        onCheckForUpdate: widget.appUpdateService == null
+            ? null
+            : () => _checkForUpdate(automatic: false),
       ),
     ];
 

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -53,6 +53,7 @@ class SpeakUpShell extends StatefulWidget {
     this.speechFeedbackController,
     this.coachingProfileController,
     this.appUpdateService,
+    this.routeObserver,
     required this.conversationController,
     required this.composerController,
     this.messageAudioController,
@@ -79,13 +80,14 @@ class SpeakUpShell extends StatefulWidget {
   final SpeechFeedbackController? speechFeedbackController;
   final CoachingProfileController? coachingProfileController;
   final AppUpdateService? appUpdateService;
+  final RouteObserver<ModalRoute<Object?>>? routeObserver;
 
   @override
   State<SpeakUpShell> createState() => _SpeakUpShellState();
 }
 
 class _SpeakUpShellState extends State<SpeakUpShell>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, RouteAware {
   static const _destinations = [
     PlatformNavigationDestination(
       label: 'SpeakUp',
@@ -133,6 +135,7 @@ class _SpeakUpShellState extends State<SpeakUpShell>
   ({InstalledAppVersion installedVersion, AppRelease release})?
   _pendingAutomaticUpdate;
   int _navigationGeneration = 0;
+  ModalRoute<Object?>? _observedRoute;
 
   @override
   void initState() {
@@ -177,10 +180,22 @@ class _SpeakUpShellState extends State<SpeakUpShell>
       _feedbackPresenter?.dispose();
       _feedbackPresenter = _createFeedbackPresenter();
     }
+    if (oldWidget.routeObserver != widget.routeObserver) {
+      oldWidget.routeObserver?.unsubscribe(this);
+      _observedRoute = null;
+      _subscribeToRoute();
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _subscribeToRoute();
   }
 
   @override
   void dispose() {
+    widget.routeObserver?.unsubscribe(this);
     widget.authController?.removeListener(_handleAuthState);
     widget.conversationController.removeListener(_handleAgentInteractionState);
     widget.composerController.removeListener(_handleAgentInteractionState);
@@ -188,6 +203,22 @@ class _SpeakUpShellState extends State<SpeakUpShell>
     _feedbackPresenter?.dispose();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  void _subscribeToRoute() {
+    final observer = widget.routeObserver;
+    final route = ModalRoute.of<Object?>(context);
+    if (observer == null || route == null || identical(route, _observedRoute)) {
+      return;
+    }
+    observer.unsubscribe(this);
+    observer.subscribe(this, route);
+    _observedRoute = route;
+  }
+
+  @override
+  void didPopNext() {
+    _schedulePendingUpdatePresentation();
   }
 
   @override

--- a/mobile/lib/features/profile/profile_page.dart
+++ b/mobile/lib/features/profile/profile_page.dart
@@ -7,6 +7,8 @@ import 'package:speakup/features/coaching/review/review.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
 import 'package:speakup/features/profile/profile_avatar_picker.dart';
 import 'package:speakup/features/profile/profile_avatar_view.dart';
+import 'package:speakup/features/update/app_update.dart';
+import 'package:speakup/features/update/app_update_ui.dart';
 import 'package:speakup/identity/client/identity_client.dart';
 import 'package:speakup/identity/model/identity_models.dart';
 
@@ -25,6 +27,9 @@ class ProfilePage extends StatelessWidget {
     required this.onLogout,
     required this.reviewHistoryController,
     required this.coachingProfileController,
+    this.appUpdateService,
+    this.updateCheckInProgress = false,
+    this.onCheckForUpdate,
     this.avatarPicker,
     super.key,
   });
@@ -42,6 +47,9 @@ class ProfilePage extends StatelessWidget {
   final VoidCallback? onLogout;
   final ReviewHistoryController? reviewHistoryController;
   final CoachingProfileController? coachingProfileController;
+  final AppUpdateService? appUpdateService;
+  final bool updateCheckInProgress;
+  final Future<void> Function()? onCheckForUpdate;
   final ProfileAvatarPicker? avatarPicker;
 
   @override
@@ -163,6 +171,14 @@ class ProfilePage extends StatelessWidget {
             CurrentIeltsAbilityProfile(
               historyController: reviewHistoryController,
             ),
+            if (appUpdateService != null && onCheckForUpdate != null) ...[
+              const SizedBox(height: SpeakUpDesign.space24),
+              AppUpdateSection(
+                service: appUpdateService!,
+                checking: updateCheckInProgress,
+                onCheck: onCheckForUpdate!,
+              ),
+            ],
           ],
         ),
       ),

--- a/mobile/lib/features/update/app_update.dart
+++ b/mobile/lib/features/update/app_update.dart
@@ -1,0 +1,478 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+final appReleaseMetadataUri = Uri(
+  scheme: 'https',
+  host: 'speak-up.top',
+  path: '/downloads/android/release.json',
+);
+
+const _maximumReleaseMetadataBytes = 16 * 1024;
+const _maximumSafeInteger = 9007199254740991;
+const _automaticCheckInterval = Duration(hours: 24);
+const _requestTimeout = Duration(seconds: 10);
+
+typedef AppReleaseBodyLoader = Future<String> Function(Uri uri);
+typedef InstalledAppVersionLoader = Future<InstalledAppVersion> Function();
+typedef AppUpdateUriLauncher = Future<bool> Function(Uri uri);
+typedef AppUpdateClock = DateTime Function();
+
+final class AppRelease {
+  const AppRelease._({
+    required this.version,
+    required this.versionCode,
+    required this.publishedAt,
+    required this.fileName,
+    required this.downloadPath,
+    required this.sizeBytes,
+    required this.minimumAndroidApi,
+    required this.abis,
+    required this.apkSha256,
+    required this.apkCertificateSha256,
+  });
+
+  final String version;
+  final int versionCode;
+  final DateTime publishedAt;
+  final String fileName;
+  final String downloadPath;
+  final int sizeBytes;
+  final int minimumAndroidApi;
+  final List<String> abis;
+  final String apkSha256;
+  final String apkCertificateSha256;
+
+  Uri get downloadUri => Uri(
+    scheme: 'https',
+    host: appReleaseMetadataUri.host,
+    path: downloadPath,
+  );
+}
+
+final class InstalledAppVersion {
+  const InstalledAppVersion({required this.version, required this.versionCode});
+
+  final String version;
+  final int versionCode;
+}
+
+enum AppUpdateCheckStatus { available, upToDate, failed, skipped }
+
+final class AppUpdateCheckResult {
+  const AppUpdateCheckResult._({
+    required this.status,
+    this.installedVersion,
+    this.release,
+  });
+
+  const AppUpdateCheckResult.available(
+    InstalledAppVersion installedVersion,
+    AppRelease release,
+  ) : this._(
+        status: AppUpdateCheckStatus.available,
+        installedVersion: installedVersion,
+        release: release,
+      );
+
+  const AppUpdateCheckResult.upToDate(
+    InstalledAppVersion installedVersion,
+    AppRelease release,
+  ) : this._(
+        status: AppUpdateCheckStatus.upToDate,
+        installedVersion: installedVersion,
+        release: release,
+      );
+
+  const AppUpdateCheckResult.failed()
+    : this._(status: AppUpdateCheckStatus.failed);
+
+  const AppUpdateCheckResult.skipped()
+    : this._(status: AppUpdateCheckStatus.skipped);
+
+  final AppUpdateCheckStatus status;
+  final InstalledAppVersion? installedVersion;
+  final AppRelease? release;
+}
+
+enum AppUpdateFailureKind { unavailable, invalidResponse }
+
+final class AppUpdateException implements Exception {
+  const AppUpdateException(this.kind);
+
+  final AppUpdateFailureKind kind;
+
+  @override
+  String toString() => 'App update ${kind.name}.';
+}
+
+final class AppReleaseClient {
+  AppReleaseClient({AppReleaseBodyLoader? bodyLoader})
+    : _bodyLoader = bodyLoader ?? _loadReleaseBody;
+
+  final AppReleaseBodyLoader _bodyLoader;
+
+  Future<AppRelease> fetchLatest() async {
+    late final String body;
+    try {
+      body = await _bodyLoader(appReleaseMetadataUri);
+    } on AppUpdateException {
+      rethrow;
+    } on Object {
+      throw const AppUpdateException(AppUpdateFailureKind.unavailable);
+    }
+    if (utf8.encode(body).length > _maximumReleaseMetadataBytes) {
+      throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+    }
+    try {
+      return parseAppReleaseMetadata(jsonDecode(body));
+    } on AppUpdateException {
+      rethrow;
+    } on Object {
+      throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+    }
+  }
+}
+
+abstract interface class AppUpdateCheckStore {
+  Future<DateTime?> readLastAutomaticCheckAt();
+
+  Future<void> writeLastAutomaticCheckAt(DateTime value);
+}
+
+final class SecureAppUpdateCheckStore implements AppUpdateCheckStore {
+  const SecureAppUpdateCheckStore([
+    this._storage = const FlutterSecureStorage(),
+  ]);
+
+  static const _lastCheckKey = 'app_update_last_automatic_check_at';
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<DateTime?> readLastAutomaticCheckAt() async {
+    final value = await _storage.read(key: _lastCheckKey);
+    if (value == null) {
+      return null;
+    }
+    final parsed = DateTime.tryParse(value);
+    if (parsed == null || !parsed.isUtc) {
+      throw const FormatException('Invalid app update check timestamp.');
+    }
+    return parsed;
+  }
+
+  @override
+  Future<void> writeLastAutomaticCheckAt(DateTime value) {
+    return _storage.write(
+      key: _lastCheckKey,
+      value: value.toUtc().toIso8601String(),
+    );
+  }
+}
+
+final class AppUpdateService {
+  factory AppUpdateService({
+    required AppReleaseClient releaseClient,
+    required AppUpdateCheckStore checkStore,
+    required InstalledAppVersionLoader installedVersionLoader,
+    required AppUpdateUriLauncher uriLauncher,
+    AppUpdateClock? clock,
+  }) {
+    return AppUpdateService._(
+      releaseClient,
+      checkStore,
+      installedVersionLoader,
+      uriLauncher,
+      clock ?? DateTime.now,
+    );
+  }
+
+  AppUpdateService._(
+    this._releaseClient,
+    this._checkStore,
+    this._installedVersionLoader,
+    this._uriLauncher,
+    this._clock,
+  );
+
+  final AppReleaseClient _releaseClient;
+  final AppUpdateCheckStore _checkStore;
+  final InstalledAppVersionLoader _installedVersionLoader;
+  final AppUpdateUriLauncher _uriLauncher;
+  final AppUpdateClock _clock;
+
+  InstalledAppVersion? _installedVersion;
+  Future<InstalledAppVersion>? _installedVersionOperation;
+  DateTime? _lastAutomaticCheckAt;
+  bool _checkStoreRead = false;
+
+  Future<InstalledAppVersion> loadInstalledVersion() {
+    final installed = _installedVersion;
+    if (installed != null) {
+      return Future<InstalledAppVersion>.value(installed);
+    }
+    final existing = _installedVersionOperation;
+    if (existing != null) {
+      return existing;
+    }
+    late final Future<InstalledAppVersion> operation;
+    operation = _installedVersionLoader()
+        .then((value) {
+          _installedVersion = value;
+          return value;
+        })
+        .whenComplete(() {
+          if (identical(_installedVersionOperation, operation)) {
+            _installedVersionOperation = null;
+          }
+        });
+    _installedVersionOperation = operation;
+    return operation;
+  }
+
+  Future<AppUpdateCheckResult> check({required bool automatic}) async {
+    if (automatic && !await _beginAutomaticCheck()) {
+      return const AppUpdateCheckResult.skipped();
+    }
+    try {
+      final installed = await loadInstalledVersion();
+      final release = await _releaseClient.fetchLatest();
+      if (release.versionCode > installed.versionCode) {
+        return AppUpdateCheckResult.available(installed, release);
+      }
+      return AppUpdateCheckResult.upToDate(installed, release);
+    } on Object {
+      return const AppUpdateCheckResult.failed();
+    }
+  }
+
+  Future<bool> openDownload(AppRelease release) async {
+    if (!_hasTrustedDownloadLocation(release)) {
+      return false;
+    }
+    try {
+      return await _uriLauncher(release.downloadUri);
+    } on Object {
+      return false;
+    }
+  }
+
+  Future<bool> _beginAutomaticCheck() async {
+    final now = _clock().toUtc();
+    if (!_checkStoreRead) {
+      _checkStoreRead = true;
+      try {
+        _lastAutomaticCheckAt = await _checkStore.readLastAutomaticCheckAt();
+      } on Object {
+        // The timestamp only rate-limits traffic. Storage failure must not
+        // suppress update discovery for the rest of the process.
+      }
+    }
+    final lastCheck = _lastAutomaticCheckAt;
+    if (lastCheck != null &&
+        now.isBefore(lastCheck.add(_automaticCheckInterval))) {
+      return false;
+    }
+    _lastAutomaticCheckAt = now;
+    try {
+      await _checkStore.writeLastAutomaticCheckAt(now);
+    } on Object {
+      // In-memory throttling remains active for this process.
+    }
+    return true;
+  }
+}
+
+Future<InstalledAppVersion> loadInstalledAppVersion() async {
+  final packageInfo = await PackageInfo.fromPlatform();
+  final version = packageInfo.version.trim();
+  final versionCode = int.tryParse(packageInfo.buildNumber);
+  if (!_versionPattern.hasMatch(version) ||
+      versionCode == null ||
+      !_isPositiveSafeInteger(versionCode)) {
+    throw const FormatException('Installed app version is invalid.');
+  }
+  return InstalledAppVersion(version: version, versionCode: versionCode);
+}
+
+Future<bool> launchAppUpdateUri(Uri uri) {
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+bool canPresentAutomaticAppUpdate({
+  required bool routeCurrent,
+  required bool practiceRouteInFlight,
+  required bool conversationBusy,
+  required bool composerActiveWorkflow,
+  required bool practiceBusy,
+  required bool practiceRecordingIdle,
+}) {
+  return routeCurrent &&
+      !practiceRouteInFlight &&
+      !conversationBusy &&
+      !composerActiveWorkflow &&
+      !practiceBusy &&
+      practiceRecordingIdle;
+}
+
+AppRelease parseAppReleaseMetadata(Object? value) {
+  const expectedKeys = <String>{
+    'abis',
+    'apk_certificate_sha256',
+    'apk_sha256',
+    'download_path',
+    'file_name',
+    'metadata_version',
+    'minimum_android_api',
+    'published_at',
+    'size_bytes',
+    'version',
+    'version_code',
+  };
+  if (value is! Map<String, Object?> ||
+      value.length != expectedKeys.length ||
+      !value.keys.every(expectedKeys.contains)) {
+    throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+  }
+
+  final version = value['version'];
+  final versionCode = value['version_code'];
+  final publishedAtValue = value['published_at'];
+  final fileName = value['file_name'];
+  final downloadPath = value['download_path'];
+  final sizeBytes = value['size_bytes'];
+  final minimumAndroidApi = value['minimum_android_api'];
+  final abis = value['abis'];
+  final apkSha256 = value['apk_sha256'];
+  final apkCertificateSha256 = value['apk_certificate_sha256'];
+
+  if (value['metadata_version'] != 1 ||
+      version is! String ||
+      !_versionPattern.hasMatch(version) ||
+      versionCode is! int ||
+      !_isPositiveSafeInteger(versionCode) ||
+      publishedAtValue is! String ||
+      !_canonicalUtcPattern.hasMatch(publishedAtValue) ||
+      fileName is! String ||
+      fileName != 'speakup-v$version-production-arm64.apk' ||
+      downloadPath is! String ||
+      downloadPath != '/downloads/android/v$version/$fileName' ||
+      sizeBytes is! int ||
+      !_isPositiveSafeInteger(sizeBytes) ||
+      minimumAndroidApi != 24 ||
+      abis is! List<Object?> ||
+      abis.length != 1 ||
+      abis.single != 'arm64-v8a' ||
+      apkSha256 is! String ||
+      !_isNonzeroSha256(apkSha256) ||
+      apkCertificateSha256 is! String ||
+      !_isNonzeroSha256(apkCertificateSha256)) {
+    throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+  }
+
+  final publishedAt = DateTime.tryParse(publishedAtValue);
+  if (publishedAt == null ||
+      !publishedAt.isUtc ||
+      _canonicalUtc(publishedAt) != publishedAtValue) {
+    throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+  }
+
+  final release = AppRelease._(
+    version: version,
+    versionCode: versionCode,
+    publishedAt: publishedAt,
+    fileName: fileName,
+    downloadPath: downloadPath,
+    sizeBytes: sizeBytes,
+    minimumAndroidApi: minimumAndroidApi as int,
+    abis: List<String>.unmodifiable(abis.cast<String>()),
+    apkSha256: apkSha256,
+    apkCertificateSha256: apkCertificateSha256,
+  );
+  if (!_hasTrustedDownloadLocation(release)) {
+    throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+  }
+  return release;
+}
+
+Future<String> _loadReleaseBody(Uri uri) async {
+  if (uri != appReleaseMetadataUri) {
+    throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+  }
+  final client = HttpClient()..connectionTimeout = _requestTimeout;
+  try {
+    final request = await client.getUrl(uri).timeout(_requestTimeout);
+    request
+      ..followRedirects = false
+      ..headers.set(HttpHeaders.acceptHeader, ContentType.json.mimeType)
+      ..headers.set(HttpHeaders.cacheControlHeader, 'no-cache');
+    final response = await request.close().timeout(_requestTimeout);
+    if (response.statusCode != HttpStatus.ok) {
+      throw const AppUpdateException(AppUpdateFailureKind.unavailable);
+    }
+    if (response.headers.contentType?.mimeType != ContentType.json.mimeType ||
+        response.contentLength > _maximumReleaseMetadataBytes) {
+      throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+    }
+    final bytes = BytesBuilder(copy: false);
+    await for (final chunk in response.timeout(_requestTimeout)) {
+      bytes.add(chunk);
+      if (bytes.length > _maximumReleaseMetadataBytes) {
+        throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+      }
+    }
+    try {
+      return utf8.decode(bytes.takeBytes(), allowMalformed: false);
+    } on FormatException {
+      throw const AppUpdateException(AppUpdateFailureKind.invalidResponse);
+    }
+  } on AppUpdateException {
+    rethrow;
+  } on Object {
+    throw const AppUpdateException(AppUpdateFailureKind.unavailable);
+  } finally {
+    client.close(force: true);
+  }
+}
+
+bool _hasTrustedDownloadLocation(AppRelease release) {
+  final expectedPath =
+      '/downloads/android/v${release.version}/'
+      'speakup-v${release.version}-production-arm64.apk';
+  final uri = release.downloadUri;
+  return release.fileName ==
+          'speakup-v${release.version}-production-arm64.apk' &&
+      release.downloadPath == expectedPath &&
+      uri.scheme == 'https' &&
+      uri.host == appReleaseMetadataUri.host &&
+      !uri.hasPort &&
+      uri.userInfo.isEmpty &&
+      uri.path == expectedPath &&
+      !uri.hasQuery &&
+      !uri.hasFragment;
+}
+
+bool _isPositiveSafeInteger(int value) {
+  return value >= 1 && value <= _maximumSafeInteger;
+}
+
+bool _isNonzeroSha256(String value) {
+  return _sha256Pattern.hasMatch(value) &&
+      !value.runes.every((rune) => rune == 48);
+}
+
+String _canonicalUtc(DateTime value) {
+  return value.toUtc().toIso8601String().replaceFirst('.000Z', 'Z');
+}
+
+final _versionPattern = RegExp(r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$');
+final _sha256Pattern = RegExp(r'^[0-9a-f]{64}$');
+final _canonicalUtcPattern = RegExp(
+  r'^\d{4}-(0[1-9]|1[0-2])-([012]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\dZ$',
+);

--- a/mobile/lib/features/update/app_update_ui.dart
+++ b/mobile/lib/features/update/app_update_ui.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/features/update/app_update.dart';
+
+class AppUpdateSection extends StatelessWidget {
+  const AppUpdateSection({
+    required this.service,
+    required this.checking,
+    required this.onCheck,
+    super.key,
+  });
+
+  final AppUpdateService service;
+  final bool checking;
+  final Future<void> Function() onCheck;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('profile-app-update-section'),
+      padding: const EdgeInsets.all(SpeakUpDesign.space20),
+      decoration: BoxDecoration(
+        border: Border.all(color: SpeakUpDesign.border),
+        borderRadius: BorderRadius.circular(22),
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final details = Row(
+            children: [
+              const Icon(Icons.system_update_alt_rounded, size: 28),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('应用版本', style: SpeakUpDesign.sectionTitle),
+                    const SizedBox(height: SpeakUpDesign.space4),
+                    FutureBuilder<InstalledAppVersion>(
+                      future: service.loadInstalledVersion(),
+                      builder: (context, snapshot) {
+                        final version = snapshot.data;
+                        final label = version == null
+                            ? snapshot.hasError
+                                  ? '当前版本暂时无法读取'
+                                  : '正在读取当前版本…'
+                            : '当前 v${version.version}（${version.versionCode}）';
+                        return Text(
+                          label,
+                          key: const Key('profile-app-version'),
+                          style: SpeakUpDesign.body,
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+          final action = TextButton(
+            key: const Key('profile-check-update'),
+            onPressed: checking ? null : onCheck,
+            child: Text(checking ? '检查中…' : '检查更新'),
+          );
+          final useStackedLayout =
+              constraints.maxWidth < 340 ||
+              MediaQuery.textScalerOf(context).scale(16) > 22;
+          if (useStackedLayout) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                details,
+                const SizedBox(height: SpeakUpDesign.space8),
+                Align(alignment: Alignment.centerRight, child: action),
+              ],
+            );
+          }
+          return Row(
+            children: [
+              Expanded(child: details),
+              action,
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+Future<bool?> showAppUpdateDialog(
+  BuildContext context, {
+  required InstalledAppVersion installedVersion,
+  required AppRelease release,
+}) {
+  return showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      key: const Key('app-update-dialog'),
+      scrollable: true,
+      title: Text('发现新版本 v${release.version}'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('当前版本：v${installedVersion.version}'),
+          const SizedBox(height: SpeakUpDesign.space8),
+          Text('安装包：${formatAppUpdateBytes(release.sizeBytes)}'),
+          const SizedBox(height: SpeakUpDesign.space8),
+          Text('发布时间：${formatAppUpdateDate(release.publishedAt)}'),
+          const SizedBox(height: SpeakUpDesign.space16),
+          Text('点击后将在系统浏览器中下载，安装时请按 Android 提示确认。', style: SpeakUpDesign.meta),
+        ],
+      ),
+      actions: [
+        TextButton(
+          key: const Key('app-update-later'),
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('稍后'),
+        ),
+        FilledButton(
+          key: const Key('app-update-now'),
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: const Text('立即更新'),
+        ),
+      ],
+    ),
+  );
+}
+
+String formatAppUpdateBytes(int bytes) {
+  return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+}
+
+String formatAppUpdateDate(DateTime value) {
+  final local = value.toLocal();
+  return '${local.year}-${_twoDigits(local.month)}-${_twoDigits(local.day)}';
+}
+
+String _twoDigits(int value) => value.toString().padLeft(2, '0');

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -47,6 +47,7 @@ import 'package:speakup/features/coaching/evaluation/wire_turn_feedback_client.d
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 import 'package:speakup/features/coaching/practice/avatar/avatar.dart';
 import 'package:speakup/features/coaching/scenario/scenario_practice_session.dart';
+import 'package:speakup/features/update/app_update.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -80,6 +81,9 @@ void main() {
       sessionEvaluationController: dependencies.sessionEvaluationController,
       speechFeedbackController: dependencies.speechFeedbackController,
       coachingProfileController: dependencies.coachingProfileController,
+      appUpdateService: defaultTargetPlatform == TargetPlatform.android
+          ? dependencies.appUpdateService
+          : null,
       avatarControllerFactory: avatarEnabled
           ? dependencies.avatarControllerFactory
           : null,
@@ -104,6 +108,7 @@ final class ProductionAppDependencies {
     required this.sessionEvaluationController,
     required this.speechFeedbackController,
     required this.coachingProfileController,
+    required this.appUpdateService,
     required this.avatarControllerFactory,
   });
 
@@ -122,6 +127,7 @@ final class ProductionAppDependencies {
   final SessionEvaluationController sessionEvaluationController;
   final SpeechFeedbackController speechFeedbackController;
   final CoachingProfileController coachingProfileController;
+  final AppUpdateService appUpdateService;
   final AvatarControllerFactory avatarControllerFactory;
 }
 
@@ -153,6 +159,7 @@ ProductionAppDependencies createProductionAppDependencies({
   AvatarControllerFactory? avatarControllerFactory,
   PracticeLaunchRecordStore? practiceLaunchRecordStore,
   SessionStore? sessionStore,
+  AppUpdateService? appUpdateService,
 }) {
   late final AuthController authController;
   final agentClient = WireAgentClient(
@@ -452,6 +459,14 @@ ProductionAppDependencies createProductionAppDependencies({
       transport: coachingProfileTransport,
     ),
   );
+  final resolvedAppUpdateService =
+      appUpdateService ??
+      AppUpdateService(
+        releaseClient: AppReleaseClient(),
+        checkStore: const SecureAppUpdateCheckStore(),
+        installedVersionLoader: loadInstalledAppVersion,
+        uriLauncher: launchAppUpdateUri,
+      );
   authController = AuthController(
     identityClient: identityClient,
     profileClient: identityClient,
@@ -489,6 +504,7 @@ ProductionAppDependencies createProductionAppDependencies({
     sessionEvaluationController: sessionEvaluationController,
     speechFeedbackController: speechFeedbackController,
     coachingProfileController: coachingProfileController,
+    appUpdateService: resolvedAppUpdateService,
     avatarControllerFactory: createAvatarController,
   );
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -535,6 +535,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_secure_storage: ^10.3.1
   file_picker: ^10.3.10
   image_picker: ^1.2.3
+  package_info_plus: ^9.0.1
   path_provider: ^2.1.5
   record: ^6.1.2
   flutter_tts: ^4.2.5

--- a/mobile/test/update/app_update_test.dart
+++ b/mobile/test/update/app_update_test.dart
@@ -1,0 +1,324 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/update/app_update.dart';
+
+void main() {
+  group('AppReleaseClient', () {
+    test('loads the fixed production metadata URL', () async {
+      Uri? requestedUri;
+      final client = AppReleaseClient(
+        bodyLoader: (uri) async {
+          requestedUri = uri;
+          return jsonEncode(_validMetadata());
+        },
+      );
+
+      final release = await client.fetchLatest();
+
+      expect(requestedUri, appReleaseMetadataUri);
+      expect(release.version, '0.1.5');
+      expect(release.versionCode, 6);
+      expect(
+        release.downloadUri,
+        Uri.parse(
+          'https://speak-up.top/downloads/android/v0.1.5/'
+          'speakup-v0.1.5-production-arm64.apk',
+        ),
+      );
+    });
+
+    test('rejects invalid JSON and oversized metadata', () async {
+      final invalidJson = AppReleaseClient(bodyLoader: (_) async => '{');
+      final oversized = AppReleaseClient(
+        bodyLoader: (_) async => 'x' * (16 * 1024 + 1),
+      );
+
+      await expectLater(invalidJson.fetchLatest(), throwsA(_invalidResponse));
+      await expectLater(oversized.fetchLatest(), throwsA(_invalidResponse));
+    });
+
+    for (final invalid in <Map<String, Object?>>[
+      {..._validMetadata(), 'unexpected': true},
+      {..._validMetadata()}..remove('version_code'),
+      {..._validMetadata(), 'metadata_version': 2},
+      {..._validMetadata(), 'version': '01.1.5'},
+      {..._validMetadata(), 'version_code': 0},
+      {..._validMetadata(), 'version_code': 6.0},
+      {..._validMetadata(), 'published_at': '2026-02-31T20:16:29Z'},
+      {..._validMetadata(), 'published_at': '2026-08-23T20:16:29.000Z'},
+      {..._validMetadata(), 'file_name': 'speakup-latest.apk'},
+      {..._validMetadata(), 'download_path': 'https://evil.example/app.apk'},
+      {..._validMetadata(), 'size_bytes': 0},
+      {..._validMetadata(), 'minimum_android_api': 23},
+      {
+        ..._validMetadata(),
+        'abis': <String>['armeabi-v7a'],
+      },
+      {..._validMetadata(), 'apk_sha256': 'A' * 64},
+      {..._validMetadata(), 'apk_certificate_sha256': '0' * 64},
+    ]) {
+      test('rejects metadata outside the release contract: $invalid', () {
+        expect(
+          () => parseAppReleaseMetadata(invalid),
+          throwsA(_invalidResponse),
+        );
+      });
+    }
+  });
+
+  group('AppUpdateService', () {
+    test('uses versionCode to decide whether an update is available', () async {
+      final available = _service(
+        installedVersion: const InstalledAppVersion(
+          version: '0.1.4',
+          versionCode: 5,
+        ),
+      );
+      final current = _service(
+        installedVersion: const InstalledAppVersion(
+          version: '0.1.5',
+          versionCode: 6,
+        ),
+      );
+      final newerLocalBuild = _service(
+        installedVersion: const InstalledAppVersion(
+          version: '0.1.6',
+          versionCode: 7,
+        ),
+      );
+
+      expect(
+        (await available.check(automatic: false)).status,
+        AppUpdateCheckStatus.available,
+      );
+      expect(
+        (await current.check(automatic: false)).status,
+        AppUpdateCheckStatus.upToDate,
+      );
+      expect(
+        (await newerLocalBuild.check(automatic: false)).status,
+        AppUpdateCheckStatus.upToDate,
+      );
+    });
+
+    test('manual failures are represented as failures, not latest', () async {
+      final service = _service(
+        bodyLoader: (_) async => throw StateError('offline'),
+      );
+
+      final result = await service.check(automatic: false);
+
+      expect(result.status, AppUpdateCheckStatus.failed);
+      expect(result.release, isNull);
+    });
+
+    test('automatic checks persist and honor the 24 hour throttle', () async {
+      final store = _MemoryCheckStore();
+      var requests = 0;
+      final first = _service(
+        store: store,
+        clock: () => DateTime.utc(2026, 8, 24, 8),
+        bodyLoader: (_) async {
+          requests++;
+          return jsonEncode(_validMetadata());
+        },
+      );
+
+      expect(
+        (await first.check(automatic: true)).status,
+        AppUpdateCheckStatus.available,
+      );
+      final restarted = _service(
+        store: store,
+        clock: () => DateTime.utc(2026, 8, 24, 9),
+        bodyLoader: (_) async {
+          requests++;
+          return jsonEncode(_validMetadata());
+        },
+      );
+      expect(
+        (await restarted.check(automatic: true)).status,
+        AppUpdateCheckStatus.skipped,
+      );
+      expect(requests, 1);
+      expect(store.value, DateTime.utc(2026, 8, 24, 8));
+    });
+
+    test('manual checks bypass the automatic throttle', () async {
+      var requests = 0;
+      final service = _service(
+        store: _MemoryCheckStore(value: DateTime.utc(2026, 8, 24, 8)),
+        clock: () => DateTime.utc(2026, 8, 24, 9),
+        bodyLoader: (_) async {
+          requests++;
+          return jsonEncode(_validMetadata());
+        },
+      );
+
+      final result = await service.check(automatic: false);
+
+      expect(result.status, AppUpdateCheckStatus.available);
+      expect(requests, 1);
+    });
+
+    test(
+      'a throttle store failure does not suppress update discovery',
+      () async {
+        final service = _service(store: _FailingCheckStore());
+
+        final result = await service.check(automatic: true);
+
+        expect(result.status, AppUpdateCheckStatus.available);
+      },
+    );
+
+    test('opens only the validated versioned HTTPS APK URL', () async {
+      Uri? launched;
+      final service = _service(
+        uriLauncher: (uri) async {
+          launched = uri;
+          return true;
+        },
+      );
+      final result = await service.check(automatic: false);
+
+      final opened = await service.openDownload(result.release!);
+
+      expect(opened, isTrue);
+      expect(
+        launched,
+        Uri.parse(
+          'https://speak-up.top/downloads/android/v0.1.5/'
+          'speakup-v0.1.5-production-arm64.apk',
+        ),
+      );
+    });
+
+    test(
+      'caches the installed package version after a successful read',
+      () async {
+        var reads = 0;
+        final service = _service(
+          installedVersionLoader: () async {
+            reads++;
+            return const InstalledAppVersion(version: '0.1.4', versionCode: 5);
+          },
+        );
+
+        await service.loadInstalledVersion();
+        await service.check(automatic: false);
+
+        expect(reads, 1);
+      },
+    );
+  });
+
+  group('automatic update presentation policy', () {
+    test('allows a prompt only while the app is idle on the current route', () {
+      expect(
+        canPresentAutomaticAppUpdate(
+          routeCurrent: true,
+          practiceRouteInFlight: false,
+          conversationBusy: false,
+          composerActiveWorkflow: false,
+          practiceBusy: false,
+          practiceRecordingIdle: true,
+        ),
+        isTrue,
+      );
+
+      for (final blocked in <Map<String, bool>>[
+        {'routeCurrent': false},
+        {'practiceRouteInFlight': true},
+        {'conversationBusy': true},
+        {'composerActiveWorkflow': true},
+        {'practiceBusy': true},
+        {'practiceRecordingIdle': false},
+      ]) {
+        expect(
+          canPresentAutomaticAppUpdate(
+            routeCurrent: blocked['routeCurrent'] ?? true,
+            practiceRouteInFlight: blocked['practiceRouteInFlight'] ?? false,
+            conversationBusy: blocked['conversationBusy'] ?? false,
+            composerActiveWorkflow: blocked['composerActiveWorkflow'] ?? false,
+            practiceBusy: blocked['practiceBusy'] ?? false,
+            practiceRecordingIdle: blocked['practiceRecordingIdle'] ?? true,
+          ),
+          isFalse,
+          reason: '$blocked must defer the prompt',
+        );
+      }
+    });
+  });
+}
+
+final _invalidResponse = isA<AppUpdateException>().having(
+  (error) => error.kind,
+  'kind',
+  AppUpdateFailureKind.invalidResponse,
+);
+
+Map<String, Object?> _validMetadata() => <String, Object?>{
+  'metadata_version': 1,
+  'version': '0.1.5',
+  'version_code': 6,
+  'published_at': '2026-08-23T20:16:29Z',
+  'file_name': 'speakup-v0.1.5-production-arm64.apk',
+  'download_path':
+      '/downloads/android/v0.1.5/speakup-v0.1.5-production-arm64.apk',
+  'size_bytes': 70024938,
+  'minimum_android_api': 24,
+  'abis': <String>['arm64-v8a'],
+  'apk_sha256': '1' * 64,
+  'apk_certificate_sha256': '2' * 64,
+};
+
+AppUpdateService _service({
+  InstalledAppVersion installedVersion = const InstalledAppVersion(
+    version: '0.1.4',
+    versionCode: 5,
+  ),
+  InstalledAppVersionLoader? installedVersionLoader,
+  AppReleaseBodyLoader? bodyLoader,
+  AppUpdateCheckStore? store,
+  AppUpdateUriLauncher? uriLauncher,
+  AppUpdateClock? clock,
+}) {
+  return AppUpdateService(
+    releaseClient: AppReleaseClient(
+      bodyLoader: bodyLoader ?? (_) async => jsonEncode(_validMetadata()),
+    ),
+    checkStore: store ?? _MemoryCheckStore(),
+    installedVersionLoader:
+        installedVersionLoader ?? () async => installedVersion,
+    uriLauncher: uriLauncher ?? (_) async => true,
+    clock: clock,
+  );
+}
+
+final class _MemoryCheckStore implements AppUpdateCheckStore {
+  _MemoryCheckStore({this.value});
+
+  DateTime? value;
+
+  @override
+  Future<DateTime?> readLastAutomaticCheckAt() async => value;
+
+  @override
+  Future<void> writeLastAutomaticCheckAt(DateTime value) async {
+    this.value = value;
+  }
+}
+
+final class _FailingCheckStore implements AppUpdateCheckStore {
+  @override
+  Future<DateTime?> readLastAutomaticCheckAt() {
+    throw StateError('read failed');
+  }
+
+  @override
+  Future<void> writeLastAutomaticCheckAt(DateTime value) {
+    throw StateError('write failed');
+  }
+}

--- a/mobile/test/update/app_update_ui_test.dart
+++ b/mobile/test/update/app_update_ui_test.dart
@@ -1,0 +1,237 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/app/speak_up_app.dart';
+import 'package:speakup/features/profile/profile_page.dart';
+import 'package:speakup/features/update/app_update.dart';
+import 'package:speakup/features/update/app_update_ui.dart';
+
+void main() {
+  testWidgets('cold start presents a validated available update once', (
+    tester,
+  ) async {
+    var metadataRequests = 0;
+    final service = _service(
+      bodyLoader: (_) async {
+        metadataRequests++;
+        return jsonEncode(_metadata());
+      },
+    );
+
+    await tester.pumpWidget(SpeakUpApp.preview(appUpdateService: service));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('app-update-dialog')), findsOneWidget);
+    expect(find.text('发现新版本 v0.1.5'), findsOneWidget);
+    expect(find.text('当前版本：v0.1.4'), findsOneWidget);
+    expect(find.text('安装包：66.8 MB'), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Text &&
+            (widget.data?.startsWith('发布时间：2026-08-2') ?? false),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('app-update-later')));
+    await tester.pumpAndSettle();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('app-update-dialog')), findsNothing);
+    expect(metadataRequests, 1);
+  });
+
+  testWidgets('profile shows the installed version and exposes manual check', (
+    tester,
+  ) async {
+    var checks = 0;
+    final service = _service();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ProfilePage(
+          showBackButton: false,
+          user: null,
+          profile: null,
+          profileErrorMessage: null,
+          profileSaving: false,
+          onSaveDisplayName: null,
+          avatarBytes: null,
+          avatarSaving: false,
+          onUploadAvatar: null,
+          onUseDefaultAvatar: null,
+          onLogout: null,
+          reviewHistoryController: null,
+          coachingProfileController: null,
+          appUpdateService: service,
+          onCheckForUpdate: () async => checks++,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('profile-app-update-section')),
+      240,
+    );
+
+    expect(find.text('当前 v0.1.4（5）'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('profile-check-update')));
+    await tester.pump();
+
+    expect(checks, 1);
+  });
+
+  testWidgets('version section remains usable on a narrow large-text screen', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(320, 568);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 3;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: AppUpdateSection(
+                service: _service(),
+                checking: false,
+                onCheck: () async {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(const Key('profile-check-update')), findsOneWidget);
+  });
+
+  testWidgets('manual current and failure results are explicit', (
+    tester,
+  ) async {
+    final currentService = _service(
+      installedVersion: const InstalledAppVersion(
+        version: '0.1.5',
+        versionCode: 6,
+      ),
+      store: _MemoryCheckStore(value: DateTime.now().toUtc()),
+    );
+    await tester.pumpWidget(
+      SpeakUpApp.preview(appUpdateService: currentService),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('primary-tab-profile')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('profile-check-update')),
+      240,
+    );
+    await tester.tap(find.byKey(const Key('profile-check-update')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('已是最新版本 v0.1.5'), findsOneWidget);
+
+    final failedService = _service(
+      bodyLoader: (_) async => throw StateError('offline'),
+      store: _MemoryCheckStore(value: DateTime.now().toUtc()),
+    );
+    await tester.pumpWidget(
+      SpeakUpApp.preview(key: UniqueKey(), appUpdateService: failedService),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('primary-tab-profile')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('profile-check-update')),
+      240,
+    );
+    await tester.tap(find.byKey(const Key('profile-check-update')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('暂时无法检查更新，请检查网络后重试'), findsOneWidget);
+  });
+
+  testWidgets('immediate update opens the exact versioned APK URL', (
+    tester,
+  ) async {
+    Uri? launched;
+    final service = _service(
+      uriLauncher: (uri) async {
+        launched = uri;
+        return true;
+      },
+    );
+    await tester.pumpWidget(SpeakUpApp.preview(appUpdateService: service));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('app-update-now')));
+    await tester.pumpAndSettle();
+
+    expect(
+      launched,
+      Uri.parse(
+        'https://speak-up.top/downloads/android/v0.1.5/'
+        'speakup-v0.1.5-production-arm64.apk',
+      ),
+    );
+  });
+}
+
+AppUpdateService _service({
+  InstalledAppVersion installedVersion = const InstalledAppVersion(
+    version: '0.1.4',
+    versionCode: 5,
+  ),
+  AppReleaseBodyLoader? bodyLoader,
+  AppUpdateCheckStore? store,
+  AppUpdateUriLauncher? uriLauncher,
+}) {
+  return AppUpdateService(
+    releaseClient: AppReleaseClient(
+      bodyLoader: bodyLoader ?? (_) async => jsonEncode(_metadata()),
+    ),
+    checkStore: store ?? _MemoryCheckStore(),
+    installedVersionLoader: () async => installedVersion,
+    uriLauncher: uriLauncher ?? (_) async => true,
+    clock: DateTime.now,
+  );
+}
+
+Map<String, Object?> _metadata() => <String, Object?>{
+  'metadata_version': 1,
+  'version': '0.1.5',
+  'version_code': 6,
+  'published_at': '2026-08-23T20:16:29Z',
+  'file_name': 'speakup-v0.1.5-production-arm64.apk',
+  'download_path':
+      '/downloads/android/v0.1.5/speakup-v0.1.5-production-arm64.apk',
+  'size_bytes': 70024938,
+  'minimum_android_api': 24,
+  'abis': <String>['arm64-v8a'],
+  'apk_sha256': '1' * 64,
+  'apk_certificate_sha256': '2' * 64,
+};
+
+final class _MemoryCheckStore implements AppUpdateCheckStore {
+  _MemoryCheckStore({this.value});
+
+  DateTime? value;
+
+  @override
+  Future<DateTime?> readLastAutomaticCheckAt() async => value;
+
+  @override
+  Future<void> writeLastAutomaticCheckAt(DateTime value) async {
+    this.value = value;
+  }
+}

--- a/mobile/test/update/app_update_ui_test.dart
+++ b/mobile/test/update/app_update_ui_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -43,6 +44,46 @@ void main() {
 
     expect(find.byKey(const Key('app-update-dialog')), findsNothing);
     expect(metadataRequests, 1);
+  });
+
+  testWidgets('deferred update appears after a blocking modal closes', (
+    tester,
+  ) async {
+    final metadata = Completer<String>();
+    final requestStarted = Completer<void>();
+    final service = _service(
+      bodyLoader: (_) {
+        requestStarted.complete();
+        return metadata.future;
+      },
+    );
+
+    await tester.pumpWidget(SpeakUpApp.preview(appUpdateService: service));
+    await tester.pump();
+    await requestStarted.future;
+
+    final shellContext = tester.element(
+      find.byKey(const Key('primary-tab-agent')),
+    );
+    unawaited(
+      showModalBottomSheet<void>(
+        context: shellContext,
+        builder: (_) =>
+            const SizedBox(key: Key('blocking-update-modal'), height: 120),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    metadata.complete(jsonEncode(_metadata()));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('app-update-dialog')), findsNothing);
+
+    Navigator.of(
+      tester.element(find.byKey(const Key('blocking-update-modal'))),
+    ).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('app-update-dialog')), findsOneWidget);
   });
 
   testWidgets('profile shows the installed version and exposes manual check', (


### PR DESCRIPTION
## 功能描述

- 固定读取 `https://speak-up.top/downloads/android/release.json`，通过 `versionCode` 判断是否存在新版本。
- Android 冷启动和恢复前台时自动检查，使用持久化 24 小时限频；自动失败不打断用户。
- “我的”页展示当前版本并提供手动检查；手动失败和已是最新版均明确反馈。
- 练习、录音或会话工作流进行中延迟自动弹窗；用户确认后由系统浏览器打开版本化 APK。

## 实现思路

- 严格校验 release.json 的字段集合、类型、版本、发布时间、ABI、摘要、证书指纹、文件名和下载路径。
- 仅接受 `https://speak-up.top/downloads/android/v{version}/speakup-v{version}-production-arm64.apk`，禁止重定向、跨域、端口、查询和片段。
- 元数据请求限制 10 秒、16 KiB、JSON MIME 和严格 UTF-8。
- 使用 `package_info_plus` 读取安装版本，使用现有 `flutter_secure_storage` 保存上次自动检查时间，复用现有 `url_launcher` 打开外部浏览器。
- 第一版不包含应用内下载器、静默安装、强制更新或 FCM。

## 可复现测试

- [x] `cd mobile && flutter analyze`
- [x] `cd mobile && flutter test test/update/app_update_test.dart test/update/app_update_ui_test.dart`（30 项）
- [x] `cd mobile && flutter test`（783 项）
- [x] `cd mobile && flutter build apk --debug --flavor production --target-platform android-arm64`
- [x] `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`：真实后端启动正常，iOS 不显示 Android 更新入口或弹窗。

本机没有 Android AVD，因此 APK 覆盖安装的最终用户链路需要在首个包含更新能力的版本发布后，用 Android 真机执行 v0.1.5 → v0.1.6 验收。

Closes #907