### PR TITLE
feat(release): 增加 Production 受控部署与回滚引擎

### DIFF
--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -1,10 +1,12 @@
 # SpeakUp immutable Production contract
 
-This directory defines the host-side Production topology for an already built
-Release Candidate. It validates immutable inputs and renders Nginx, but it does
-not deploy containers, run a migration, alter Nginx, or connect to a server.
-Those state-changing steps remain unavailable until backup and rollback
-orchestration is reviewed separately.
+This directory defines the host-side Production topology and the reviewed
+promotion contract for an already built Release Candidate. It validates
+immutable inputs, captures the initial live baseline, gates a deployment on two
+restore-verified backups, publishes but does not activate the Android APK,
+installs the SpeakUp-only Nginx vhost, and records every successful state as an
+immutable receipt. Rollback changes only application images and Nginx; it never
+runs a down migration or restores Production data.
 
 ## Verified boundaries
 
@@ -30,7 +32,7 @@ release. Its one-time creation belongs to the audited server bootstrap.
 
 ## Prerequisites
 
-- Bash, `jq`, `curl`, Docker Engine, and Docker Compose.
+- Bash, `jq`, `curl`, `flock`, Docker Engine, and Docker Compose.
 - The two external volumes above already exist on the intended host.
 - The external Server edge network exists with an audited, non-conflicting
   subnet and fixed gateway.
@@ -42,6 +44,10 @@ release. Its one-time creation belongs to the audited server bootstrap.
   digests, or the verified offline bundle described below.
 - A real, current-UID-owned `PRODUCTION_PUBLIC_ROOT` that is not group- or
   world-writable.
+- The installed PostgreSQL and Portal backup programs, their mode `0600`
+  environment files, and successful isolated restore contracts described below.
+- The exact host Nginx binary and existing SpeakUp-only vhost file. Both must be
+  owned by the invoking user and must not be writable by another user.
 
 Do not copy local `.env` defaults into Production and do not commit any filled
 environment file. The Server environment file contains real provider
@@ -76,6 +82,24 @@ not be symbolic links.
 characters because it is inserted into a PostgreSQL URL. `PORTAL_ADMIN_PASSWORD`
 must contain at least 16 characters. Hostnames and file paths are validated and
 unknown configuration keys are rejected.
+
+The following paths are explicit trust boundaries rather than values discovered
+from `PATH` or the shared server:
+
+- `PRODUCTION_NGINX_BINARY` and `PRODUCTION_NGINX_CONFIG` identify the host
+  Nginx program and the one `xe3-speakup-*.conf` file this contract may replace.
+- `PRODUCTION_POSTGRES_BACKUP_PROGRAM` and
+  `PRODUCTION_POSTGRES_BACKUP_ENV_FILE` identify the audited PostgreSQL backup
+  program and its private policy/identity configuration.
+- `PRODUCTION_PORTAL_BACKUP_PROGRAM` and
+  `PRODUCTION_PORTAL_BACKUP_ENV_FILE` identify the corresponding Portal SQLite
+  program and configuration.
+
+The backup environment files must describe the currently deployed release.
+After a successful deploy or rollback, `manage.sh` atomically replaces each
+file with the new release identity, immutable image and container name while
+preserving its explicit retention and maximum-age policies. No database or
+Portal admin password is written to either backup file.
 
 Set `PRODUCTION_SERVER_EDGE_GATEWAY_CIDR` to the external network's exact IPv4
 gateway followed by `/32`. For example, if `docker network inspect` reports
@@ -214,13 +238,14 @@ mismatches, a missing exact PostgreSQL or application RepoDigest, a non-amd64
 image, or incorrect source/revision/version labels. It never pulls and never
 falls back to a tag, image ID, local Registry, `latest`, or a host-side build.
 
-The reviewed deployment orchestration must combine `compose.yaml` with
-`compose.offline.yaml` and still pass `--pull never` explicitly to every
-state-changing `docker compose up` invocation. The override changes only the
-four pull policies for `postgres`, `migrate`, `server`, and `portal`. This
-repository intentionally does not add a Production `deploy` command in this
-Issue; backup, migration, health, rollback, and approval sequencing remain
-mandatory before that command is enabled.
+The managed `deploy` command below is the registry-backed path: it deliberately
+pulls each digest before entering the migration window and does not silently
+switch to the offline override. `compose.offline.yaml` changes only the four
+pull policies for `postgres`, `migrate`, `server`, and `portal`, but authorizing
+that alternate state-changing path still requires its own reviewed command
+contract. Loading an offline archive alone does not authorize a Production
+deployment; if Registry access is unavailable, stop after validation rather
+than editing this script or its Compose arguments on the host.
 
 ## Render Nginx for review
 
@@ -264,9 +289,125 @@ After a later audited deployment has installed this stack:
 ```
 
 `verify` checks Portal `/`, Server `/health`, and Server `/readyz` over the
-loopback bindings. Public HTTPS and business-route smoke tests belong to the
-release smoke contract. There is intentionally no `deploy` or `down` command in
-this directory yet.
+loopback bindings, the exact runtime identities and image digests, and the clean
+database schema from the selected manifest. Public HTTPS and business-route
+smoke tests remain part of the higher-level release Workflow.
+
+## Capture the initial Production baseline
+
+Create the first receipt once, before the first automated promotion. The live
+containers, database schema, backup configurations and installed Nginx vhost
+must already match the selected release manifest and reviewed template:
+
+```sh
+./deploy/production/manage.sh baseline \
+  --manifest /opt/speakup/releases/v0.1.4/release-manifest.json \
+  --env-file /etc/speakup/production.env \
+  --receipt /opt/speakup/releases/v0.1.4/production-baseline-receipt.json
+```
+
+The receipt is strict v1 JSON created with mode `0444` and a no-clobber hard
+link. It binds the manifest SHA-256, version, Git SHA, schema, Portal/Server
+digests, signed APK identity, runtime container IDs, and the complete installed
+Nginx vhost plus its SHA-256. It contains no application Secret. Container IDs
+are audit evidence; a later container restart is accepted when the complete
+Compose identity, digest, mount, network, environment and health contract still
+matches.
+
+`baseline`, `deploy`, and `rollback` share the non-blocking lock at
+`/run/lock/xe3-speakup-production/deploy.lock`. A concurrent operation fails
+without waiting or changing Production. A successful receipt path can never be
+reused or overwritten. The root operator creates the private SpeakUp lock
+directory on first use; the backup locks remain the exact paths shared with the
+systemd units under root-owned `/run/lock`.
+
+## Promote one reviewed Release Candidate
+
+The Android bundle must be generated from the same release manifest and remain
+in its strict `bundle-manifest.json` layout. Run:
+
+```sh
+./deploy/production/manage.sh deploy \
+  --manifest /opt/speakup/releases/v0.1.5/release-manifest.json \
+  --env-file /etc/speakup/production.env \
+  --bundle /opt/speakup/releases/v0.1.5/android-download-bundle \
+  --current-receipt /opt/speakup/releases/v0.1.4/production-baseline-receipt.json \
+  --receipt /opt/speakup/releases/v0.1.5/production-deployment-receipt.json
+```
+
+The command revalidates all inputs after taking the lock, then:
+
+1. proves that the live runtime, schema, Nginx vhost and backup configuration
+   still match `--current-receipt`;
+2. takes the PostgreSQL backup lock, creates a `predeploy` logical backup, and
+   runs a second named isolated restore check;
+3. takes the Portal backup lock, creates a consistent SQLite Online Backup, and
+   confirms the same backup ID through an isolated restore check;
+4. pulls only the manifest-pinned PostgreSQL, migration, Server and Portal
+   images, starts PostgreSQL, runs `migrate up`, and requires the exact clean
+   manifest schema;
+5. starts Portal and Server with `--pull never --no-build`, then checks their
+   runtime identity, health and loopback endpoints;
+6. publishes the validated versioned APK, checksum and metadata under
+   `PRODUCTION_PUBLIC_ROOT`, without changing
+   `downloads/android/release.json`;
+7. installs the rendered SpeakUp Nginx vhost atomically, runs `nginx -t`, and
+   performs a graceful reload. A test or reload failure restores the previous
+   receipt's vhost;
+8. verifies the final deployment again, updates both backup configurations, and
+   writes the immutable deployment receipt.
+
+The public APK pointer is deliberately a later release step. After public HTTPS,
+API and business-route smoke tests pass, activate it explicitly:
+
+```sh
+./deploy/android-download/manage.sh activate \
+  --root /var/www/speakup-production-public \
+  --version 0.1.5
+```
+
+## Roll back application images and Nginx
+
+Select a previous immutable manifest and its receipt, and preserve the receipt
+for the currently live state:
+
+```sh
+./deploy/production/manage.sh rollback \
+  --manifest /opt/speakup/releases/v0.1.4/release-manifest.json \
+  --env-file /etc/speakup/production.env \
+  --current-receipt /opt/speakup/releases/v0.1.5/production-deployment-receipt.json \
+  --target-receipt /opt/speakup/releases/v0.1.4/production-baseline-receipt.json \
+  --receipt /opt/speakup/releases/rollback-v0.1.5-to-v0.1.4.json
+```
+
+Rollback takes both backup locks, uses only already present target images with
+`--pull never`, restores Portal and Server, validates the target runtime,
+restores the exact target Nginx vhost, refreshes backup release identity, and
+writes a new rollback receipt linked to both the previous live receipt and the
+selected rollback target receipt. It does not run a migration, restore either
+backup, alter PostgreSQL, remove a versioned APK, or change the active Android
+metadata.
+
+The current database schema must equal the target receipt schema. If the failed
+release advanced the schema, rollback stops before changing an application
+container. Resolve that case with a reviewed forward-compatible hotfix or a
+separate disaster-recovery procedure; this script never guesses that an older
+binary is compatible and never executes `migrate down`.
+
+## Failure boundaries
+
+- A manifest, receipt, bundle, lock, backup, restore check or migration failure
+  prevents all later steps and never creates a success receipt.
+- A failure after a successful `migrate up` leaves the advanced schema in place;
+  it is intentionally not reversed automatically.
+- APK publication is no-clobber and not publicly activated. If a later step
+  fails, inspect the unactivated version directory and failed operation before
+  retrying; never delete or replace it without reconciling its SHA-256 evidence.
+- A missing success receipt means the operation is incomplete even when some
+  host state changed. Verify the live manifest, schema, Nginx and backup files,
+  then capture a newly reviewed baseline or execute an allowed rollback.
+- Production data restoration is never part of image rollback. It requires the
+  separately reviewed outage and recovery procedure described below.
 
 ## PostgreSQL logical backup and isolated restore check
 
@@ -401,8 +542,10 @@ the four pull policies, and fail-closed behavior without contacting Production.
 - [Docker Compose project names](https://docs.docker.com/compose/how-tos/project-name/)
 - [Docker Compose startup order](https://docs.docker.com/compose/how-tos/startup-order/)
 - [Docker image pull](https://docs.docker.com/reference/cli/docker/image/pull/)
+- [Linux `flock`](https://man7.org/linux/man-pages/man1/flock.1.html)
 - [GitHub workflow API](https://docs.github.com/en/rest/actions/workflows#get-a-workflow)
 - [GitHub workflow run API](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)
+- [Nginx command-line parameters](https://nginx.org/en/docs/switches.html)
 - [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)
 - [PostgreSQL SQL dump backup](https://www.postgresql.org/docs/18/backup-dump.html)
 - [PostgreSQL `pg_restore`](https://www.postgresql.org/docs/18/app-pgrestore.html)

--- a/deploy/production/manage.sh
+++ b/deploy/production/manage.sh
@@ -12,6 +12,12 @@ readonly server_edge_network="xe3-speakup-production-server-edge"
 readonly portal_image_repository="ghcr.io/1024xengineer/xe3-esl-portal"
 readonly server_image_repository="ghcr.io/1024xengineer/xe3-esl-server"
 readonly postgres_image="postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
+readonly android_download_manager="$production_directory/../android-download/manage.sh"
+readonly production_lock_file="${SPEAKUP_PRODUCTION_LOCK_FILE:-/run/lock/xe3-speakup-production/deploy.lock}"
+readonly postgres_backup_lock_file="${SPEAKUP_POSTGRES_BACKUP_LOCK_FILE:-/run/lock/xe3-postgres-backup.lock}"
+readonly portal_backup_lock_file="${SPEAKUP_PORTAL_BACKUP_LOCK_FILE:-/run/lock/xe3-portal-sqlite-backup.lock}"
+readonly postgres_backup_root="/var/lib/speakup/postgres-backups"
+readonly portal_backup_root="/var/lib/speakup/portal-backups"
 readonly portal_health_url="http://127.0.0.1:18082/"
 readonly server_health_url="http://127.0.0.1:18083/health"
 readonly server_readiness_url="http://127.0.0.1:18083/readyz"
@@ -20,6 +26,9 @@ usage() {
   cat >&2 <<'EOF'
 Usage:
   manage.sh validate --manifest FILE --env-file FILE
+  manage.sh baseline --manifest FILE --env-file FILE --receipt FILE
+  manage.sh deploy --manifest FILE --env-file FILE --bundle DIRECTORY --current-receipt FILE --receipt FILE
+  manage.sh rollback --manifest FILE --env-file FILE --current-receipt FILE --target-receipt FILE --receipt FILE
   manage.sh verify --manifest FILE --env-file FILE
   manage.sh status --manifest FILE --env-file FILE
   manage.sh render-nginx --env-file FILE --output FILE
@@ -131,6 +140,127 @@ require_owned_public_directory() {
     fail "$description cannot be group or world writable: $directory"
 }
 
+path_mode() {
+  local path=$1
+  local mode
+
+  if mode=$(stat -Lc '%a' -- "$path" 2>/dev/null); then
+    :
+  elif mode=$(stat -L -f '%Lp' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$mode"
+}
+
+path_owner() {
+  local path=$1
+  local owner
+
+  if owner=$(stat -Lc '%u' -- "$path" 2>/dev/null); then
+    :
+  elif owner=$(stat -L -f '%u' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$owner"
+}
+
+path_group() {
+  local path=$1
+  local group
+
+  if group=$(stat -Lc '%g' -- "$path" 2>/dev/null); then
+    :
+  elif group=$(stat -L -f '%g' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$group"
+}
+
+path_identity() {
+  local path=$1
+  local identity
+
+  if identity=$(stat -Lc '%i' -- "$path" 2>/dev/null); then
+    :
+  elif identity=$(stat -L -f '%i' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$identity"
+}
+
+path_parent() {
+  local path=$1
+  local parent=${path%/*}
+
+  printf '%s\n' "${parent:-/}"
+}
+
+require_owned_directory() {
+  local description=$1
+  local directory=$2
+  local mode owner
+
+  [[ ! -L "$directory" && -d "$directory" ]] ||
+    fail "$description must be a real directory: $directory"
+  owner=$(path_owner "$directory") ||
+    fail "cannot inspect owner for $description: $directory"
+  [[ "$owner" == "$(id -u)" ]] ||
+    fail "$description must be owned by the current user: $directory"
+  mode=$(path_mode "$directory") ||
+    fail "cannot inspect permissions for $description: $directory"
+  (( (8#$mode & 0022) == 0 )) ||
+    fail "$description cannot be group or world writable: $directory"
+}
+
+require_owned_executable() {
+  local description=$1
+  local file=$2
+  local mode owner
+
+  [[ ! -L "$file" ]] || fail "$description must not be a symbolic link: $file"
+  require_regular_file "$description" "$file"
+  [[ -x "$file" ]] || fail "$description is not executable: $file"
+  owner=$(path_owner "$file") || fail "cannot inspect owner for $description: $file"
+  [[ "$owner" == "$(id -u)" ]] ||
+    fail "$description must be owned by the current user: $file"
+  mode=$(path_mode "$file") || fail "cannot inspect permissions for $description: $file"
+  (( (8#$mode & 0022) == 0 )) ||
+    fail "$description cannot be group or world writable: $file"
+}
+
+require_owned_nonwritable_file() {
+  local description=$1
+  local file=$2
+  local mode owner
+
+  [[ ! -L "$file" ]] || fail "$description must not be a symbolic link: $file"
+  require_regular_file "$description" "$file"
+  owner=$(path_owner "$file") || fail "cannot inspect owner for $description: $file"
+  [[ "$owner" == "$(id -u)" ]] ||
+    fail "$description must be owned by the current user: $file"
+  mode=$(path_mode "$file") || fail "cannot inspect permissions for $description: $file"
+  (( (8#$mode & 0022) == 0 )) ||
+    fail "$description cannot be group or world writable: $file"
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  else
+    fail "sha256sum or shasum is required"
+  fi
+}
+
 allowed_configuration_key() {
   case "$1" in
     PRODUCTION_POSTGRES_DB | \
@@ -145,7 +275,13 @@ allowed_configuration_key() {
       PRODUCTION_TLS_CERTIFICATE | \
       PRODUCTION_TLS_CERTIFICATE_KEY | \
       PRODUCTION_ACME_ROOT | \
-      PRODUCTION_PUBLIC_ROOT)
+      PRODUCTION_PUBLIC_ROOT | \
+      PRODUCTION_NGINX_BINARY | \
+      PRODUCTION_NGINX_CONFIG | \
+      PRODUCTION_POSTGRES_BACKUP_PROGRAM | \
+      PRODUCTION_POSTGRES_BACKUP_ENV_FILE | \
+      PRODUCTION_PORTAL_BACKUP_PROGRAM | \
+      PRODUCTION_PORTAL_BACKUP_ENV_FILE)
       return 0
       ;;
     *)
@@ -173,7 +309,13 @@ load_configuration() {
     PRODUCTION_TLS_CERTIFICATE \
     PRODUCTION_TLS_CERTIFICATE_KEY \
     PRODUCTION_ACME_ROOT \
-    PRODUCTION_PUBLIC_ROOT
+    PRODUCTION_PUBLIC_ROOT \
+    PRODUCTION_NGINX_BINARY \
+    PRODUCTION_NGINX_CONFIG \
+    PRODUCTION_POSTGRES_BACKUP_PROGRAM \
+    PRODUCTION_POSTGRES_BACKUP_ENV_FILE \
+    PRODUCTION_PORTAL_BACKUP_PROGRAM \
+    PRODUCTION_PORTAL_BACKUP_ENV_FILE
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line=${line%$'\r'}
@@ -252,6 +394,12 @@ validate_configuration() {
     PRODUCTION_TLS_CERTIFICATE_KEY
     PRODUCTION_ACME_ROOT
     PRODUCTION_PUBLIC_ROOT
+    PRODUCTION_NGINX_BINARY
+    PRODUCTION_NGINX_CONFIG
+    PRODUCTION_POSTGRES_BACKUP_PROGRAM
+    PRODUCTION_POSTGRES_BACKUP_ENV_FILE
+    PRODUCTION_PORTAL_BACKUP_PROGRAM
+    PRODUCTION_PORTAL_BACKUP_ENV_FILE
   )
   for name in "${required[@]}"; do
     require_value "$name"
@@ -286,13 +434,33 @@ validate_configuration() {
     PRODUCTION_TLS_CERTIFICATE \
     PRODUCTION_TLS_CERTIFICATE_KEY \
     PRODUCTION_ACME_ROOT \
-    PRODUCTION_PUBLIC_ROOT; do
+    PRODUCTION_PUBLIC_ROOT \
+    PRODUCTION_NGINX_BINARY \
+    PRODUCTION_NGINX_CONFIG \
+    PRODUCTION_POSTGRES_BACKUP_PROGRAM \
+    PRODUCTION_POSTGRES_BACKUP_ENV_FILE \
+    PRODUCTION_PORTAL_BACKUP_PROGRAM \
+    PRODUCTION_PORTAL_BACKUP_ENV_FILE; do
     valid_absolute_path "${!name}" || fail "$name must be a safe absolute path"
   done
 
   require_private_file "server environment file" "$PRODUCTION_SERVER_ENV_FILE"
   require_regular_file "TLS certificate" "$PRODUCTION_TLS_CERTIFICATE"
   require_private_tls_key "TLS certificate key" "$PRODUCTION_TLS_CERTIFICATE_KEY"
+  require_owned_executable "Nginx binary" "$PRODUCTION_NGINX_BINARY"
+  require_owned_nonwritable_file "Nginx vhost" "$PRODUCTION_NGINX_CONFIG"
+  [[ "${PRODUCTION_NGINX_CONFIG##*/}" == xe3-speakup-*.conf ]] ||
+    fail "PRODUCTION_NGINX_CONFIG must name a SpeakUp-only vhost"
+  require_owned_directory \
+    "Nginx vhost directory" "$(path_parent "$PRODUCTION_NGINX_CONFIG")"
+  require_owned_executable \
+    "PostgreSQL backup program" "$PRODUCTION_POSTGRES_BACKUP_PROGRAM"
+  require_private_file \
+    "PostgreSQL backup environment" "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE"
+  require_owned_executable \
+    "Portal backup program" "$PRODUCTION_PORTAL_BACKUP_PROGRAM"
+  require_private_file \
+    "Portal backup environment" "$PRODUCTION_PORTAL_BACKUP_ENV_FILE"
   [[ -d "$PRODUCTION_ACME_ROOT" ]] ||
     fail "ACME root directory does not exist: $PRODUCTION_ACME_ROOT"
   require_owned_public_directory "PRODUCTION_PUBLIC_ROOT" "$PRODUCTION_PUBLIC_ROOT"
@@ -376,8 +544,14 @@ validate_manifest() {
   PORTAL_IMAGE_DIGEST=$(jq --raw-output '.portal_image_digest' "$file")
   SERVER_IMAGE_DIGEST=$(jq --raw-output '.server_image_digest' "$file")
   RELEASE_VERSION=$(jq --raw-output '.version' "$file")
+  RELEASE_VERSION_CODE=$(jq --raw-output '.version_code' "$file")
   RELEASE_GIT_SHA=$(jq --raw-output '.git_sha' "$file")
   RELEASE_SCHEMA_VERSION=$(jq --raw-output '.database_schema_version' "$file")
+  RELEASE_PRODUCTION_APK_FILE=$(jq --raw-output '.production_apk_file' "$file")
+  RELEASE_PRODUCTION_APK_SIZE=$(jq --raw-output '.production_apk_size_bytes' "$file")
+  RELEASE_PRODUCTION_APK_SHA256=$(jq --raw-output '.production_apk_sha256' "$file")
+  RELEASE_APK_CERTIFICATE_SHA256=$(jq --raw-output '.apk_certificate_sha256' "$file")
+  RELEASE_MANIFEST_SHA256=$(sha256_file "$file")
   export PORTAL_IMAGE_DIGEST SERVER_IMAGE_DIGEST
 }
 
@@ -420,6 +594,553 @@ validate_server_edge_network() {
       )
     ' <<<"$inspection" >/dev/null 2>&1 ||
     fail "$server_edge_network gateway does not match PRODUCTION_SERVER_EDGE_GATEWAY_CIDR"
+}
+
+save_release_state() {
+  local prefix=$1
+
+  printf -v "${prefix}_MANIFEST_SHA256" '%s' "$RELEASE_MANIFEST_SHA256"
+  printf -v "${prefix}_VERSION" '%s' "$RELEASE_VERSION"
+  printf -v "${prefix}_VERSION_CODE" '%s' "$RELEASE_VERSION_CODE"
+  printf -v "${prefix}_GIT_SHA" '%s' "$RELEASE_GIT_SHA"
+  printf -v "${prefix}_SCHEMA_VERSION" '%s' "$RELEASE_SCHEMA_VERSION"
+  printf -v "${prefix}_PORTAL_IMAGE_DIGEST" '%s' "$PORTAL_IMAGE_DIGEST"
+  printf -v "${prefix}_SERVER_IMAGE_DIGEST" '%s' "$SERVER_IMAGE_DIGEST"
+  printf -v "${prefix}_PRODUCTION_APK_FILE" '%s' "$RELEASE_PRODUCTION_APK_FILE"
+  printf -v "${prefix}_PRODUCTION_APK_SIZE" '%s' "$RELEASE_PRODUCTION_APK_SIZE"
+  printf -v "${prefix}_PRODUCTION_APK_SHA256" '%s' "$RELEASE_PRODUCTION_APK_SHA256"
+  printf -v "${prefix}_APK_CERTIFICATE_SHA256" '%s' "$RELEASE_APK_CERTIFICATE_SHA256"
+}
+
+use_release_state() {
+  local prefix=$1
+  local manifest_name="${prefix}_MANIFEST_SHA256"
+  local version_name="${prefix}_VERSION"
+  local version_code_name="${prefix}_VERSION_CODE"
+  local git_name="${prefix}_GIT_SHA"
+  local schema_name="${prefix}_SCHEMA_VERSION"
+  local portal_name="${prefix}_PORTAL_IMAGE_DIGEST"
+  local server_name="${prefix}_SERVER_IMAGE_DIGEST"
+  local apk_file_name="${prefix}_PRODUCTION_APK_FILE"
+  local apk_size_name="${prefix}_PRODUCTION_APK_SIZE"
+  local apk_sha_name="${prefix}_PRODUCTION_APK_SHA256"
+  local apk_certificate_name="${prefix}_APK_CERTIFICATE_SHA256"
+
+  RELEASE_MANIFEST_SHA256=${!manifest_name}
+  RELEASE_VERSION=${!version_name}
+  RELEASE_VERSION_CODE=${!version_code_name}
+  RELEASE_GIT_SHA=${!git_name}
+  RELEASE_SCHEMA_VERSION=${!schema_name}
+  PORTAL_IMAGE_DIGEST=${!portal_name}
+  SERVER_IMAGE_DIGEST=${!server_name}
+  RELEASE_PRODUCTION_APK_FILE=${!apk_file_name}
+  RELEASE_PRODUCTION_APK_SIZE=${!apk_size_name}
+  RELEASE_PRODUCTION_APK_SHA256=${!apk_sha_name}
+  RELEASE_APK_CERTIFICATE_SHA256=${!apk_certificate_name}
+  export PORTAL_IMAGE_DIGEST SERVER_IMAGE_DIGEST
+}
+
+require_receipt_file() {
+  local file=$1
+  local mode
+
+  valid_absolute_path "$file" || fail "receipt must use a safe absolute path"
+  require_owned_nonwritable_file "Production receipt" "$file"
+  mode=$(path_mode "$file") || fail "cannot inspect Production receipt permissions"
+  [[ "$mode" == 400 || "$mode" == 444 ]] ||
+    fail "Production receipt must have mode 0400 or 0444: $file"
+}
+
+validate_receipt() {
+  local file=$1
+  local config temporary
+
+  require_receipt_file "$file"
+  jq --exit-status --slurp '
+    length == 1 and
+    (.[0] |
+      type == "object" and
+      keys == [
+        "android_bundle_manifest_sha256",
+        "apk_certificate_sha256",
+        "database_schema_version",
+        "environment",
+        "git_sha",
+        "manifest_sha256",
+        "nginx_config",
+        "nginx_config_sha256",
+        "operation",
+        "portal_backup_id",
+        "portal_container_id",
+        "portal_image_digest",
+        "postgres_backup_id",
+        "postgres_container_id",
+        "previous_receipt_sha256",
+        "production_apk_file",
+        "production_apk_sha256",
+        "production_apk_size_bytes",
+        "receipt_version",
+        "recorded_at_utc",
+        "rollback_target_receipt_sha256",
+        "server_container_id",
+        "server_image_digest",
+        "version",
+        "version_code"
+      ] and
+      .receipt_version == 1 and
+      .environment == "production" and
+      (.operation == "baseline" or .operation == "deploy" or
+        .operation == "rollback") and
+      (.manifest_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      (.version | type == "string" and
+        test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+      (.version_code | type == "number" and . >= 1 and
+        . <= 9007199254740991 and . == floor) and
+      (.git_sha | type == "string" and test("^[0-9a-f]{40}$") and
+        test("[1-9a-f]")) and
+      (.database_schema_version | type == "number" and . >= 1 and
+        . <= 9007199254740991 and . == floor) and
+      (.portal_image_digest | type == "string" and
+        test("^sha256:[0-9a-f]{64}$") and
+        (ltrimstr("sha256:") | test("[1-9a-f]"))) and
+      (.server_image_digest | type == "string" and
+        test("^sha256:[0-9a-f]{64}$") and
+        (ltrimstr("sha256:") | test("[1-9a-f]"))) and
+      .production_apk_file ==
+        ("speakup-v" + .version + "-production-arm64.apk") and
+      (.production_apk_size_bytes | type == "number" and . >= 1 and
+        . <= 9007199254740991 and . == floor) and
+      (.production_apk_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      (.apk_certificate_sha256 | type == "string" and
+        test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+      (.portal_container_id | type == "string" and test("^[0-9a-f]{12,64}$")) and
+      (.server_container_id | type == "string" and test("^[0-9a-f]{12,64}$")) and
+      (.postgres_container_id | type == "string" and test("^[0-9a-f]{12,64}$")) and
+      (.nginx_config | type == "string" and length > 0) and
+      (.nginx_config_sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+      (.recorded_at_utc | type == "string" and
+        test("^[0-9]{4}-(0[1-9]|1[0-2])-([012][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$") and
+        (. as $timestamp |
+          try ((fromdateiso8601 | todateiso8601) == $timestamp) catch false)) and
+      (if .operation == "deploy" then
+        (.postgres_backup_id | type == "string" and
+          test("^[0-9]{8}T[0-9]{6}Z-predeploy$")) and
+        (.portal_backup_id | type == "string" and
+          test("^[0-9]{8}T[0-9]{9}Z$")) and
+        (.android_bundle_manifest_sha256 | type == "string" and
+          test("^[0-9a-f]{64}$")) and
+        (.previous_receipt_sha256 | type == "string" and
+          test("^[0-9a-f]{64}$")) and
+        .rollback_target_receipt_sha256 == null
+      elif .operation == "rollback" then
+        .postgres_backup_id == null and .portal_backup_id == null and
+        .android_bundle_manifest_sha256 == null and
+        (.previous_receipt_sha256 | type == "string" and
+          test("^[0-9a-f]{64}$")) and
+        (.rollback_target_receipt_sha256 | type == "string" and
+          test("^[0-9a-f]{64}$"))
+      else
+        .postgres_backup_id == null and .portal_backup_id == null and
+        .android_bundle_manifest_sha256 == null and
+        .previous_receipt_sha256 == null and
+        .rollback_target_receipt_sha256 == null
+      end)
+    )
+  ' "$file" >/dev/null || fail "Production receipt is invalid: $file"
+
+  temporary=$(mktemp)
+  jq --join-output --raw-output '.nginx_config' "$file" >"$temporary" || {
+    rm -f "$temporary"
+    fail "cannot extract Nginx configuration from Production receipt"
+  }
+  config=$(sha256_file "$temporary")
+  rm -f "$temporary"
+  [[ "$config" == "$(jq --raw-output '.nginx_config_sha256' "$file")" ]] ||
+    fail "Production receipt Nginx SHA-256 is invalid: $file"
+}
+
+load_receipt() {
+  local file=$1
+  local prefix=$2
+
+  validate_receipt "$file"
+  printf -v "${prefix}_RECEIPT_SHA256" '%s' "$(sha256_file "$file")"
+  printf -v "${prefix}_MANIFEST_SHA256" '%s' "$(jq --raw-output '.manifest_sha256' "$file")"
+  printf -v "${prefix}_VERSION" '%s' "$(jq --raw-output '.version' "$file")"
+  printf -v "${prefix}_VERSION_CODE" '%s' "$(jq --raw-output '.version_code' "$file")"
+  printf -v "${prefix}_GIT_SHA" '%s' "$(jq --raw-output '.git_sha' "$file")"
+  printf -v "${prefix}_SCHEMA_VERSION" '%s' "$(jq --raw-output '.database_schema_version' "$file")"
+  printf -v "${prefix}_PORTAL_IMAGE_DIGEST" '%s' "$(jq --raw-output '.portal_image_digest' "$file")"
+  printf -v "${prefix}_SERVER_IMAGE_DIGEST" '%s' "$(jq --raw-output '.server_image_digest' "$file")"
+  printf -v "${prefix}_PRODUCTION_APK_FILE" '%s' "$(jq --raw-output '.production_apk_file' "$file")"
+  printf -v "${prefix}_PRODUCTION_APK_SIZE" '%s' "$(jq --raw-output '.production_apk_size_bytes' "$file")"
+  printf -v "${prefix}_PRODUCTION_APK_SHA256" '%s' "$(jq --raw-output '.production_apk_sha256' "$file")"
+  printf -v "${prefix}_APK_CERTIFICATE_SHA256" '%s' "$(jq --raw-output '.apk_certificate_sha256' "$file")"
+}
+
+validate_receipt_matches_release() {
+  local prefix=$1
+  local manifest_name="${prefix}_MANIFEST_SHA256"
+  local version_name="${prefix}_VERSION"
+  local version_code_name="${prefix}_VERSION_CODE"
+  local git_name="${prefix}_GIT_SHA"
+  local schema_name="${prefix}_SCHEMA_VERSION"
+  local portal_name="${prefix}_PORTAL_IMAGE_DIGEST"
+  local server_name="${prefix}_SERVER_IMAGE_DIGEST"
+  local apk_file_name="${prefix}_PRODUCTION_APK_FILE"
+  local apk_size_name="${prefix}_PRODUCTION_APK_SIZE"
+  local apk_sha_name="${prefix}_PRODUCTION_APK_SHA256"
+  local apk_certificate_name="${prefix}_APK_CERTIFICATE_SHA256"
+
+  [[ "${!manifest_name}" == "$RELEASE_MANIFEST_SHA256" &&
+    "${!version_name}" == "$RELEASE_VERSION" &&
+    "${!version_code_name}" == "$RELEASE_VERSION_CODE" &&
+    "${!git_name}" == "$RELEASE_GIT_SHA" &&
+    "${!schema_name}" == "$RELEASE_SCHEMA_VERSION" &&
+    "${!portal_name}" == "$PORTAL_IMAGE_DIGEST" &&
+    "${!server_name}" == "$SERVER_IMAGE_DIGEST" &&
+    "${!apk_file_name}" == "$RELEASE_PRODUCTION_APK_FILE" &&
+    "${!apk_size_name}" == "$RELEASE_PRODUCTION_APK_SIZE" &&
+    "${!apk_sha_name}" == "$RELEASE_PRODUCTION_APK_SHA256" &&
+    "${!apk_certificate_name}" == "$RELEASE_APK_CERTIFICATE_SHA256" ]] ||
+    fail "Production receipt does not match the selected release manifest"
+}
+
+validate_receipt_target() {
+  local receipt=$1
+  local directory
+
+  valid_absolute_path "$receipt" || fail "--receipt must be a safe absolute path"
+  [[ ! -e "$receipt" && ! -L "$receipt" ]] ||
+    fail "Production receipt already exists: $receipt"
+  directory=$(path_parent "$receipt")
+  require_owned_directory "Production receipt directory" "$directory"
+  [[ -w "$directory" ]] ||
+    fail "Production receipt directory is not writable: $directory"
+}
+
+require_safe_lock_file() {
+  local description=$1
+  local file=$2
+  local mode
+
+  [[ ! -L "$file" && -f "$file" && -r "$file" && -w "$file" ]] ||
+    fail "$description lock must be a readable and writable regular file"
+  [[ "$(path_owner "$file")" == "$(id -u)" ]] ||
+    fail "$description lock must be owned by the current user"
+  mode=$(path_mode "$file") || fail "cannot inspect $description lock permissions"
+  [[ "$mode" == 600 ]] || fail "$description lock must have mode 0600"
+}
+
+require_system_lock_directory() {
+  local directory=$1
+  local mode owner group
+
+  [[ "$directory" == /run/lock && ! -L "$directory" && -d "$directory" ]] ||
+    fail "system lock directory is invalid: $directory"
+  owner=$(path_owner "$directory") || fail "cannot inspect system lock owner"
+  group=$(path_group "$directory") || fail "cannot inspect system lock group"
+  [[ "$(id -u)" == 0 && "$owner" == 0 && "$group" == 0 ]] ||
+    fail "system lock directory requires the root operator and root ownership"
+  mode=$(path_mode "$directory") || fail "cannot inspect system lock permissions"
+  (( (8#$mode & 0002) == 0 || (8#$mode & 01000) != 0 )) ||
+    fail "world-writable system lock directory must have the sticky bit"
+}
+
+prepare_lock_file() {
+  local description=$1
+  local file=$2
+  local directory
+
+  valid_absolute_path "$file" || fail "$description lock must use a safe absolute path"
+  directory=$(path_parent "$file")
+  if [[ "$directory" == /run/lock/xe3-speakup-production &&
+    ! -e "$directory" && ! -L "$directory" ]]; then
+    require_system_lock_directory /run/lock
+    (umask 077 && mkdir -- "$directory") 2>/dev/null ||
+      [[ ! -L "$directory" && -d "$directory" ]] ||
+      fail "cannot create Production deployment lock directory"
+  fi
+  if [[ "$directory" == /run/lock ]]; then
+    require_system_lock_directory "$directory"
+  else
+    require_owned_directory "$description lock directory" "$directory"
+  fi
+  if [[ ! -e "$file" && ! -L "$file" ]]; then
+    (umask 077 && set -o noclobber && : >"$file") 2>/dev/null ||
+      [[ -e "$file" || -L "$file" ]] || fail "cannot create $description lock"
+  fi
+  require_safe_lock_file "$description" "$file"
+}
+
+require_lock_identity() {
+  local description=$1
+  local file=$2
+  local fd=$3
+
+  [[ "$(path_identity "/dev/fd/$fd")" == "$(path_identity "$file")" ]] ||
+    fail "$description lock changed while it was being acquired"
+}
+
+acquire_production_lock() {
+  require_command flock
+  prepare_lock_file "Production deployment" "$production_lock_file"
+  exec 9>>"$production_lock_file" || fail "cannot open Production deployment lock"
+  require_lock_identity "Production deployment" "$production_lock_file" 9
+  flock --nonblock 9 || fail "another Production deployment operation is running"
+  require_lock_identity "Production deployment" "$production_lock_file" 9
+}
+
+acquire_backup_locks() {
+  prepare_lock_file "PostgreSQL backup" "$postgres_backup_lock_file"
+  exec 8>>"$postgres_backup_lock_file" || fail "cannot open PostgreSQL backup lock"
+  require_lock_identity "PostgreSQL backup" "$postgres_backup_lock_file" 8
+  flock --nonblock 8 || fail "another PostgreSQL backup operation is running"
+  require_lock_identity "PostgreSQL backup" "$postgres_backup_lock_file" 8
+
+  prepare_lock_file "Portal backup" "$portal_backup_lock_file"
+  exec 7>>"$portal_backup_lock_file" || fail "cannot open Portal backup lock"
+  require_lock_identity "Portal backup" "$portal_backup_lock_file" 7
+  flock --nonblock 7 || fail "another Portal backup operation is running"
+  require_lock_identity "Portal backup" "$portal_backup_lock_file" 7
+}
+
+load_backup_configuration() {
+  local family=$1
+  local file=$2
+  local line name value
+
+  require_private_file "$family backup environment" "$file"
+  unset \
+    POSTGRES_BACKUP_IMAGE \
+    POSTGRES_BACKUP_DATABASE \
+    POSTGRES_BACKUP_USER \
+    POSTGRES_BACKUP_SOURCE_VOLUME \
+    POSTGRES_BACKUP_DEPLOYMENT_VERSION \
+    POSTGRES_BACKUP_GIT_SHA \
+    POSTGRES_BACKUP_RETENTION_DAYS \
+    POSTGRES_BACKUP_MAX_AGE_SECONDS \
+    PORTAL_BACKUP_CONTAINER \
+    PORTAL_BACKUP_SOURCE_VOLUME \
+    PORTAL_BACKUP_IMAGE \
+    PORTAL_BACKUP_DEPLOYMENT_VERSION \
+    PORTAL_BACKUP_RETENTION_DAYS \
+    PORTAL_BACKUP_MAX_AGE_SECONDS
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line=${line%$'\r'}
+    case "$line" in
+      "" | \#*) continue ;;
+    esac
+    [[ "$line" == *=* ]] || fail "invalid $family backup environment line"
+    name=${line%%=*}
+    value=${line#*=}
+    case "$family:$name" in
+      postgres:POSTGRES_BACKUP_IMAGE | \
+        postgres:POSTGRES_BACKUP_DATABASE | \
+        postgres:POSTGRES_BACKUP_USER | \
+        postgres:POSTGRES_BACKUP_SOURCE_VOLUME | \
+        postgres:POSTGRES_BACKUP_DEPLOYMENT_VERSION | \
+        postgres:POSTGRES_BACKUP_GIT_SHA | \
+        postgres:POSTGRES_BACKUP_RETENTION_DAYS | \
+        postgres:POSTGRES_BACKUP_MAX_AGE_SECONDS | \
+        portal:PORTAL_BACKUP_CONTAINER | \
+        portal:PORTAL_BACKUP_SOURCE_VOLUME | \
+        portal:PORTAL_BACKUP_IMAGE | \
+        portal:PORTAL_BACKUP_DEPLOYMENT_VERSION | \
+        portal:PORTAL_BACKUP_RETENTION_DAYS | \
+        portal:PORTAL_BACKUP_MAX_AGE_SECONDS)
+        ;;
+      *) fail "unsupported $family backup environment key: $name" ;;
+    esac
+    printf -v "$name" '%s' "$value"
+    export "$name"
+  done <"$file"
+}
+
+require_positive_integer() {
+  local name=$1
+
+  require_value "$name"
+  [[ "${!name}" =~ ^[1-9][0-9]*$ ]] || fail "$name must be a positive integer"
+}
+
+validate_postgres_backup_configuration() {
+  local version=$1
+  local git_sha=$2
+  local name
+
+  for name in \
+    POSTGRES_BACKUP_IMAGE \
+    POSTGRES_BACKUP_DATABASE \
+    POSTGRES_BACKUP_USER \
+    POSTGRES_BACKUP_SOURCE_VOLUME \
+    POSTGRES_BACKUP_DEPLOYMENT_VERSION \
+    POSTGRES_BACKUP_GIT_SHA; do
+    require_value "$name"
+  done
+  require_positive_integer POSTGRES_BACKUP_RETENTION_DAYS
+  require_positive_integer POSTGRES_BACKUP_MAX_AGE_SECONDS
+  [[ "$POSTGRES_BACKUP_IMAGE" == "$postgres_image" &&
+    "$POSTGRES_BACKUP_DATABASE" == "$PRODUCTION_POSTGRES_DB" &&
+    "$POSTGRES_BACKUP_USER" == "$PRODUCTION_POSTGRES_USER" &&
+    "$POSTGRES_BACKUP_SOURCE_VOLUME" == "$postgres_data_volume" &&
+    "$POSTGRES_BACKUP_DEPLOYMENT_VERSION" == "$version" &&
+    "$POSTGRES_BACKUP_GIT_SHA" == "$git_sha" ]] ||
+    fail "PostgreSQL backup configuration does not match the current Production release"
+}
+
+validate_portal_backup_configuration() {
+  local version=$1
+  local portal_digest=$2
+  local name
+
+  for name in \
+    PORTAL_BACKUP_CONTAINER \
+    PORTAL_BACKUP_SOURCE_VOLUME \
+    PORTAL_BACKUP_IMAGE \
+    PORTAL_BACKUP_DEPLOYMENT_VERSION; do
+    require_value "$name"
+  done
+  require_positive_integer PORTAL_BACKUP_RETENTION_DAYS
+  require_positive_integer PORTAL_BACKUP_MAX_AGE_SECONDS
+  [[ "$PORTAL_BACKUP_CONTAINER" == "$RUNTIME_PORTAL_CONTAINER_NAME" &&
+    "$PORTAL_BACKUP_SOURCE_VOLUME" == "$portal_data_volume" &&
+    "$PORTAL_BACKUP_IMAGE" == "$portal_image_repository@$portal_digest" &&
+    "$PORTAL_BACKUP_DEPLOYMENT_VERSION" == "$version" ]] ||
+    fail "Portal backup configuration does not match the current Production release"
+}
+
+validate_backup_configurations() {
+  load_backup_configuration postgres "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE"
+  validate_postgres_backup_configuration "$RELEASE_VERSION" "$RELEASE_GIT_SHA"
+  POSTGRES_RETENTION_DAYS=$POSTGRES_BACKUP_RETENTION_DAYS
+  POSTGRES_MAX_AGE_SECONDS=$POSTGRES_BACKUP_MAX_AGE_SECONDS
+
+  load_backup_configuration portal "$PRODUCTION_PORTAL_BACKUP_ENV_FILE"
+  validate_portal_backup_configuration "$RELEASE_VERSION" "$PORTAL_IMAGE_DIGEST"
+  PORTAL_RETENTION_DAYS=$PORTAL_BACKUP_RETENTION_DAYS
+  PORTAL_MAX_AGE_SECONDS=$PORTAL_BACKUP_MAX_AGE_SECONDS
+}
+
+run_predeploy_backups() {
+  local output check_output
+
+  acquire_backup_locks
+
+  load_backup_configuration postgres "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE"
+  validate_postgres_backup_configuration "$RELEASE_VERSION" "$RELEASE_GIT_SHA"
+  POSTGRES_RETENTION_DAYS=$POSTGRES_BACKUP_RETENTION_DAYS
+  POSTGRES_MAX_AGE_SECONDS=$POSTGRES_BACKUP_MAX_AGE_SECONDS
+  export POSTGRES_BACKUP_ROOT="$postgres_backup_root"
+  output=$(
+    unset PRODUCTION_POSTGRES_PASSWORD PORTAL_ADMIN_PASSWORD
+    "$PRODUCTION_POSTGRES_BACKUP_PROGRAM" backup predeploy
+  ) ||
+    fail "PostgreSQL pre-deploy backup failed"
+  [[ "$output" =~ ^backup_id=([0-9]{8}T[0-9]{6}Z-predeploy)\ restore=verified$ ]] ||
+    fail "PostgreSQL pre-deploy backup returned invalid evidence"
+  POSTGRES_BACKUP_ID=${BASH_REMATCH[1]}
+  check_output=$(
+    unset PRODUCTION_POSTGRES_PASSWORD PORTAL_ADMIN_PASSWORD
+    "$PRODUCTION_POSTGRES_BACKUP_PROGRAM" check "$POSTGRES_BACKUP_ID"
+  ) ||
+    fail "PostgreSQL restore verification failed"
+  [[ "$check_output" == "backup_id=$POSTGRES_BACKUP_ID restore=verified" ]] ||
+    fail "PostgreSQL restore verification returned invalid evidence"
+
+  load_backup_configuration portal "$PRODUCTION_PORTAL_BACKUP_ENV_FILE"
+  validate_portal_backup_configuration "$RELEASE_VERSION" "$PORTAL_IMAGE_DIGEST"
+  PORTAL_RETENTION_DAYS=$PORTAL_BACKUP_RETENTION_DAYS
+  PORTAL_MAX_AGE_SECONDS=$PORTAL_BACKUP_MAX_AGE_SECONDS
+  export PORTAL_BACKUP_ROOT="$portal_backup_root"
+  output=$(
+    unset PRODUCTION_POSTGRES_PASSWORD PORTAL_ADMIN_PASSWORD
+    "$PRODUCTION_PORTAL_BACKUP_PROGRAM" backup
+  ) ||
+    fail "Portal pre-deploy backup failed"
+  PORTAL_BACKUP_ID=$(sed -nE \
+    's/^Portal SQLite backup completed: ([0-9]{8}T[0-9]{9}Z) \([1-9][0-9]* bytes, SHA-256 [0-9a-f]{64}\)$/\1/p' \
+    <<<"$output")
+  [[ -n "$PORTAL_BACKUP_ID" ]] ||
+    fail "Portal pre-deploy backup returned invalid evidence"
+  check_output=$(
+    unset PRODUCTION_POSTGRES_PASSWORD PORTAL_ADMIN_PASSWORD
+    "$PRODUCTION_PORTAL_BACKUP_PROGRAM" check
+  ) ||
+    fail "Portal restore verification failed"
+  [[ "$check_output" =~ ^Portal\ SQLite\ restore\ check\ passed:\ ([0-9]{8}T[0-9]{9}Z)\ \([1-9][0-9]*\ bytes,\ SHA-256\ [0-9a-f]{64}\)$ &&
+    "${BASH_REMATCH[1]}" == "$PORTAL_BACKUP_ID" ]] ||
+    fail "Portal restore verification returned invalid evidence"
+}
+
+write_backup_configuration() {
+  local family=$1
+  local destination=$2
+  local temporary=$3
+
+  case "$family" in
+    postgres)
+      printf '%s\n' \
+        '# Managed by deploy/production/manage.sh. Raw KEY=value only.' \
+        "POSTGRES_BACKUP_IMAGE=$postgres_image" \
+        "POSTGRES_BACKUP_DATABASE=$PRODUCTION_POSTGRES_DB" \
+        "POSTGRES_BACKUP_USER=$PRODUCTION_POSTGRES_USER" \
+        "POSTGRES_BACKUP_SOURCE_VOLUME=$postgres_data_volume" \
+        "POSTGRES_BACKUP_DEPLOYMENT_VERSION=$RELEASE_VERSION" \
+        "POSTGRES_BACKUP_GIT_SHA=$RELEASE_GIT_SHA" \
+        "POSTGRES_BACKUP_RETENTION_DAYS=$POSTGRES_RETENTION_DAYS" \
+        "POSTGRES_BACKUP_MAX_AGE_SECONDS=$POSTGRES_MAX_AGE_SECONDS" >"$temporary"
+      ;;
+    portal)
+      printf '%s\n' \
+        '# Managed by deploy/production/manage.sh. Contains no application Secret.' \
+        "PORTAL_BACKUP_CONTAINER=$RUNTIME_PORTAL_CONTAINER_NAME" \
+        "PORTAL_BACKUP_SOURCE_VOLUME=$portal_data_volume" \
+        "PORTAL_BACKUP_IMAGE=$portal_image_repository@$PORTAL_IMAGE_DIGEST" \
+        "PORTAL_BACKUP_DEPLOYMENT_VERSION=$RELEASE_VERSION" \
+        "PORTAL_BACKUP_RETENTION_DAYS=$PORTAL_RETENTION_DAYS" \
+        "PORTAL_BACKUP_MAX_AGE_SECONDS=$PORTAL_MAX_AGE_SECONDS" >"$temporary"
+      ;;
+    *) fail "unsupported backup configuration family: $family" ;;
+  esac
+  chmod 0600 "$temporary"
+  require_private_file "$family backup configuration candidate" "$temporary"
+  [[ "$(path_parent "$destination")" == "$(path_parent "$temporary")" ]] ||
+    fail "$family backup candidate is outside its destination directory"
+}
+
+update_backup_configurations() {
+  local postgres_directory portal_directory
+  local postgres_candidate portal_candidate postgres_previous portal_previous
+
+  postgres_directory=$(path_parent "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE")
+  portal_directory=$(path_parent "$PRODUCTION_PORTAL_BACKUP_ENV_FILE")
+  postgres_candidate=$(mktemp "$postgres_directory/.postgres-backup.next.XXXXXX")
+  portal_candidate=$(mktemp "$portal_directory/.portal-backup.next.XXXXXX")
+  postgres_previous=$(mktemp "$postgres_directory/.postgres-backup.previous.XXXXXX")
+  portal_previous=$(mktemp "$portal_directory/.portal-backup.previous.XXXXXX")
+  install -m 0600 "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE" "$postgres_previous"
+  install -m 0600 "$PRODUCTION_PORTAL_BACKUP_ENV_FILE" "$portal_previous"
+  write_backup_configuration postgres \
+    "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE" "$postgres_candidate"
+  write_backup_configuration portal \
+    "$PRODUCTION_PORTAL_BACKUP_ENV_FILE" "$portal_candidate"
+
+  if ! mv -f "$postgres_candidate" "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE"; then
+    rm -f "$portal_candidate" "$postgres_previous" "$portal_previous"
+    fail "cannot install PostgreSQL backup configuration"
+  fi
+  if ! mv -f "$portal_candidate" "$PRODUCTION_PORTAL_BACKUP_ENV_FILE"; then
+    mv -f "$postgres_previous" "$PRODUCTION_POSTGRES_BACKUP_ENV_FILE" ||
+      fail "cannot restore PostgreSQL backup configuration after Portal update failure"
+    rm -f "$portal_candidate" "$portal_previous"
+    fail "cannot install Portal backup configuration"
+  fi
+  rm -f "$postgres_previous" "$portal_previous"
+  validate_backup_configurations
 }
 
 render_nginx() {
@@ -468,6 +1189,22 @@ verify_endpoints() {
   wait_for_endpoint "Portal" "$portal_health_url"
   wait_for_endpoint "Server liveness" "$server_health_url"
   wait_for_endpoint "Server readiness" "$server_readiness_url"
+}
+
+database_schema_version() {
+  local output
+
+  output=$(compose run --pull never --rm --no-deps migrate \
+    /usr/local/bin/speakup-migrate version) ||
+    fail "cannot verify the Production database schema"
+  [[ "$output" =~ ^version=([1-9][0-9]*)\ dirty=false$ ]] ||
+    fail "database schema output must be exactly version=N dirty=false"
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+verify_database_schema() {
+  [[ "$(database_schema_version)" == "$RELEASE_SCHEMA_VERSION" ]] ||
+    fail "database schema version does not match the selected release"
 }
 
 runtime_container_id() {
@@ -590,6 +1327,362 @@ verify_runtime() {
     (.NetworkSettings.Networks | keys) == [$network]
   ' <<<"$postgres" >/dev/null 2>&1 ||
     fail "$compose_project/postgres runtime configuration is invalid"
+
+  RUNTIME_PORTAL_CONTAINER_ID=$(jq --raw-output '.[0].Id' <<<"$portal")
+  RUNTIME_SERVER_CONTAINER_ID=$(jq --raw-output '.[0].Id' <<<"$server")
+  RUNTIME_POSTGRES_CONTAINER_ID=$(jq --raw-output '.[0].Id' <<<"$postgres")
+  RUNTIME_PORTAL_CONTAINER_NAME=$(jq --raw-output '.[0].Name | ltrimstr("/")' <<<"$portal")
+  [[ "$RUNTIME_PORTAL_CONTAINER_NAME" =~ ^xe3-speakup-production-portal-[1-9][0-9]*$ ]] ||
+    fail "$compose_project/portal returned an invalid container name"
+}
+
+verify_deployment() {
+  verify_runtime
+  verify_database_schema
+  verify_endpoints
+}
+
+receipt_nginx_configuration() {
+  local receipt=$1
+  local output=$2
+
+  jq --join-output --raw-output '.nginx_config' "$receipt" >"$output" ||
+    fail "cannot extract Nginx configuration from Production receipt"
+  [[ "$(sha256_file "$output")" == \
+    "$(jq --raw-output '.nginx_config_sha256' "$receipt")" ]] ||
+    fail "Production receipt Nginx configuration changed"
+}
+
+verify_live_nginx_against_receipt() {
+  local receipt=$1
+  local temporary
+
+  temporary=$(mktemp)
+  receipt_nginx_configuration "$receipt" "$temporary"
+  if ! cmp -s "$temporary" "$PRODUCTION_NGINX_CONFIG"; then
+    rm -f "$temporary"
+    fail "live Nginx vhost does not match the current Production receipt"
+  fi
+  rm -f "$temporary"
+  "$PRODUCTION_NGINX_BINARY" -t || fail "nginx -t failed for the live Production vhost"
+}
+
+verify_live_nginx_against_template() {
+  local temporary
+
+  temporary=$(mktemp)
+  render_nginx "$temporary"
+  if ! cmp -s "$temporary" "$PRODUCTION_NGINX_CONFIG"; then
+    rm -f "$temporary"
+    fail "live Nginx vhost does not match the reviewed Production template"
+  fi
+  rm -f "$temporary"
+  "$PRODUCTION_NGINX_BINARY" -t || fail "nginx -t failed for the live Production vhost"
+}
+
+restore_nginx_configuration() {
+  local previous=$1
+  local reload=$2
+  local temporary
+
+  temporary=$(mktemp "$(path_parent "$PRODUCTION_NGINX_CONFIG")/.nginx-restore.XXXXXX") ||
+    return 1
+  if ! install -m 0644 "$previous" "$temporary" ||
+    ! mv -f "$temporary" "$PRODUCTION_NGINX_CONFIG" ||
+    ! "$PRODUCTION_NGINX_BINARY" -t; then
+    rm -f "$temporary"
+    return 1
+  fi
+  if [[ "$reload" == true ]]; then
+    "$PRODUCTION_NGINX_BINARY" -s reload || return 1
+  fi
+}
+
+install_nginx_configuration() {
+  local candidate=$1
+  local current_receipt=$2
+  local previous temporary
+
+  require_regular_file "rendered Production Nginx candidate" "$candidate"
+  verify_live_nginx_against_receipt "$current_receipt"
+  previous=$(mktemp)
+  receipt_nginx_configuration "$current_receipt" "$previous"
+  temporary=$(mktemp "$(path_parent "$PRODUCTION_NGINX_CONFIG")/.nginx-next.XXXXXX")
+  install -m 0644 "$candidate" "$temporary" || {
+    rm -f "$previous" "$temporary"
+    fail "cannot stage the Production Nginx vhost"
+  }
+  mv -f "$temporary" "$PRODUCTION_NGINX_CONFIG" || {
+    rm -f "$previous" "$temporary"
+    fail "cannot install the Production Nginx vhost"
+  }
+  if ! "$PRODUCTION_NGINX_BINARY" -t; then
+    restore_nginx_configuration "$previous" false ||
+      fail "nginx -t failed and the previous vhost could not be restored"
+    rm -f "$previous"
+    fail "nginx -t failed; the previous vhost was restored without reload"
+  fi
+  if ! "$PRODUCTION_NGINX_BINARY" -s reload; then
+    restore_nginx_configuration "$previous" true ||
+      fail "Nginx reload failed and the previous vhost could not be reloaded"
+    rm -f "$previous"
+    fail "Nginx reload failed; the previous vhost was restored and reloaded"
+  fi
+  rm -f "$previous"
+  cmp -s "$candidate" "$PRODUCTION_NGINX_CONFIG" ||
+    fail "installed Production Nginx vhost changed after reload"
+}
+
+validate_android_bundle() {
+  local bundle=$1
+  local bundle_manifest="$bundle/bundle-manifest.json"
+  local metadata="$bundle/downloads/android/v$RELEASE_VERSION/release.json"
+
+  valid_absolute_path "$bundle" || fail "--bundle must be a safe absolute path"
+  [[ ! -L "$bundle" && -d "$bundle" ]] ||
+    fail "Android download bundle must be a real directory"
+  "$android_download_manager" validate \
+    --bundle "$bundle" \
+    --root "$PRODUCTION_PUBLIC_ROOT" >/dev/null ||
+    fail "Android download bundle validation failed"
+  [[ "$(jq --raw-output '.version' "$bundle_manifest")" == "$RELEASE_VERSION" &&
+    "$(jq --raw-output '.release_manifest_sha256' "$bundle_manifest")" == \
+      "$RELEASE_MANIFEST_SHA256" ]] ||
+    fail "Android download bundle does not match the selected release manifest"
+  jq --exit-status \
+    --arg version "$RELEASE_VERSION" \
+    --argjson version_code "$RELEASE_VERSION_CODE" \
+    --arg file "$RELEASE_PRODUCTION_APK_FILE" \
+    --argjson size "$RELEASE_PRODUCTION_APK_SIZE" \
+    --arg sha256 "$RELEASE_PRODUCTION_APK_SHA256" \
+    --arg certificate "$RELEASE_APK_CERTIFICATE_SHA256" '
+      .version == $version and
+      .version_code == $version_code and
+      .file_name == $file and
+      .size_bytes == $size and
+      .apk_sha256 == $sha256 and
+      .apk_certificate_sha256 == $certificate
+    ' "$metadata" >/dev/null ||
+    fail "Android public metadata does not match the selected release manifest"
+  ANDROID_BUNDLE_MANIFEST_SHA256=$(sha256_file "$bundle_manifest")
+}
+
+publish_android_bundle() {
+  local bundle=$1
+
+  "$android_download_manager" publish \
+    --bundle "$bundle" \
+    --root "$PRODUCTION_PUBLIC_ROOT" >/dev/null ||
+    fail "Android download bundle publication failed"
+}
+
+write_production_receipt() {
+  local manifest=$1
+  local receipt=$2
+  local operation=$3
+  local previous_receipt_sha256=$4
+  local postgres_backup_id=$5
+  local portal_backup_id=$6
+  local android_bundle_manifest_sha256=$7
+  local rollback_target_receipt_sha256=$8
+  local timestamp directory temporary nginx_sha current_manifest_sha
+
+  current_manifest_sha=$(sha256_file "$manifest")
+  [[ "$current_manifest_sha" == "$RELEASE_MANIFEST_SHA256" ]] ||
+    fail "release manifest changed during the Production operation"
+  validate_receipt_target "$receipt"
+  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  directory=$(path_parent "$receipt")
+  nginx_sha=$(sha256_file "$PRODUCTION_NGINX_CONFIG")
+  temporary=$(mktemp "$directory/.production-receipt.tmp.XXXXXX") ||
+    fail "cannot create temporary Production receipt"
+  if ! jq --null-input \
+    --arg operation "$operation" \
+    --arg manifest_sha256 "$RELEASE_MANIFEST_SHA256" \
+    --arg version "$RELEASE_VERSION" \
+    --argjson version_code "$RELEASE_VERSION_CODE" \
+    --arg git_sha "$RELEASE_GIT_SHA" \
+    --argjson database_schema_version "$RELEASE_SCHEMA_VERSION" \
+    --arg portal_image_digest "$PORTAL_IMAGE_DIGEST" \
+    --arg server_image_digest "$SERVER_IMAGE_DIGEST" \
+    --arg production_apk_file "$RELEASE_PRODUCTION_APK_FILE" \
+    --argjson production_apk_size_bytes "$RELEASE_PRODUCTION_APK_SIZE" \
+    --arg production_apk_sha256 "$RELEASE_PRODUCTION_APK_SHA256" \
+    --arg apk_certificate_sha256 "$RELEASE_APK_CERTIFICATE_SHA256" \
+    --arg portal_container_id "$RUNTIME_PORTAL_CONTAINER_ID" \
+    --arg server_container_id "$RUNTIME_SERVER_CONTAINER_ID" \
+    --arg postgres_container_id "$RUNTIME_POSTGRES_CONTAINER_ID" \
+    --arg nginx_config_sha256 "$nginx_sha" \
+    --rawfile nginx_config "$PRODUCTION_NGINX_CONFIG" \
+    --arg postgres_backup_id "$postgres_backup_id" \
+    --arg portal_backup_id "$portal_backup_id" \
+    --arg android_bundle_manifest_sha256 "$android_bundle_manifest_sha256" \
+    --arg previous_receipt_sha256 "$previous_receipt_sha256" \
+    --arg rollback_target_receipt_sha256 "$rollback_target_receipt_sha256" \
+    --arg recorded_at_utc "$timestamp" '
+      {
+        receipt_version: 1,
+        environment: "production",
+        operation: $operation,
+        manifest_sha256: $manifest_sha256,
+        version: $version,
+        version_code: $version_code,
+        git_sha: $git_sha,
+        database_schema_version: $database_schema_version,
+        portal_image_digest: $portal_image_digest,
+        server_image_digest: $server_image_digest,
+        production_apk_file: $production_apk_file,
+        production_apk_size_bytes: $production_apk_size_bytes,
+        production_apk_sha256: $production_apk_sha256,
+        apk_certificate_sha256: $apk_certificate_sha256,
+        portal_container_id: $portal_container_id,
+        server_container_id: $server_container_id,
+        postgres_container_id: $postgres_container_id,
+        nginx_config_sha256: $nginx_config_sha256,
+        nginx_config: $nginx_config,
+        postgres_backup_id:
+          (if $postgres_backup_id == "" then null else $postgres_backup_id end),
+        portal_backup_id:
+          (if $portal_backup_id == "" then null else $portal_backup_id end),
+        android_bundle_manifest_sha256:
+          (if $android_bundle_manifest_sha256 == "" then null
+           else $android_bundle_manifest_sha256 end),
+        previous_receipt_sha256:
+          (if $previous_receipt_sha256 == "" then null
+           else $previous_receipt_sha256 end),
+        rollback_target_receipt_sha256:
+          (if $rollback_target_receipt_sha256 == "" then null
+           else $rollback_target_receipt_sha256 end),
+        recorded_at_utc: $recorded_at_utc
+      }
+    ' >"$temporary"; then
+    rm -f "$temporary"
+    fail "cannot render Production receipt"
+  fi
+  chmod 0444 "$temporary"
+  validate_receipt "$temporary"
+  if ! ln "$temporary" "$receipt"; then
+    rm -f "$temporary"
+    fail "Production receipt already exists: $receipt"
+  fi
+  rm -f "$temporary"
+  validate_receipt "$receipt"
+}
+
+validate_current_receipt_state() {
+  local receipt=$1
+  local prefix=$2
+
+  use_release_state "$prefix"
+  verify_deployment
+  verify_live_nginx_against_receipt "$receipt"
+  validate_backup_configurations
+}
+
+baseline_production() {
+  local manifest=$1
+  local receipt=$2
+
+  validate_receipt_target "$receipt"
+  acquire_production_lock
+  validate_all "$manifest"
+  validate_receipt_target "$receipt"
+  verify_deployment
+  validate_backup_configurations
+  verify_live_nginx_against_template
+  write_production_receipt "$manifest" "$receipt" baseline "" "" "" "" ""
+}
+
+deploy_production() {
+  local manifest=$1
+  local bundle=$2
+  local current_receipt=$3
+  local receipt=$4
+  local initial_current_sha candidate
+
+  validate_receipt_target "$receipt"
+  validate_android_bundle "$bundle"
+  load_receipt "$current_receipt" CURRENT
+  initial_current_sha=$CURRENT_RECEIPT_SHA256
+  acquire_production_lock
+  validate_all "$manifest"
+  save_release_state SELECTED
+  validate_receipt_target "$receipt"
+  validate_android_bundle "$bundle"
+  load_receipt "$current_receipt" CURRENT
+  [[ "$CURRENT_RECEIPT_SHA256" == "$initial_current_sha" ]] ||
+    fail "current Production receipt changed while waiting for the deployment lock"
+  validate_current_receipt_state "$current_receipt" CURRENT
+  run_predeploy_backups
+
+  use_release_state SELECTED
+  compose pull postgres migrate server portal
+  compose up --pull never --detach --no-build --wait --wait-timeout 90 postgres
+  compose run --pull never --rm --no-deps migrate
+  verify_database_schema
+  compose up --pull never --detach --no-build --wait --wait-timeout 90 portal server
+  verify_deployment
+  validate_android_bundle "$bundle"
+  publish_android_bundle "$bundle"
+  candidate=$(mktemp)
+  render_nginx "$candidate"
+  install_nginx_configuration "$candidate" "$current_receipt"
+  rm -f "$candidate"
+  verify_deployment
+  update_backup_configurations
+  write_production_receipt \
+    "$manifest" "$receipt" deploy "$CURRENT_RECEIPT_SHA256" \
+    "$POSTGRES_BACKUP_ID" "$PORTAL_BACKUP_ID" \
+    "$ANDROID_BUNDLE_MANIFEST_SHA256" ""
+}
+
+rollback_production() {
+  local manifest=$1
+  local current_receipt=$2
+  local target_receipt=$3
+  local receipt=$4
+  local initial_current_sha initial_target_sha candidate target_candidate
+
+  validate_receipt_target "$receipt"
+  load_receipt "$current_receipt" CURRENT
+  load_receipt "$target_receipt" TARGET
+  initial_current_sha=$CURRENT_RECEIPT_SHA256
+  initial_target_sha=$TARGET_RECEIPT_SHA256
+  validate_receipt_matches_release TARGET
+  acquire_production_lock
+  validate_all "$manifest"
+  save_release_state SELECTED
+  validate_receipt_target "$receipt"
+  load_receipt "$current_receipt" CURRENT
+  load_receipt "$target_receipt" TARGET
+  [[ "$CURRENT_RECEIPT_SHA256" == "$initial_current_sha" &&
+    "$TARGET_RECEIPT_SHA256" == "$initial_target_sha" ]] ||
+    fail "a Production receipt changed while waiting for the deployment lock"
+  validate_receipt_matches_release TARGET
+  validate_current_receipt_state "$current_receipt" CURRENT
+  [[ "$CURRENT_SCHEMA_VERSION" == "$SELECTED_SCHEMA_VERSION" ]] ||
+    fail "rollback requires the current database schema to match the target release"
+  acquire_backup_locks
+
+  use_release_state SELECTED
+  compose up --pull never --detach --no-build --wait --wait-timeout 90 portal server
+  verify_deployment
+  candidate=$(mktemp)
+  target_candidate=$(mktemp)
+  render_nginx "$candidate"
+  receipt_nginx_configuration "$target_receipt" "$target_candidate"
+  if ! cmp -s "$candidate" "$target_candidate"; then
+    rm -f "$candidate" "$target_candidate"
+    fail "target receipt Nginx vhost does not match the selected release configuration"
+  fi
+  rm -f "$target_candidate"
+  install_nginx_configuration "$candidate" "$current_receipt"
+  rm -f "$candidate"
+  verify_deployment
+  update_backup_configurations
+  write_production_receipt \
+    "$manifest" "$receipt" rollback "$CURRENT_RECEIPT_SHA256" "" "" "" \
+    "$TARGET_RECEIPT_SHA256"
 }
 
 validate_all() {
@@ -611,6 +1704,10 @@ main() {
   local manifest=""
   local environment_file=""
   local output=""
+  local bundle=""
+  local receipt=""
+  local current_receipt=""
+  local target_receipt=""
 
   [[ -n "$command" ]] || {
     usage
@@ -634,6 +1731,26 @@ main() {
         output=$2
         shift 2
         ;;
+      --bundle)
+        (($# >= 2)) || fail "--bundle requires a value"
+        bundle=$2
+        shift 2
+        ;;
+      --receipt)
+        (($# >= 2)) || fail "--receipt requires a value"
+        receipt=$2
+        shift 2
+        ;;
+      --current-receipt)
+        (($# >= 2)) || fail "--current-receipt requires a value"
+        current_receipt=$2
+        shift 2
+        ;;
+      --target-receipt)
+        (($# >= 2)) || fail "--target-receipt requires a value"
+        target_receipt=$2
+        shift 2
+        ;;
       *)
         fail "unknown argument: $1"
         ;;
@@ -646,14 +1763,39 @@ main() {
   case "$command" in
     render-nginx)
       [[ -z "$manifest" ]] || fail "render-nginx does not accept --manifest"
+      [[ -z "$bundle$receipt$current_receipt$target_receipt" ]] ||
+        fail "render-nginx accepts only --env-file and --output"
       [[ -n "$output" ]] || fail "render-nginx requires --output"
       validate_configuration
       render_nginx "$output"
       printf 'rendered=%s\n' "$output"
       ;;
-    validate | verify | status)
+    validate | verify | status | baseline | deploy | rollback)
       [[ -n "$manifest" ]] || fail "$command requires --manifest"
       [[ -z "$output" ]] || fail "$command does not accept --output"
+      case "$command" in
+        validate | verify | status)
+          [[ -z "$bundle$receipt$current_receipt$target_receipt" ]] ||
+            fail "$command accepts only --manifest and --env-file"
+          ;;
+        baseline)
+          [[ -n "$receipt" ]] || fail "baseline requires --receipt"
+          [[ -z "$bundle$current_receipt$target_receipt" ]] ||
+            fail "baseline does not accept bundle or input receipts"
+          ;;
+        deploy)
+          [[ -n "$bundle" ]] || fail "deploy requires --bundle"
+          [[ -n "$current_receipt" ]] || fail "deploy requires --current-receipt"
+          [[ -n "$receipt" ]] || fail "deploy requires --receipt"
+          [[ -z "$target_receipt" ]] || fail "deploy does not accept --target-receipt"
+          ;;
+        rollback)
+          [[ -n "$current_receipt" ]] || fail "rollback requires --current-receipt"
+          [[ -n "$target_receipt" ]] || fail "rollback requires --target-receipt"
+          [[ -n "$receipt" ]] || fail "rollback requires --receipt"
+          [[ -z "$bundle" ]] || fail "rollback does not accept --bundle"
+          ;;
+      esac
       validate_all "$manifest"
       case "$command" in
         validate)
@@ -661,12 +1803,27 @@ main() {
             "$RELEASE_VERSION" "$RELEASE_GIT_SHA" "$RELEASE_SCHEMA_VERSION"
           ;;
         verify)
-          verify_runtime
-          verify_endpoints
+          verify_deployment
           printf 'version=%s verified=true\n' "$RELEASE_VERSION"
           ;;
         status)
           compose ps
+          ;;
+        baseline)
+          baseline_production "$manifest" "$receipt"
+          printf 'version=%s receipt=%s baseline=true\n' \
+            "$RELEASE_VERSION" "$receipt"
+          ;;
+        deploy)
+          deploy_production "$manifest" "$bundle" "$current_receipt" "$receipt"
+          printf 'version=%s receipt=%s deployed=true apk_activated=false\n' \
+            "$RELEASE_VERSION" "$receipt"
+          ;;
+        rollback)
+          rollback_production \
+            "$manifest" "$current_receipt" "$target_receipt" "$receipt"
+          printf 'version=%s receipt=%s rolled_back=true database_restored=false\n' \
+            "$RELEASE_VERSION" "$receipt"
           ;;
       esac
       ;;

--- a/deploy/production/production.env.example
+++ b/deploy/production/production.env.example
@@ -16,3 +16,11 @@ PRODUCTION_TLS_CERTIFICATE=/opt/xe3-speakup-portal/certbot/conf/live/speak-up.to
 PRODUCTION_TLS_CERTIFICATE_KEY=/opt/xe3-speakup-portal/certbot/conf/live/speak-up.top/privkey.pem
 PRODUCTION_ACME_ROOT=/opt/xe3-speakup-portal/certbot/www
 PRODUCTION_PUBLIC_ROOT=/var/www/speakup-production-public
+
+# Exact host-side programs and private state owned by the SpeakUp deployment.
+PRODUCTION_NGINX_BINARY=/usr/local/nginx/sbin/nginx
+PRODUCTION_NGINX_CONFIG=/usr/local/nginx/conf/vhost/xe3-speakup-portal.conf
+PRODUCTION_POSTGRES_BACKUP_PROGRAM=/usr/local/sbin/xe3-postgres-backup
+PRODUCTION_POSTGRES_BACKUP_ENV_FILE=/etc/speakup/postgres-backup.env
+PRODUCTION_PORTAL_BACKUP_PROGRAM=/usr/local/sbin/xe3-portal-sqlite-backup
+PRODUCTION_PORTAL_BACKUP_ENV_FILE=/etc/speakup/portal-backup.env

--- a/deploy/production/test-nginx.sh
+++ b/deploy/production/test-nginx.sh
@@ -82,9 +82,23 @@ assert_curl_succeeds() {
 }
 
 mkdir -p "$temporary_directory/acme"
+mkdir -p "$temporary_directory/host-nginx"
 mkdir -p "$temporary_directory/logs"
 mkdir -p "$temporary_directory/public/downloads/android/v0.1.0"
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
+printf '%s\n' '#!/usr/bin/env sh' 'exit 0' >"$temporary_directory/host-nginx/nginx"
+printf '%s\n' '#!/usr/bin/env sh' 'exit 0' >"$temporary_directory/postgres-backup"
+printf '%s\n' '#!/usr/bin/env sh' 'exit 0' >"$temporary_directory/portal-backup"
+printf '%s\n' 'placeholder' >"$temporary_directory/host-nginx/xe3-speakup-production.conf"
+printf '%s\n' 'POSTGRES_BACKUP_RETENTION_DAYS=14' >"$temporary_directory/postgres-backup.env"
+printf '%s\n' 'PORTAL_BACKUP_RETENTION_DAYS=14' >"$temporary_directory/portal-backup.env"
+chmod 0755 \
+  "$temporary_directory/host-nginx/nginx" \
+  "$temporary_directory/postgres-backup" \
+  "$temporary_directory/portal-backup"
+chmod 0600 \
+  "$temporary_directory/postgres-backup.env" \
+  "$temporary_directory/portal-backup.env"
 printf '%s\n' 'signed-production-apk-fixture' > \
   "$temporary_directory/public/downloads/android/v0.1.0/speakup-v0.1.0-production-arm64.apk"
 apk_sha=$(sha256sum \
@@ -144,6 +158,12 @@ printf '%s\n' \
   "PRODUCTION_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
   "PRODUCTION_ACME_ROOT=$temporary_directory/acme" \
   "PRODUCTION_PUBLIC_ROOT=$temporary_directory/public" \
+  "PRODUCTION_NGINX_BINARY=$temporary_directory/host-nginx/nginx" \
+  "PRODUCTION_NGINX_CONFIG=$temporary_directory/host-nginx/xe3-speakup-production.conf" \
+  "PRODUCTION_POSTGRES_BACKUP_PROGRAM=$temporary_directory/postgres-backup" \
+  "PRODUCTION_POSTGRES_BACKUP_ENV_FILE=$temporary_directory/postgres-backup.env" \
+  "PRODUCTION_PORTAL_BACKUP_PROGRAM=$temporary_directory/portal-backup" \
+  "PRODUCTION_PORTAL_BACKUP_ENV_FILE=$temporary_directory/portal-backup.env" \
   >"$temporary_directory/production.env"
 chmod 600 "$temporary_directory/production.env"
 

--- a/deploy/production/test.sh
+++ b/deploy/production/test.sh
@@ -9,7 +9,8 @@ readonly portal_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 readonly server_digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 readonly git_sha="cccccccccccccccccccccccccccccccccccccccc"
 readonly staging_apk_sha="dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-readonly production_apk_sha="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+production_apk_sha=""
+production_apk_size=""
 readonly certificate_sha="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 
 fail() {
@@ -44,7 +45,13 @@ write_environment() {
     "PRODUCTION_TLS_CERTIFICATE=$certificate" \
     "PRODUCTION_TLS_CERTIFICATE_KEY=$certificate_key" \
     "PRODUCTION_ACME_ROOT=$temporary_directory/acme" \
-    "PRODUCTION_PUBLIC_ROOT=$temporary_directory/public" > "$destination"
+    "PRODUCTION_PUBLIC_ROOT=$temporary_directory/public" \
+    "PRODUCTION_NGINX_BINARY=$temporary_directory/fake-bin/nginx" \
+    "PRODUCTION_NGINX_CONFIG=$temporary_directory/nginx/xe3-speakup-production.conf" \
+    "PRODUCTION_POSTGRES_BACKUP_PROGRAM=$temporary_directory/fake-bin/postgres-backup" \
+    "PRODUCTION_POSTGRES_BACKUP_ENV_FILE=$temporary_directory/postgres-backup.env" \
+    "PRODUCTION_PORTAL_BACKUP_PROGRAM=$temporary_directory/fake-bin/portal-backup" \
+    "PRODUCTION_PORTAL_BACKUP_ENV_FILE=$temporary_directory/portal-backup.env" > "$destination"
   chmod 0600 "$destination"
 }
 
@@ -65,7 +72,7 @@ write_manifest() {
     '  "staging_apk_file": "speakup-v0.1.1-staging-arm64.apk",' \
     "  \"staging_apk_sha256\": \"$staging_apk_sha\"," \
     '  "production_apk_file": "speakup-v0.1.1-production-arm64.apk",' \
-    '  "production_apk_size_bytes": 123456,' \
+    "  \"production_apk_size_bytes\": $production_apk_size," \
     "  \"production_apk_sha256\": \"$production_apk_sha\"," \
     '  "application_id": "com.xengineer.speakup",' \
     '  "minimum_android_api": 24,' \
@@ -74,6 +81,98 @@ write_manifest() {
     '  "database_schema_version": 7,' \
     '  "quality_run_url": "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456"' \
     '}' > "$destination"
+  }
+
+test_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  else
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  fi
+}
+
+test_file_size() {
+  if stat -c '%s' -- "$1" >/dev/null 2>&1; then
+    stat -c '%s' -- "$1"
+  else
+    stat -f '%z' "$1"
+  fi
+}
+
+write_android_bundle() {
+  local destination=$1
+  local manifest=$2
+  local apk_source=$3
+  local version_directory="$destination/downloads/android/v0.1.1"
+  local apk_name="speakup-v0.1.1-production-arm64.apk"
+  local apk="$version_directory/$apk_name"
+  local checksum="$apk.sha256"
+  local metadata="$version_directory/release.json"
+  local manifest_sha apk_sha checksum_sha metadata_sha
+  local apk_size checksum_size metadata_size
+
+  mkdir -p "$version_directory"
+  install -m 0644 "$apk_source" "$apk"
+  apk_sha=$(test_sha256 "$apk")
+  apk_size=$(test_file_size "$apk")
+  printf '%s  %s\n' "$apk_sha" "$apk_name" >"$checksum"
+  jq --null-input \
+    --arg version '0.1.1' \
+    --arg file "$apk_name" \
+    --arg sha "$apk_sha" \
+    --arg certificate "$certificate_sha" \
+    --argjson size "$apk_size" '
+      {
+        metadata_version: 1,
+        version: $version,
+        version_code: 2,
+        published_at: "2026-08-24T00:00:00Z",
+        file_name: $file,
+        download_path: ("/downloads/android/v" + $version + "/" + $file),
+        size_bytes: $size,
+        minimum_android_api: 24,
+        abis: ["arm64-v8a"],
+        apk_sha256: $sha,
+        apk_certificate_sha256: $certificate
+      }
+    ' >"$metadata"
+  manifest_sha=$(test_sha256 "$manifest")
+  checksum_sha=$(test_sha256 "$checksum")
+  metadata_sha=$(test_sha256 "$metadata")
+  checksum_size=$(test_file_size "$checksum")
+  metadata_size=$(test_file_size "$metadata")
+  jq --null-input \
+    --arg manifest_sha "$manifest_sha" \
+    --arg apk_sha "$apk_sha" \
+    --arg checksum_sha "$checksum_sha" \
+    --arg metadata_sha "$metadata_sha" \
+    --argjson apk_size "$apk_size" \
+    --argjson checksum_size "$checksum_size" \
+    --argjson metadata_size "$metadata_size" '
+      {
+        bundle_version: 1,
+        version: "0.1.1",
+        published_at: "2026-08-24T00:00:00Z",
+        release_manifest_sha256: $manifest_sha,
+        files: [
+          {
+            path: "downloads/android/v0.1.1/speakup-v0.1.1-production-arm64.apk",
+            size_bytes: $apk_size,
+            sha256: $apk_sha
+          },
+          {
+            path: "downloads/android/v0.1.1/speakup-v0.1.1-production-arm64.apk.sha256",
+            size_bytes: $checksum_size,
+            sha256: $checksum_sha
+          },
+          {
+            path: "downloads/android/v0.1.1/release.json",
+            size_bytes: $metadata_size,
+            sha256: $metadata_sha
+          }
+        ]
+      }
+    ' >"$destination/bundle-manifest.json"
 }
 
 temporary_directory=$(mktemp -d)
@@ -83,13 +182,49 @@ trap 'rm -rf "$temporary_directory"' EXIT
 mkdir -p \
   "$temporary_directory/acme" \
   "$temporary_directory/fake-bin" \
-  "$temporary_directory/public"
+  "$temporary_directory/locks/production" \
+  "$temporary_directory/locks/postgres" \
+  "$temporary_directory/locks/portal" \
+  "$temporary_directory/nginx" \
+  "$temporary_directory/public" \
+  "$temporary_directory/receipts"
+printf '%s\n' 'signed-production-apk-fixture' >"$temporary_directory/production.apk"
+production_apk_size=$(test_file_size "$temporary_directory/production.apk")
+production_apk_sha=$(test_sha256 "$temporary_directory/production.apk")
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' > "$temporary_directory/server.env"
 printf '%s\n' 'test-certificate-placeholder' > "$temporary_directory/fullchain.pem"
 printf '%s\n' 'test-key-placeholder' > "$temporary_directory/privkey.pem"
+printf '%s\n' 'placeholder' >"$temporary_directory/nginx/xe3-speakup-production.conf"
+printf '%s\n' \
+  "POSTGRES_BACKUP_IMAGE=postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108" \
+  'POSTGRES_BACKUP_DATABASE=speakup' \
+  'POSTGRES_BACKUP_USER=speakup' \
+  'POSTGRES_BACKUP_SOURCE_VOLUME=xe3-speakup-postgres-data' \
+  'POSTGRES_BACKUP_DEPLOYMENT_VERSION=0.1.1' \
+  "POSTGRES_BACKUP_GIT_SHA=$git_sha" \
+  'POSTGRES_BACKUP_RETENTION_DAYS=14' \
+  'POSTGRES_BACKUP_MAX_AGE_SECONDS=172800' >"$temporary_directory/postgres-backup.env"
+printf '%s\n' \
+  'PORTAL_BACKUP_CONTAINER=xe3-speakup-production-portal-1' \
+  'PORTAL_BACKUP_SOURCE_VOLUME=xe3-speakup-portal-data' \
+  "PORTAL_BACKUP_IMAGE=ghcr.io/1024xengineer/xe3-esl-portal@$portal_digest" \
+  'PORTAL_BACKUP_DEPLOYMENT_VERSION=0.1.1' \
+  'PORTAL_BACKUP_RETENTION_DAYS=14' \
+  'PORTAL_BACKUP_MAX_AGE_SECONDS=172800' >"$temporary_directory/portal-backup.env"
 chmod 0600 "$temporary_directory/server.env" "$temporary_directory/privkey.pem"
+chmod 0600 \
+  "$temporary_directory/postgres-backup.env" \
+  "$temporary_directory/portal-backup.env"
 write_environment "$temporary_directory/production.env" "$temporary_directory/server.env"
 write_manifest "$temporary_directory/release-manifest.json"
+write_android_bundle \
+  "$temporary_directory/android-bundle" \
+  "$temporary_directory/release-manifest.json" \
+  "$temporary_directory/production.apk"
+
+export SPEAKUP_PRODUCTION_LOCK_FILE="$temporary_directory/locks/production/deploy.lock"
+export SPEAKUP_POSTGRES_BACKUP_LOCK_FILE="$temporary_directory/locks/postgres/backup.lock"
+export SPEAKUP_PORTAL_BACKUP_LOCK_FILE="$temporary_directory/locks/portal/backup.lock"
 
 real_docker="$(command -v docker)"
 readonly real_docker
@@ -98,6 +233,32 @@ readonly real_stat
 cat > "$temporary_directory/fake-bin/docker" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ "${1:-}" == compose ]]; then
+  operation=""
+  for argument in "$@"; do
+    case "$argument" in
+      config | pull | up | run | ps) operation=$argument; break ;;
+    esac
+  done
+  case "$operation" in
+    config) exec "$TEST_REAL_DOCKER" "$@" ;;
+    run)
+      [[ -z "${COMMAND_LOG:-}" ]] || printf 'docker %s\n' "$*" >>"$COMMAND_LOG"
+      if [[ " $* " == *' /usr/local/bin/speakup-migrate version '* ]]; then
+        printf 'version=%s dirty=%s\n' \
+          "${TEST_SCHEMA_VERSION:-7}" "${TEST_SCHEMA_DIRTY:-false}"
+      elif [[ "${FAIL_MIGRATION:-0}" == 1 ]]; then
+        exit 1
+      fi
+      exit
+      ;;
+    pull | up | ps)
+      [[ -z "${COMMAND_LOG:-}" ]] || printf 'docker %s\n' "$*" >>"$COMMAND_LOG"
+      [[ "${FAIL_COMPOSE_OPERATION:-}" != "$operation" ]]
+      exit
+      ;;
+  esac
+fi
 if [[ "${1:-}" == volume && "${2:-}" == inspect ]]; then
   volume=${3:-}
   [[ "$volume" == xe3-speakup-portal-data || "$volume" == xe3-speakup-postgres-data ]] || exit 1
@@ -200,6 +361,7 @@ if [[ "${1:-}" == inspect && "$#" == 2 ]]; then
   fi
   jq --null-input \
     --arg id "$2" \
+    --arg name "/xe3-speakup-production-${service}-1" \
     --arg project "${TEST_RUNTIME_PROJECT:-xe3-speakup-production}" \
     --arg service "$service" \
     --arg image "$image" \
@@ -210,6 +372,7 @@ if [[ "${1:-}" == inspect && "$#" == 2 ]]; then
     --argjson networks "$networks" '
       [{
         Id: $id,
+        Name: $name,
         Config: {
           Image: $image,
           Env: $environment,
@@ -230,7 +393,7 @@ EOF
 cat > "$temporary_directory/fake-bin/curl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-printf 'curl %s\n' "$*" >> "$COMMAND_LOG"
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'curl %s\n' "$*" >>"$COMMAND_LOG"
 [[ "${FAIL_HEALTH:-0}" != 1 ]]
 EOF
 cat > "$temporary_directory/fake-bin/sleep" <<'EOF'
@@ -250,11 +413,63 @@ if [[ "${TEST_TLS_KEY_OWNER_MISMATCH:-0}" == 1 ]]; then
 fi
 exec "$TEST_REAL_STAT" "$@"
 EOF
+cat >"$temporary_directory/fake-bin/nginx" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'nginx %s\n' "$*" >>"$COMMAND_LOG"
+case "${1:-}" in
+  -t) [[ "${FAIL_NGINX_TEST:-0}" != 1 ]] ;;
+  -s) [[ "${2:-}" == reload && "${FAIL_NGINX_RELOAD:-0}" != 1 ]] ;;
+  *) exit 2 ;;
+esac
+EOF
+cat >"$temporary_directory/fake-bin/postgres-backup" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'postgres-backup %s\n' "$*" >>"$COMMAND_LOG"
+if [[ "${FAIL_POSTGRES_BACKUP:-0}" == 1 ]]; then exit 1; fi
+case "${1:-}" in
+  backup)
+    [[ "${2:-}" == predeploy ]]
+    printf '%s\n' 'backup_id=20260824T010203Z-predeploy restore=verified'
+    ;;
+  check)
+    [[ "${2:-}" == 20260824T010203Z-predeploy ]]
+    printf 'backup_id=%s restore=verified\n' "$2"
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+cat >"$temporary_directory/fake-bin/portal-backup" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'portal-backup %s\n' "$*" >>"$COMMAND_LOG"
+if [[ "${FAIL_PORTAL_BACKUP:-0}" == 1 ]]; then exit 1; fi
+case "${1:-}" in
+  backup)
+    printf '%s\n' 'Portal SQLite backup completed: 20260824T010203000Z (1024 bytes, SHA-256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)'
+    ;;
+  check)
+    printf '%s\n' 'Portal SQLite restore check passed: 20260824T010203000Z (1024 bytes, SHA-256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)'
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+cat >"$temporary_directory/fake-bin/flock" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'flock %s\n' "$*" >>"$COMMAND_LOG"
+if [[ "${TEST_LOCK_BUSY:-0}" == 1 ]]; then exit 1; fi
+EOF
 chmod +x \
   "$temporary_directory/fake-bin/docker" \
   "$temporary_directory/fake-bin/curl" \
   "$temporary_directory/fake-bin/sleep" \
-  "$temporary_directory/fake-bin/stat"
+  "$temporary_directory/fake-bin/stat" \
+  "$temporary_directory/fake-bin/nginx" \
+  "$temporary_directory/fake-bin/postgres-backup" \
+  "$temporary_directory/fake-bin/portal-backup" \
+  "$temporary_directory/fake-bin/flock"
 
 export TEST_REAL_DOCKER="$real_docker"
 export TEST_REAL_STAT="$real_stat"
@@ -723,9 +938,204 @@ expect_failure "missing Production PostgreSQL container" \
 [[ ! -s "$temporary_directory/missing-postgres.log" ]] ||
   fail "endpoint checks ran before all Production services were identified"
 
-expect_failure "unsupported deployment mutation" \
+install -m 0644 \
+  "$temporary_directory/production.conf" \
+  "$temporary_directory/nginx/xe3-speakup-production.conf"
+
+baseline_receipt="$temporary_directory/receipts/production-baseline.json"
+expect_failure "busy Production deployment lock" \
+  env \
+    COMMAND_LOG="$temporary_directory/busy-lock.log" \
+    TEST_LOCK_BUSY=1 \
+  "$manage" baseline \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --receipt "$temporary_directory/receipts/busy-baseline.json"
+[[ ! -e "$temporary_directory/receipts/busy-baseline.json" ]] ||
+  fail "busy Production lock wrote a baseline receipt"
+COMMAND_LOG="$temporary_directory/baseline.log" \
+  "$manage" baseline \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --receipt "$baseline_receipt" \
+    >"$temporary_directory/baseline.out"
+[[ -f "$baseline_receipt" ]] || fail "Production baseline did not write a receipt"
+jq --exit-status '
+  .receipt_version == 1 and
+  .environment == "production" and
+  .operation == "baseline" and
+  .version == "0.1.1" and
+  .version_code == 2 and
+  .database_schema_version == 7 and
+  .postgres_backup_id == null and
+  .portal_backup_id == null and
+  .android_bundle_manifest_sha256 == null and
+  .previous_receipt_sha256 == null and
+  .rollback_target_receipt_sha256 == null
+' "$baseline_receipt" >/dev/null || fail "Production baseline receipt is incomplete"
+if grep -Fq \
+  -e 'portal-admin-password-for-tests' \
+  -e '0123456789abcdef0123456789abcdef' \
+  "$baseline_receipt"; then
+  fail "Production baseline receipt exposed a Secret"
+fi
+
+: >"$temporary_directory/existing-receipt.log"
+expect_failure "existing baseline receipt" \
+  env COMMAND_LOG="$temporary_directory/existing-receipt.log" \
+  "$manage" baseline \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --receipt "$baseline_receipt"
+[[ ! -s "$temporary_directory/existing-receipt.log" ]] ||
+  fail "existing baseline receipt was rejected only after a side effect"
+
+failed_deploy_receipt="$temporary_directory/receipts/failed-deploy.json"
+expect_failure "PostgreSQL pre-deploy backup failure" \
+  env \
+    COMMAND_LOG="$temporary_directory/failed-backup.log" \
+    FAIL_POSTGRES_BACKUP=1 \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/production.env"
+    --env-file "$temporary_directory/production.env" \
+    --bundle "$temporary_directory/android-bundle" \
+    --current-receipt "$baseline_receipt" \
+    --receipt "$failed_deploy_receipt"
+[[ ! -e "$failed_deploy_receipt" ]] ||
+  fail "failed backup gate wrote a Production receipt"
+[[ ! -e "$temporary_directory/public/downloads/android/v0.1.1" ]] ||
+  fail "failed backup gate published the Android bundle"
+if grep -Fq \
+  -e ' portal-backup ' \
+  -e 'nginx -s reload' \
+  "$temporary_directory/failed-backup.log"; then
+  fail "failed backup gate allowed a deployment side effect"
+fi
+if grep -Eq 'docker compose .* (pull|up) ' \
+  "$temporary_directory/failed-backup.log"; then
+  fail "failed backup gate changed the Production Compose project"
+fi
+
+failed_portal_receipt="$temporary_directory/receipts/failed-portal-backup.json"
+expect_failure "Portal pre-deploy backup failure" \
+  env \
+    COMMAND_LOG="$temporary_directory/failed-portal-backup.log" \
+    FAIL_PORTAL_BACKUP=1 \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --bundle "$temporary_directory/android-bundle" \
+    --current-receipt "$baseline_receipt" \
+    --receipt "$failed_portal_receipt"
+[[ ! -e "$failed_portal_receipt" ]] ||
+  fail "failed Portal backup gate wrote a Production receipt"
+[[ ! -e "$temporary_directory/public/downloads/android/v0.1.1" ]] ||
+  fail "failed Portal backup gate published the Android bundle"
+if grep -Fq 'nginx -s reload' "$temporary_directory/failed-portal-backup.log" ||
+  grep -Eq 'docker compose .* (pull|up) ' \
+    "$temporary_directory/failed-portal-backup.log"; then
+  fail "failed Portal backup gate allowed a deployment side effect"
+fi
+
+deploy_receipt="$temporary_directory/receipts/production-deploy.json"
+COMMAND_LOG="$temporary_directory/deploy.log" \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --bundle "$temporary_directory/android-bundle" \
+    --current-receipt "$baseline_receipt" \
+    --receipt "$deploy_receipt" \
+    >"$temporary_directory/deploy.out"
+[[ -f "$deploy_receipt" ]] || fail "Production deploy did not write a receipt"
+jq --exit-status \
+  --arg previous "$(test_sha256 "$baseline_receipt")" '
+    .operation == "deploy" and
+    .postgres_backup_id == "20260824T010203Z-predeploy" and
+    .portal_backup_id == "20260824T010203000Z" and
+    (.android_bundle_manifest_sha256 | type == "string" and length == 64) and
+    .previous_receipt_sha256 == $previous and
+    .rollback_target_receipt_sha256 == null
+  ' "$deploy_receipt" >/dev/null || fail "Production deployment receipt is incomplete"
+for evidence in \
+  'postgres-backup backup predeploy' \
+  'postgres-backup check 20260824T010203Z-predeploy' \
+  'portal-backup backup' \
+  'portal-backup check' \
+  'docker compose --env-file /dev/null --project-name xe3-speakup-production' \
+  'nginx -s reload'; do
+  grep -Fq "$evidence" "$temporary_directory/deploy.log" ||
+    fail "Production deploy did not record required evidence: $evidence"
+done
+[[ -f "$temporary_directory/public/downloads/android/v0.1.1/release.json" ]] ||
+  fail "Production deploy did not publish the versioned Android metadata"
+[[ ! -e "$temporary_directory/public/downloads/android/release.json" ]] ||
+  fail "Production deploy activated the public Android release"
+
+: >"$temporary_directory/reused-receipt.log"
+expect_failure "reused deployment receipt" \
+  env COMMAND_LOG="$temporary_directory/reused-receipt.log" \
+  "$manage" deploy \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --bundle "$temporary_directory/android-bundle" \
+    --current-receipt "$deploy_receipt" \
+    --receipt "$deploy_receipt"
+[[ ! -s "$temporary_directory/reused-receipt.log" ]] ||
+  fail "reused deployment receipt was rejected only after a side effect"
+
+rollback_receipt="$temporary_directory/receipts/production-rollback.json"
+COMMAND_LOG="$temporary_directory/rollback.log" \
+  "$manage" rollback \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --current-receipt "$deploy_receipt" \
+    --target-receipt "$baseline_receipt" \
+    --receipt "$rollback_receipt" \
+    >"$temporary_directory/rollback.out"
+jq --exit-status \
+  --arg previous "$(test_sha256 "$deploy_receipt")" \
+  --arg target "$(test_sha256 "$baseline_receipt")" '
+    .operation == "rollback" and
+    .database_schema_version == 7 and
+    .postgres_backup_id == null and
+    .portal_backup_id == null and
+    .android_bundle_manifest_sha256 == null and
+    .previous_receipt_sha256 == $previous and
+    .rollback_target_receipt_sha256 == $target
+  ' "$rollback_receipt" >/dev/null || fail "Production rollback receipt is incomplete"
+if grep -Eq 'migrate (up|down)|android-download.*(publish|activate)' \
+  "$temporary_directory/rollback.log"; then
+  fail "Production rollback changed the database schema or Android publication"
+fi
+if grep -Eq 'docker compose .* pull ' "$temporary_directory/rollback.log"; then
+  fail "Production rollback pulled an image"
+fi
+grep -Eq 'docker compose .* up --pull never .* portal server$' \
+  "$temporary_directory/rollback.log" ||
+  fail "Production rollback did not use the local target images only"
+[[ "$(grep -Fc 'flock --nonblock' "$temporary_directory/rollback.log")" == 3 ]] ||
+  fail "Production rollback did not hold deployment and both backup locks"
+
+jq '.database_schema_version = 6' \
+  "$temporary_directory/release-manifest.json" >"$temporary_directory/schema-6-manifest.json"
+schema_6_manifest_sha=$(test_sha256 "$temporary_directory/schema-6-manifest.json")
+jq --arg manifest_sha "$schema_6_manifest_sha" '
+  .database_schema_version = 6 |
+  .manifest_sha256 = $manifest_sha
+' "$baseline_receipt" >"$temporary_directory/receipts/schema-6-target.json"
+chmod 0444 "$temporary_directory/receipts/schema-6-target.json"
+expect_failure "rollback across a database schema change" \
+  env COMMAND_LOG="$temporary_directory/schema-rollback.log" \
+  "$manage" rollback \
+    --manifest "$temporary_directory/schema-6-manifest.json" \
+    --env-file "$temporary_directory/production.env" \
+    --current-receipt "$rollback_receipt" \
+    --target-receipt "$temporary_directory/receipts/schema-6-target.json" \
+    --receipt "$temporary_directory/receipts/schema-rollback.json"
+[[ ! -e "$temporary_directory/receipts/schema-rollback.json" ]] ||
+  fail "schema-incompatible rollback wrote a receipt"
+if grep -Eq 'migrate (up|down)' "$temporary_directory/schema-rollback.log"; then
+  fail "schema-incompatible rollback attempted a migration"
+fi
 
 printf '%s\n' 'Production contract tests passed'


### PR DESCRIPTION
## 功能描述

补齐 Production 从已审核 Release Candidate 到受控部署、不可变回执和同 schema 应用回滚的主机侧合同。新增 `baseline`、`deploy`、`rollback` 命令；部署前强制 PostgreSQL 与 Portal SQLite 双备份及恢复验证，发布版本化 APK 但不激活公开入口，并以 Nginx 配置测试和不可覆盖回执收口。

本 PR 不操作生产服务器、不新增 GitHub Workflow、不配置监控或日志轮转。

## 实现思路

- 固定 release manifest SHA、Portal/Server digest、schema、签名 APK 身份、运行容器和完整 Nginx vhost，生成严格 v1 只读回执。
- 所有状态变更使用 Production 非阻塞 `flock`；部署与回滚在更新备份配置时同时持有现有 PostgreSQL/Portal 备份锁。
- `deploy` 先证明当前回执仍匹配 live state，再执行双备份与恢复校验、digest pull、`migrate up`、精确 schema/运行时/端点验证、APK publish（不 activate）、Nginx `-t`/原子安装/reload。
- `rollback` 只使用本地目标 digest，要求当前 schema 与目标相同，只切换 Portal/Server 与 Nginx；不 pull、不迁移、不恢复数据库、不改变 APK active metadata。
- Nginx 测试或 reload 失败时恢复上一回执中的 vhost；任何失败均不写成功回执，且绝不自动执行 down migration。
- 复用既有 staging、PostgreSQL backup、Portal backup 与 android-download 合同，不修改 Compose 或监控配置。

## 测试方式

1. `make check-production-deploy`
2. `make check-production-nginx`
3. `make check-production-backup`
4. `make check-android-download`
5. `make check-offline-release`
6. `bash -n deploy/production/manage.sh deploy/production/test.sh deploy/production/test-nginx.sh && git diff --check`

预期：全部退出码为 0；主合同输出 `Production contract tests passed`，并覆盖任一备份失败即阻断、APK 不激活、回执 no-clobber、rollback 不 pull/不 migrate 及 schema 不兼容时拒绝。

## 相关 Issue / 备注

Closes #908

后续 GitHub 审批 Workflow 单独建 Issue；公开 APK 的 `activate` 仍由生产冒烟与人工批准后的发布步骤负责。

## AI 辅助说明

使用 Codex 复核现有 staging、备份、Nginx 与 Android 发布合同，按 #908 的已审核边界实现并补充失败路径测试。已完成逐段 diff 审计、敏感信息扫描和上述本地合同验证；合入前仍需 Reviewer 人工复现并确认运维语义。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [ ] 我能够解释本 PR 中的全部代码和配置（待提交者人工确认）