### PR TITLE
fix(mobile): 实时语音驱动数字人嘴型并保证单一输出

### DIFF
--- a/mobile/lib/features/coaching/practice/avatar/avatar_controller.dart
+++ b/mobile/lib/features/coaching/practice/avatar/avatar_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -46,6 +47,10 @@ final class AvatarController extends ChangeNotifier {
   bool _disposed = false;
   Future<void>? _interruptFuture;
   Future<void>? _closeFuture;
+  int? _realtimePcmGeneration;
+  Uint8List? _pendingRealtimePcm;
+  int _realtimePcmChunkCount = 0;
+  int _realtimePcmByteCount = 0;
 
   AvatarControllerState get state => _state;
 
@@ -216,10 +221,123 @@ final class AvatarController extends ChangeNotifier {
     }
   }
 
+  /// Starts one realtime PCM utterance owned by the avatar.
+  ///
+  /// One chunk is retained so the final non-empty SDK send can be marked with
+  /// `end: true`, as required by AvatarKit. A stream failure never starts the
+  /// local player halfway through the utterance.
+  Future<void> startPcmStream() async {
+    _ensureOpen();
+    await interrupt();
+    if (_closed || !_renderer.state.canAcceptAudio) {
+      throw AvatarRendererException(
+        _renderer.state.failure ?? AvatarRendererFailure.unavailable,
+      );
+    }
+    final generation = ++_generation;
+    _realtimePcmGeneration = generation;
+    _realtimePcmChunkCount = 0;
+    _realtimePcmByteCount = 0;
+    _setState(
+      AvatarControllerState(
+        phase: AvatarControllerPhase.speaking,
+        renderer: _renderer.state,
+      ),
+    );
+    developer.log(
+      'realtime_pcm_started sample_rate_hz=24000 channels=1 bits=16',
+      name: 'speakup.avatar',
+    );
+  }
+
+  Future<void> appendPcm(Uint8List pcmBytes) async {
+    _ensureOpen();
+    final generation = _realtimePcmGeneration;
+    if (generation == null ||
+        !_isCurrent(generation) ||
+        pcmBytes.isEmpty ||
+        pcmBytes.length.isOdd) {
+      throw const AvatarRendererException(
+        AvatarRendererFailure.invalidConfiguration,
+      );
+    }
+
+    final owned = Uint8List.fromList(pcmBytes);
+    final previous = _pendingRealtimePcm;
+    _pendingRealtimePcm = owned;
+    _realtimePcmChunkCount++;
+    _realtimePcmByteCount += owned.length;
+    if (previous == null) {
+      return;
+    }
+    try {
+      await _renderer.sendPcm(previous, end: false);
+    } catch (_) {
+      if (_isCurrent(generation)) {
+        _failRealtimePcmStream(
+          _renderer.state.failure ?? AvatarRendererFailure.rendering,
+        );
+      }
+      throw AvatarRendererException(
+        _renderer.state.failure ?? AvatarRendererFailure.rendering,
+      );
+    } finally {
+      previous.fillRange(0, previous.length, 0);
+    }
+    if (!_isCurrent(generation) || _realtimePcmGeneration != generation) {
+      throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+    }
+  }
+
+  Future<void> finishPcmStream() async {
+    _ensureOpen();
+    final generation = _realtimePcmGeneration;
+    final finalChunk = _pendingRealtimePcm;
+    _pendingRealtimePcm = null;
+    if (generation == null || finalChunk == null || !_isCurrent(generation)) {
+      finalChunk?.fillRange(0, finalChunk.length, 0);
+      throw const AvatarRendererException(
+        AvatarRendererFailure.invalidConfiguration,
+      );
+    }
+    try {
+      await _renderer.sendPcm(finalChunk, end: true);
+    } catch (_) {
+      if (_isCurrent(generation)) {
+        _failRealtimePcmStream(
+          _renderer.state.failure ?? AvatarRendererFailure.rendering,
+        );
+      }
+      throw AvatarRendererException(
+        _renderer.state.failure ?? AvatarRendererFailure.rendering,
+      );
+    } finally {
+      finalChunk.fillRange(0, finalChunk.length, 0);
+    }
+    if (!_isCurrent(generation) || _realtimePcmGeneration != generation) {
+      return;
+    }
+    _realtimePcmGeneration = null;
+    developer.log(
+      'realtime_pcm_completed chunks=$_realtimePcmChunkCount '
+      'bytes=$_realtimePcmByteCount',
+      name: 'speakup.avatar',
+    );
+    _setState(
+      AvatarControllerState(
+        phase: AvatarControllerPhase.ready,
+        renderer: _renderer.state,
+      ),
+    );
+  }
+
+  Future<void> stopPcmStream() => interrupt();
+
   Future<void> interrupt() {
     if (_closed) {
       return Future<void>.value();
     }
+    _clearRealtimePcmStream();
     _generation++;
     final existing = _interruptFuture;
     if (existing != null) {
@@ -293,6 +411,7 @@ final class AvatarController extends ChangeNotifier {
       return Future<void>.value();
     }
     _closed = true;
+    _clearRealtimePcmStream();
     _generation++;
     final completion = _performClose();
     _closeFuture = completion;
@@ -382,6 +501,30 @@ final class AvatarController extends ChangeNotifier {
       ),
     );
     return AvatarSpeechResult.fallback;
+  }
+
+  void _failRealtimePcmStream(AvatarRendererFailure failure) {
+    _clearRealtimePcmStream();
+    developer.log(
+      'realtime_pcm_failed failure=${failure.name}',
+      name: 'speakup.avatar',
+    );
+    _setState(
+      AvatarControllerState(
+        phase: AvatarControllerPhase.failed,
+        renderer: _renderer.state,
+        failure: failure,
+      ),
+    );
+  }
+
+  void _clearRealtimePcmStream() {
+    final pending = _pendingRealtimePcm;
+    _pendingRealtimePcm = null;
+    pending?.fillRange(0, pending.length, 0);
+    _realtimePcmGeneration = null;
+    _realtimePcmChunkCount = 0;
+    _realtimePcmByteCount = 0;
   }
 
   void _onRendererState(AvatarRendererState rendererState) {

--- a/mobile/lib/features/coaching/practice/practice_audio_player.dart
+++ b/mobile/lib/features/coaching/practice/practice_audio_player.dart
@@ -21,7 +21,12 @@ abstract interface class PracticeAudioPlayer {
   Future<void> dispose();
 }
 
-abstract interface class PracticePCMStreamPlayer {
+/// One selected destination for a single raw PCM utterance.
+///
+/// The caller selects the sink before [startPCMStream] and must not switch it
+/// until the utterance finishes or is stopped. Implementations copy each chunk
+/// before [appendPCM] completes.
+abstract interface class PracticePCMStreamSink {
   Future<void> startPCMStream();
 
   Future<void> appendPCM(Uint8List bytes);
@@ -29,7 +34,10 @@ abstract interface class PracticePCMStreamPlayer {
   Future<void> finishPCMStream();
 
   Future<void> stopPCMStream();
+}
 
+abstract interface class PracticePCMStreamPlayer
+    implements PracticePCMStreamSink {
   Future<void> disposePCMStream();
 }
 

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -25,6 +25,7 @@ final class PracticeController extends ChangeNotifier
     this.mediaClient,
     this.audioPlayer,
     this.questionSpeechPlayer,
+    this.automaticQuestionSpeechEnabled = true,
     PracticeClientIdFactory? clientIdFactory,
     Duration recordingLimit = const Duration(seconds: 58),
   }) : recorder = recorder ?? FakePracticeRecorder(),
@@ -67,6 +68,7 @@ final class PracticeController extends ChangeNotifier
   final PracticeMediaClient? mediaClient;
   final PracticeAudioPlayer? audioPlayer;
   final PracticePCMStreamPlayer? questionSpeechPlayer;
+  final bool automaticQuestionSpeechEnabled;
   late final CoachingSpeechPlayer promptSpeaker;
   final PracticeClientIdFactory _clientIdFactory;
   final Duration _recordingLimit;
@@ -124,6 +126,7 @@ final class PracticeController extends ChangeNotifier
   Future<void>? _mediaOperation;
   Future<void>? _questionSpeechOperation;
   StreamIterator<Uint8List>? _questionSpeechIterator;
+  PracticePCMStreamSink? _activeQuestionSpeechOutput;
   String? _autoPlayedQuestionId;
   String? get practiceSessionId => _practiceSessionId;
   String? get practicePlanId => _practicePlanId;
@@ -458,6 +461,19 @@ final class PracticeController extends ChangeNotifier
     );
   }
 
+  /// Plays the current question through one output selected for the complete
+  /// realtime utterance. Supplying [output] lets an avatar own both audio and
+  /// lip animation without racing the default device player.
+  Future<void> playCurrentQuestionSpeech({
+    PracticePCMStreamSink? output,
+  }) async {
+    final question = _currentQuestion;
+    if (question == null || !supportsRealtimeQuestionSpeech) {
+      return;
+    }
+    await _playRealtimeQuestionSpeech(question, output: output);
+  }
+
   Future<void> toggleRecordingAudio(String audioAssetId) async {
     if (!_recordings.any(
       (recording) => recording.audioAssetId == audioAssetId,
@@ -552,6 +568,8 @@ final class PracticeController extends ChangeNotifier
     _mediaGeneration++;
     _playingMediaKey = null;
     _loadingMediaKey = null;
+    final activeQuestionSpeechOutput = _activeQuestionSpeechOutput;
+    _activeQuestionSpeechOutput = null;
     if (notify && !_disposed) {
       notifyListeners();
     }
@@ -559,16 +577,32 @@ final class PracticeController extends ChangeNotifier
       final iterator = _questionSpeechIterator;
       _questionSpeechIterator = null;
       await iterator?.cancel();
-      await questionSpeechPlayer?.stopPCMStream();
+      await _stopQuestionSpeechOutputs(activeQuestionSpeechOutput);
       await audioPlayer?.stop();
     } catch (_) {
       // The private UI is already cleared; native cleanup remains best effort.
     }
   }
 
-  Future<void> _playRealtimeQuestionSpeech(PracticeQuestion question) async {
+  Future<void> _stopQuestionSpeechOutputs(
+    PracticePCMStreamSink? activeOutput,
+  ) async {
+    if (activeOutput != null) {
+      await activeOutput.stopPCMStream();
+    }
+    final defaultOutput = questionSpeechPlayer;
+    if (defaultOutput != null &&
+        (activeOutput == null || !identical(activeOutput, defaultOutput))) {
+      await defaultOutput.stopPCMStream();
+    }
+  }
+
+  Future<void> _playRealtimeQuestionSpeech(
+    PracticeQuestion question, {
+    PracticePCMStreamSink? output,
+  }) async {
     final speechClient = mediaClient;
-    final player = questionSpeechPlayer;
+    final player = output ?? questionSpeechPlayer;
     if (speechClient is! PracticeQuestionSpeechClient ||
         player == null ||
         _disposed ||
@@ -689,9 +723,10 @@ final class PracticeController extends ChangeNotifier
     required String key,
     required PracticeQuestion question,
     required PracticeQuestionSpeechClient client,
-    required PracticePCMStreamPlayer player,
+    required PracticePCMStreamSink player,
   }) async {
     var started = false;
+    var streamEnded = false;
     final iterator = StreamIterator<Uint8List>(
       client.streamQuestionSpeech(question.id),
     );
@@ -704,9 +739,13 @@ final class PracticeController extends ChangeNotifier
           return;
         }
         if (!started) {
+          _activeQuestionSpeechOutput = player;
           await player.startPCMStream();
           if (!_isCurrentMedia(generation) ||
               _currentQuestion?.id != question.id) {
+            if (identical(_activeQuestionSpeechOutput, player)) {
+              _activeQuestionSpeechOutput = null;
+            }
             await player.stopPCMStream();
             return;
           }
@@ -721,6 +760,7 @@ final class PracticeController extends ChangeNotifier
           bytes.fillRange(0, bytes.length, 0);
         }
       }
+      streamEnded = true;
       if (started && _isCurrentMedia(generation)) {
         await player.finishPCMStream();
       }
@@ -739,10 +779,17 @@ final class PracticeController extends ChangeNotifier
         await player.stopPCMStream();
       }
     } finally {
+      if (identical(_activeQuestionSpeechOutput, player)) {
+        _activeQuestionSpeechOutput = null;
+      }
       if (identical(_questionSpeechIterator, iterator)) {
         _questionSpeechIterator = null;
       }
-      await iterator.cancel();
+      // A naturally exhausted StreamIterator is already detached. Cancelling
+      // it again can keep this operation alive and delay the next question.
+      if (!streamEnded) {
+        await iterator.cancel();
+      }
       if (_isCurrentMedia(generation)) {
         notifyListeners();
       }
@@ -752,7 +799,8 @@ final class PracticeController extends ChangeNotifier
   void _scheduleAutomaticQuestionSpeech() {
     final question = _currentQuestion;
     final experience = _practiceExperience;
-    if (!supportsRealtimeQuestionSpeech ||
+    if (!automaticQuestionSpeechEnabled ||
+        !supportsRealtimeQuestionSpeech ||
         question == null ||
         _sessionCompleted ||
         _autoPlayedQuestionId == question.id ||
@@ -2147,6 +2195,8 @@ final class PracticeController extends ChangeNotifier
   /// Invalidates private UI state synchronously, then removes temporary audio
   /// and waits for all account-scoped transports to stop.
   Future<void> clearPrivateState() async {
+    final activeQuestionSpeechOutput = _activeQuestionSpeechOutput;
+    _activeQuestionSpeechOutput = null;
     _cancelRecordingLimit();
     _epoch++;
     _practiceGeneration++;
@@ -2201,12 +2251,12 @@ final class PracticeController extends ChangeNotifier
         Future<void>.sync(media.clearAccountState),
       if (audioPlayer case final player?)
         Future<void>.sync(player.clearAccountState),
-      if (questionSpeechPlayer case final player?)
+      if (questionSpeechPlayer != null)
         Future<void>.sync(() async {
           final iterator = _questionSpeechIterator;
           _questionSpeechIterator = null;
           await iterator?.cancel();
-          await player.stopPCMStream();
+          await _stopQuestionSpeechOutputs(activeQuestionSpeechOutput);
         }),
     ]);
     _accountCleanupFuture = cleanup;
@@ -2227,6 +2277,8 @@ final class PracticeController extends ChangeNotifier
   void dispose() {
     final pendingPracticeAudio = _pendingPracticeAudio;
     final practiceAudioOperation = _stopRecordingFuture;
+    final activeQuestionSpeechOutput = _activeQuestionSpeechOutput;
+    _activeQuestionSpeechOutput = null;
     _pendingPracticeAudio = null;
     _disposed = true;
     if (mediaClient != null || questionSpeechPlayer != null) {
@@ -2259,6 +2311,7 @@ final class PracticeController extends ChangeNotifier
     unawaited(
       Future<void>.sync(() async {
         await _questionSpeechIterator?.cancel();
+        await _stopQuestionSpeechOutputs(activeQuestionSpeechOutput);
         await questionSpeechPlayer?.disposePCMStream();
       }),
     );
@@ -2287,6 +2340,8 @@ final class PracticeController extends ChangeNotifier
         'Pending Practice audio must be resolved before replacing its snapshot.',
       );
     }
+    final activeQuestionSpeechOutput = _activeQuestionSpeechOutput;
+    _activeQuestionSpeechOutput = null;
     final previousSessionId = _practiceSessionId;
     _cancelRecordingLimit();
     _practiceGeneration++;
@@ -2304,7 +2359,7 @@ final class PracticeController extends ChangeNotifier
     _mediaGeneration++;
     _autoPlayedQuestionId = null;
     unawaited(audioPlayer?.stop());
-    unawaited(questionSpeechPlayer?.stopPCMStream());
+    unawaited(_stopQuestionSpeechOutputs(activeQuestionSpeechOutput));
     if (snapshot == null) {
       _practiceSessionId = null;
       _practicePlanId = null;

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/scenario/scenario_practice.dart';
 import 'package:speakup/features/coaching/practice/avatar/avatar.dart';
@@ -23,7 +25,7 @@ final class PracticeAvatarSessionView {
     required this.replayPlaying,
   });
 
-  final WidgetBuilder surfaceBuilder;
+  final WidgetBuilder? surfaceBuilder;
   final String? statusLabel;
   final Future<void> Function() interruptForUserTurn;
   final Future<void> Function()? onReplayQuestion;
@@ -118,6 +120,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
   bool _syncAgain = false;
   bool _foreground = true;
   bool _hasLiveAvatarController = true;
+  bool _hasUsableAvatarSurface = false;
   bool _disposed = false;
   int _connectionAttempts = 0;
   int _connectionOperationId = 0;
@@ -211,6 +214,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       _connectionInFlight = false;
       _connectionAttemptedSessionId = null;
       _readinessExpired = false;
+      _hasUsableAvatarSurface = false;
       if (resetConnectionAttempts) {
         _connectionAttempts = 0;
       }
@@ -265,7 +269,16 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     if (!_hasLiveAvatarController) {
       return;
     }
-    if (_avatarController.state.canUseAvatar) {
+    final avatarState = _avatarController.state;
+    if (switch (avatarState.renderer.connection) {
+      AvatarRendererConnection.surfaceReady ||
+      AvatarRendererConnection.connecting ||
+      AvatarRendererConnection.connected => true,
+      _ => false,
+    }) {
+      _hasUsableAvatarSurface = true;
+    }
+    if (avatarState.canUseAvatar) {
       _connectionAttempts = 0;
       _readinessTimer?.cancel();
       _readinessTimer = null;
@@ -347,9 +360,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     }
     _autoHandledQuestionId = question.id;
     if (widget.practiceController.supportsRealtimeQuestionSpeech) {
-      // The shared Practice controller starts cloud PCM as soon as the new
-      // question is presented. Do not replace it with the avatar's slower
-      // complete-WAV path or the two players would race each other.
+      await _speakRealtimeQuestion(question);
       return;
     }
     await _speakQuestion(question);
@@ -547,6 +558,49 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     }
   }
 
+  Future<void> _speakRealtimeQuestion(
+    PracticeQuestion question, {
+    bool replay = false,
+  }) async {
+    if (_speechInFlight || !_hasLiveAvatarController) {
+      return;
+    }
+    final sessionId = widget.practiceController.practiceSessionId;
+    if (sessionId == null || question.sessionId != sessionId) {
+      return;
+    }
+    final avatarController = _avatarController;
+    final useAvatar = avatarController.state.canUseAvatar;
+    _speechInFlight = true;
+    if (replay) {
+      _replayLoading = true;
+    }
+    if (mounted) {
+      setState(() {});
+    }
+    final fallbackReason =
+        avatarController.state.failure?.name ??
+        (_readinessExpired ? 'readiness_timeout' : 'not_ready');
+    developer.log(
+      useAvatar
+          ? 'realtime_question_route output=avatar'
+          : 'realtime_question_route output=native reason=$fallbackReason',
+      name: 'speakup.avatar',
+    );
+    try {
+      await widget.practiceController.playCurrentQuestionSpeech(
+        output: useAvatar ? _AvatarQuestionSpeechSink(avatarController) : null,
+      );
+    } finally {
+      _speechInFlight = false;
+      _replayLoading = false;
+      if (mounted) {
+        setState(() {});
+      }
+      _scheduleSync();
+    }
+  }
+
   bool _speechFenceMatches({
     required int generation,
     required String sessionId,
@@ -569,12 +623,17 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     if (_replayLoading || !_canSpeakNow(widget.practiceController)) {
       return;
     }
-    if (_isAvatarSpeaking) {
+    if (_isAvatarSpeaking ||
+        widget.practiceController.isQuestionAudioLoading ||
+        widget.practiceController.isQuestionAudioPlaying) {
       await _interruptForUserTurn();
       return;
     }
     if (widget.practiceController.supportsRealtimeQuestionSpeech) {
-      await widget.practiceController.toggleQuestionAudio();
+      final question = widget.practiceController.currentQuestion;
+      if (question != null) {
+        await _speakRealtimeQuestion(question, replay: true);
+      }
       return;
     }
     final question = widget.practiceController.currentQuestion;
@@ -628,9 +687,9 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     return widget.builder(
       context,
       PracticeAvatarSessionView(
-        surfaceBuilder: (_) => _hasLiveAvatarController
-            ? _avatarController.buildSurface(key: widget.surfaceKey)
-            : SizedBox.expand(key: widget.surfaceKey),
+        surfaceBuilder: _hasLiveAvatarController && _hasUsableAvatarSurface
+            ? (_) => _avatarController.buildSurface(key: widget.surfaceKey)
+            : null,
         statusLabel: _avatarStatusLabel,
         interruptForUserTurn: _interruptForUserTurn,
         onReplayQuestion: !widget.practiceController.canPlayQuestionAudio
@@ -661,6 +720,24 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     }
     super.dispose();
   }
+}
+
+final class _AvatarQuestionSpeechSink implements PracticePCMStreamSink {
+  const _AvatarQuestionSpeechSink(this._controller);
+
+  final AvatarController _controller;
+
+  @override
+  Future<void> startPCMStream() => _controller.startPcmStream();
+
+  @override
+  Future<void> appendPCM(Uint8List bytes) => _controller.appendPcm(bytes);
+
+  @override
+  Future<void> finishPCMStream() => _controller.finishPcmStream();
+
+  @override
+  Future<void> stopPCMStream() => _controller.stopPcmStream();
 }
 
 bool _canSpeakNow(PracticeController controller) {

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -570,7 +570,10 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       return;
     }
     final avatarController = _avatarController;
-    final useAvatar = avatarController.state.canUseAvatar;
+    final nativeOutput = widget.practiceController.questionSpeechPlayer;
+    if (nativeOutput == null) {
+      return;
+    }
     _speechInFlight = true;
     if (replay) {
       _replayLoading = true;
@@ -578,18 +581,13 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     if (mounted) {
       setState(() {});
     }
-    final fallbackReason =
-        avatarController.state.failure?.name ??
-        (_readinessExpired ? 'readiness_timeout' : 'not_ready');
-    developer.log(
-      useAvatar
-          ? 'realtime_question_route output=avatar'
-          : 'realtime_question_route output=native reason=$fallbackReason',
-      name: 'speakup.avatar',
-    );
     try {
       await widget.practiceController.playCurrentQuestionSpeech(
-        output: useAvatar ? _AvatarQuestionSpeechSink(avatarController) : null,
+        output: _AvatarOrNativeQuestionSpeechSink(
+          avatarController,
+          nativeOutput,
+          _readinessExpired,
+        ),
       );
     } finally {
       _speechInFlight = false;
@@ -719,6 +717,87 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       unawaited(_bestEffort(controller.close));
     }
     super.dispose();
+  }
+}
+
+final class _AvatarOrNativeQuestionSpeechSink implements PracticePCMStreamSink {
+  _AvatarOrNativeQuestionSpeechSink(
+    this._avatarController,
+    this._nativeOutput,
+    this._readinessExpired,
+  );
+
+  final AvatarController _avatarController;
+  final PracticePCMStreamSink _nativeOutput;
+  final bool _readinessExpired;
+  PracticePCMStreamSink? _selectedOutput;
+  bool _stopped = false;
+
+  @override
+  Future<void> startPCMStream() async {
+    if (_selectedOutput != null) {
+      throw StateError('A realtime question output was already selected.');
+    }
+    if (_avatarController.state.canUseAvatar) {
+      _selectedOutput = _AvatarQuestionSpeechSink(_avatarController);
+      try {
+        await _selectedOutput!.startPCMStream();
+        if (_stopped) {
+          await _selectedOutput!.stopPCMStream();
+          throw const AvatarRendererException(
+            AvatarRendererFailure.unavailable,
+          );
+        }
+        developer.log(
+          'realtime_question_route output=avatar',
+          name: 'speakup.avatar',
+        );
+        return;
+      } catch (_) {
+        if (_stopped) {
+          rethrow;
+        }
+        await _bestEffort(_selectedOutput!.stopPCMStream);
+      }
+    }
+
+    final fallbackReason =
+        _avatarController.state.failure?.name ??
+        (_readinessExpired ? 'readiness_timeout' : 'not_ready');
+    _selectedOutput = _nativeOutput;
+    await _nativeOutput.startPCMStream();
+    if (_stopped) {
+      await _nativeOutput.stopPCMStream();
+      throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+    }
+    developer.log(
+      'realtime_question_route output=native reason=$fallbackReason',
+      name: 'speakup.avatar',
+    );
+  }
+
+  @override
+  Future<void> appendPCM(Uint8List bytes) {
+    final output = _selectedOutput;
+    if (_stopped || output == null) {
+      throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+    }
+    return output.appendPCM(bytes);
+  }
+
+  @override
+  Future<void> finishPCMStream() {
+    final output = _selectedOutput;
+    if (_stopped || output == null) {
+      throw const AvatarRendererException(AvatarRendererFailure.unavailable);
+    }
+    return output.finishPCMStream();
+  }
+
+  @override
+  Future<void> stopPCMStream() async {
+    _stopped = true;
+    await _selectedOutput?.stopPCMStream();
   }
 }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -61,7 +61,10 @@ void main() {
     isAndroid: defaultTargetPlatform == TargetPlatform.android,
     explicitBaseUrl: explicitApiBaseUrl,
   );
-  final dependencies = createProductionAppDependencies(baseUri: apiBaseUri);
+  final dependencies = createProductionAppDependencies(
+    baseUri: apiBaseUri,
+    avatarEnabled: avatarEnabled,
+  );
   runApp(
     SpeakUpApp(
       authController: dependencies.authController,
@@ -127,6 +130,7 @@ final class ProductionAppDependencies {
 
 ProductionAppDependencies createProductionAppDependencies({
   required Uri baseUri,
+  bool avatarEnabled = false,
   IdentityHttpTransport? identityTransport,
   IdentityHttpTransport? agentTransport,
   AgentVoiceWireTransport? agentVoiceTransport,
@@ -299,6 +303,7 @@ ProductionAppDependencies createProductionAppDependencies({
         resolvedPracticeMediaClient is PracticeQuestionSpeechClient
         ? MethodChannelPracticePCMStreamPlayer()
         : null,
+    automaticQuestionSpeechEnabled: !avatarEnabled,
   );
   final reviewHistoryController = ReviewHistoryController(
     client: WireReviewHistoryClient(

--- a/mobile/test/coaching/practice/avatar/avatar_controller_test.dart
+++ b/mobile/test/coaching/practice/avatar/avatar_controller_test.dart
@@ -58,6 +58,96 @@ void main() {
     expect(renderer.sends.where((send) => send.end), hasLength(1));
   });
 
+  test(
+    'avatar owns a realtime PCM utterance and marks only its last chunk',
+    () async {
+      final renderer = FakeAvatarRenderer();
+      var fallbackCount = 0;
+      final controller = AvatarController(
+        renderer: renderer,
+        tokenClient: FakeAvatarSessionTokenClient(),
+        fallbackPlayback: (_) async => fallbackCount++,
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+      addTearDown(controller.close);
+      await controller.connect(practiceSessionId: 'practice-1');
+
+      await controller.startPcmStream();
+      await controller.appendPcm(Uint8List.fromList(<int>[1, 2, 3, 4]));
+      expect(renderer.sends, isEmpty);
+      await controller.appendPcm(Uint8List.fromList(<int>[5, 6, 7, 8]));
+      expect(renderer.sends.map((send) => send.end), <bool>[false]);
+      await controller.finishPcmStream();
+
+      expect(renderer.sends.map((send) => send.bytes), <Uint8List>[
+        Uint8List.fromList(<int>[1, 2, 3, 4]),
+        Uint8List.fromList(<int>[5, 6, 7, 8]),
+      ]);
+      expect(renderer.sends.map((send) => send.end), <bool>[false, true]);
+      expect(fallbackCount, 0);
+      expect(controller.state.phase, AvatarControllerPhase.ready);
+    },
+  );
+
+  test(
+    'realtime PCM failure never starts a second local player mid-utterance',
+    () async {
+      final renderer = FakeAvatarRenderer()..failSendAt = 0;
+      var fallbackCount = 0;
+      final controller = AvatarController(
+        renderer: renderer,
+        tokenClient: FakeAvatarSessionTokenClient(),
+        fallbackPlayback: (_) async => fallbackCount++,
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+      addTearDown(controller.close);
+      await controller.connect(practiceSessionId: 'practice-1');
+      await controller.startPcmStream();
+      await controller.appendPcm(Uint8List.fromList(<int>[1, 2, 3, 4]));
+
+      await expectLater(
+        controller.appendPcm(Uint8List.fromList(<int>[5, 6, 7, 8])),
+        throwsA(isA<AvatarRendererException>()),
+      );
+
+      expect(renderer.sends, hasLength(1));
+      expect(fallbackCount, 0);
+      expect(controller.state.phase, AvatarControllerPhase.failed);
+    },
+  );
+
+  test(
+    'interrupt fences a realtime PCM utterance without sending its tail',
+    () async {
+      final renderer = FakeAvatarRenderer()..holdSends = true;
+      final controller = AvatarController(
+        renderer: renderer,
+        tokenClient: FakeAvatarSessionTokenClient(),
+        fallbackPlayback: (_) async {},
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+      addTearDown(controller.close);
+      await controller.connect(practiceSessionId: 'practice-1');
+      await controller.startPcmStream();
+      await controller.appendPcm(Uint8List.fromList(<int>[1, 2, 3, 4]));
+      final append = controller.appendPcm(
+        Uint8List.fromList(<int>[5, 6, 7, 8]),
+      );
+      await _until(() => renderer.pendingSends.isNotEmpty);
+
+      await controller.stopPcmStream();
+      renderer.pendingSends.single.complete();
+      await expectLater(append, throwsA(isA<AvatarRendererException>()));
+
+      expect(renderer.sends, hasLength(1));
+      expect(renderer.sends.single.end, isFalse);
+      expect(controller.state.phase, AvatarControllerPhase.ready);
+    },
+  );
+
   test('invalid WAV exclusively falls back without sending PCM', () async {
     final renderer = FakeAvatarRenderer();
     final fallbackWaves = <Uint8List>[];

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -1,0 +1,381 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/features/coaching/practice/avatar/avatar.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
+import 'package:speakup/features/coaching/practice/practice_client.dart';
+import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_media.dart';
+import 'package:speakup/features/coaching/scenario/scenario_practice_session.dart';
+import 'package:speakup/features/coaching/scene/scene.dart';
+
+import '../../support/practice_fixtures.dart';
+import '../../support/scene_fixtures.dart';
+import 'avatar/avatar_test_fakes.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('routes realtime question PCM exclusively through the avatar', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    final nativePlayer = _RecordingPCMStreamPlayer();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: nativePlayer,
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+
+    final renderer = FakeAvatarRenderer();
+    final avatarController = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async {},
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => avatarController,
+          surfaceKey: const Key('avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return avatar.surfaceBuilder?.call(context) ??
+                const SizedBox.expand();
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+    media.release();
+    await tester.pumpAndSettle();
+
+    expect(renderer.sends.map((send) => send.bytes), <Uint8List>[
+      Uint8List.fromList(<int>[1, 2, 3, 4]),
+      Uint8List.fromList(<int>[5, 6, 7, 8]),
+    ]);
+    expect(renderer.sends.map((send) => send.end), <bool>[false, true]);
+    expect(nativePlayer.events, isEmpty);
+
+    final firstQuestionId = practiceController.questionId;
+    await sessionView!.interruptForUserTurn();
+    expect(
+      await practiceController.submitPracticeText('My first answer.'),
+      isTrue,
+    );
+    expect(practiceController.questionId, isNot(firstQuestionId));
+    await tester.pumpAndSettle();
+    expect(
+      renderer.sends.length,
+      4,
+      reason:
+          'questions=${media.questionIds}, native=${nativePlayer.events}, '
+          'loading=${practiceController.isQuestionAudioLoading}, '
+          'playing=${practiceController.isQuestionAudioPlaying}, '
+          'mediaError=${practiceController.mediaErrorMessage}, '
+          'avatar=${avatarController.state.phase}, '
+          'replayLoading=${sessionView?.replayLoading}, '
+          'replayPlaying=${sessionView?.replayPlaying}, '
+          'recording=${practiceController.recordingState}, '
+          'busy=${practiceController.isBusy}',
+    );
+    expect(renderer.sends.map((send) => send.end), <bool>[
+      false,
+      true,
+      false,
+      true,
+    ]);
+    expect(nativePlayer.events, isEmpty);
+
+    await sessionView!.onReplayQuestion!();
+    await _pumpUntil(tester, () => renderer.sends.length == 6);
+    expect(renderer.sends.map((send) => send.end), <bool>[
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+    ]);
+    expect(nativePlayer.events, isEmpty);
+  });
+
+  testWidgets('routes the first IELTS realtime question through the avatar', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    final nativePlayer = _RecordingPCMStreamPlayer();
+    const mode = PracticeMode.part1;
+    final scene = testScene(
+      id: 'ielts-avatar-realtime',
+      experience: PracticeExperience.ieltsSpeaking,
+      category: SceneCategory.ieltsSpeaking,
+      practiceOptions: const <PracticeOption>[
+        PracticeOption(
+          id: 'ielts-part-1',
+          sceneId: 'ielts-avatar-realtime',
+          mode: mode,
+          displayName: 'Part 1',
+          suggestedDurationSeconds: 300,
+          turnPolicyRef: 'turn-ielts-avatar',
+          sessionPolicyRef: 'session-ielts-avatar',
+          evaluationPolicyRef: 'evaluation-ielts-avatar',
+        ),
+      ],
+    );
+    final practiceController = PracticeController(
+      client: FakePracticeClient(
+        practiceExperience: PracticeExperience.ieltsSpeaking,
+        sceneCategory: SceneCategory.ieltsSpeaking,
+        practiceMode: mode,
+        turnLimit: 3,
+        ieltsAssignment: testIeltsAssignment(mode: mode, part1QuestionCount: 3),
+      ),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: nativePlayer,
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(controller: practiceController, scene: scene);
+
+    final renderer = FakeAvatarRenderer();
+    final avatarController = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async {},
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => avatarController,
+          surfaceKey: const Key('ielts-avatar-surface'),
+          builder: (context, avatar) =>
+              avatar.surfaceBuilder?.call(context) ?? const SizedBox.expand(),
+        ),
+      ),
+    );
+    await tester.pump();
+    media.release();
+    await tester.pumpAndSettle();
+
+    expect(renderer.sends.map((send) => send.end), <bool>[false, true]);
+    expect(nativePlayer.events, isEmpty);
+  });
+
+  testWidgets('keeps a loaded avatar surface visible after a disconnect', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: _RecordingPCMStreamPlayer(),
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final renderer = FakeAvatarRenderer();
+    final avatarController = AvatarController(
+      renderer: renderer,
+      tokenClient: FakeAvatarSessionTokenClient(),
+      fallbackPlayback: (_) async {},
+      fallbackStop: () async {},
+      delay: (_) async {},
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => avatarController,
+          surfaceKey: const Key('retained-avatar-surface'),
+          builder: (context, avatar) =>
+              avatar.surfaceBuilder?.call(context) ??
+              const SizedBox(key: Key('static-fallback')),
+        ),
+      ),
+    );
+    await tester.pump();
+    media.release();
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('retained-avatar-surface')), findsOneWidget);
+
+    renderer.emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('retained-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('static-fallback')), findsNothing);
+  });
+
+  testWidgets(
+    'keeps the existing static role and native speech when avatar prepare fails',
+    (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final media = _RealtimeQuestionMediaClient();
+      final nativePlayer = _RecordingPCMStreamPlayer();
+      final practiceController = PracticeController(
+        client: FakePracticeClient(),
+        mediaClient: media,
+        audioPlayer: _SilentPracticeAudioPlayer(),
+        questionSpeechPlayer: nativePlayer,
+        automaticQuestionSpeechEnabled: false,
+      );
+      addTearDown(practiceController.dispose);
+      await activateTestPractice(
+        controller: practiceController,
+        scene: testScenes[2],
+      );
+      final renderer = FakeAvatarRenderer(
+        prepareFailure: AvatarRendererFailure.unsupportedDevice,
+      );
+      final avatarController = AvatarController(
+        renderer: renderer,
+        tokenClient: FakeAvatarSessionTokenClient(),
+        fallbackPlayback: (_) async {},
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ScenarioPracticeSession(
+            practiceController: practiceController,
+            avatarControllerFactory: () => avatarController,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('scenario-role-placeholder')),
+        findsOneWidget,
+      );
+      expect(find.text('画面暂不可用，语音仍可继续'), findsOneWidget);
+
+      media.release();
+      await tester.pumpAndSettle();
+
+      expect(renderer.sends, isEmpty);
+      expect(nativePlayer.events, <String>[
+        'start',
+        'append:4',
+        'append:4',
+        'finish',
+      ]);
+    },
+  );
+}
+
+Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
+  for (var attempts = 0; attempts < 50; attempts++) {
+    if (condition()) {
+      return;
+    }
+    await tester.pump(const Duration(milliseconds: 10));
+  }
+  fail('Condition was not reached.');
+}
+
+final class _RealtimeQuestionMediaClient
+    implements PracticeMediaClient, PracticeQuestionSpeechClient {
+  final Completer<void> _release = Completer<void>();
+  final List<String> questionIds = <String>[];
+
+  void release() => _release.complete();
+
+  @override
+  Stream<Uint8List> streamQuestionSpeech(String questionId) async* {
+    questionIds.add(questionId);
+    await _release.future;
+    yield Uint8List.fromList(<int>[1, 2, 3, 4]);
+    yield Uint8List.fromList(<int>[5, 6, 7, 8]);
+  }
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> deleteRecording(String audioAssetId) async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<Uint8List> loadQuestionSpeech(String speechPath) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Uint8List> loadRecording(String audioAssetId) =>
+      throw UnimplementedError();
+}
+
+final class _RecordingPCMStreamPlayer implements PracticePCMStreamPlayer {
+  final List<String> events = <String>[];
+
+  @override
+  Future<void> appendPCM(Uint8List bytes) async {
+    events.add('append:${bytes.length}');
+  }
+
+  @override
+  Future<void> disposePCMStream() async {}
+
+  @override
+  Future<void> finishPCMStream() async {
+    events.add('finish');
+  }
+
+  @override
+  Future<void> startPCMStream() async {
+    events.add('start');
+  }
+
+  @override
+  Future<void> stopPCMStream() async {}
+}
+
+final class _SilentPracticeAudioPlayer implements PracticeAudioPlayer {
+  @override
+  Stream<void> get onComplete => const Stream<void>.empty();
+
+  @override
+  Future<void> clearAccountState() async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> playWav(Uint8List bytes) async {}
+
+  @override
+  Future<void> stop() async {}
+}

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -180,6 +180,66 @@ void main() {
     expect(nativePlayer.events, isEmpty);
   });
 
+  testWidgets(
+    'uses native speech when the avatar disconnects before the first PCM send',
+    (tester) async {
+      final media = _RealtimeQuestionMediaClient();
+      final nativePlayer = _RecordingPCMStreamPlayer();
+      final practiceController = PracticeController(
+        client: FakePracticeClient(),
+        mediaClient: media,
+        audioPlayer: _SilentPracticeAudioPlayer(),
+        questionSpeechPlayer: nativePlayer,
+        automaticQuestionSpeechEnabled: false,
+      );
+      addTearDown(practiceController.dispose);
+      await activateTestPractice(
+        controller: practiceController,
+        scene: testScenes[2],
+      );
+
+      final renderer = FakeAvatarRenderer()..interruptGate = Completer<void>();
+      final avatarController = AvatarController(
+        renderer: renderer,
+        tokenClient: FakeAvatarSessionTokenClient(),
+        fallbackPlayback: (_) async {},
+        fallbackStop: () async {},
+        delay: (_) async {},
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PracticeAvatarSession(
+            practiceController: practiceController,
+            avatarControllerFactory: () => avatarController,
+            surfaceKey: const Key('disconnect-before-pcm-surface'),
+            builder: (context, avatar) =>
+                avatar.surfaceBuilder?.call(context) ?? const SizedBox.expand(),
+          ),
+        ),
+      );
+      await tester.pump();
+      media.release();
+      await _pumpUntil(tester, () => renderer.interruptCount == 1);
+
+      renderer.emit(
+        const AvatarRendererState(
+          connection: AvatarRendererConnection.failed,
+          failure: AvatarRendererFailure.network,
+        ),
+      );
+      renderer.interruptGate!.complete();
+      await tester.pumpAndSettle();
+
+      expect(renderer.sends, isEmpty);
+      expect(nativePlayer.events, <String>[
+        'start',
+        'append:4',
+        'append:4',
+        'finish',
+      ]);
+    },
+  );
+
   testWidgets('keeps a loaded avatar surface visible after a disconnect', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

- 修复正式练习的实时题目语音绕过 AvatarKit、数字人有画面但嘴型不动的问题。
- Avatar 可用时，整段 PCM 只交给 AvatarKit；Avatar 不可用时，整段只交给原生播放器，禁止同一 utterance 双路播放。
- 覆盖初始题、回答后的下一题、重播与用户中断；Avatar 首次准备失败时保留现有静态角色/IELTS 考官图和原生语音，已加载画面断连后不立即变成空白。

## 实现思路

- 在 Practice 层增加 utterance 级 PCM sink 边界，由会话协调器在首个 PCM 真正开始前一次性选定 Avatar 或原生输出。
- AvatarController 流式接收原始 PCM16 24 kHz 单声道数据，缓存一个 chunk，使最后一个非空 SDK send 使用 end=true；中断、关闭和失败都通过 generation fence 清理尾包。
- Avatar 在首个 PCM 发出前断连时只走原生输出；一旦 Avatar 启动成功，流式发送失败也不会在同一 utterance 中途切换原生播放器，避免重音和竞态。
- 正式启用 Avatar 时由 PracticeAvatarSession 统一触发题目语音；显式禁用 Avatar 的模拟器/非 Avatar 组合仍保留原生自动播放。
- 诊断只记录路由、格式、chunk/字节计数和稳定失败类型，不记录音频内容、题目文本、token 或密钥。
- 实时流自然结束后不再重复等待 StreamIterator.cancel，避免上一题清理拖住下一题。

## 测试方式

1. `cd mobile && flutter test --no-pub test/main_wiring_test.dart test/coaching/practice/scenario_practice_session_test.dart test/coaching/practice/avatar/avatar_controller_test.dart`
   - 预期：22 项通过；验证场景/IELTS 初始题、下一题、重播、prepare 失败静态兜底、首 PCM 前断连原生兜底、断连保留 surface、end 标志、发送失败和 interrupt fence。
2. `cd mobile && flutter analyze --no-pub`
   - 预期：No issues found。
3. `cd mobile && flutter test --no-pub`
   - 预期：762 项全部通过。
4. `cd mobile && flutter build apk --debug --flavor production --target-platform android-arm64`
   - 预期：成功生成 production arm64 debug APK。
5. 合并前请在 Android 真机进入任一正式情景练习和 IELTS Part 1：确认问题有声、嘴型随声音运动；回答进入下一题并重播；说话中点击录音可立即中断，且无双声。

## 相关 Issue / 备注

Closes #906

- 对照 AvatarKit 官方 SDK Mode、Flutter Quickstart 和 API Reference，实时输入必须是配置一致的 mono PCM16，末个非空 chunk 使用 end=true，用户抢话调用 interrupt。
- iOS Simulator + 真实本地后端用例已成功注册、创建并进入 IELTS Part 1，且生成练习页截图；该仓库用例随后在本 Issue 验收之后的既有后置步骤“提前结束会话后返回练习中心”超时，因此未将整条集成用例标为通过，也未在本 PR 扩范围修改导航。
- 真正的嘴型同步仍需 Android 真机连接 AvatarKit 做最终人工验收；本 PR 没有猜测或修改供应商参数。

## AI 辅助说明

使用 Codex 审查现有 Practice/Avatar 生命周期、对照官方资料、实现最小路由改动并生成回归测试。已人工逐项核对输出唯一性、PCM 所有权、generation fence、失败兜底、隐私日志和 diff 范围，能够解释全部改动。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
