### PR TITLE
feat(observability): 统一外部服务调用与用量指标

### DIFF
--- a/server/cmd/server/agent_image_storage.go
+++ b/server/cmd/server/agent_image_storage.go
@@ -5,15 +5,18 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 func newAgentImageStore(
 	ctx context.Context,
 	storageConfig config.ObjectStorageConfig,
+	observer providerobservability.Recorder,
 ) (objectstore.Store, error) {
 	return newProtectedObjectStore(
 		ctx,
 		storageConfig,
 		storageConfig.ImagePrefix,
+		observer,
 	)
 }

--- a/server/cmd/server/interview_resume.go
+++ b/server/cmd/server/interview_resume.go
@@ -12,6 +12,7 @@ import (
 	resumefieldextractor "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/interviewresume/fieldextractor"
 	resumeparser "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/interviewresume/parser"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/paddleocr"
 )
 
@@ -20,6 +21,8 @@ func buildInterviewResumeConfiguration(
 	storageConfig config.ObjectStorageConfig,
 	textConfig config.TextGenerationConfig,
 	ocrConfig config.ResumeOCRConfig,
+	providerFactory *app.ProviderFactory,
+	providerObserver providerobservability.Recorder,
 ) (*app.InterviewResumeConfiguration, error) {
 	if !storageConfig.Enabled {
 		if ocrConfig.Enabled {
@@ -27,7 +30,7 @@ func buildInterviewResumeConfiguration(
 		}
 		return nil, nil
 	}
-	generator, err := app.NewResumeFieldGenerator(textConfig)
+	generator, err := providerFactory.ResumeFieldGenerator(textConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -46,6 +49,7 @@ func buildInterviewResumeConfiguration(
 		client, clientErr := paddleocr.New(paddleocr.Config{
 			AccessToken: ocrConfig.AccessToken, BaseURL: ocrConfig.BaseURL,
 			Model: ocrConfig.Model, Timeout: ocrConfig.Timeout,
+			Observer: providerObserver,
 		})
 		if clientErr != nil {
 			return nil, clientErr
@@ -66,7 +70,7 @@ func buildInterviewResumeConfiguration(
 		return nil, err
 	}
 	store, err := newProtectedObjectStore(
-		ctx, storageConfig, storageConfig.ResumePrefix,
+		ctx, storageConfig, storageConfig.ResumePrefix, providerObserver,
 	)
 	if err != nil {
 		return nil, err

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -333,7 +333,7 @@ func run() int {
 		}
 		acousticProviderTimeout = iseConfig.Timeout
 		acousticEvaluator, err =
-			app.NewEvaluationAcousticEvaluator(
+			providerFactory.EvaluationAcousticEvaluator(
 				databasePool.Native(),
 				recordingStore,
 				iseConfig,
@@ -474,6 +474,7 @@ func run() int {
 		avatarProvider, err = spatius.NewClient(spatius.Config{
 			Enabled: true, ConsoleBaseURL: spatiusConfig.ConsoleBaseURL,
 			APIKey: spatiusConfig.APIKey.Reveal(), Timeout: spatiusConfig.Timeout,
+			Observer: providerObserver,
 		})
 		if err != nil {
 			logger.Error("Practice avatar provider startup failed")

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -27,7 +27,9 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/logging"
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/spatius"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -53,6 +55,17 @@ func run() int {
 	cfg := config.Load()
 	logger := logging.New(cfg.LogLevel)
 	slog.SetDefault(logger)
+	metricsRegistry := prometheus.NewRegistry()
+	providerObserver, err := providerobservability.New(metricsRegistry)
+	if err != nil {
+		logger.Error("provider observability startup failed")
+		return 1
+	}
+	providerFactory, err := app.NewProviderFactory(providerObserver)
+	if err != nil {
+		logger.Error("provider composition startup failed")
+		return 1
+	}
 	textConfig, err := config.LoadTextGeneration()
 	if err != nil {
 		logger.Error("text generation configuration failed")
@@ -63,25 +76,25 @@ func run() int {
 		logger.Error("Agent Run configuration failed")
 		return 1
 	}
-	modelProviders, err := app.NewAgentModelProviders(textConfig)
+	modelProviders, err := providerFactory.AgentModelProviders(textConfig)
 	if err != nil {
 		logger.Error("text generation startup failed")
 		return 1
 	}
 	preparationJobTargets, err :=
-		app.NewPreparationJobTargetGenerator(textConfig)
+		providerFactory.PreparationJobTargetGenerator(textConfig)
 	if err != nil {
 		logger.Error("Preparation job target generation startup failed")
 		return 1
 	}
 	evaluationScoringGenerator, err :=
-		app.NewEvaluationScoringGenerator(textConfig)
+		providerFactory.EvaluationScoringGenerator(textConfig)
 	if err != nil {
 		logger.Error("evaluation scoring startup failed")
 		return 1
 	}
 	evaluationSpeechFeedbackGenerator, err :=
-		app.NewEvaluationSpeechFeedbackGenerator(textConfig)
+		providerFactory.EvaluationSpeechFeedbackGenerator(textConfig)
 	if err != nil {
 		logger.Error("evaluation speech feedback startup failed")
 		return 1
@@ -96,38 +109,38 @@ func run() int {
 		logger.Error("speech synthesis configuration failed")
 		return 1
 	}
-	recognizer, err := app.NewAgentSpeechRecognizer(asrConfig)
+	recognizer, err := providerFactory.AgentSpeechRecognizer(asrConfig)
 	if err != nil {
 		logger.Error("speech recognition startup failed")
 		return 1
 	}
-	synthesizer, err := app.NewAgentSpeechSynthesizer(ttsConfig)
+	synthesizer, err := providerFactory.AgentSpeechSynthesizer(ttsConfig)
 	if err != nil {
 		logger.Error("speech synthesis startup failed")
 		return 1
 	}
-	practiceRecognizer, err := app.NewPracticeSpeechRecognizer(asrConfig)
+	practiceRecognizer, err := providerFactory.PracticeSpeechRecognizer(asrConfig)
 	if err != nil {
 		logger.Error("Practice speech recognition startup failed")
 		return 1
 	}
 	practiceRecordedRecognizer, err :=
-		app.NewPracticeRecordedSpeechRecognizer(asrConfig)
+		providerFactory.PracticeRecordedSpeechRecognizer(asrConfig)
 	if err != nil {
 		logger.Error("recorded Practice speech recognition startup failed")
 		return 1
 	}
-	practiceSynthesizer, err := app.NewPracticeSpeechSynthesizer(ttsConfig)
+	practiceSynthesizer, err := providerFactory.PracticeSpeechSynthesizer(ttsConfig)
 	if err != nil {
 		logger.Error("Practice speech synthesis startup failed")
 		return 1
 	}
-	practiceQuestions, err := app.NewPracticeQuestionGenerator(textConfig)
+	practiceQuestions, err := providerFactory.PracticeQuestionGenerator(textConfig)
 	if err != nil {
 		logger.Error("Practice question generation startup failed")
 		return 1
 	}
-	practiceAnswerTips, err := app.NewPracticeAnswerTipGenerator(textConfig)
+	practiceAnswerTips, err := providerFactory.PracticeAnswerTipGenerator(textConfig)
 	if err != nil {
 		logger.Error("Practice answer Tip generation startup failed")
 		return 1
@@ -229,7 +242,7 @@ func run() int {
 		logger.Error("IELTS speech HTTP startup failed")
 		return 1
 	}
-	ieltsAnswerGenerator, err := app.NewIELTSAnswerGenerator(textConfig)
+	ieltsAnswerGenerator, err := providerFactory.IELTSAnswerGenerator(textConfig)
 	if err != nil {
 		logger.Error("IELTS answer generator startup failed", slog.String("error_kind", "dependency"))
 		return 1
@@ -250,6 +263,8 @@ func run() int {
 		storageConfig,
 		textConfig,
 		resumeOCRConfig,
+		providerFactory,
+		providerObserver,
 	)
 	if err != nil {
 		logger.Error(
@@ -269,6 +284,7 @@ func run() int {
 			ctx,
 			storageConfig,
 			storageConfig.AudioPrefix,
+			providerObserver,
 		)
 		if err != nil {
 			logger.Error(
@@ -277,7 +293,11 @@ func run() int {
 			)
 			return 1
 		}
-		imageStore, err = newAgentImageStore(ctx, storageConfig)
+		imageStore, err = newAgentImageStore(
+			ctx,
+			storageConfig,
+			providerObserver,
+		)
 		if err != nil {
 			logger.Error(
 				"image object storage startup failed",
@@ -564,9 +584,10 @@ func run() int {
 		evaluationWorkers.Run(ctx)
 	}()
 
-	router, metricsHandler := app.NewObservableRouterWithReadinessAndRoutes(
+	router, metricsHandler, err := app.NewObservableRouterWithRegistry(
 		logger,
 		databasePool,
+		metricsRegistry,
 		[]app.RouteRegistrar{
 			applicationComposition.IdentityModule(),
 			applicationComposition.AgentModule(),
@@ -575,6 +596,10 @@ func run() int {
 		preparation.New(),
 		practice.New(),
 	)
+	if err != nil {
+		logger.Error("HTTP observability startup failed")
+		return 1
+	}
 	app.RegisterSceneCatalog(router, sceneCatalog)
 	app.RegisterIELTSQuestionBank(router, ieltsQuestionBank)
 

--- a/server/cmd/server/object_storage.go
+++ b/server/cmd/server/object_storage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore/kodostore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore/ossstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 type protectedObjectStore interface {
@@ -20,6 +21,7 @@ func newProtectedObjectStore(
 	ctx context.Context,
 	storageConfig config.ObjectStorageConfig,
 	prefix string,
+	observer providerobservability.Recorder,
 ) (protectedObjectStore, error) {
 	switch storageConfig.Provider {
 	case "", config.ObjectStorageProviderAliyunOSS:
@@ -27,9 +29,13 @@ func newProtectedObjectStore(
 		if err != nil {
 			return nil, err
 		}
-		return ossstore.NewForPrefix(ctx, storageConfig, prefix, provider)
+		return ossstore.NewForPrefixObserved(
+			ctx, storageConfig, prefix, provider, observer,
+		)
 	case config.ObjectStorageProviderQiniuKodo:
-		return kodostore.NewForPrefix(ctx, storageConfig, prefix)
+		return kodostore.NewForPrefixObserved(
+			ctx, storageConfig, prefix, observer,
+		)
 	default:
 		return nil, errors.New("object storage provider is not registered")
 	}

--- a/server/internal/app/ai_acoustic.go
+++ b/server/internal/app/ai_acoustic.go
@@ -10,6 +10,7 @@ import (
 	mediapostgres "github.com/1024XEngineer/XE3-ESL/server/internal/media/postgres"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/xfyun"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -19,6 +20,25 @@ func NewEvaluationAcousticEvaluator(
 	store objectstore.Store,
 	configuration config.ISEConfig,
 ) (evaluation.AcousticEvaluator, error) {
+	return newEvaluationAcousticEvaluator(database, store, configuration, nil)
+}
+
+func (factory *ProviderFactory) EvaluationAcousticEvaluator(
+	database *pgxpool.Pool,
+	store objectstore.Store,
+	configuration config.ISEConfig,
+) (evaluation.AcousticEvaluator, error) {
+	return newEvaluationAcousticEvaluator(
+		database, store, configuration, factory.observer,
+	)
+}
+
+func newEvaluationAcousticEvaluator(
+	database *pgxpool.Pool,
+	store objectstore.Store,
+	configuration config.ISEConfig,
+	observer providerobservability.Recorder,
+) (evaluation.AcousticEvaluator, error) {
 	if database == nil || store == nil {
 		return nil, errors.New("bootstrap: Evaluation acoustic dependencies are required")
 	}
@@ -26,6 +46,7 @@ func NewEvaluationAcousticEvaluator(
 		xfyun.ISEConfig{
 			Endpoint: configuration.Endpoint,
 			Timeout:  configuration.Timeout,
+			Observer: observer,
 		},
 		configuration.AppID.Reveal(),
 		configuration.APIKey.Reveal(),

--- a/server/internal/app/ai_speech.go
+++ b/server/internal/app/ai_speech.go
@@ -7,6 +7,7 @@ import (
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
 	practiceinteraction "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/interaction"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
 )
 
@@ -19,6 +20,19 @@ type AgentSpeechSynthesizer interface {
 func NewAgentSpeechRecognizer(
 	configuration config.SpeechRecognitionConfig,
 ) (agentvoice.StreamingSpeechRecognizer, error) {
+	return newAgentSpeechRecognizer(configuration, nil)
+}
+
+func (factory *ProviderFactory) AgentSpeechRecognizer(
+	configuration config.SpeechRecognitionConfig,
+) (agentvoice.StreamingSpeechRecognizer, error) {
+	return newAgentSpeechRecognizer(configuration, factory.observer)
+}
+
+func newAgentSpeechRecognizer(
+	configuration config.SpeechRecognitionConfig,
+	observer providerobservability.Recorder,
+) (agentvoice.StreamingSpeechRecognizer, error) {
 	if configuration.Provider != config.SpeechProviderQianwen {
 		return nil, errors.New(
 			"bootstrap: speech recognition provider is not registered",
@@ -26,9 +40,10 @@ func NewAgentSpeechRecognizer(
 	}
 	return qianwen.NewAgentVoiceRecognizer(
 		qianwen.ASRConfig{
-			BaseURL: configuration.BaseURL,
-			Model:   configuration.Model,
-			Timeout: configuration.Timeout,
+			BaseURL:  configuration.BaseURL,
+			Model:    configuration.Model,
+			Timeout:  configuration.Timeout,
+			Observer: observer,
 		},
 		configuration.APIKey.Reveal(),
 	)
@@ -37,6 +52,19 @@ func NewAgentSpeechRecognizer(
 // NewAgentSpeechSynthesizer selects the Agent Voice TTS implementation.
 func NewAgentSpeechSynthesizer(
 	configuration config.SpeechSynthesisConfig,
+) (AgentSpeechSynthesizer, error) {
+	return newAgentSpeechSynthesizer(configuration, nil)
+}
+
+func (factory *ProviderFactory) AgentSpeechSynthesizer(
+	configuration config.SpeechSynthesisConfig,
+) (AgentSpeechSynthesizer, error) {
+	return newAgentSpeechSynthesizer(configuration, factory.observer)
+}
+
+func newAgentSpeechSynthesizer(
+	configuration config.SpeechSynthesisConfig,
+	observer providerobservability.Recorder,
 ) (AgentSpeechSynthesizer, error) {
 	if configuration.Provider != config.SpeechProviderQianwen {
 		return nil, errors.New(
@@ -51,6 +79,7 @@ func NewAgentSpeechSynthesizer(
 			LanguageHint:  configuration.LanguageHint,
 			Timeout:       configuration.Timeout,
 			TempDirectory: configuration.TempDirectory,
+			Observer:      observer,
 		},
 		configuration.APIKey.Reveal(),
 	)
@@ -60,6 +89,19 @@ func NewAgentSpeechSynthesizer(
 func NewPracticeSpeechRecognizer(
 	configuration config.SpeechRecognitionConfig,
 ) (practiceinteraction.SpeechRecognizer, error) {
+	return newPracticeSpeechRecognizer(configuration, nil)
+}
+
+func (factory *ProviderFactory) PracticeSpeechRecognizer(
+	configuration config.SpeechRecognitionConfig,
+) (practiceinteraction.SpeechRecognizer, error) {
+	return newPracticeSpeechRecognizer(configuration, factory.observer)
+}
+
+func newPracticeSpeechRecognizer(
+	configuration config.SpeechRecognitionConfig,
+	observer providerobservability.Recorder,
+) (practiceinteraction.SpeechRecognizer, error) {
 	if configuration.Provider != config.SpeechProviderQianwen {
 		return nil, errors.New(
 			"bootstrap: Practice speech recognition provider is not registered",
@@ -67,9 +109,10 @@ func NewPracticeSpeechRecognizer(
 	}
 	return qianwen.NewPracticeVoiceRecognizer(
 		qianwen.ASRConfig{
-			BaseURL: configuration.BaseURL,
-			Model:   configuration.Model,
-			Timeout: configuration.Timeout,
+			BaseURL:  configuration.BaseURL,
+			Model:    configuration.Model,
+			Timeout:  configuration.Timeout,
+			Observer: observer,
 		},
 		configuration.APIKey.Reveal(),
 	)
@@ -80,6 +123,19 @@ func NewPracticeSpeechRecognizer(
 func NewPracticeRecordedSpeechRecognizer(
 	configuration config.SpeechRecognitionConfig,
 ) (practiceinteraction.SpeechRecognizer, error) {
+	return newPracticeRecordedSpeechRecognizer(configuration, nil)
+}
+
+func (factory *ProviderFactory) PracticeRecordedSpeechRecognizer(
+	configuration config.SpeechRecognitionConfig,
+) (practiceinteraction.SpeechRecognizer, error) {
+	return newPracticeRecordedSpeechRecognizer(configuration, factory.observer)
+}
+
+func newPracticeRecordedSpeechRecognizer(
+	configuration config.SpeechRecognitionConfig,
+	observer providerobservability.Recorder,
+) (practiceinteraction.SpeechRecognizer, error) {
 	if configuration.Provider != config.SpeechProviderQianwen {
 		return nil, errors.New(
 			"bootstrap: recorded Practice speech recognition provider is not registered",
@@ -87,9 +143,10 @@ func NewPracticeRecordedSpeechRecognizer(
 	}
 	return qianwen.NewPracticeRecordedVoiceRecognizer(
 		qianwen.ASRConfig{
-			BaseURL: configuration.BaseURL,
-			Model:   configuration.RecordedModel,
-			Timeout: configuration.RecordedTimeout,
+			BaseURL:  configuration.BaseURL,
+			Model:    configuration.RecordedModel,
+			Timeout:  configuration.RecordedTimeout,
+			Observer: observer,
 		},
 		configuration.APIKey.Reveal(),
 	)
@@ -98,6 +155,19 @@ func NewPracticeRecordedSpeechRecognizer(
 // NewPracticeSpeechSynthesizer selects the Practice Voice TTS adapter.
 func NewPracticeSpeechSynthesizer(
 	configuration config.SpeechSynthesisConfig,
+) (practiceinteraction.SpeechSynthesizer, error) {
+	return newPracticeSpeechSynthesizer(configuration, nil)
+}
+
+func (factory *ProviderFactory) PracticeSpeechSynthesizer(
+	configuration config.SpeechSynthesisConfig,
+) (practiceinteraction.SpeechSynthesizer, error) {
+	return newPracticeSpeechSynthesizer(configuration, factory.observer)
+}
+
+func newPracticeSpeechSynthesizer(
+	configuration config.SpeechSynthesisConfig,
+	observer providerobservability.Recorder,
 ) (practiceinteraction.SpeechSynthesizer, error) {
 	if configuration.Provider != config.SpeechProviderQianwen {
 		return nil, errors.New(
@@ -112,6 +182,7 @@ func NewPracticeSpeechSynthesizer(
 			LanguageHint:  configuration.LanguageHint,
 			Timeout:       configuration.Timeout,
 			TempDirectory: configuration.TempDirectory,
+			Observer:      observer,
 		},
 		configuration.APIKey.Reveal(),
 	)

--- a/server/internal/app/ai_text.go
+++ b/server/internal/app/ai_text.go
@@ -13,6 +13,7 @@ import (
 	preparationagentcapability "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/agentcapability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/interviewresume/fieldextractor"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
 	sharedtranslation "github.com/1024XEngineer/XE3-ESL/server/internal/translation"
 )
@@ -26,10 +27,39 @@ type AgentModelProviders struct {
 	PracticeTurnIntent preparationagentcapability.PracticeTurnIntentGenerator
 }
 
+// ProviderFactory supplies one required service-level observer to every
+// production provider adapter. Direct constructors remain available for
+// deterministic tests and non-serving tools.
+type ProviderFactory struct {
+	observer providerobservability.Recorder
+}
+
+func NewProviderFactory(
+	observer providerobservability.Recorder,
+) (*ProviderFactory, error) {
+	if observer == nil {
+		return nil, errors.New("bootstrap: provider observer is required")
+	}
+	return &ProviderFactory{observer: observer}, nil
+}
+
 func NewAgentModelProviders(
 	configuration config.TextGenerationConfig,
 ) (AgentModelProviders, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newAgentModelProviders(configuration, nil)
+}
+
+func (factory *ProviderFactory) AgentModelProviders(
+	configuration config.TextGenerationConfig,
+) (AgentModelProviders, error) {
+	return newAgentModelProviders(configuration, factory.observer)
+}
+
+func newAgentModelProviders(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (AgentModelProviders, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return AgentModelProviders{}, err
 	}
@@ -63,7 +93,20 @@ func NewAgentModelProviders(
 func NewPreparationJobTargetGenerator(
 	configuration config.TextGenerationConfig,
 ) (preparation.JobTargetGenerator, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newPreparationJobTargetGenerator(configuration, nil)
+}
+
+func (factory *ProviderFactory) PreparationJobTargetGenerator(
+	configuration config.TextGenerationConfig,
+) (preparation.JobTargetGenerator, error) {
+	return newPreparationJobTargetGenerator(configuration, factory.observer)
+}
+
+func newPreparationJobTargetGenerator(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (preparation.JobTargetGenerator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +116,20 @@ func NewPreparationJobTargetGenerator(
 func NewIELTSAnswerGenerator(
 	configuration config.TextGenerationConfig,
 ) (ielts.AnswerGenerator, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newIELTSAnswerGenerator(configuration, nil)
+}
+
+func (factory *ProviderFactory) IELTSAnswerGenerator(
+	configuration config.TextGenerationConfig,
+) (ielts.AnswerGenerator, error) {
+	return newIELTSAnswerGenerator(configuration, factory.observer)
+}
+
+func newIELTSAnswerGenerator(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (ielts.AnswerGenerator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +139,20 @@ func NewIELTSAnswerGenerator(
 func NewEvaluationScoringGenerator(
 	configuration config.TextGenerationConfig,
 ) (textgeneration.Generator, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newEvaluationScoringGenerator(configuration, nil)
+}
+
+func (factory *ProviderFactory) EvaluationScoringGenerator(
+	configuration config.TextGenerationConfig,
+) (textgeneration.Generator, error) {
+	return newEvaluationScoringGenerator(configuration, factory.observer)
+}
+
+func newEvaluationScoringGenerator(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (textgeneration.Generator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +163,20 @@ func NewEvaluationScoringGenerator(
 func NewEvaluationSpeechFeedbackGenerator(
 	configuration config.TextGenerationConfig,
 ) (speechfeedback.TextGenerator, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newEvaluationSpeechFeedbackGenerator(configuration, nil)
+}
+
+func (factory *ProviderFactory) EvaluationSpeechFeedbackGenerator(
+	configuration config.TextGenerationConfig,
+) (speechfeedback.TextGenerator, error) {
+	return newEvaluationSpeechFeedbackGenerator(configuration, factory.observer)
+}
+
+func newEvaluationSpeechFeedbackGenerator(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (speechfeedback.TextGenerator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +187,20 @@ func NewEvaluationSpeechFeedbackGenerator(
 func NewResumeFieldGenerator(
 	configuration config.TextGenerationConfig,
 ) (fieldextractor.Generator, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newResumeFieldGenerator(configuration, nil)
+}
+
+func (factory *ProviderFactory) ResumeFieldGenerator(
+	configuration config.TextGenerationConfig,
+) (fieldextractor.Generator, error) {
+	return newResumeFieldGenerator(configuration, factory.observer)
+}
+
+func newResumeFieldGenerator(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (fieldextractor.Generator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +215,20 @@ func NewResumeFieldGenerator(
 func NewPracticeQuestionGenerator(
 	configuration config.TextGenerationConfig,
 ) (practiceinteraction.QuestionGenerator, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newPracticeQuestionGenerator(configuration, nil)
+}
+
+func (factory *ProviderFactory) PracticeQuestionGenerator(
+	configuration config.TextGenerationConfig,
+) (practiceinteraction.QuestionGenerator, error) {
+	return newPracticeQuestionGenerator(configuration, factory.observer)
+}
+
+func newPracticeQuestionGenerator(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (practiceinteraction.QuestionGenerator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +239,20 @@ func NewPracticeQuestionGenerator(
 func NewPracticeAnswerTipGenerator(
 	configuration config.TextGenerationConfig,
 ) (practiceinteraction.AnswerTipGenerator, error) {
-	providerConfig, apiKey, err := textProvider(configuration)
+	return newPracticeAnswerTipGenerator(configuration, nil)
+}
+
+func (factory *ProviderFactory) PracticeAnswerTipGenerator(
+	configuration config.TextGenerationConfig,
+) (practiceinteraction.AnswerTipGenerator, error) {
+	return newPracticeAnswerTipGenerator(configuration, factory.observer)
+}
+
+func newPracticeAnswerTipGenerator(
+	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
+) (practiceinteraction.AnswerTipGenerator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, observer)
 	if err != nil {
 		return nil, err
 	}
@@ -140,6 +261,7 @@ func NewPracticeAnswerTipGenerator(
 
 func textProvider(
 	configuration config.TextGenerationConfig,
+	observer providerobservability.Recorder,
 ) (qianwen.TextConfig, string, error) {
 	if configuration.Provider != config.TextProviderQianwen &&
 		configuration.Provider != config.TextProviderQiniu {
@@ -153,5 +275,6 @@ func textProvider(
 		Model:           configuration.Model,
 		Timeout:         configuration.Timeout,
 		MaxOutputTokens: configuration.MaxOutputTokens,
+		Observer:        observer,
 	}, configuration.APIKey.Reveal(), nil
 }

--- a/server/internal/app/router.go
+++ b/server/internal/app/router.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/apperror"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/httpobservability"
@@ -71,15 +72,49 @@ func NewObservableRouterWithReadinessAndRoutes(
 	return newRouter(logger, readiness, routes, modules...)
 }
 
+// NewObservableRouterWithRegistry mounts HTTP metrics in the same service
+// registry already used by provider instrumentation.
+func NewObservableRouterWithRegistry(
+	logger *slog.Logger,
+	readiness ReadinessChecker,
+	registry *prometheus.Registry,
+	routes []RouteRegistrar,
+	modules ...Module,
+) (*gin.Engine, http.Handler, error) {
+	observer, err := httpobservability.NewWithRegistry(logger, registry)
+	if err != nil {
+		return nil, nil, err
+	}
+	router, metrics := buildRouter(
+		logger, readiness, routes, observer, modules...,
+	)
+	return router, metrics, nil
+}
+
 func newRouter(
 	logger *slog.Logger,
 	readiness ReadinessChecker,
 	routes []RouteRegistrar,
 	modules ...Module,
 ) (*gin.Engine, http.Handler) {
+	return buildRouter(
+		logger,
+		readiness,
+		routes,
+		httpobservability.New(logger),
+		modules...,
+	)
+}
+
+func buildRouter(
+	logger *slog.Logger,
+	readiness ReadinessChecker,
+	routes []RouteRegistrar,
+	observer *httpobservability.Observer,
+	modules ...Module,
+) (*gin.Engine, http.Handler) {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
-	observer := httpobservability.New(logger)
 	router.Use(observer.Middleware(), gin.RecoveryWithWriter(io.Discard))
 	errorRenderer := httpresponse.NewRenderer(nil)
 

--- a/server/internal/app/router_test.go
+++ b/server/internal/app/router_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/app"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type readinessChecker func(context.Context) error
@@ -378,6 +380,41 @@ func TestDynamicPathUsesRouteTemplateInLogAndMetrics(t *testing.T) {
 		`speakup_http_server_request_duration_seconds_count{method="GET",route="/users/:user_id"} 1`,
 	) {
 		t.Fatalf("metrics missing templated duration histogram: %s", metricsOutput)
+	}
+}
+
+func TestSharedRegistryExportsHTTPAndProviderMetricsFromOneHandler(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	providerObserver, err := providerobservability.New(registry)
+	if err != nil {
+		t.Fatalf("provider observability: %v", err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router, metrics, err := app.NewObservableRouterWithRegistry(
+		logger,
+		nil,
+		registry,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewObservableRouterWithRegistry: %v", err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/health", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	providerObserver.Record(providerobservability.Observation{
+		Provider:   providerobservability.ProviderQianwen,
+		Capability: providerobservability.CapabilityTextGeneration,
+		ErrorKind:  providerobservability.ErrorNone,
+	})
+	output := scrapeMetrics(t, metrics)
+	for _, name := range []string{
+		"speakup_http_server_requests_total",
+		"speakup_provider_calls_total",
+	} {
+		if !strings.Contains(output, name) {
+			t.Fatalf("shared metrics endpoint missing %q: %s", name, output)
+		}
 	}
 }
 

--- a/server/internal/platform/httpobservability/http.go
+++ b/server/internal/platform/httpobservability/http.go
@@ -4,6 +4,8 @@ package httpobservability
 
 import (
 	"crypto/rand"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -32,6 +34,23 @@ type Observer struct {
 
 // New creates an Observer backed by a private Prometheus registry.
 func New(logger *slog.Logger) *Observer {
+	registry := prometheus.NewRegistry()
+	observer, err := NewWithRegistry(logger, registry)
+	if err != nil {
+		panic(err)
+	}
+	return observer
+}
+
+// NewWithRegistry registers HTTP metrics in the service-level registry shared
+// with external-provider metrics.
+func NewWithRegistry(
+	logger *slog.Logger,
+	registry *prometheus.Registry,
+) (*Observer, error) {
+	if registry == nil {
+		return nil, errors.New("http observability registry is required")
+	}
 	requests := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "speakup",
@@ -50,15 +69,20 @@ func New(logger *slog.Logger) *Observer {
 		},
 		[]string{"method", "route"},
 	)
-	registry := prometheus.NewRegistry()
-	registry.MustRegister(requests, requestDuration)
+	if err := registry.Register(requests); err != nil {
+		return nil, fmt.Errorf("register HTTP request metrics: %w", err)
+	}
+	if err := registry.Register(requestDuration); err != nil {
+		registry.Unregister(requests)
+		return nil, fmt.Errorf("register HTTP duration metrics: %w", err)
+	}
 
 	return &Observer{
 		logger:          logger,
 		requests:        requests,
 		requestDuration: requestDuration,
 		metricsHandler:  metricsMux(registry),
-	}
+	}, nil
 }
 
 // Middleware correlates, logs, and measures each request without retaining

--- a/server/internal/platform/objectstore/kodostore/client.go
+++ b/server/internal/platform/objectstore/kodostore/client.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 const maxSignedURLTTL = 2 * time.Minute
@@ -52,6 +53,7 @@ type Client struct {
 	prefix       string
 	signedURLTTL time.Duration
 	now          func() time.Time
+	observer     providerobservability.Recorder
 }
 
 func New(ctx context.Context, storageConfig config.ObjectStorageConfig) (*Client, error) {
@@ -117,6 +119,25 @@ func NewForPrefix(
 	return client, nil
 }
 
+// NewForPrefixObserved creates a production client using the service-level
+// provider observer.
+func NewForPrefixObserved(
+	ctx context.Context,
+	storageConfig config.ObjectStorageConfig,
+	prefix string,
+	observer providerobservability.Recorder,
+) (*Client, error) {
+	if observer == nil {
+		return nil, errors.New("Kodo provider observer is required")
+	}
+	client, err := NewForPrefix(ctx, storageConfig, prefix)
+	if err != nil {
+		return nil, err
+	}
+	client.observer = observer
+	return client, nil
+}
+
 func (client *Client) Preflight(ctx context.Context) error {
 	if client == nil || client.api == nil || ctx == nil {
 		return objectstore.ErrOperationFailed
@@ -150,7 +171,7 @@ func bucketHasPublicGrant(grants []types.Grant) bool {
 func (client *Client) Put(
 	ctx context.Context,
 	request objectstore.PutRequest,
-) (objectstore.PutResult, error) {
+) (callResult objectstore.PutResult, callErr error) {
 	if client == nil || client.api == nil || ctx == nil {
 		return objectstore.PutResult{}, objectstore.ErrOperationFailed
 	}
@@ -167,6 +188,18 @@ func (client *Client) Put(
 		return objectstore.PutResult{}, objectstore.ErrInvalidObject
 	}
 	defer func() { _, _ = request.Body.Seek(startOffset, io.SeekStart) }()
+	startedAt := time.Now()
+	storedBytes := int64(0)
+	defer func() {
+		objectstore.RecordProviderCall(
+			client.observer,
+			providerobservability.ProviderQiniuKodo,
+			providerobservability.CapabilityObjectPut,
+			startedAt,
+			callErr,
+			storedBytes,
+		)
+	}()
 
 	existing, found, err := client.findExisting(ctx, request)
 	if err != nil {
@@ -190,6 +223,12 @@ func (client *Client) Put(
 		Metadata:      map[string]string{"sha256": request.ChecksumSHA256},
 	})
 	if err != nil {
+		if client.observer != nil {
+			client.observer.RecordRetry(
+				providerobservability.ProviderQiniuKodo,
+				providerobservability.CapabilityObjectPut,
+			)
+		}
 		if existing, matches := client.reconcileExisting(ctx, request); matches {
 			return existing, nil
 		}
@@ -198,6 +237,7 @@ func (client *Client) Put(
 	if result == nil || strings.Trim(aws.ToString(result.ETag), "\"") == "" {
 		return objectstore.PutResult{}, objectstore.ErrOperationFailed
 	}
+	storedBytes = request.Size
 	return objectstore.PutResult{ETag: strings.Trim(aws.ToString(result.ETag), "\"")}, nil
 }
 
@@ -266,7 +306,7 @@ func metadataValue(metadata map[string]string, key string) string {
 func (client *Client) SignedGet(
 	ctx context.Context,
 	key string,
-) (objectstore.SignedGetResult, error) {
+) (callResult objectstore.SignedGetResult, callErr error) {
 	if client == nil || client.presigner == nil || ctx == nil {
 		return objectstore.SignedGetResult{}, objectstore.ErrOperationFailed
 	}
@@ -276,6 +316,17 @@ func (client *Client) SignedGet(
 	if client.signedURLTTL <= 0 || client.signedURLTTL > maxSignedURLTTL {
 		return objectstore.SignedGetResult{}, objectstore.ErrInvalidTTL
 	}
+	startedAt := time.Now()
+	defer func() {
+		objectstore.RecordProviderCall(
+			client.observer,
+			providerobservability.ProviderQiniuKodo,
+			providerobservability.CapabilityObjectSignedGet,
+			startedAt,
+			callErr,
+			0,
+		)
+	}()
 	request, err := client.presigner.PresignGetObject(
 		ctx,
 		&s3.GetObjectInput{Bucket: aws.String(client.bucket), Key: aws.String(key)},
@@ -295,13 +346,27 @@ func (client *Client) SignedGet(
 	}, nil
 }
 
-func (client *Client) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+func (client *Client) Open(
+	ctx context.Context,
+	key string,
+) (callResult io.ReadCloser, callErr error) {
 	if client == nil || client.api == nil || ctx == nil {
 		return nil, objectstore.ErrOperationFailed
 	}
 	if err := objectstore.ValidateKey(client.prefix, key); err != nil {
 		return nil, err
 	}
+	startedAt := time.Now()
+	defer func() {
+		objectstore.RecordProviderCall(
+			client.observer,
+			providerobservability.ProviderQiniuKodo,
+			providerobservability.CapabilityObjectOpen,
+			startedAt,
+			callErr,
+			0,
+		)
+	}()
 	result, err := client.api.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(client.bucket),
 		Key:    aws.String(key),
@@ -320,13 +385,24 @@ func (client *Client) Open(ctx context.Context, key string) (io.ReadCloser, erro
 	return result.Body, nil
 }
 
-func (client *Client) Delete(ctx context.Context, key string) error {
+func (client *Client) Delete(ctx context.Context, key string) (callErr error) {
 	if client == nil || client.api == nil || ctx == nil {
 		return objectstore.ErrOperationFailed
 	}
 	if err := objectstore.ValidateKey(client.prefix, key); err != nil {
 		return err
 	}
+	startedAt := time.Now()
+	defer func() {
+		objectstore.RecordProviderCall(
+			client.observer,
+			providerobservability.ProviderQiniuKodo,
+			providerobservability.CapabilityObjectDelete,
+			startedAt,
+			callErr,
+			0,
+		)
+	}()
 	_, err := client.api.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(client.bucket),
 		Key:    aws.String(key),

--- a/server/internal/platform/objectstore/kodostore/client.go
+++ b/server/internal/platform/objectstore/kodostore/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -223,12 +224,6 @@ func (client *Client) Put(
 		Metadata:      map[string]string{"sha256": request.ChecksumSHA256},
 	})
 	if err != nil {
-		if client.observer != nil {
-			client.observer.RecordRetry(
-				providerobservability.ProviderQiniuKodo,
-				providerobservability.CapabilityObjectPut,
-			)
-		}
 		if existing, matches := client.reconcileExisting(ctx, request); matches {
 			return existing, nil
 		}
@@ -306,7 +301,7 @@ func metadataValue(metadata map[string]string, key string) string {
 func (client *Client) SignedGet(
 	ctx context.Context,
 	key string,
-) (callResult objectstore.SignedGetResult, callErr error) {
+) (objectstore.SignedGetResult, error) {
 	if client == nil || client.presigner == nil || ctx == nil {
 		return objectstore.SignedGetResult{}, objectstore.ErrOperationFailed
 	}
@@ -316,17 +311,6 @@ func (client *Client) SignedGet(
 	if client.signedURLTTL <= 0 || client.signedURLTTL > maxSignedURLTTL {
 		return objectstore.SignedGetResult{}, objectstore.ErrInvalidTTL
 	}
-	startedAt := time.Now()
-	defer func() {
-		objectstore.RecordProviderCall(
-			client.observer,
-			providerobservability.ProviderQiniuKodo,
-			providerobservability.CapabilityObjectSignedGet,
-			startedAt,
-			callErr,
-			0,
-		)
-	}()
 	request, err := client.presigner.PresignGetObject(
 		ctx,
 		&s3.GetObjectInput{Bucket: aws.String(client.bucket), Key: aws.String(key)},
@@ -349,7 +333,7 @@ func (client *Client) SignedGet(
 func (client *Client) Open(
 	ctx context.Context,
 	key string,
-) (callResult io.ReadCloser, callErr error) {
+) (io.ReadCloser, error) {
 	if client == nil || client.api == nil || ctx == nil {
 		return nil, objectstore.ErrOperationFailed
 	}
@@ -357,32 +341,41 @@ func (client *Client) Open(
 		return nil, err
 	}
 	startedAt := time.Now()
-	defer func() {
+	recordFailure := func(err error) {
 		objectstore.RecordProviderCall(
 			client.observer,
 			providerobservability.ProviderQiniuKodo,
 			providerobservability.CapabilityObjectOpen,
 			startedAt,
-			callErr,
+			err,
 			0,
 		)
-	}()
+	}
 	result, err := client.api.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(client.bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return nil, safeError("get", err)
+		callErr := safeError("get", err)
+		recordFailure(callErr)
+		return nil, callErr
 	}
 	if result == nil || result.Body == nil {
+		recordFailure(objectstore.ErrOperationFailed)
 		return nil, objectstore.ErrOperationFailed
 	}
 	mediaType, _, mediaErr := mime.ParseMediaType(aws.ToString(result.ContentType))
 	if mediaErr != nil || mediaType != "application/pdf" {
 		_ = result.Body.Close()
+		recordFailure(objectstore.ErrInvalidObject)
 		return nil, objectstore.ErrInvalidObject
 	}
-	return result.Body, nil
+	return objectstore.ObserveOpenReadCloser(
+		result.Body,
+		client.observer,
+		providerobservability.ProviderQiniuKodo,
+		startedAt,
+	), nil
 }
 
 func (client *Client) Delete(ctx context.Context, key string) (callErr error) {
@@ -418,6 +411,7 @@ type OperationError struct {
 	Code      string
 	Status    int
 	RequestID string
+	cause     error
 }
 
 func (err *OperationError) Error() string {
@@ -434,18 +428,34 @@ func (err *OperationError) Error() string {
 	)
 }
 
-func (err *OperationError) Unwrap() error {
+func (err *OperationError) Unwrap() []error {
 	if err.Code == "PreconditionFailed" || err.Status == 412 {
-		return objectstore.ErrAlreadyExists
+		return []error{objectstore.ErrAlreadyExists}
 	}
-	return objectstore.ErrOperationFailed
+	causes := []error{objectstore.ErrOperationFailed}
+	if err.cause != nil {
+		causes = append(causes, err.cause)
+	}
+	return causes
+}
+
+// ProviderMetricErrorKind exposes only a bounded category, never provider
+// error text or identifiers.
+func (err *OperationError) ProviderMetricErrorKind() providerobservability.ErrorKind {
+	if err == nil {
+		return providerobservability.ErrorOperationFailed
+	}
+	return kodoMetricErrorKind(err.Code, err.Status, err.cause)
 }
 
 func safeError(operation string, err error) error {
 	if err == nil {
 		return &OperationError{Operation: operation}
 	}
-	result := &OperationError{Operation: operation}
+	result := &OperationError{
+		Operation: operation,
+		cause:     stableContextCause(err),
+	}
 	var apiError smithy.APIError
 	if errors.As(err, &apiError) {
 		result.Code = safeIdentifier(apiError.ErrorCode())
@@ -456,6 +466,58 @@ func safeError(operation string, err error) error {
 		result.RequestID = safeIdentifier(responseError.ServiceRequestID())
 	}
 	return result
+}
+
+func stableContextCause(err error) error {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return context.DeadlineExceeded
+	case errors.Is(err, context.Canceled):
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func kodoMetricErrorKind(
+	code string,
+	status int,
+	cause error,
+) providerobservability.ErrorKind {
+	switch {
+	case errors.Is(cause, context.DeadlineExceeded):
+		return providerobservability.ErrorTimeout
+	case errors.Is(cause, context.Canceled):
+		return providerobservability.ErrorCancelled
+	}
+	switch strings.ToLower(strings.TrimSpace(code)) {
+	case "preconditionfailed":
+		return providerobservability.ErrorAlreadyExists
+	case "invalidaccesskeyid", "invalidaccesskey", "signaturedoesnotmatch", "invalidtoken":
+		return providerobservability.ErrorAuthentication
+	case "accessdenied":
+		return providerobservability.ErrorAuthorization
+	case "requesttimeout":
+		return providerobservability.ErrorTimeout
+	case "toomanyrequests", "throttling", "slowdown":
+		return providerobservability.ErrorRateLimited
+	case "serviceunavailable", "internalerror":
+		return providerobservability.ErrorProviderUnavailable
+	}
+	switch {
+	case status == http.StatusUnauthorized:
+		return providerobservability.ErrorAuthentication
+	case status == http.StatusForbidden:
+		return providerobservability.ErrorAuthorization
+	case status == http.StatusRequestTimeout:
+		return providerobservability.ErrorTimeout
+	case status == http.StatusTooManyRequests:
+		return providerobservability.ErrorRateLimited
+	case status >= http.StatusInternalServerError:
+		return providerobservability.ErrorProviderUnavailable
+	default:
+		return providerobservability.ErrorOperationFailed
+	}
 }
 
 func isNotFound(err error) bool {

--- a/server/internal/platform/objectstore/kodostore/client_test.go
+++ b/server/internal/platform/objectstore/kodostore/client_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 var fixedNow = time.Date(2026, 8, 10, 10, 0, 0, 0, time.UTC)
@@ -36,6 +38,7 @@ type apiStub struct {
 	deleted    *s3.DeleteObjectInput
 	deleteErr  error
 	inspectPut func(*s3.PutObjectInput) error
+	headCall   func() (*s3.HeadObjectOutput, error)
 }
 
 func (stub *apiStub) GetBucketAcl(context.Context, *s3.GetBucketAclInput, ...func(*s3.Options)) (*s3.GetBucketAclOutput, error) {
@@ -52,6 +55,9 @@ func (stub *apiStub) PutObject(_ context.Context, input *s3.PutObjectInput, _ ..
 }
 
 func (stub *apiStub) HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	if stub.headCall != nil {
+		return stub.headCall()
+	}
 	return stub.head, stub.headErr
 }
 
@@ -109,6 +115,8 @@ func TestClientPutSignAndDelete(t *testing.T) {
 		URL: "https://s3.cn-east-1.qiniucs.com/private-bucket/" + key + "?X-Amz-Signature=signed",
 	}}
 	client := newTestClient(api, presigner)
+	recorder := &kodoProviderRecorder{}
+	client.observer = recorder
 	body := bytes.NewReader(payload)
 
 	result, err := client.Put(context.Background(), objectstore.PutRequest{
@@ -144,6 +152,18 @@ func TestClientPutSignAndDelete(t *testing.T) {
 		aws.ToString(api.deleted.Key) != key {
 		t.Fatalf("DeleteObject input = %#v", api.deleted)
 	}
+	if len(recorder.observations) != 2 {
+		t.Fatalf("local signing created a provider observation: %#v", recorder.observations)
+	}
+	for _, capability := range []providerobservability.Capability{
+		providerobservability.CapabilityObjectPut,
+		providerobservability.CapabilityObjectDelete,
+	} {
+		observation, found := recorder.find(capability)
+		if !found || observation.ErrorKind != providerobservability.ErrorNone {
+			t.Fatalf("observation for %q = %#v, found = %v", capability, observation, found)
+		}
+	}
 }
 
 func TestClientReconcilesMatchingExistingObject(t *testing.T) {
@@ -166,6 +186,119 @@ func TestClientReconcilesMatchingExistingObject(t *testing.T) {
 	})
 	if err != nil || result.ETag != "existing-etag" {
 		t.Fatalf("Put() = %#v, %v", result, err)
+	}
+}
+
+func TestClientReconcilesLostResponseAsOneLogicalCall(t *testing.T) {
+	payload := []byte("lost response")
+	digest := sha256.Sum256(payload)
+	checksum := hex.EncodeToString(digest[:])
+	headCalls := 0
+	stub := &apiStub{putErr: io.ErrUnexpectedEOF}
+	stub.headCall = func() (*s3.HeadObjectOutput, error) {
+		headCalls++
+		if headCalls == 1 {
+			return nil, &smithy.GenericAPIError{Code: "NotFound", Message: "not found"}
+		}
+		return &s3.HeadObjectOutput{
+			ContentLength: aws.Int64(int64(len(payload))),
+			ContentType:   aws.String("audio/wav"),
+			ETag:          aws.String("\"reconciled-etag\""),
+			Metadata:      map[string]string{"sha256": checksum},
+		}, nil
+	}
+	client := newTestClient(stub, &presignerStub{})
+	recorder := &kodoProviderRecorder{}
+	client.observer = recorder
+	result, err := client.Put(context.Background(), objectstore.PutRequest{
+		Key: "audio/v1/lost.wav", Body: bytes.NewReader(payload),
+		Size: int64(len(payload)), ContentType: "audio/wav",
+		ChecksumSHA256: checksum,
+	})
+	if err != nil || result.ETag != "reconciled-etag" || headCalls != 2 {
+		t.Fatalf("Put() = %#v, %v; head calls = %d", result, err, headCalls)
+	}
+	observation, found := recorder.find(providerobservability.CapabilityObjectPut)
+	if !found || len(recorder.observations) != 1 ||
+		observation.ErrorKind != providerobservability.ErrorNone ||
+		observation.Usage.Bytes != 0 {
+		t.Fatalf("observations = %#v", recorder.observations)
+	}
+}
+
+func TestClientRecordsPutOpenDeleteContextOutcome(t *testing.T) {
+	for causeName, cause := range map[string]error{
+		"cancelled": context.Canceled,
+		"timeout":   context.DeadlineExceeded,
+	} {
+		wantKind := providerobservability.ErrorCancelled
+		if errors.Is(cause, context.DeadlineExceeded) {
+			wantKind = providerobservability.ErrorTimeout
+		}
+		for operationName, capability := range map[string]providerobservability.Capability{
+			"put":    providerobservability.CapabilityObjectPut,
+			"open":   providerobservability.CapabilityObjectOpen,
+			"delete": providerobservability.CapabilityObjectDelete,
+		} {
+			t.Run(causeName+"/"+operationName, func(t *testing.T) {
+				stub := &apiStub{
+					headErr: &smithy.GenericAPIError{Code: "NotFound", Message: "not found"},
+				}
+				switch operationName {
+				case "put":
+					stub.putErr = cause
+				case "open":
+					stub.getErr = cause
+				case "delete":
+					stub.deleteErr = cause
+				}
+				client := newTestClient(stub, &presignerStub{})
+				recorder := &kodoProviderRecorder{}
+				client.observer = recorder
+				var err error
+				switch operationName {
+				case "put":
+					payload := []byte("context outcome")
+					digest := sha256.Sum256(payload)
+					_, err = client.Put(context.Background(), objectstore.PutRequest{
+						Key: "audio/v1/context.wav", Body: bytes.NewReader(payload),
+						Size: int64(len(payload)), ContentType: "audio/wav",
+						ChecksumSHA256: hex.EncodeToString(digest[:]),
+					})
+				case "open":
+					_, err = client.Open(context.Background(), "audio/v1/context.pdf")
+				case "delete":
+					err = client.Delete(context.Background(), "audio/v1/context.wav")
+				}
+				if !errors.Is(err, cause) {
+					t.Fatalf("operation error = %v, want context cause %v", err, cause)
+				}
+				observation, found := recorder.find(capability)
+				if !found || len(recorder.observations) != 1 ||
+					observation.ErrorKind != wantKind {
+					t.Fatalf("observations = %#v", recorder.observations)
+				}
+			})
+		}
+	}
+}
+
+func TestOperationErrorMapsBoundedProviderCategory(t *testing.T) {
+	tests := []struct {
+		code   string
+		status int
+		want   providerobservability.ErrorKind
+	}{
+		{code: "InvalidAccessKeyId", want: providerobservability.ErrorAuthentication},
+		{code: "AccessDenied", want: providerobservability.ErrorAuthorization},
+		{status: http.StatusTooManyRequests, want: providerobservability.ErrorRateLimited},
+		{status: http.StatusServiceUnavailable, want: providerobservability.ErrorProviderUnavailable},
+	}
+	for _, test := range tests {
+		err := &OperationError{Code: test.code, Status: test.status}
+		if got := objectstore.ProviderErrorKind(err); got != test.want {
+			t.Fatalf("ProviderErrorKind(%q, %d) = %q, want %q", test.code, test.status, got, test.want)
+		}
 	}
 }
 
@@ -238,4 +371,25 @@ func newTestClient(api s3API, presigner s3Presigner) *Client {
 		prefix: "audio/v1", signedURLTTL: 2 * time.Minute,
 		now: func() time.Time { return fixedNow },
 	}
+}
+
+type kodoProviderRecorder struct {
+	observations []providerobservability.Observation
+}
+
+func (recorder *kodoProviderRecorder) Record(
+	observation providerobservability.Observation,
+) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+func (recorder *kodoProviderRecorder) find(
+	capability providerobservability.Capability,
+) (providerobservability.Observation, bool) {
+	for _, observation := range recorder.observations {
+		if observation.Capability == capability {
+			return observation, true
+		}
+	}
+	return providerobservability.Observation{}, false
 }

--- a/server/internal/platform/objectstore/observability.go
+++ b/server/internal/platform/objectstore/observability.go
@@ -3,6 +3,9 @@ package objectstore
 import (
 	"context"
 	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
@@ -29,6 +32,69 @@ func RecordProviderCall(
 	})
 }
 
+// ObserveOpenReadCloser completes an object-open observation only when the
+// response body reaches EOF, fails while reading, or is closed early.
+func ObserveOpenReadCloser(
+	body io.ReadCloser,
+	observer providerobservability.Recorder,
+	provider providerobservability.Provider,
+	startedAt time.Time,
+) io.ReadCloser {
+	if observer == nil {
+		return body
+	}
+	return &observedReadCloser{
+		body: body, observer: observer, provider: provider, startedAt: startedAt,
+	}
+}
+
+type observedReadCloser struct {
+	body      io.ReadCloser
+	observer  providerobservability.Recorder
+	provider  providerobservability.Provider
+	startedAt time.Time
+	bytesRead atomic.Int64
+	finished  sync.Once
+}
+
+func (reader *observedReadCloser) Read(buffer []byte) (int, error) {
+	count, err := reader.body.Read(buffer)
+	if count > 0 {
+		reader.bytesRead.Add(int64(count))
+	}
+	if errors.Is(err, io.EOF) {
+		reader.finish(nil)
+	} else if err != nil {
+		reader.finish(err)
+	}
+	return count, err
+}
+
+func (reader *observedReadCloser) Close() error {
+	err := reader.body.Close()
+	if err != nil {
+		reader.finish(err)
+	} else {
+		reader.finish(context.Canceled)
+	}
+	return err
+}
+
+func (reader *observedReadCloser) finish(err error) {
+	reader.finished.Do(func() {
+		RecordProviderCall(
+			reader.observer,
+			reader.provider,
+			providerobservability.CapabilityObjectOpen,
+			reader.startedAt,
+			err,
+			reader.bytesRead.Load(),
+		)
+	})
+}
+
+var _ io.ReadCloser = (*observedReadCloser)(nil)
+
 // ProviderErrorKind maps object-storage errors to a fixed metric category.
 func ProviderErrorKind(err error) providerobservability.ErrorKind {
 	switch {
@@ -38,6 +104,14 @@ func ProviderErrorKind(err error) providerobservability.ErrorKind {
 		return providerobservability.ErrorTimeout
 	case errors.Is(err, context.Canceled):
 		return providerobservability.ErrorCancelled
+	}
+	var stableError interface {
+		ProviderMetricErrorKind() providerobservability.ErrorKind
+	}
+	if errors.As(err, &stableError) {
+		return stableError.ProviderMetricErrorKind()
+	}
+	switch {
 	case errors.Is(err, ErrCredentials):
 		return providerobservability.ErrorCredentials
 	case errors.Is(err, ErrInvalidKey), errors.Is(err, ErrInvalidTTL):

--- a/server/internal/platform/objectstore/observability.go
+++ b/server/internal/platform/objectstore/observability.go
@@ -1,0 +1,52 @@
+package objectstore
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+)
+
+// RecordProviderCall records one sanitized object-provider operation.
+func RecordProviderCall(
+	observer providerobservability.Recorder,
+	provider providerobservability.Provider,
+	capability providerobservability.Capability,
+	startedAt time.Time,
+	err error,
+	bytes int64,
+) {
+	if observer == nil {
+		return
+	}
+	observer.Record(providerobservability.Observation{
+		Provider:   provider,
+		Capability: capability,
+		Duration:   time.Since(startedAt),
+		ErrorKind:  ProviderErrorKind(err),
+		Usage:      providerobservability.Usage{Bytes: float64(bytes)},
+	})
+}
+
+// ProviderErrorKind maps object-storage errors to a fixed metric category.
+func ProviderErrorKind(err error) providerobservability.ErrorKind {
+	switch {
+	case err == nil:
+		return providerobservability.ErrorNone
+	case errors.Is(err, context.DeadlineExceeded):
+		return providerobservability.ErrorTimeout
+	case errors.Is(err, context.Canceled):
+		return providerobservability.ErrorCancelled
+	case errors.Is(err, ErrCredentials):
+		return providerobservability.ErrorCredentials
+	case errors.Is(err, ErrInvalidKey), errors.Is(err, ErrInvalidTTL):
+		return providerobservability.ErrorInvalidRequest
+	case errors.Is(err, ErrInvalidObject):
+		return providerobservability.ErrorInvalidObject
+	case errors.Is(err, ErrAlreadyExists):
+		return providerobservability.ErrorAlreadyExists
+	default:
+		return providerobservability.ErrorOperationFailed
+	}
+}

--- a/server/internal/platform/objectstore/observability_test.go
+++ b/server/internal/platform/objectstore/observability_test.go
@@ -1,0 +1,39 @@
+package objectstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+)
+
+func TestProviderErrorKindUsesOnlyStableCategories(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want providerobservability.ErrorKind
+	}{
+		{name: "success", want: providerobservability.ErrorNone},
+		{name: "timeout", err: context.DeadlineExceeded, want: providerobservability.ErrorTimeout},
+		{name: "cancelled", err: context.Canceled, want: providerobservability.ErrorCancelled},
+		{name: "credentials", err: fmt.Errorf("wrapped: %w", ErrCredentials), want: providerobservability.ErrorCredentials},
+		{name: "invalid key", err: ErrInvalidKey, want: providerobservability.ErrorInvalidRequest},
+		{name: "invalid TTL", err: ErrInvalidTTL, want: providerobservability.ErrorInvalidRequest},
+		{name: "invalid object", err: ErrInvalidObject, want: providerobservability.ErrorInvalidObject},
+		{name: "already exists", err: ErrAlreadyExists, want: providerobservability.ErrorAlreadyExists},
+		{
+			name: "provider detail is discarded",
+			err:  errors.New("private-user@example.com provider response"),
+			want: providerobservability.ErrorOperationFailed,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ProviderErrorKind(test.err); got != test.want {
+				t.Fatalf("ProviderErrorKind() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/server/internal/platform/objectstore/observability_test.go
+++ b/server/internal/platform/objectstore/observability_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
@@ -37,3 +40,103 @@ func TestProviderErrorKindUsesOnlyStableCategories(t *testing.T) {
 		})
 	}
 }
+
+func TestObservedReadCloserCompletesAtBodyOutcome(t *testing.T) {
+	t.Run("complete read", func(t *testing.T) {
+		recorder := &readObservationRecorder{}
+		reader := ObserveOpenReadCloser(
+			io.NopCloser(strings.NewReader("payload")),
+			recorder,
+			providerobservability.ProviderAliyunOSS,
+			time.Now(),
+		)
+		if len(recorder.observations) != 0 {
+			t.Fatal("opening a body recorded success before it was consumed")
+		}
+		data, err := io.ReadAll(reader)
+		if err != nil || string(data) != "payload" {
+			t.Fatalf("ReadAll() = %q, %v", data, err)
+		}
+		if err := reader.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		observation := onlyReadObservation(t, recorder)
+		if observation.ErrorKind != providerobservability.ErrorNone ||
+			observation.Usage.Bytes != 7 {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+
+	t.Run("read error", func(t *testing.T) {
+		recorder := &readObservationRecorder{}
+		reader := ObserveOpenReadCloser(
+			&failingReadCloser{},
+			recorder,
+			providerobservability.ProviderQiniuKodo,
+			time.Now(),
+		)
+		data, err := io.ReadAll(reader)
+		if err == nil || string(data) != "bad" {
+			t.Fatalf("ReadAll() = %q, %v", data, err)
+		}
+		_ = reader.Close()
+		observation := onlyReadObservation(t, recorder)
+		if observation.ErrorKind != providerobservability.ErrorOperationFailed ||
+			observation.Usage.Bytes != 3 {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+
+	t.Run("early close", func(t *testing.T) {
+		recorder := &readObservationRecorder{}
+		reader := ObserveOpenReadCloser(
+			io.NopCloser(strings.NewReader("unread")),
+			recorder,
+			providerobservability.ProviderAliyunOSS,
+			time.Now(),
+		)
+		if err := reader.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		observation := onlyReadObservation(t, recorder)
+		if observation.ErrorKind != providerobservability.ErrorCancelled ||
+			observation.Usage.Bytes != 0 {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+}
+
+type readObservationRecorder struct {
+	observations []providerobservability.Observation
+}
+
+func (recorder *readObservationRecorder) Record(
+	observation providerobservability.Observation,
+) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+func onlyReadObservation(
+	t *testing.T,
+	recorder *readObservationRecorder,
+) providerobservability.Observation {
+	t.Helper()
+	if len(recorder.observations) != 1 {
+		t.Fatalf("observations = %#v", recorder.observations)
+	}
+	return recorder.observations[0]
+}
+
+type failingReadCloser struct {
+	read bool
+}
+
+func (reader *failingReadCloser) Read(buffer []byte) (int, error) {
+	if reader.read {
+		return 0, errors.New("private-user@example.com provider read detail")
+	}
+	reader.read = true
+	return copy(buffer, "bad"), nil
+}
+
+func (*failingReadCloser) Close() error { return nil }

--- a/server/internal/platform/objectstore/ossstore/client.go
+++ b/server/internal/platform/objectstore/ossstore/client.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 const (
@@ -39,6 +40,7 @@ type Client struct {
 	bucket       string
 	prefix       string
 	signedURLTTL time.Duration
+	observer     providerobservability.Recorder
 }
 
 // NewFromEnvironment is intended for explicit local and CI use. It reads an
@@ -113,6 +115,26 @@ func NewForPrefix(
 		nil,
 		true,
 	)
+}
+
+// NewForPrefixObserved creates a production client using the service-level
+// provider observer.
+func NewForPrefixObserved(
+	ctx context.Context,
+	storageConfig config.ObjectStorageConfig,
+	prefix string,
+	provider credentials.CredentialsProvider,
+	observer providerobservability.Recorder,
+) (*Client, error) {
+	if observer == nil {
+		return nil, errors.New("OSS provider observer is required")
+	}
+	client, err := NewForPrefix(ctx, storageConfig, prefix, provider)
+	if err != nil {
+		return nil, err
+	}
+	client.observer = observer
+	return client, nil
 }
 
 func newClient(
@@ -194,7 +216,7 @@ func (c *Client) Preflight(ctx context.Context) error {
 func (c *Client) Put(
 	ctx context.Context,
 	request objectstore.PutRequest,
-) (objectstore.PutResult, error) {
+) (callResult objectstore.PutResult, callErr error) {
 	if err := objectstore.ValidateKey(c.prefix, request.Key); err != nil {
 		return objectstore.PutResult{}, err
 	}
@@ -212,6 +234,18 @@ func (c *Client) Put(
 	defer func() {
 		_, _ = request.Body.Seek(startOffset, io.SeekStart)
 	}()
+	startedAt := time.Now()
+	storedBytes := int64(0)
+	defer func() {
+		objectstore.RecordProviderCall(
+			c.observer,
+			providerobservability.ProviderAliyunOSS,
+			providerobservability.CapabilityObjectPut,
+			startedAt,
+			callErr,
+			storedBytes,
+		)
+	}()
 
 	result, err := c.sdk.PutObject(ctx, &aliyunoss.PutObjectRequest{
 		Bucket:               aliyunoss.Ptr(c.bucket),
@@ -227,6 +261,12 @@ func (c *Client) Put(
 	})
 	if err != nil {
 		if shouldReconcilePut(err) {
+			if c.observer != nil {
+				c.observer.RecordRetry(
+					providerobservability.ProviderAliyunOSS,
+					providerobservability.CapabilityObjectPut,
+				)
+			}
 			if existing, matches := c.reconcileExisting(ctx, request); matches {
 				return existing, nil
 			}
@@ -234,6 +274,7 @@ func (c *Client) Put(
 		return objectstore.PutResult{}, safeError("put", err)
 	}
 
+	storedBytes = request.Size
 	return objectstore.PutResult{ETag: strings.Trim(aliyunoss.ToString(result.ETag), `"`)}, nil
 }
 
@@ -276,13 +317,24 @@ func metadataValue(metadata map[string]string, key string) string {
 func (c *Client) SignedGet(
 	ctx context.Context,
 	key string,
-) (objectstore.SignedGetResult, error) {
+) (callResult objectstore.SignedGetResult, callErr error) {
 	if err := objectstore.ValidateKey(c.prefix, key); err != nil {
 		return objectstore.SignedGetResult{}, err
 	}
 	if c.signedURLTTL <= 0 || c.signedURLTTL > 2*time.Minute {
 		return objectstore.SignedGetResult{}, objectstore.ErrInvalidTTL
 	}
+	startedAt := time.Now()
+	defer func() {
+		objectstore.RecordProviderCall(
+			c.observer,
+			providerobservability.ProviderAliyunOSS,
+			providerobservability.CapabilityObjectSignedGet,
+			startedAt,
+			callErr,
+			0,
+		)
+	}()
 
 	result, err := c.sdk.Presign(
 		ctx,
@@ -303,10 +355,24 @@ func (c *Client) SignedGet(
 }
 
 // Open 通过私有 OSS 客户端打开对象流，供服务端受控解析使用。
-func (c *Client) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+func (c *Client) Open(
+	ctx context.Context,
+	key string,
+) (callResult io.ReadCloser, callErr error) {
 	if err := objectstore.ValidateKey(c.prefix, key); err != nil {
 		return nil, err
 	}
+	startedAt := time.Now()
+	defer func() {
+		objectstore.RecordProviderCall(
+			c.observer,
+			providerobservability.ProviderAliyunOSS,
+			providerobservability.CapabilityObjectOpen,
+			startedAt,
+			callErr,
+			0,
+		)
+	}()
 	result, err := c.sdk.GetObject(ctx, &aliyunoss.GetObjectRequest{
 		Bucket: aliyunoss.Ptr(c.bucket),
 		Key:    aliyunoss.Ptr(key),
@@ -323,10 +389,21 @@ func (c *Client) Open(ctx context.Context, key string) (io.ReadCloser, error) {
 	return result.Body, nil
 }
 
-func (c *Client) Delete(ctx context.Context, key string) error {
+func (c *Client) Delete(ctx context.Context, key string) (callErr error) {
 	if err := objectstore.ValidateKey(c.prefix, key); err != nil {
 		return err
 	}
+	startedAt := time.Now()
+	defer func() {
+		objectstore.RecordProviderCall(
+			c.observer,
+			providerobservability.ProviderAliyunOSS,
+			providerobservability.CapabilityObjectDelete,
+			startedAt,
+			callErr,
+			0,
+		)
+	}()
 
 	_, err := c.sdk.DeleteObject(ctx, &aliyunoss.DeleteObjectRequest{
 		Bucket: aliyunoss.Ptr(c.bucket),

--- a/server/internal/platform/objectstore/ossstore/client.go
+++ b/server/internal/platform/objectstore/ossstore/client.go
@@ -261,12 +261,6 @@ func (c *Client) Put(
 	})
 	if err != nil {
 		if shouldReconcilePut(err) {
-			if c.observer != nil {
-				c.observer.RecordRetry(
-					providerobservability.ProviderAliyunOSS,
-					providerobservability.CapabilityObjectPut,
-				)
-			}
 			if existing, matches := c.reconcileExisting(ctx, request); matches {
 				return existing, nil
 			}
@@ -317,25 +311,13 @@ func metadataValue(metadata map[string]string, key string) string {
 func (c *Client) SignedGet(
 	ctx context.Context,
 	key string,
-) (callResult objectstore.SignedGetResult, callErr error) {
+) (objectstore.SignedGetResult, error) {
 	if err := objectstore.ValidateKey(c.prefix, key); err != nil {
 		return objectstore.SignedGetResult{}, err
 	}
 	if c.signedURLTTL <= 0 || c.signedURLTTL > 2*time.Minute {
 		return objectstore.SignedGetResult{}, objectstore.ErrInvalidTTL
 	}
-	startedAt := time.Now()
-	defer func() {
-		objectstore.RecordProviderCall(
-			c.observer,
-			providerobservability.ProviderAliyunOSS,
-			providerobservability.CapabilityObjectSignedGet,
-			startedAt,
-			callErr,
-			0,
-		)
-	}()
-
 	result, err := c.sdk.Presign(
 		ctx,
 		&aliyunoss.GetObjectRequest{
@@ -358,35 +340,43 @@ func (c *Client) SignedGet(
 func (c *Client) Open(
 	ctx context.Context,
 	key string,
-) (callResult io.ReadCloser, callErr error) {
+) (io.ReadCloser, error) {
 	if err := objectstore.ValidateKey(c.prefix, key); err != nil {
 		return nil, err
 	}
 	startedAt := time.Now()
-	defer func() {
+	recordFailure := func(err error) {
 		objectstore.RecordProviderCall(
 			c.observer,
 			providerobservability.ProviderAliyunOSS,
 			providerobservability.CapabilityObjectOpen,
 			startedAt,
-			callErr,
+			err,
 			0,
 		)
-	}()
+	}
 	result, err := c.sdk.GetObject(ctx, &aliyunoss.GetObjectRequest{
 		Bucket: aliyunoss.Ptr(c.bucket),
 		Key:    aliyunoss.Ptr(key),
 	})
 	if err != nil {
-		return nil, safeError("get", err)
+		callErr := safeError("get", err)
+		recordFailure(callErr)
+		return nil, callErr
 	}
 	if result.Body == nil || aliyunoss.ToString(result.ContentType) != "application/pdf" {
 		if result.Body != nil {
 			_ = result.Body.Close()
 		}
+		recordFailure(objectstore.ErrInvalidObject)
 		return nil, objectstore.ErrInvalidObject
 	}
-	return result.Body, nil
+	return objectstore.ObserveOpenReadCloser(
+		result.Body,
+		c.observer,
+		providerobservability.ProviderAliyunOSS,
+		startedAt,
+	), nil
 }
 
 func (c *Client) Delete(ctx context.Context, key string) (callErr error) {
@@ -420,6 +410,7 @@ type OperationError struct {
 	Code       string
 	StatusCode int
 	RequestID  string
+	cause      error
 }
 
 func (e *OperationError) Error() string {
@@ -436,14 +427,28 @@ func (e *OperationError) Error() string {
 	)
 }
 
-func (e *OperationError) Unwrap() error {
+func (e *OperationError) Unwrap() []error {
 	if e.Code == "FileAlreadyExists" {
-		return objectstore.ErrAlreadyExists
+		return []error{objectstore.ErrAlreadyExists}
 	}
-	return objectstore.ErrOperationFailed
+	causes := []error{objectstore.ErrOperationFailed}
+	if e.cause != nil {
+		causes = append(causes, e.cause)
+	}
+	return causes
+}
+
+// ProviderMetricErrorKind exposes only a bounded category, never provider
+// error text or identifiers.
+func (e *OperationError) ProviderMetricErrorKind() providerobservability.ErrorKind {
+	if e == nil {
+		return providerobservability.ErrorOperationFailed
+	}
+	return ossMetricErrorKind(e.Code, e.StatusCode, e.cause)
 }
 
 func safeError(operation string, err error) error {
+	cause := stableContextCause(err)
 	var serviceError *aliyunoss.ServiceError
 	if errors.As(err, &serviceError) {
 		return &OperationError{
@@ -451,7 +456,60 @@ func safeError(operation string, err error) error {
 			Code:       serviceError.Code,
 			StatusCode: serviceError.StatusCode,
 			RequestID:  serviceError.RequestID,
+			cause:      cause,
 		}
 	}
-	return &OperationError{Operation: operation}
+	return &OperationError{Operation: operation, cause: cause}
+}
+
+func stableContextCause(err error) error {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return context.DeadlineExceeded
+	case errors.Is(err, context.Canceled):
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func ossMetricErrorKind(
+	code string,
+	status int,
+	cause error,
+) providerobservability.ErrorKind {
+	switch {
+	case errors.Is(cause, context.DeadlineExceeded):
+		return providerobservability.ErrorTimeout
+	case errors.Is(cause, context.Canceled):
+		return providerobservability.ErrorCancelled
+	}
+	switch strings.ToLower(strings.TrimSpace(code)) {
+	case "filealreadyexists":
+		return providerobservability.ErrorAlreadyExists
+	case "invalidaccesskeyid", "signaturedoesnotmatch", "invalidsecuritytoken", "securitytokenexpired":
+		return providerobservability.ErrorAuthentication
+	case "accessdenied":
+		return providerobservability.ErrorAuthorization
+	case "requesttimeout":
+		return providerobservability.ErrorTimeout
+	case "toomanyrequests", "throttling", "slowdown":
+		return providerobservability.ErrorRateLimited
+	case "serviceunavailable", "internalerror":
+		return providerobservability.ErrorProviderUnavailable
+	}
+	switch {
+	case status == http.StatusUnauthorized:
+		return providerobservability.ErrorAuthentication
+	case status == http.StatusForbidden:
+		return providerobservability.ErrorAuthorization
+	case status == http.StatusRequestTimeout:
+		return providerobservability.ErrorTimeout
+	case status == http.StatusTooManyRequests:
+		return providerobservability.ErrorRateLimited
+	case status >= http.StatusInternalServerError:
+		return providerobservability.ErrorProviderUnavailable
+	default:
+		return providerobservability.ErrorOperationFailed
+	}
 }

--- a/server/internal/platform/objectstore/ossstore/client_test.go
+++ b/server/internal/platform/objectstore/ossstore/client_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -82,6 +83,8 @@ func TestClientPutSignAndDelete(t *testing.T) {
 	}
 
 	client := newTestClient(t, httpClient)
+	recorder := &objectProviderRecorder{}
+	client.observer = recorder
 	putResult, err := client.Put(context.Background(), objectstore.PutRequest{
 		Key:            key,
 		Body:           bytes.NewReader(payload),
@@ -127,6 +130,11 @@ func TestClientPutSignAndDelete(t *testing.T) {
 	if strings.Join(methods, ",") != "PUT,DELETE" {
 		t.Fatalf("unexpected provider calls: %v", methods)
 	}
+	putObservation, found := recorder.find(providerobservability.CapabilityObjectPut)
+	if !found || putObservation.ErrorKind != providerobservability.ErrorNone ||
+		putObservation.Usage.Bytes != float64(len(payload)) {
+		t.Fatalf("put observation = %#v, found = %v", putObservation, found)
+	}
 }
 
 func TestClientPutReconcilesLostResponse(t *testing.T) {
@@ -157,6 +165,8 @@ func TestClientPutReconcilesLostResponse(t *testing.T) {
 			}
 		}),
 	})
+	recorder := &objectProviderRecorder{}
+	client.observer = recorder
 
 	body := bytes.NewReader(payload)
 	result, err := client.Put(context.Background(), objectstore.PutRequest{
@@ -174,6 +184,14 @@ func TestClientPutReconcilesLostResponse(t *testing.T) {
 	}
 	if offset, seekErr := body.Seek(0, io.SeekCurrent); seekErr != nil || offset != 0 {
 		t.Fatalf("body offset after Put = %d, err = %v", offset, seekErr)
+	}
+	observation, found := recorder.find(providerobservability.CapabilityObjectPut)
+	if !found || observation.ErrorKind != providerobservability.ErrorNone ||
+		observation.Usage.Bytes != 0 || recorder.retries != 1 {
+		t.Fatalf(
+			"reconciled observation = %#v, found = %v, retries = %d",
+			observation, found, recorder.retries,
+		)
 	}
 }
 
@@ -614,4 +632,33 @@ func response(status int, header http.Header, body string) *http.Response {
 		Header:     header,
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
+}
+
+type objectProviderRecorder struct {
+	observations []providerobservability.Observation
+	retries      int
+}
+
+func (recorder *objectProviderRecorder) Record(
+	observation providerobservability.Observation,
+) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+func (recorder *objectProviderRecorder) RecordRetry(
+	providerobservability.Provider,
+	providerobservability.Capability,
+) {
+	recorder.retries++
+}
+
+func (recorder *objectProviderRecorder) find(
+	capability providerobservability.Capability,
+) (providerobservability.Observation, bool) {
+	for _, observation := range recorder.observations {
+		if observation.Capability == capability {
+			return observation, true
+		}
+	}
+	return providerobservability.Observation{}, false
 }

--- a/server/internal/platform/objectstore/ossstore/client_test.go
+++ b/server/internal/platform/objectstore/ossstore/client_test.go
@@ -135,6 +135,11 @@ func TestClientPutSignAndDelete(t *testing.T) {
 		putObservation.Usage.Bytes != float64(len(payload)) {
 		t.Fatalf("put observation = %#v, found = %v", putObservation, found)
 	}
+	deleteObservation, found := recorder.find(providerobservability.CapabilityObjectDelete)
+	if !found || deleteObservation.ErrorKind != providerobservability.ErrorNone ||
+		len(recorder.observations) != 2 {
+		t.Fatalf("local signing created a provider observation: %#v", recorder.observations)
+	}
 }
 
 func TestClientPutReconcilesLostResponse(t *testing.T) {
@@ -187,11 +192,77 @@ func TestClientPutReconcilesLostResponse(t *testing.T) {
 	}
 	observation, found := recorder.find(providerobservability.CapabilityObjectPut)
 	if !found || observation.ErrorKind != providerobservability.ErrorNone ||
-		observation.Usage.Bytes != 0 || recorder.retries != 1 {
+		observation.Usage.Bytes != 0 || len(recorder.observations) != 1 {
 		t.Fatalf(
-			"reconciled observation = %#v, found = %v, retries = %d",
-			observation, found, recorder.retries,
+			"reconciled observations = %#v, found = %v",
+			recorder.observations, found,
 		)
+	}
+}
+
+func TestClientRecordsPutOpenDeleteContextOutcome(t *testing.T) {
+	for causeName, cause := range map[string]error{
+		"cancelled": context.Canceled,
+		"timeout":   context.DeadlineExceeded,
+	} {
+		wantKind := providerobservability.ErrorCancelled
+		if errors.Is(cause, context.DeadlineExceeded) {
+			wantKind = providerobservability.ErrorTimeout
+		}
+		for operationName, capability := range map[string]providerobservability.Capability{
+			"put":    providerobservability.CapabilityObjectPut,
+			"open":   providerobservability.CapabilityObjectOpen,
+			"delete": providerobservability.CapabilityObjectDelete,
+		} {
+			t.Run(causeName+"/"+operationName, func(t *testing.T) {
+				client := newTestClient(t, &http.Client{Transport: roundTripFunc(
+					func(*http.Request) (*http.Response, error) { return nil, cause },
+				)})
+				recorder := &objectProviderRecorder{}
+				client.observer = recorder
+				var err error
+				switch operationName {
+				case "put":
+					payload := []byte("context outcome")
+					_, err = client.Put(context.Background(), objectstore.PutRequest{
+						Key: "audio/v1/assets/context.wav", Body: bytes.NewReader(payload),
+						Size: int64(len(payload)), ContentType: "audio/wav",
+						ChecksumSHA256: sha256Hex(payload),
+					})
+				case "open":
+					_, err = client.Open(context.Background(), "audio/v1/context.pdf")
+				case "delete":
+					err = client.Delete(context.Background(), "audio/v1/context.wav")
+				}
+				if !errors.Is(err, cause) {
+					t.Fatalf("operation error = %v, want context cause %v", err, cause)
+				}
+				observation, found := recorder.find(capability)
+				if !found || len(recorder.observations) != 1 ||
+					observation.ErrorKind != wantKind {
+					t.Fatalf("observations = %#v", recorder.observations)
+				}
+			})
+		}
+	}
+}
+
+func TestOperationErrorMapsBoundedProviderCategory(t *testing.T) {
+	tests := []struct {
+		code   string
+		status int
+		want   providerobservability.ErrorKind
+	}{
+		{code: "InvalidAccessKeyId", want: providerobservability.ErrorAuthentication},
+		{code: "AccessDenied", want: providerobservability.ErrorAuthorization},
+		{status: http.StatusTooManyRequests, want: providerobservability.ErrorRateLimited},
+		{status: http.StatusServiceUnavailable, want: providerobservability.ErrorProviderUnavailable},
+	}
+	for _, test := range tests {
+		err := &OperationError{Code: test.code, StatusCode: test.status}
+		if got := objectstore.ProviderErrorKind(err); got != test.want {
+			t.Fatalf("ProviderErrorKind(%q, %d) = %q, want %q", test.code, test.status, got, test.want)
+		}
 	}
 }
 
@@ -636,20 +707,12 @@ func response(status int, header http.Header, body string) *http.Response {
 
 type objectProviderRecorder struct {
 	observations []providerobservability.Observation
-	retries      int
 }
 
 func (recorder *objectProviderRecorder) Record(
 	observation providerobservability.Observation,
 ) {
 	recorder.observations = append(recorder.observations, observation)
-}
-
-func (recorder *objectProviderRecorder) RecordRetry(
-	providerobservability.Provider,
-	providerobservability.Capability,
-) {
-	recorder.retries++
 }
 
 func (recorder *objectProviderRecorder) find(

--- a/server/internal/platform/providerobservability/observer.go
+++ b/server/internal/platform/providerobservability/observer.go
@@ -1,0 +1,263 @@
+// Package providerobservability records bounded, content-free metrics for
+// external provider calls.
+package providerobservability
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Provider is a configured external service. Values are deliberately closed
+// so user, request, model, bucket, and object identifiers cannot become labels.
+type Provider string
+
+const (
+	ProviderQianwen   Provider = "qianwen"
+	ProviderQiniu     Provider = "qiniu"
+	ProviderPaddleOCR Provider = "paddleocr"
+	ProviderAliyunOSS Provider = "aliyun_oss"
+	ProviderQiniuKodo Provider = "qiniu_kodo"
+)
+
+// Capability is one bounded external operation family.
+type Capability string
+
+const (
+	CapabilityTextGeneration    Capability = "text_generation"
+	CapabilitySpeechRecognition Capability = "speech_recognition"
+	CapabilitySpeechSynthesis   Capability = "speech_synthesis"
+	CapabilityDocumentOCR       Capability = "document_ocr"
+	CapabilityObjectPut         Capability = "object_put"
+	CapabilityObjectSignedGet   Capability = "object_signed_get"
+	CapabilityObjectOpen        Capability = "object_open"
+	CapabilityObjectDelete      Capability = "object_delete"
+)
+
+// ErrorKind is a stable, sanitized failure class.
+type ErrorKind string
+
+const (
+	ErrorNone                ErrorKind = "none"
+	ErrorInvalidRequest      ErrorKind = "invalid_request"
+	ErrorConfiguration       ErrorKind = "configuration"
+	ErrorAuthentication      ErrorKind = "authentication"
+	ErrorAuthorization       ErrorKind = "authorization"
+	ErrorQuotaExhausted      ErrorKind = "quota_exhausted"
+	ErrorRateLimited         ErrorKind = "rate_limited"
+	ErrorTimeout             ErrorKind = "timeout"
+	ErrorProviderUnavailable ErrorKind = "provider_unavailable"
+	ErrorInvalidResponse     ErrorKind = "invalid_response"
+	ErrorCancelled           ErrorKind = "cancelled"
+	ErrorPageLimitExceeded   ErrorKind = "page_limit_exceeded"
+	ErrorCredentials         ErrorKind = "credentials"
+	ErrorInvalidObject       ErrorKind = "invalid_object"
+	ErrorAlreadyExists       ErrorKind = "already_exists"
+	ErrorOperationFailed     ErrorKind = "operation_failed"
+)
+
+const (
+	outcomeSuccess   = "success"
+	outcomeFailure   = "failure"
+	outcomeTimeout   = "timeout"
+	outcomeCancelled = "cancelled"
+)
+
+// Usage contains only fixed-unit billable quantities already available at the
+// provider boundary. Zero means the provider did not report that quantity.
+type Usage struct {
+	Tokens       float64
+	AudioSeconds float64
+	Characters   float64
+	Pages        float64
+	Bytes        float64
+}
+
+// Observation is one completed logical provider call.
+type Observation struct {
+	Provider   Provider
+	Capability Capability
+	Duration   time.Duration
+	ErrorKind  ErrorKind
+	Usage      Usage
+}
+
+// Recorder is the narrow dependency used by provider adapters.
+type Recorder interface {
+	Record(Observation)
+	RecordRetry(Provider, Capability)
+}
+
+// Observer owns all external-provider metrics for one service registry.
+type Observer struct {
+	calls        *prometheus.CounterVec
+	duration     *prometheus.HistogramVec
+	retries      *prometheus.CounterVec
+	tokens       *prometheus.CounterVec
+	audioSeconds *prometheus.CounterVec
+	characters   *prometheus.CounterVec
+	pages        *prometheus.CounterVec
+	bytes        *prometheus.CounterVec
+}
+
+// New registers the complete provider metric family. Registration is
+// transactional so startup cannot continue with a partially visible family.
+func New(registerer prometheus.Registerer) (*Observer, error) {
+	if registerer == nil {
+		return nil, errors.New("provider observability registerer is required")
+	}
+	observer := &Observer{
+		calls: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "speakup", Subsystem: "provider", Name: "calls_total",
+			Help: "Completed external provider calls by bounded outcome and error kind.",
+		}, []string{"provider", "capability", "outcome", "error_kind"}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "speakup", Subsystem: "provider", Name: "call_duration_seconds",
+			Help:    "External provider call duration in seconds by bounded outcome.",
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300},
+		}, []string{"provider", "capability", "outcome"}),
+		retries: providerCounter("retries_total", "External provider retries."),
+		tokens:  providerCounter("usage_tokens_total", "Provider-reported tokens consumed."),
+		audioSeconds: providerCounter(
+			"usage_audio_seconds_total", "Provider-reported audio seconds consumed.",
+		),
+		characters: providerCounter(
+			"usage_characters_total", "Provider-reported or submitted TTS characters consumed.",
+		),
+		pages: providerCounter("usage_pages_total", "Provider-reported document pages consumed."),
+		bytes: providerCounter("usage_bytes_total", "Provider-reported object bytes stored."),
+	}
+	collectors := []prometheus.Collector{
+		observer.calls, observer.duration, observer.retries, observer.tokens,
+		observer.audioSeconds, observer.characters, observer.pages, observer.bytes,
+	}
+	registered := make([]prometheus.Collector, 0, len(collectors))
+	for _, collector := range collectors {
+		if err := registerer.Register(collector); err != nil {
+			for _, current := range registered {
+				registerer.Unregister(current)
+			}
+			return nil, fmt.Errorf("register provider metrics: %w", err)
+		}
+		registered = append(registered, collector)
+	}
+	return observer, nil
+}
+
+func providerCounter(name string, help string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "speakup", Subsystem: "provider", Name: name, Help: help,
+	}, []string{"provider", "capability"})
+}
+
+// Record records one completed provider call. Invalid enum or numeric values
+// are programmer errors and panic instead of silently dropping production
+// observability.
+func (observer *Observer) Record(observation Observation) {
+	if observer == nil {
+		panic("providerobservability: observer is required")
+	}
+	validateObservation(observation)
+	outcome := outcomeFor(observation.ErrorKind)
+	provider := string(observation.Provider)
+	capability := string(observation.Capability)
+	observer.calls.WithLabelValues(
+		provider, capability, outcome, string(observation.ErrorKind),
+	).Inc()
+	observer.duration.WithLabelValues(provider, capability, outcome).
+		Observe(observation.Duration.Seconds())
+	addPositive(observer.tokens, provider, capability, observation.Usage.Tokens)
+	addPositive(observer.audioSeconds, provider, capability, observation.Usage.AudioSeconds)
+	addPositive(observer.characters, provider, capability, observation.Usage.Characters)
+	addPositive(observer.pages, provider, capability, observation.Usage.Pages)
+	addPositive(observer.bytes, provider, capability, observation.Usage.Bytes)
+}
+
+// RecordRetry records a real additional provider attempt, not merely a
+// retryable error classification.
+func (observer *Observer) RecordRetry(provider Provider, capability Capability) {
+	if observer == nil {
+		panic("providerobservability: observer is required")
+	}
+	validateProvider(provider)
+	validateCapability(capability)
+	observer.retries.WithLabelValues(string(provider), string(capability)).Inc()
+}
+
+func addPositive(counter *prometheus.CounterVec, provider string, capability string, value float64) {
+	if value > 0 {
+		counter.WithLabelValues(provider, capability).Add(value)
+	}
+}
+
+func validateObservation(observation Observation) {
+	validateProvider(observation.Provider)
+	validateCapability(observation.Capability)
+	validateErrorKind(observation.ErrorKind)
+	if observation.Duration < 0 {
+		panic("providerobservability: duration must not be negative")
+	}
+	for _, value := range []float64{
+		observation.Usage.Tokens,
+		observation.Usage.AudioSeconds,
+		observation.Usage.Characters,
+		observation.Usage.Pages,
+		observation.Usage.Bytes,
+	} {
+		if value < 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+			panic("providerobservability: usage must be finite and non-negative")
+		}
+	}
+}
+
+func validateProvider(provider Provider) {
+	switch provider {
+	case ProviderQianwen, ProviderQiniu, ProviderPaddleOCR,
+		ProviderAliyunOSS, ProviderQiniuKodo:
+		return
+	default:
+		panic("providerobservability: invalid provider")
+	}
+}
+
+func validateCapability(capability Capability) {
+	switch capability {
+	case CapabilityTextGeneration, CapabilitySpeechRecognition,
+		CapabilitySpeechSynthesis, CapabilityDocumentOCR, CapabilityObjectPut,
+		CapabilityObjectSignedGet, CapabilityObjectOpen, CapabilityObjectDelete:
+		return
+	default:
+		panic("providerobservability: invalid capability")
+	}
+}
+
+func validateErrorKind(kind ErrorKind) {
+	switch kind {
+	case ErrorNone, ErrorInvalidRequest, ErrorConfiguration, ErrorAuthentication,
+		ErrorAuthorization, ErrorQuotaExhausted, ErrorRateLimited, ErrorTimeout,
+		ErrorProviderUnavailable, ErrorInvalidResponse, ErrorCancelled,
+		ErrorPageLimitExceeded, ErrorCredentials, ErrorInvalidObject,
+		ErrorAlreadyExists, ErrorOperationFailed:
+		return
+	default:
+		panic("providerobservability: invalid error kind")
+	}
+}
+
+func outcomeFor(kind ErrorKind) string {
+	switch kind {
+	case ErrorNone:
+		return outcomeSuccess
+	case ErrorTimeout:
+		return outcomeTimeout
+	case ErrorCancelled:
+		return outcomeCancelled
+	default:
+		return outcomeFailure
+	}
+}
+
+var _ Recorder = (*Observer)(nil)

--- a/server/internal/platform/providerobservability/observer.go
+++ b/server/internal/platform/providerobservability/observer.go
@@ -21,20 +21,23 @@ const (
 	ProviderPaddleOCR Provider = "paddleocr"
 	ProviderAliyunOSS Provider = "aliyun_oss"
 	ProviderQiniuKodo Provider = "qiniu_kodo"
+	ProviderXFYunISE  Provider = "xfyun_ise"
+	ProviderSpatius   Provider = "spatius"
 )
 
 // Capability is one bounded external operation family.
 type Capability string
 
 const (
-	CapabilityTextGeneration    Capability = "text_generation"
-	CapabilitySpeechRecognition Capability = "speech_recognition"
-	CapabilitySpeechSynthesis   Capability = "speech_synthesis"
-	CapabilityDocumentOCR       Capability = "document_ocr"
-	CapabilityObjectPut         Capability = "object_put"
-	CapabilityObjectSignedGet   Capability = "object_signed_get"
-	CapabilityObjectOpen        Capability = "object_open"
-	CapabilityObjectDelete      Capability = "object_delete"
+	CapabilityTextGeneration     Capability = "text_generation"
+	CapabilitySpeechRecognition  Capability = "speech_recognition"
+	CapabilitySpeechSynthesis    Capability = "speech_synthesis"
+	CapabilityDocumentOCR        Capability = "document_ocr"
+	CapabilitySpeechEvaluation   Capability = "speech_evaluation"
+	CapabilityAvatarSessionToken Capability = "avatar_session_token"
+	CapabilityObjectPut          Capability = "object_put"
+	CapabilityObjectOpen         Capability = "object_open"
+	CapabilityObjectDelete       Capability = "object_delete"
 )
 
 // ErrorKind is a stable, sanitized failure class.
@@ -88,14 +91,12 @@ type Observation struct {
 // Recorder is the narrow dependency used by provider adapters.
 type Recorder interface {
 	Record(Observation)
-	RecordRetry(Provider, Capability)
 }
 
 // Observer owns all external-provider metrics for one service registry.
 type Observer struct {
 	calls        *prometheus.CounterVec
 	duration     *prometheus.HistogramVec
-	retries      *prometheus.CounterVec
 	tokens       *prometheus.CounterVec
 	audioSeconds *prometheus.CounterVec
 	characters   *prometheus.CounterVec
@@ -119,8 +120,7 @@ func New(registerer prometheus.Registerer) (*Observer, error) {
 			Help:    "External provider call duration in seconds by bounded outcome.",
 			Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300},
 		}, []string{"provider", "capability", "outcome"}),
-		retries: providerCounter("retries_total", "External provider retries."),
-		tokens:  providerCounter("usage_tokens_total", "Provider-reported tokens consumed."),
+		tokens: providerCounter("usage_tokens_total", "Provider-reported tokens consumed."),
 		audioSeconds: providerCounter(
 			"usage_audio_seconds_total", "Provider-reported audio seconds consumed.",
 		),
@@ -128,10 +128,10 @@ func New(registerer prometheus.Registerer) (*Observer, error) {
 			"usage_characters_total", "Provider-reported or submitted TTS characters consumed.",
 		),
 		pages: providerCounter("usage_pages_total", "Provider-reported document pages consumed."),
-		bytes: providerCounter("usage_bytes_total", "Provider-reported object bytes stored."),
+		bytes: providerCounter("usage_bytes_total", "Provider-reported or transferred object bytes."),
 	}
 	collectors := []prometheus.Collector{
-		observer.calls, observer.duration, observer.retries, observer.tokens,
+		observer.calls, observer.duration, observer.tokens,
 		observer.audioSeconds, observer.characters, observer.pages, observer.bytes,
 	}
 	registered := make([]prometheus.Collector, 0, len(collectors))
@@ -176,17 +176,6 @@ func (observer *Observer) Record(observation Observation) {
 	addPositive(observer.bytes, provider, capability, observation.Usage.Bytes)
 }
 
-// RecordRetry records a real additional provider attempt, not merely a
-// retryable error classification.
-func (observer *Observer) RecordRetry(provider Provider, capability Capability) {
-	if observer == nil {
-		panic("providerobservability: observer is required")
-	}
-	validateProvider(provider)
-	validateCapability(capability)
-	observer.retries.WithLabelValues(string(provider), string(capability)).Inc()
-}
-
 func addPositive(counter *prometheus.CounterVec, provider string, capability string, value float64) {
 	if value > 0 {
 		counter.WithLabelValues(provider, capability).Add(value)
@@ -216,7 +205,8 @@ func validateObservation(observation Observation) {
 func validateProvider(provider Provider) {
 	switch provider {
 	case ProviderQianwen, ProviderQiniu, ProviderPaddleOCR,
-		ProviderAliyunOSS, ProviderQiniuKodo:
+		ProviderAliyunOSS, ProviderQiniuKodo, ProviderXFYunISE,
+		ProviderSpatius:
 		return
 	default:
 		panic("providerobservability: invalid provider")
@@ -226,8 +216,10 @@ func validateProvider(provider Provider) {
 func validateCapability(capability Capability) {
 	switch capability {
 	case CapabilityTextGeneration, CapabilitySpeechRecognition,
-		CapabilitySpeechSynthesis, CapabilityDocumentOCR, CapabilityObjectPut,
-		CapabilityObjectSignedGet, CapabilityObjectOpen, CapabilityObjectDelete:
+		CapabilitySpeechSynthesis, CapabilityDocumentOCR,
+		CapabilitySpeechEvaluation, CapabilityAvatarSessionToken,
+		CapabilityObjectPut,
+		CapabilityObjectOpen, CapabilityObjectDelete:
 		return
 	default:
 		panic("providerobservability: invalid capability")

--- a/server/internal/platform/providerobservability/observer_test.go
+++ b/server/internal/platform/providerobservability/observer_test.go
@@ -1,0 +1,119 @@
+package providerobservability
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestObserverRecordsBoundedCallsRetriesAndFixedUsage(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	observer, err := New(registry)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	observer.Record(Observation{
+		Provider: ProviderQianwen, Capability: CapabilitySpeechRecognition,
+		Duration: 250 * time.Millisecond, ErrorKind: ErrorNone,
+		Usage: Usage{Tokens: 7, AudioSeconds: 3},
+	})
+	observer.Record(Observation{
+		Provider: ProviderQianwen, Capability: CapabilitySpeechRecognition,
+		Duration: time.Second, ErrorKind: ErrorTimeout,
+	})
+	observer.Record(Observation{
+		Provider: ProviderQianwen, Capability: CapabilitySpeechRecognition,
+		Duration: time.Millisecond, ErrorKind: ErrorCancelled,
+	})
+	observer.RecordRetry(ProviderQianwen, CapabilitySpeechRecognition)
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	want := map[string]float64{
+		`speakup_provider_calls_total|capability=speech_recognition,error_kind=none,outcome=success,provider=qianwen`:        1,
+		`speakup_provider_calls_total|capability=speech_recognition,error_kind=timeout,outcome=timeout,provider=qianwen`:     1,
+		`speakup_provider_calls_total|capability=speech_recognition,error_kind=cancelled,outcome=cancelled,provider=qianwen`: 1,
+		`speakup_provider_retries_total|capability=speech_recognition,provider=qianwen`:                                      1,
+		`speakup_provider_usage_audio_seconds_total|capability=speech_recognition,provider=qianwen`:                          3,
+		`speakup_provider_usage_tokens_total|capability=speech_recognition,provider=qianwen`:                                 7,
+	}
+	for _, family := range families {
+		for _, metric := range family.Metric {
+			labels := make([]string, 0, len(metric.Label))
+			for _, label := range metric.Label {
+				labels = append(labels, label.GetName()+"="+label.GetValue())
+			}
+			key := family.GetName() + "|" + strings.Join(labels, ",")
+			if expected, exists := want[key]; exists {
+				if metric.GetCounter().GetValue() != expected {
+					t.Fatalf("%s = %v, want %v", key, metric.GetCounter().GetValue(), expected)
+				}
+				delete(want, key)
+			}
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing metrics: %#v", want)
+	}
+}
+
+func TestObserverNoUsageDoesNotInventUsageSeriesOrLeakInput(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	observer, err := New(registry)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	observer.Record(Observation{
+		Provider: ProviderPaddleOCR, Capability: CapabilityDocumentOCR,
+		Duration: time.Millisecond, ErrorKind: ErrorProviderUnavailable,
+	})
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, family := range families {
+		name := family.GetName()
+		if strings.Contains(name, "usage_") {
+			t.Fatalf("zero usage created %q", name)
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if strings.Contains(label.GetValue(), "private-user@example.com") {
+					t.Fatalf("metric leaked private input: %s", label.GetValue())
+				}
+			}
+		}
+	}
+}
+
+func TestObserverDuplicateRegistrationFailsWithoutPartialReplacement(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	if _, err := New(registry); err != nil {
+		t.Fatalf("first New: %v", err)
+	}
+	if observer, err := New(registry); err == nil || observer != nil {
+		t.Fatalf("duplicate New = %#v, %v", observer, err)
+	}
+}
+
+func TestObserverRejectsUnboundedLabels(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	observer, err := New(registry)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer func() {
+		if recover() == nil {
+			t.Fatal("invalid provider did not panic")
+		}
+	}()
+	observer.Record(Observation{
+		Provider:   Provider("private-user@example.com"),
+		Capability: CapabilityTextGeneration,
+		ErrorKind:  ErrorNone,
+	})
+}

--- a/server/internal/platform/providerobservability/observer_test.go
+++ b/server/internal/platform/providerobservability/observer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func TestObserverRecordsBoundedCallsRetriesAndFixedUsage(t *testing.T) {
+func TestObserverRecordsBoundedCallsAndFixedUsage(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	observer, err := New(registry)
 	if err != nil {
@@ -27,19 +27,27 @@ func TestObserverRecordsBoundedCallsRetriesAndFixedUsage(t *testing.T) {
 		Provider: ProviderQianwen, Capability: CapabilitySpeechRecognition,
 		Duration: time.Millisecond, ErrorKind: ErrorCancelled,
 	})
-	observer.RecordRetry(ProviderQianwen, CapabilitySpeechRecognition)
+	observer.Record(Observation{
+		Provider: ProviderXFYunISE, Capability: CapabilitySpeechEvaluation,
+		Duration: time.Millisecond, ErrorKind: ErrorNone,
+	})
+	observer.Record(Observation{
+		Provider: ProviderSpatius, Capability: CapabilityAvatarSessionToken,
+		Duration: time.Millisecond, ErrorKind: ErrorAuthentication,
+	})
 
 	families, err := registry.Gather()
 	if err != nil {
 		t.Fatalf("Gather: %v", err)
 	}
 	want := map[string]float64{
-		`speakup_provider_calls_total|capability=speech_recognition,error_kind=none,outcome=success,provider=qianwen`:        1,
-		`speakup_provider_calls_total|capability=speech_recognition,error_kind=timeout,outcome=timeout,provider=qianwen`:     1,
-		`speakup_provider_calls_total|capability=speech_recognition,error_kind=cancelled,outcome=cancelled,provider=qianwen`: 1,
-		`speakup_provider_retries_total|capability=speech_recognition,provider=qianwen`:                                      1,
-		`speakup_provider_usage_audio_seconds_total|capability=speech_recognition,provider=qianwen`:                          3,
-		`speakup_provider_usage_tokens_total|capability=speech_recognition,provider=qianwen`:                                 7,
+		`speakup_provider_calls_total|capability=speech_recognition,error_kind=none,outcome=success,provider=qianwen`:             1,
+		`speakup_provider_calls_total|capability=speech_recognition,error_kind=timeout,outcome=timeout,provider=qianwen`:          1,
+		`speakup_provider_calls_total|capability=speech_recognition,error_kind=cancelled,outcome=cancelled,provider=qianwen`:      1,
+		`speakup_provider_calls_total|capability=speech_evaluation,error_kind=none,outcome=success,provider=xfyun_ise`:            1,
+		`speakup_provider_calls_total|capability=avatar_session_token,error_kind=authentication,outcome=failure,provider=spatius`: 1,
+		`speakup_provider_usage_audio_seconds_total|capability=speech_recognition,provider=qianwen`:                               3,
+		`speakup_provider_usage_tokens_total|capability=speech_recognition,provider=qianwen`:                                      7,
 	}
 	for _, family := range families {
 		for _, metric := range family.Metric {

--- a/server/internal/providers/paddleocr/client.go
+++ b/server/internal/providers/paddleocr/client.go
@@ -75,20 +75,22 @@ func (client *Client) RecognizePDF(
 	callCtx, cancel := context.WithTimeout(ctx, client.config.Timeout)
 	defer cancel()
 	startedAt := time.Now()
+	providerErr := error(nil)
+	reportedPages := 0
 	defer func() {
 		if client.observer == nil {
 			return
 		}
-		pages := 0
-		if callErr == nil {
-			pages = callResult.PageCount
+		metricErr := callErr
+		if providerErr != nil {
+			metricErr = providerErr
 		}
 		client.observer.Record(providerobservability.Observation{
 			Provider:   providerobservability.ProviderPaddleOCR,
 			Capability: providerobservability.CapabilityDocumentOCR,
 			Duration:   time.Since(startedAt),
-			ErrorKind:  observedOCRFailure(callErr),
-			Usage:      providerobservability.Usage{Pages: float64(pages)},
+			ErrorKind:  observedOCRFailure(metricErr),
+			Usage:      providerobservability.Usage{Pages: float64(reportedPages)},
 		})
 	}()
 	result, err := client.parse(callCtx, &paddleapi.DocParsingRequest{
@@ -102,15 +104,51 @@ func (client *Client) RecognizePDF(
 			ReturnMarkdownImages:      paddleapi.Bool(false),
 		},
 	})
+	if result != nil {
+		reportedPages = len(result.Pages)
+	}
 	if err != nil {
+		providerErr = err
+		if ctx.Err() != nil {
+			providerErr = ctx.Err()
+		} else if callCtx.Err() != nil {
+			providerErr = callCtx.Err()
+		}
 		return resumeocr.Result{}, mapProviderFailure(err)
 	}
 	return mapResponse(result)
 }
 
 func observedOCRFailure(err error) providerobservability.ErrorKind {
-	if err == nil {
+	switch {
+	case err == nil:
 		return providerobservability.ErrorNone
+	case errors.Is(err, context.Canceled):
+		return providerobservability.ErrorCancelled
+	case errors.Is(err, context.DeadlineExceeded):
+		return providerobservability.ErrorTimeout
+	}
+	var auth *paddleapi.AuthError
+	if errors.As(err, &auth) {
+		return providerobservability.ErrorAuthentication
+	}
+	var invalidRequest *paddleapi.InvalidRequestError
+	if errors.As(err, &invalidRequest) {
+		return providerobservability.ErrorInvalidRequest
+	}
+	var rateLimit *paddleapi.RateLimitError
+	if errors.As(err, &rateLimit) {
+		return providerobservability.ErrorRateLimited
+	}
+	var responseFormat *paddleapi.ResponseFormatError
+	var resultParse *paddleapi.ResultParseError
+	if errors.As(err, &responseFormat) || errors.As(err, &resultParse) {
+		return providerobservability.ErrorInvalidResponse
+	}
+	var requestTimeout *paddleapi.RequestTimeoutError
+	var pollTimeout *paddleapi.PollTimeoutError
+	if errors.As(err, &requestTimeout) || errors.As(err, &pollTimeout) {
+		return providerobservability.ErrorTimeout
 	}
 	var failure *resumeocr.Failure
 	if !errors.As(err, &failure) {

--- a/server/internal/providers/paddleocr/client.go
+++ b/server/internal/providers/paddleocr/client.go
@@ -11,6 +11,7 @@ import (
 	paddleapi "github.com/PaddlePaddle/PaddleOCR/api_sdk/go"
 
 	resumeocr "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/interviewresume/ocr"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 // Config contains the server-only PaddleOCR settings.
@@ -19,6 +20,7 @@ type Config struct {
 	BaseURL     string
 	Model       string
 	Timeout     time.Duration
+	Observer    providerobservability.Recorder
 }
 
 type parseDocumentCall func(
@@ -28,8 +30,9 @@ type parseDocumentCall func(
 
 // Client calls PaddleOCR without exposing its response DTOs to Resume.
 type Client struct {
-	config Config
-	parse  parseDocumentCall
+	config   Config
+	parse    parseDocumentCall
+	observer providerobservability.Recorder
 }
 
 // New creates a PaddleOCR hosted document parsing client.
@@ -54,8 +57,9 @@ func New(configuration Config) (*Client, error) {
 		return nil, errors.New("PaddleOCR Resume OCR client initialization failed")
 	}
 	return &Client{
-		config: configuration,
-		parse:  sdkClient.ParseDocument,
+		config:   configuration,
+		parse:    sdkClient.ParseDocument,
+		observer: configuration.Observer,
 	}, nil
 }
 
@@ -63,13 +67,30 @@ func New(configuration Config) (*Client, error) {
 func (client *Client) RecognizePDF(
 	ctx context.Context,
 	sourceURL string,
-) (resumeocr.Result, error) {
+) (callResult resumeocr.Result, callErr error) {
 	if client == nil || client.parse == nil || ctx == nil || ctx.Err() != nil ||
 		strings.TrimSpace(sourceURL) == "" {
 		return resumeocr.Result{}, resumeocr.NewFailure(resumeocr.FailureProvider)
 	}
 	callCtx, cancel := context.WithTimeout(ctx, client.config.Timeout)
 	defer cancel()
+	startedAt := time.Now()
+	defer func() {
+		if client.observer == nil {
+			return
+		}
+		pages := 0
+		if callErr == nil {
+			pages = callResult.PageCount
+		}
+		client.observer.Record(providerobservability.Observation{
+			Provider:   providerobservability.ProviderPaddleOCR,
+			Capability: providerobservability.CapabilityDocumentOCR,
+			Duration:   time.Since(startedAt),
+			ErrorKind:  observedOCRFailure(callErr),
+			Usage:      providerobservability.Usage{Pages: float64(pages)},
+		})
+	}()
 	result, err := client.parse(callCtx, &paddleapi.DocParsingRequest{
 		Model:   client.config.Model,
 		FileURL: sourceURL,
@@ -85,6 +106,26 @@ func (client *Client) RecognizePDF(
 		return resumeocr.Result{}, mapProviderFailure(err)
 	}
 	return mapResponse(result)
+}
+
+func observedOCRFailure(err error) providerobservability.ErrorKind {
+	if err == nil {
+		return providerobservability.ErrorNone
+	}
+	var failure *resumeocr.Failure
+	if !errors.As(err, &failure) {
+		return providerobservability.ErrorProviderUnavailable
+	}
+	switch failure.FailureCode() {
+	case resumeocr.FailureTimeout:
+		return providerobservability.ErrorTimeout
+	case resumeocr.FailureOutputInvalid:
+		return providerobservability.ErrorInvalidResponse
+	case resumeocr.FailurePageLimit:
+		return providerobservability.ErrorPageLimitExceeded
+	default:
+		return providerobservability.ErrorProviderUnavailable
+	}
 }
 
 func mapResponse(result *paddleapi.DocParsingResult) (resumeocr.Result, error) {

--- a/server/internal/providers/paddleocr/client_test.go
+++ b/server/internal/providers/paddleocr/client_test.go
@@ -99,7 +99,9 @@ func TestNewRejectsMissingTokenAndNonDocumentModel(t *testing.T) {
 }
 
 func TestClientRecordsPagesAndStableFailureOnly(t *testing.T) {
+	cancelledContext, cancel := context.WithCancel(context.Background())
 	for name, test := range map[string]struct {
+		ctx       context.Context
 		call      parseDocumentCall
 		wantKind  providerobservability.ErrorKind
 		wantPages float64
@@ -118,15 +120,34 @@ func TestClientRecordsPagesAndStableFailureOnly(t *testing.T) {
 			},
 			wantKind: providerobservability.ErrorTimeout,
 		},
+		"caller cancellation": {
+			ctx: cancelledContext,
+			call: func(callCtx context.Context, _ *paddleapi.DocParsingRequest) (*paddleapi.DocParsingResult, error) {
+				cancel()
+				<-callCtx.Done()
+				return nil, &paddleapi.PollTimeoutError{}
+			},
+			wantKind: providerobservability.ErrorCancelled,
+		},
+		"provider usage before local validation": {
+			call: func(context.Context, *paddleapi.DocParsingRequest) (*paddleapi.DocParsingResult, error) {
+				return &paddleapi.DocParsingResult{Pages: []paddleapi.DocParsingPage{
+					{}, {},
+				}}, nil
+			},
+			wantKind: providerobservability.ErrorInvalidResponse, wantPages: 2,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			recorder := &paddleProviderRecorder{}
 			client := testClient()
 			client.parse = test.call
 			client.observer = recorder
-			_, _ = client.RecognizePDF(
-				context.Background(), "https://private.example/file.pdf?secret",
-			)
+			callContext := test.ctx
+			if callContext == nil {
+				callContext = context.Background()
+			}
+			_, _ = client.RecognizePDF(callContext, "https://private.example/file.pdf?secret")
 			if len(recorder.observations) != 1 {
 				t.Fatalf("observations = %#v", recorder.observations)
 			}
@@ -141,6 +162,52 @@ func TestClientRecordsPagesAndStableFailureOnly(t *testing.T) {
 	}
 }
 
+func TestObservedOCRFailureMapsSDKTypesToClosedKinds(t *testing.T) {
+	for name, test := range map[string]struct {
+		err  error
+		want providerobservability.ErrorKind
+	}{
+		"authentication": {
+			err: &paddleapi.AuthError{}, want: providerobservability.ErrorAuthentication,
+		},
+		"invalid request": {
+			err: &paddleapi.InvalidRequestError{}, want: providerobservability.ErrorInvalidRequest,
+		},
+		"page limit": {
+			err:  resumeocr.NewFailure(resumeocr.FailurePageLimit),
+			want: providerobservability.ErrorPageLimitExceeded,
+		},
+		"rate limited": {
+			err: &paddleapi.RateLimitError{}, want: providerobservability.ErrorRateLimited,
+		},
+		"response format": {
+			err: &paddleapi.ResponseFormatError{}, want: providerobservability.ErrorInvalidResponse,
+		},
+		"result parse": {
+			err: &paddleapi.ResultParseError{}, want: providerobservability.ErrorInvalidResponse,
+		},
+		"request timeout": {
+			err: &paddleapi.RequestTimeoutError{}, want: providerobservability.ErrorTimeout,
+		},
+		"poll timeout": {
+			err: &paddleapi.PollTimeoutError{}, want: providerobservability.ErrorTimeout,
+		},
+		"service unavailable": {
+			err:  &paddleapi.ServiceUnavailableError{},
+			want: providerobservability.ErrorProviderUnavailable,
+		},
+		"network": {
+			err: &paddleapi.NetworkError{}, want: providerobservability.ErrorProviderUnavailable,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := observedOCRFailure(test.err); got != test.want {
+				t.Fatalf("observedOCRFailure() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 type paddleProviderRecorder struct {
 	observations []providerobservability.Observation
 }
@@ -149,12 +216,6 @@ func (recorder *paddleProviderRecorder) Record(
 	observation providerobservability.Observation,
 ) {
 	recorder.observations = append(recorder.observations, observation)
-}
-
-func (*paddleProviderRecorder) RecordRetry(
-	providerobservability.Provider,
-	providerobservability.Capability,
-) {
 }
 
 func testClient() *Client {

--- a/server/internal/providers/paddleocr/client_test.go
+++ b/server/internal/providers/paddleocr/client_test.go
@@ -9,6 +9,7 @@ import (
 	paddleapi "github.com/PaddlePaddle/PaddleOCR/api_sdk/go"
 
 	resumeocr "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/interviewresume/ocr"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 func TestClientMapsDocumentParsingResponseWithoutLeakingURL(t *testing.T) {
@@ -95,6 +96,65 @@ func TestNewRejectsMissingTokenAndNonDocumentModel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientRecordsPagesAndStableFailureOnly(t *testing.T) {
+	for name, test := range map[string]struct {
+		call      parseDocumentCall
+		wantKind  providerobservability.ErrorKind
+		wantPages float64
+	}{
+		"success": {
+			call: func(context.Context, *paddleapi.DocParsingRequest) (*paddleapi.DocParsingResult, error) {
+				return &paddleapi.DocParsingResult{Pages: []paddleapi.DocParsingPage{
+					{MarkdownText: "page one"}, {MarkdownText: "page two"},
+				}}, nil
+			},
+			wantKind: providerobservability.ErrorNone, wantPages: 2,
+		},
+		"timeout": {
+			call: func(context.Context, *paddleapi.DocParsingRequest) (*paddleapi.DocParsingResult, error) {
+				return nil, &paddleapi.PollTimeoutError{}
+			},
+			wantKind: providerobservability.ErrorTimeout,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := &paddleProviderRecorder{}
+			client := testClient()
+			client.parse = test.call
+			client.observer = recorder
+			_, _ = client.RecognizePDF(
+				context.Background(), "https://private.example/file.pdf?secret",
+			)
+			if len(recorder.observations) != 1 {
+				t.Fatalf("observations = %#v", recorder.observations)
+			}
+			observation := recorder.observations[0]
+			if observation.Provider != providerobservability.ProviderPaddleOCR ||
+				observation.Capability != providerobservability.CapabilityDocumentOCR ||
+				observation.ErrorKind != test.wantKind ||
+				observation.Usage.Pages != test.wantPages {
+				t.Fatalf("observation = %#v", observation)
+			}
+		})
+	}
+}
+
+type paddleProviderRecorder struct {
+	observations []providerobservability.Observation
+}
+
+func (recorder *paddleProviderRecorder) Record(
+	observation providerobservability.Observation,
+) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+func (*paddleProviderRecorder) RecordRetry(
+	providerobservability.Provider,
+	providerobservability.Capability,
+) {
 }
 
 func testClient() *Client {

--- a/server/internal/providers/qianwen/agent_adapters_test.go
+++ b/server/internal/providers/qianwen/agent_adapters_test.go
@@ -1,6 +1,7 @@
 package qianwen
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"reflect"
@@ -8,6 +9,7 @@ import (
 
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
 	agentrun "github.com/1024XEngineer/XE3-ESL/server/internal/agent/run"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
@@ -127,4 +129,48 @@ func TestAgentVoiceAdapterMapsTranscriptionResult(t *testing.T) {
 	if !reflect.DeepEqual(mapped, want) {
 		t.Fatalf("mapped transcription = %#v, want %#v", mapped, want)
 	}
+}
+
+func TestAgentVoiceObserverClassifiesCallbackFailureAsCancelled(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("client stream write failed")
+	adapter := agentVoiceTranscriptionObserver{
+		observer: agentVoiceObserverFunc(func(
+			context.Context,
+			agentvoice.TranscriptionUpdate,
+		) error {
+			return cause
+		}),
+	}
+	err := adapter.OnTranscriptionUpdate(
+		context.Background(),
+		protocol.TranscriptionUpdate{Transcript: "partial"},
+	)
+	var speechError *protocol.SpeechError
+	if !errors.As(err, &speechError) ||
+		speechError.Kind != protocol.ErrorCancelled ||
+		!errors.Is(err, cause) ||
+		observedErrorKind(err) != providerobservability.ErrorCancelled {
+		t.Fatalf("callback error = %#v", err)
+	}
+	mapped := mapAgentVoiceError(err, agentvoice.SpeechOperationTranscription)
+	var mappedError *agentvoice.SpeechError
+	if !errors.As(mapped, &mappedError) ||
+		mappedError.Kind != agentvoice.ErrorCancelled ||
+		!errors.Is(mapped, cause) {
+		t.Fatalf("mapped callback error = %#v", mapped)
+	}
+}
+
+type agentVoiceObserverFunc func(
+	context.Context,
+	agentvoice.TranscriptionUpdate,
+) error
+
+func (observe agentVoiceObserverFunc) OnTranscriptionUpdate(
+	ctx context.Context,
+	update agentvoice.TranscriptionUpdate,
+) error {
+	return observe(ctx, update)
 }

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -29,7 +29,10 @@ func (synthesizer *AgentVoiceSynthesizer) OpenAssistantSpeech(
 		)
 	}
 	startedAt := time.Now()
-	session, err := synthesizer.synthesizer.openRealtimeSpeech(ctx, consume)
+	session, err := synthesizer.synthesizer.openRealtimeSpeech(
+		ctx,
+		downstreamSpeechConsumer(consume),
+	)
 	if err != nil {
 		recordSpeechCall(
 			synthesizer.synthesizer.observer,
@@ -190,12 +193,15 @@ func (observer agentVoiceTranscriptionObserver) OnTranscriptionUpdate(
 	ctx context.Context,
 	update protocol.TranscriptionUpdate,
 ) error {
-	return observer.observer.OnTranscriptionUpdate(
-		ctx,
-		agentvoice.TranscriptionUpdate{
-			Transcript: update.Transcript,
-			Final:      update.Final,
-		},
+	return downstreamSpeechCallbackError(
+		protocol.SpeechOperationTranscription,
+		observer.observer.OnTranscriptionUpdate(
+			ctx,
+			agentvoice.TranscriptionUpdate{
+				Transcript: update.Transcript,
+				Final:      update.Final,
+			},
+		),
 	)
 }
 

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"time"
-	"unicode/utf8"
 
 	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
@@ -234,10 +233,7 @@ func (synthesizer *AgentVoiceSynthesizer) Synthesize(
 		ctx,
 		protocol.SynthesisRequest{Text: request.Text},
 	)
-	characters := 0
-	if err == nil {
-		characters = utf8.RuneCountInString(request.Text)
-	}
+	characters := observedSynthesisCharacters(request.Text, err)
 	recordSpeechCall(
 		synthesizer.synthesizer.observer,
 		providerobservability.CapabilitySpeechSynthesis,

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -3,9 +3,12 @@ package qianwen
 import (
 	"context"
 	"errors"
+	"time"
+	"unicode/utf8"
 
 	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
 	agentvoice "github.com/1024XEngineer/XE3-ESL/server/internal/agent/input/voice"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
@@ -26,7 +29,26 @@ func (synthesizer *AgentVoiceSynthesizer) OpenAssistantSpeech(
 			"qianwen: Agent assistant speech synthesizer is required",
 		)
 	}
-	return synthesizer.synthesizer.openRealtimeSpeech(ctx, consume)
+	startedAt := time.Now()
+	session, err := synthesizer.synthesizer.openRealtimeSpeech(ctx, consume)
+	if err != nil {
+		recordSpeechCall(
+			synthesizer.synthesizer.observer,
+			providerobservability.CapabilitySpeechSynthesis,
+			startedAt,
+			protocol.SpeechUsage{},
+			err,
+			0,
+		)
+		return nil, err
+	}
+	if synthesizer.synthesizer.observer == nil {
+		return session, nil
+	}
+	return &observedAssistantSpeechSession{
+		delegate: session, recorder: synthesizer.synthesizer.observer,
+		startedAt: startedAt,
+	}, nil
 }
 
 func NewAgentVoiceRecognizer(
@@ -60,9 +82,18 @@ func (recognizer *AgentVoiceRecognizer) Transcribe(
 			errors.New("qianwen: Agent Voice recognizer is required"),
 		)
 	}
+	startedAt := time.Now()
 	result, err := recognizer.recognizer.Transcribe(
 		ctx,
 		protocol.TranscriptionRequest{Audio: request.Audio},
+	)
+	recordSpeechCall(
+		recognizer.recognizer.observer,
+		providerobservability.CapabilitySpeechRecognition,
+		startedAt,
+		result.Usage,
+		err,
+		0,
 	)
 	if err != nil {
 		return agentvoice.TranscriptionResult{}, mapAgentVoiceError(
@@ -88,10 +119,19 @@ func (recognizer *AgentVoiceRecognizer) TranscribeStream(
 			errors.New("qianwen: streaming Agent Voice recognizer is required"),
 		)
 	}
+	startedAt := time.Now()
 	result, err := recognizer.recognizer.TranscribeStream(
 		ctx,
 		protocol.TranscriptionRequest{Audio: request.Audio},
 		agentVoiceTranscriptionObserver{observer: observer},
+	)
+	recordSpeechCall(
+		recognizer.recognizer.observer,
+		providerobservability.CapabilitySpeechRecognition,
+		startedAt,
+		result.Usage,
+		err,
+		0,
 	)
 	if err != nil {
 		return agentvoice.TranscriptionResult{}, mapAgentVoiceError(
@@ -119,11 +159,20 @@ func (recognizer *agentRealtimeVoiceRecognizer) TranscribePCMStream(
 			errors.New("qianwen: realtime Agent Voice recognizer is required"),
 		)
 	}
+	startedAt := time.Now()
 	result, err := recognizer.recognizer.transcribeRealtimePCM(
 		ctx,
 		request.PCM,
 		request.SampleRate,
 		agentVoiceTranscriptionObserver{observer: observer},
+	)
+	recordSpeechCall(
+		recognizer.recognizer.observer,
+		providerobservability.CapabilitySpeechRecognition,
+		startedAt,
+		result.Usage,
+		err,
+		0,
 	)
 	if err != nil {
 		return agentvoice.TranscriptionResult{}, mapAgentVoiceError(
@@ -180,9 +229,22 @@ func (synthesizer *AgentVoiceSynthesizer) Synthesize(
 			errors.New("qianwen: Agent Voice synthesizer is required"),
 		)
 	}
+	startedAt := time.Now()
 	result, err := synthesizer.synthesizer.Synthesize(
 		ctx,
 		protocol.SynthesisRequest{Text: request.Text},
+	)
+	characters := 0
+	if err == nil {
+		characters = utf8.RuneCountInString(request.Text)
+	}
+	recordSpeechCall(
+		synthesizer.synthesizer.observer,
+		providerobservability.CapabilitySpeechSynthesis,
+		startedAt,
+		result.Usage,
+		err,
+		characters,
 	)
 	if err != nil {
 		return agentvoice.SynthesisResult{}, mapAgentVoiceError(

--- a/server/internal/providers/qianwen/observability.go
+++ b/server/internal/providers/qianwen/observability.go
@@ -1,0 +1,185 @@
+package qianwen
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
+)
+
+func recordTextCall(
+	recorder providerobservability.Recorder,
+	provider string,
+	startedAt time.Time,
+	usage protocol.TokenUsage,
+	err error,
+) {
+	if recorder == nil {
+		return
+	}
+	recorder.Record(providerobservability.Observation{
+		Provider:   observedTextProvider(provider),
+		Capability: providerobservability.CapabilityTextGeneration,
+		Duration:   time.Since(startedAt),
+		ErrorKind:  observedErrorKind(err),
+		Usage: providerobservability.Usage{
+			Tokens: float64(usage.TotalTokens),
+		},
+	})
+}
+
+func recordSpeechCall(
+	recorder providerobservability.Recorder,
+	capability providerobservability.Capability,
+	startedAt time.Time,
+	usage protocol.SpeechUsage,
+	err error,
+	characters int,
+) {
+	if recorder == nil {
+		return
+	}
+	if usage.Characters > 0 {
+		characters = usage.Characters
+	}
+	recorder.Record(providerobservability.Observation{
+		Provider:   providerobservability.ProviderQianwen,
+		Capability: capability,
+		Duration:   time.Since(startedAt),
+		ErrorKind:  observedErrorKind(err),
+		Usage: providerobservability.Usage{
+			Tokens:       float64(usage.TotalTokens),
+			AudioSeconds: float64(usage.AudioSeconds),
+			Characters:   float64(characters),
+		},
+	})
+}
+
+func observedTextProvider(provider string) providerobservability.Provider {
+	switch provider {
+	case providerName:
+		return providerobservability.ProviderQianwen
+	case qiniuProviderName:
+		return providerobservability.ProviderQiniu
+	default:
+		panic("qianwen: unregistered observable text provider")
+	}
+}
+
+func observedErrorKind(err error) providerobservability.ErrorKind {
+	if err == nil {
+		return providerobservability.ErrorNone
+	}
+	var generationError *protocol.GenerationError
+	if errors.As(err, &generationError) {
+		return observedStableErrorKind(string(generationError.Kind))
+	}
+	var speechError *protocol.SpeechError
+	if errors.As(err, &speechError) {
+		return observedStableErrorKind(string(speechError.Kind))
+	}
+	var stableError interface{ StableCategory() string }
+	if errors.As(err, &stableError) {
+		return observedStableErrorKind(stableError.StableCategory())
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return providerobservability.ErrorTimeout
+	case errors.Is(err, context.Canceled):
+		return providerobservability.ErrorCancelled
+	default:
+		return providerobservability.ErrorProviderUnavailable
+	}
+}
+
+func observedStableErrorKind(kind string) providerobservability.ErrorKind {
+	switch protocol.ErrorKind(kind) {
+	case protocol.ErrorInvalidRequest:
+		return providerobservability.ErrorInvalidRequest
+	case protocol.ErrorConfiguration:
+		return providerobservability.ErrorConfiguration
+	case protocol.ErrorAuthentication:
+		return providerobservability.ErrorAuthentication
+	case protocol.ErrorAuthorization:
+		return providerobservability.ErrorAuthorization
+	case protocol.ErrorQuotaExhausted:
+		return providerobservability.ErrorQuotaExhausted
+	case protocol.ErrorRateLimited:
+		return providerobservability.ErrorRateLimited
+	case protocol.ErrorTimeout:
+		return providerobservability.ErrorTimeout
+	case protocol.ErrorInvalidResponse:
+		return providerobservability.ErrorInvalidResponse
+	case protocol.ErrorCancelled:
+		return providerobservability.ErrorCancelled
+	default:
+		return providerobservability.ErrorProviderUnavailable
+	}
+}
+
+type observedAssistantSpeechSession struct {
+	delegate   agentconversation.AssistantSpeechSession
+	recorder   providerobservability.Recorder
+	startedAt  time.Time
+	characters int
+	recorded   sync.Once
+}
+
+func (session *observedAssistantSpeechSession) AppendText(text string) error {
+	err := session.delegate.AppendText(text)
+	if err != nil {
+		session.finish(err)
+		return err
+	}
+	session.characters += utf8.RuneCountInString(text)
+	return nil
+}
+
+func (session *observedAssistantSpeechSession) Finish() error {
+	err := session.delegate.Finish()
+	session.finish(err)
+	return err
+}
+
+func (session *observedAssistantSpeechSession) Close() error {
+	err := session.delegate.Close()
+	if err != nil {
+		session.finish(err)
+	} else {
+		session.recorded.Do(func() {
+			recordSpeechCall(
+				session.recorder,
+				providerobservability.CapabilitySpeechSynthesis,
+				session.startedAt,
+				protocol.SpeechUsage{},
+				context.Canceled,
+				0,
+			)
+		})
+	}
+	return err
+}
+
+func (session *observedAssistantSpeechSession) finish(err error) {
+	session.recorded.Do(func() {
+		characters := 0
+		if err == nil {
+			characters = session.characters
+		}
+		recordSpeechCall(
+			session.recorder,
+			providerobservability.CapabilitySpeechSynthesis,
+			session.startedAt,
+			protocol.SpeechUsage{},
+			err,
+			characters,
+		)
+	})
+}
+
+var _ agentconversation.AssistantSpeechSession = (*observedAssistantSpeechSession)(nil)

--- a/server/internal/providers/qianwen/observability.go
+++ b/server/internal/providers/qianwen/observability.go
@@ -122,6 +122,35 @@ func observedStableErrorKind(kind string) providerobservability.ErrorKind {
 	}
 }
 
+func downstreamSpeechCallbackError(
+	operation protocol.SpeechOperation,
+	err error,
+) error {
+	if err == nil {
+		return nil
+	}
+	return protocol.NewSpeechError(
+		operation,
+		protocol.ErrorCancelled,
+		0,
+		"",
+		"",
+		err,
+	)
+}
+
+func downstreamSpeechConsumer(consume func([]byte) error) func([]byte) error {
+	if consume == nil {
+		return nil
+	}
+	return func(audio []byte) error {
+		return downstreamSpeechCallbackError(
+			protocol.SpeechOperationSynthesis,
+			consume(audio),
+		)
+	}
+}
+
 type observedAssistantSpeechSession struct {
 	delegate   agentconversation.AssistantSpeechSession
 	recorder   providerobservability.Recorder

--- a/server/internal/providers/qianwen/observability.go
+++ b/server/internal/providers/qianwen/observability.go
@@ -128,6 +128,8 @@ type observedAssistantSpeechSession struct {
 	startedAt  time.Time
 	characters int
 	recorded   sync.Once
+	state      sync.Mutex
+	finished   bool
 }
 
 func (session *observedAssistantSpeechSession) AppendText(text string) error {
@@ -136,11 +138,16 @@ func (session *observedAssistantSpeechSession) AppendText(text string) error {
 		session.finish(err)
 		return err
 	}
+	session.state.Lock()
 	session.characters += utf8.RuneCountInString(text)
+	session.state.Unlock()
 	return nil
 }
 
 func (session *observedAssistantSpeechSession) Finish() error {
+	session.state.Lock()
+	session.finished = true
+	session.state.Unlock()
 	err := session.delegate.Finish()
 	session.finish(err)
 	return err
@@ -148,28 +155,26 @@ func (session *observedAssistantSpeechSession) Finish() error {
 
 func (session *observedAssistantSpeechSession) Close() error {
 	err := session.delegate.Close()
-	if err != nil {
-		session.finish(err)
-	} else {
-		session.recorded.Do(func() {
-			recordSpeechCall(
-				session.recorder,
-				providerobservability.CapabilitySpeechSynthesis,
-				session.startedAt,
-				protocol.SpeechUsage{},
-				context.Canceled,
-				0,
-			)
-		})
+	session.state.Lock()
+	finished := session.finished
+	session.state.Unlock()
+	if !finished {
+		session.finish(context.Canceled)
+		return err
 	}
+	session.finish(err)
 	return err
 }
 
 func (session *observedAssistantSpeechSession) finish(err error) {
 	session.recorded.Do(func() {
 		characters := 0
-		if err == nil {
+		kind := observedErrorKind(err)
+		if kind == providerobservability.ErrorNone ||
+			kind == providerobservability.ErrorInvalidResponse {
+			session.state.Lock()
 			characters = session.characters
+			session.state.Unlock()
 		}
 		recordSpeechCall(
 			session.recorder,
@@ -180,6 +185,15 @@ func (session *observedAssistantSpeechSession) finish(err error) {
 			characters,
 		)
 	})
+}
+
+func observedSynthesisCharacters(text string, err error) int {
+	kind := observedErrorKind(err)
+	if kind != providerobservability.ErrorNone &&
+		kind != providerobservability.ErrorInvalidResponse {
+		return 0
+	}
+	return utf8.RuneCountInString(text)
 }
 
 var _ agentconversation.AssistantSpeechSession = (*observedAssistantSpeechSession)(nil)

--- a/server/internal/providers/qianwen/observability_test.go
+++ b/server/internal/providers/qianwen/observability_test.go
@@ -16,18 +16,10 @@ import (
 
 type providerRecorder struct {
 	observations []providerobservability.Observation
-	retries      int
 }
 
 func (recorder *providerRecorder) Record(observation providerobservability.Observation) {
 	recorder.observations = append(recorder.observations, observation)
-}
-
-func (recorder *providerRecorder) RecordRetry(
-	providerobservability.Provider,
-	providerobservability.Capability,
-) {
-	recorder.retries++
 }
 
 func TestTextClientRecordsSuccessUsageAndSanitizedTransportFailure(t *testing.T) {
@@ -69,6 +61,25 @@ func TestTextClientRecordsSuccessUsageAndSanitizedTransportFailure(t *testing.T)
 		}
 		if strings.Contains(fmt.Sprintf("%#v", observation), sensitiveError) {
 			t.Fatal("observation retained provider error text")
+		}
+	})
+
+	t.Run("reported usage survives local response validation", func(t *testing.T) {
+		recorder := &providerRecorder{}
+		generator := observedTextGenerator(t, recorder, doerFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{
+				"id":"chatcmpl-observed","model":"qwen3.5-flash",
+				"choices":[{"finish_reason":"stop","index":0,"message":{"role":"tool","content":"invalid"}}],
+				"usage":{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16}
+			}`), nil
+		}))
+		if _, err := generator.Generate(context.Background(), validRequest()); err == nil {
+			t.Fatal("Generate error = nil")
+		}
+		observation := onlyObservation(t, recorder)
+		if observation.ErrorKind != providerobservability.ErrorInvalidResponse ||
+			observation.Usage.Tokens != 16 {
+			t.Fatalf("observation = %#v", observation)
 		}
 	})
 }
@@ -119,6 +130,73 @@ func TestObservedAssistantSpeechSessionRecordsCharactersOnce(t *testing.T) {
 	}
 }
 
+func TestObservedAssistantSpeechSessionCloseBeforeFinishIsCancelled(t *testing.T) {
+	recorder := &providerRecorder{}
+	session := &observedAssistantSpeechSession{
+		delegate: &assistantSpeechSessionStub{closeErr: errors.New("private provider close detail")},
+		recorder: recorder, startedAt: time.Now(),
+	}
+	if err := session.Close(); err == nil {
+		t.Fatal("Close error = nil")
+	}
+	observation := onlyObservation(t, recorder)
+	if observation.ErrorKind != providerobservability.ErrorCancelled {
+		t.Fatalf("observation = %#v", observation)
+	}
+}
+
+func TestObservedAssistantSpeechSessionKeepsCharactersAfterLocalValidationFailure(t *testing.T) {
+	recorder := &providerRecorder{}
+	finishErr := protocol.NewSpeechError(
+		protocol.SpeechOperationSynthesis,
+		protocol.ErrorInvalidResponse,
+		200,
+		"",
+		"",
+		errors.New("local final response validation"),
+	)
+	session := &observedAssistantSpeechSession{
+		delegate: &assistantSpeechSessionStub{finishErr: finishErr},
+		recorder: recorder, startedAt: time.Now(),
+	}
+	if err := session.AppendText("你好"); err != nil {
+		t.Fatalf("AppendText: %v", err)
+	}
+	if err := session.Finish(); !errors.Is(err, finishErr) {
+		t.Fatalf("Finish error = %v", err)
+	}
+	observation := onlyObservation(t, recorder)
+	if observation.ErrorKind != providerobservability.ErrorInvalidResponse ||
+		observation.Usage.Characters != 2 {
+		t.Fatalf("observation = %#v", observation)
+	}
+}
+
+func TestObservedSynthesisCharactersSurviveLocalResponseValidation(t *testing.T) {
+	invalidResponse := protocol.NewSpeechError(
+		protocol.SpeechOperationSynthesis,
+		protocol.ErrorInvalidResponse,
+		200,
+		"",
+		"",
+		errors.New("local response validation"),
+	)
+	if got := observedSynthesisCharacters("你好", invalidResponse); got != 2 {
+		t.Fatalf("observedSynthesisCharacters() = %d, want 2", got)
+	}
+	invalidRequest := protocol.NewSpeechError(
+		protocol.SpeechOperationSynthesis,
+		protocol.ErrorInvalidRequest,
+		0,
+		"",
+		"",
+		errors.New("local request validation"),
+	)
+	if got := observedSynthesisCharacters("你好", invalidRequest); got != 0 {
+		t.Fatalf("invalid request characters = %d, want 0", got)
+	}
+}
+
 func observedTextGenerator(
 	t *testing.T,
 	recorder providerobservability.Recorder,
@@ -147,10 +225,13 @@ func onlyObservation(
 	return recorder.observations[0]
 }
 
-type assistantSpeechSessionStub struct{}
+type assistantSpeechSessionStub struct {
+	finishErr error
+	closeErr  error
+}
 
 func (*assistantSpeechSessionStub) AppendText(string) error { return nil }
-func (*assistantSpeechSessionStub) Finish() error           { return nil }
-func (*assistantSpeechSessionStub) Close() error            { return nil }
+func (stub *assistantSpeechSessionStub) Finish() error      { return stub.finishErr }
+func (stub *assistantSpeechSessionStub) Close() error       { return stub.closeErr }
 
 var _ agentconversation.AssistantSpeechSession = (*assistantSpeechSessionStub)(nil)

--- a/server/internal/providers/qianwen/observability_test.go
+++ b/server/internal/providers/qianwen/observability_test.go
@@ -145,6 +145,33 @@ func TestObservedAssistantSpeechSessionCloseBeforeFinishIsCancelled(t *testing.T
 	}
 }
 
+func TestObservedAssistantSpeechSessionRecordsConsumerFailureAsCancelled(t *testing.T) {
+	cause := errors.New("client audio write failed")
+	consume := downstreamSpeechConsumer(func([]byte) error { return cause })
+	callbackErr := consume([]byte{1, 2, 3})
+	if !errors.Is(callbackErr, cause) ||
+		observedErrorKind(callbackErr) != providerobservability.ErrorCancelled {
+		t.Fatalf("consumer error = %#v", callbackErr)
+	}
+
+	recorder := &providerRecorder{}
+	session := &observedAssistantSpeechSession{
+		delegate: &assistantSpeechSessionStub{finishErr: callbackErr},
+		recorder: recorder, startedAt: time.Now(),
+	}
+	if err := session.AppendText("你好"); err != nil {
+		t.Fatalf("AppendText: %v", err)
+	}
+	if err := session.Finish(); !errors.Is(err, cause) {
+		t.Fatalf("Finish error = %v", err)
+	}
+	observation := onlyObservation(t, recorder)
+	if observation.ErrorKind != providerobservability.ErrorCancelled ||
+		observation.Usage.Characters != 0 {
+		t.Fatalf("observation = %#v", observation)
+	}
+}
+
 func TestObservedAssistantSpeechSessionKeepsCharactersAfterLocalValidationFailure(t *testing.T) {
 	recorder := &providerRecorder{}
 	finishErr := protocol.NewSpeechError(

--- a/server/internal/providers/qianwen/observability_test.go
+++ b/server/internal/providers/qianwen/observability_test.go
@@ -1,0 +1,156 @@
+package qianwen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	agentconversation "github.com/1024XEngineer/XE3-ESL/server/internal/agent/conversation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
+)
+
+type providerRecorder struct {
+	observations []providerobservability.Observation
+	retries      int
+}
+
+func (recorder *providerRecorder) Record(observation providerobservability.Observation) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+func (recorder *providerRecorder) RecordRetry(
+	providerobservability.Provider,
+	providerobservability.Capability,
+) {
+	recorder.retries++
+}
+
+func TestTextClientRecordsSuccessUsageAndSanitizedTransportFailure(t *testing.T) {
+	const sensitiveError = "private-user@example.com secret provider payload"
+
+	t.Run("success", func(t *testing.T) {
+		recorder := &providerRecorder{}
+		generator := observedTextGenerator(t, recorder, doerFunc(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(http.StatusOK, `{
+				"id":"chatcmpl-observed","model":"qwen3.5-flash",
+				"choices":[{"finish_reason":"stop","index":0,"message":{"role":"assistant","content":"answer"}}],
+				"usage":{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16}
+			}`), nil
+		}))
+		if _, err := generator.Generate(context.Background(), validRequest()); err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		observation := onlyObservation(t, recorder)
+		if observation.Provider != providerobservability.ProviderQianwen ||
+			observation.Capability != providerobservability.CapabilityTextGeneration ||
+			observation.ErrorKind != providerobservability.ErrorNone ||
+			observation.Usage.Tokens != 16 || observation.Duration < 0 {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+
+	t.Run("transport failure", func(t *testing.T) {
+		recorder := &providerRecorder{}
+		generator := observedTextGenerator(t, recorder, doerFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New(sensitiveError)
+		}))
+		if _, err := generator.Generate(context.Background(), validRequest()); err == nil {
+			t.Fatal("Generate error = nil")
+		}
+		observation := onlyObservation(t, recorder)
+		if observation.ErrorKind != providerobservability.ErrorProviderUnavailable ||
+			observation.Usage != (providerobservability.Usage{}) {
+			t.Fatalf("observation = %#v", observation)
+		}
+		if strings.Contains(fmt.Sprintf("%#v", observation), sensitiveError) {
+			t.Fatal("observation retained provider error text")
+		}
+	})
+}
+
+func TestSpeechCallMapsTimeoutAndFixedUsage(t *testing.T) {
+	recorder := &providerRecorder{}
+	recordSpeechCall(
+		recorder,
+		providerobservability.CapabilitySpeechRecognition,
+		time.Now(),
+		protocol.SpeechUsage{TotalTokens: 9, AudioSeconds: 4},
+		protocol.NewSpeechError(
+			protocol.SpeechOperationTranscription,
+			protocol.ErrorTimeout,
+			0,
+			"",
+			"",
+			context.DeadlineExceeded,
+		),
+		0,
+	)
+	observation := onlyObservation(t, recorder)
+	if observation.ErrorKind != providerobservability.ErrorTimeout ||
+		observation.Usage.Tokens != 9 || observation.Usage.AudioSeconds != 4 {
+		t.Fatalf("observation = %#v", observation)
+	}
+}
+
+func TestObservedAssistantSpeechSessionRecordsCharactersOnce(t *testing.T) {
+	recorder := &providerRecorder{}
+	session := &observedAssistantSpeechSession{
+		delegate: &assistantSpeechSessionStub{}, recorder: recorder,
+		startedAt: time.Now(),
+	}
+	if err := session.AppendText("你好"); err != nil {
+		t.Fatalf("AppendText: %v", err)
+	}
+	if err := session.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	observation := onlyObservation(t, recorder)
+	if observation.ErrorKind != providerobservability.ErrorNone ||
+		observation.Usage.Characters != 2 {
+		t.Fatalf("observation = %#v", observation)
+	}
+}
+
+func observedTextGenerator(
+	t *testing.T,
+	recorder providerobservability.Recorder,
+	doer httpDoer,
+) *textClient {
+	t.Helper()
+	generator, err := newWithClient(TextConfig{
+		BaseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+		Model:   "qwen3.5-flash", Timeout: time.Second, MaxOutputTokens: 512,
+		Observer: recorder,
+	}, "test-api-key", doer)
+	if err != nil {
+		t.Fatalf("newWithClient: %v", err)
+	}
+	return generator
+}
+
+func onlyObservation(
+	t *testing.T,
+	recorder *providerRecorder,
+) providerobservability.Observation {
+	t.Helper()
+	if len(recorder.observations) != 1 {
+		t.Fatalf("observations = %#v", recorder.observations)
+	}
+	return recorder.observations[0]
+}
+
+type assistantSpeechSessionStub struct{}
+
+func (*assistantSpeechSessionStub) AppendText(string) error { return nil }
+func (*assistantSpeechSessionStub) Finish() error           { return nil }
+func (*assistantSpeechSessionStub) Close() error            { return nil }
+
+var _ agentconversation.AssistantSpeechSession = (*assistantSpeechSessionStub)(nil)

--- a/server/internal/providers/qianwen/practice_interaction.go
+++ b/server/internal/providers/qianwen/practice_interaction.go
@@ -3,8 +3,11 @@ package qianwen
 import (
 	"context"
 	"errors"
+	"time"
+	"unicode/utf8"
 
 	practiceinteraction "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/interaction"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
@@ -53,9 +56,18 @@ func (recognizer *PracticeVoiceRecognizer) Transcribe(
 				errors.New("Qianwen Practice Voice recognizer is required"),
 			)
 	}
+	startedAt := time.Now()
 	result, err := recognizer.recognizer.Transcribe(
 		ctx,
 		protocol.TranscriptionRequest{Audio: request.Audio},
+	)
+	recordSpeechCall(
+		recognizer.recognizer.observer,
+		providerobservability.CapabilitySpeechRecognition,
+		startedAt,
+		result.Usage,
+		err,
+		0,
 	)
 	if err != nil {
 		return practiceinteraction.TranscriptionResult{},
@@ -88,11 +100,20 @@ func (recognizer *PracticeVoiceRecognizer) TranscribeStream(
 				errors.New("Qianwen streaming Practice Voice recognizer is required"),
 			)
 	}
+	startedAt := time.Now()
 	result, err := recognizer.recognizer.transcribeRealtimePCM(
 		ctx,
 		request.PCM,
 		request.SampleRate,
 		practiceVoiceTranscriptionObserver{observer: observer},
+	)
+	recordSpeechCall(
+		recognizer.recognizer.observer,
+		providerobservability.CapabilitySpeechRecognition,
+		startedAt,
+		result.Usage,
+		err,
+		0,
 	)
 	if err != nil {
 		return practiceinteraction.TranscriptionResult{},
@@ -155,9 +176,22 @@ func (synthesizer *PracticeVoiceSynthesizer) Synthesize(
 				errors.New("Qianwen Practice Voice synthesizer is required"),
 			)
 	}
+	startedAt := time.Now()
 	result, err := synthesizer.synthesizer.Synthesize(
 		ctx,
 		protocol.SynthesisRequest{Text: request.Text},
+	)
+	characters := 0
+	if err == nil {
+		characters = utf8.RuneCountInString(request.Text)
+	}
+	recordSpeechCall(
+		synthesizer.synthesizer.observer,
+		providerobservability.CapabilitySpeechSynthesis,
+		startedAt,
+		result.Usage,
+		err,
+		characters,
 	)
 	if err != nil {
 		return practiceinteraction.SynthesisResult{},

--- a/server/internal/providers/qianwen/practice_interaction.go
+++ b/server/internal/providers/qianwen/practice_interaction.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"time"
-	"unicode/utf8"
 
 	practiceinteraction "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/interaction"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
@@ -181,10 +180,7 @@ func (synthesizer *PracticeVoiceSynthesizer) Synthesize(
 		ctx,
 		protocol.SynthesisRequest{Text: request.Text},
 	)
-	characters := 0
-	if err == nil {
-		characters = utf8.RuneCountInString(request.Text)
-	}
+	characters := observedSynthesisCharacters(request.Text, err)
 	recordSpeechCall(
 		synthesizer.synthesizer.observer,
 		providerobservability.CapabilitySpeechSynthesis,

--- a/server/internal/providers/qianwen/practice_interaction.go
+++ b/server/internal/providers/qianwen/practice_interaction.go
@@ -138,12 +138,15 @@ func (observer practiceVoiceTranscriptionObserver) OnTranscriptionUpdate(
 	ctx context.Context,
 	update protocol.TranscriptionUpdate,
 ) error {
-	return observer.observer.OnTranscriptionUpdate(
-		ctx,
-		practiceinteraction.TranscriptionUpdate{
-			Transcript: update.Transcript,
-			Final:      update.Final,
-		},
+	return downstreamSpeechCallbackError(
+		protocol.SpeechOperationTranscription,
+		observer.observer.OnTranscriptionUpdate(
+			ctx,
+			practiceinteraction.TranscriptionUpdate{
+				Transcript: update.Transcript,
+				Final:      update.Final,
+			},
+		),
 	)
 }
 

--- a/server/internal/providers/qianwen/practice_interaction_test.go
+++ b/server/internal/providers/qianwen/practice_interaction_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	practiceinteraction "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/interaction"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 	sharedtranslation "github.com/1024XEngineer/XE3-ESL/server/internal/translation"
 )
@@ -143,6 +144,31 @@ func TestPracticeVoiceStreamingObserverMapsProviderSnapshot(t *testing.T) {
 	}
 }
 
+func TestPracticeVoiceObserverClassifiesCallbackFailureAsCancelled(t *testing.T) {
+	cause := errors.New("client stream write failed")
+	adapter := practiceVoiceTranscriptionObserver{
+		observer: &practiceVoiceObserverRecorder{err: cause},
+	}
+	err := adapter.OnTranscriptionUpdate(
+		context.Background(),
+		protocol.TranscriptionUpdate{Transcript: "partial"},
+	)
+	if !errors.Is(err, cause) ||
+		observedErrorKind(err) != providerobservability.ErrorCancelled {
+		t.Fatalf("callback error = %#v", err)
+	}
+	mapped := mapPracticeInteractionError(
+		err,
+		practiceinteraction.ProviderOperationTranscription,
+	)
+	var mappedError *practiceinteraction.ProviderError
+	if !errors.As(mapped, &mappedError) ||
+		mappedError.Kind != practiceinteraction.ProviderErrorCancelled ||
+		!errors.Is(mapped, cause) {
+		t.Fatalf("mapped callback error = %#v", mapped)
+	}
+}
+
 func TestPracticeVoiceStreamingRejectsNonRealtimeModel(t *testing.T) {
 	recognizer := &PracticeVoiceRecognizer{
 		recognizer: &speechRecognizer{model: "fun-asr-flash-2026-06-15"},
@@ -186,6 +212,7 @@ func TestPracticeRecordedVoiceRecognizerRequiresFlashModel(t *testing.T) {
 
 type practiceVoiceObserverRecorder struct {
 	update practiceinteraction.TranscriptionUpdate
+	err    error
 }
 
 func (recorder *practiceVoiceObserverRecorder) OnTranscriptionUpdate(
@@ -193,7 +220,7 @@ func (recorder *practiceVoiceObserverRecorder) OnTranscriptionUpdate(
 	update practiceinteraction.TranscriptionUpdate,
 ) error {
 	recorder.update = update
-	return nil
+	return recorder.err
 }
 
 func isTranslationConfigurationError(err error) bool {

--- a/server/internal/providers/qianwen/speech_recognizer.go
+++ b/server/internal/providers/qianwen/speech_recognizer.go
@@ -14,15 +14,17 @@ import (
 	"time"
 
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
 const maxASRDataURLBytes = 10_000_000
 
 type ASRConfig struct {
-	BaseURL string
-	Model   string
-	Timeout time.Duration
+	BaseURL  string
+	Model    string
+	Timeout  time.Duration
+	Observer providerobservability.Recorder
 }
 
 type speechRecognizer struct {
@@ -32,6 +34,7 @@ type speechRecognizer struct {
 	timeout    time.Duration
 	apiKey     providerSecret
 	client     httpDoer
+	observer   providerobservability.Recorder
 }
 
 func (recognizer *speechRecognizer) String() string {
@@ -89,6 +92,7 @@ func newRecognizerWithClient(
 		timeout:    config.Timeout,
 		apiKey:     newProviderSecret(apiKey),
 		client:     client,
+		observer:   config.Observer,
 	}, nil
 }
 

--- a/server/internal/providers/qianwen/speech_synthesizer.go
+++ b/server/internal/providers/qianwen/speech_synthesizer.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	platformmedia "github.com/1024XEngineer/XE3-ESL/server/internal/platform/media"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
@@ -35,6 +36,7 @@ type TTSConfig struct {
 	LanguageHint  string
 	Timeout       time.Duration
 	TempDirectory string
+	Observer      providerobservability.Recorder
 }
 
 type speechSynthesizer struct {
@@ -48,6 +50,7 @@ type speechSynthesizer struct {
 	tempDirectory    string
 	apiKey           providerSecret
 	client           httpDoer
+	observer         providerobservability.Recorder
 	now              func() time.Time
 }
 
@@ -130,6 +133,7 @@ func newSynthesizerWithClient(
 		tempDirectory:    strings.TrimSpace(config.TempDirectory),
 		apiKey:           newProviderSecret(apiKey),
 		client:           client,
+		observer:         config.Observer,
 		now:              time.Now,
 	}, nil
 }

--- a/server/internal/providers/qianwen/text_generator.go
+++ b/server/internal/providers/qianwen/text_generator.go
@@ -211,12 +211,13 @@ func (generator *textClient) Generate(
 	httpRequest.Header.Set("Accept", "application/json")
 
 	startedAt := time.Now()
+	observedUsage := protocol.TokenUsage{}
 	defer func() {
 		recordTextCall(
 			generator.observer,
 			generator.provider,
 			startedAt,
-			callResult.Usage,
+			observedUsage,
 			callErr,
 		)
 	}()
@@ -268,6 +269,7 @@ func (generator *textClient) Generate(
 			errors.New("decode Qianwen response"),
 		)
 	}
+	observedUsage = completion.reportedUsage()
 	result, err := completion.result(generator.provider, providerToInternal)
 	if err != nil {
 		return protocol.TextResult{}, protocol.NewGenerationError(
@@ -352,12 +354,13 @@ func (generator *textClient) GenerateStream(
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Accept", "text/event-stream")
 	startedAt := time.Now()
+	observedUsage := protocol.TokenUsage{}
 	defer func() {
 		recordTextCall(
 			generator.observer,
 			generator.provider,
 			startedAt,
-			callResult.Usage,
+			observedUsage,
 			callErr,
 		)
 	}()
@@ -390,6 +393,7 @@ func (generator *textClient) GenerateStream(
 		generator.provider,
 		providerToInternal,
 		observer,
+		&observedUsage,
 	)
 	if err != nil {
 		var generationError *protocol.GenerationError
@@ -651,6 +655,7 @@ func decodeCompletionStream(
 	provider string,
 	providerToInternal map[string]string,
 	observer protocol.TextDeltaObserver,
+	reportedUsage *protocol.TokenUsage,
 ) (protocol.TextResult, error) {
 	scanner := bufio.NewScanner(io.LimitReader(body, maxStreamBytes+1))
 	scanner.Buffer(make([]byte, 16<<10), maxStreamEventBytes)
@@ -722,6 +727,13 @@ func decodeCompletionStream(
 			if usage.prompt < 0 || usage.completion < 0 || usage.total < 0 ||
 				usage.total-usage.prompt != usage.completion {
 				return protocol.TextResult{}, errors.New("Qianwen stream has invalid token usage")
+			}
+			if reportedUsage != nil {
+				*reportedUsage = protocol.TokenUsage{
+					InputTokens:  usage.prompt,
+					OutputTokens: usage.completion,
+					TotalTokens:  usage.total,
+				}
 			}
 			sawUsage = true
 			if len(chunk.Choices) == 0 {
@@ -955,6 +967,22 @@ func (response chatCompletionResponse) result(
 			TotalTokens:  *response.Usage.TotalTokens,
 		},
 	}, nil
+}
+
+func (response chatCompletionResponse) reportedUsage() protocol.TokenUsage {
+	if response.Usage == nil || response.Usage.PromptTokens == nil ||
+		response.Usage.CompletionTokens == nil || response.Usage.TotalTokens == nil ||
+		*response.Usage.PromptTokens < 0 || *response.Usage.CompletionTokens < 0 ||
+		*response.Usage.TotalTokens < 0 ||
+		*response.Usage.TotalTokens-*response.Usage.PromptTokens !=
+			*response.Usage.CompletionTokens {
+		return protocol.TokenUsage{}
+	}
+	return protocol.TokenUsage{
+		InputTokens:  *response.Usage.PromptTokens,
+		OutputTokens: *response.Usage.CompletionTokens,
+		TotalTokens:  *response.Usage.TotalTokens,
+	}
 }
 
 func toolNameMappings(request protocol.TextRequest) (map[string]string, map[string]string, error) {

--- a/server/internal/providers/qianwen/text_generator.go
+++ b/server/internal/providers/qianwen/text_generator.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/modelid"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
@@ -46,6 +47,7 @@ type TextConfig struct {
 	Model           string
 	Timeout         time.Duration
 	MaxOutputTokens int
+	Observer        providerobservability.Recorder
 }
 
 type textClient struct {
@@ -57,6 +59,7 @@ type textClient struct {
 	maxOutputTokens int
 	apiKey          providerSecret
 	client          httpDoer
+	observer        providerobservability.Recorder
 }
 
 func (generator *textClient) String() string {
@@ -129,13 +132,14 @@ func newWithClient(config TextConfig, apiKey string, client httpDoer) (*textClie
 		maxOutputTokens: config.MaxOutputTokens,
 		apiKey:          newProviderSecret(apiKey),
 		client:          client,
+		observer:        config.Observer,
 	}, nil
 }
 
 func (generator *textClient) Generate(
 	ctx context.Context,
 	request protocol.TextRequest,
-) (protocol.TextResult, error) {
+) (callResult protocol.TextResult, callErr error) {
 	if ctx == nil {
 		return protocol.TextResult{}, protocol.NewGenerationError(
 			protocol.ErrorInvalidRequest,
@@ -206,6 +210,16 @@ func (generator *textClient) Generate(
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Accept", "application/json")
 
+	startedAt := time.Now()
+	defer func() {
+		recordTextCall(
+			generator.observer,
+			generator.provider,
+			startedAt,
+			callResult.Usage,
+			callErr,
+		)
+	}()
 	response, err := generator.client.Do(httpRequest)
 	if err != nil {
 		return protocol.TextResult{}, transportError(callContext, err)
@@ -292,7 +306,7 @@ func (generator *textClient) GenerateStream(
 	ctx context.Context,
 	request protocol.TextRequest,
 	observer protocol.TextDeltaObserver,
-) (protocol.TextResult, error) {
+) (callResult protocol.TextResult, callErr error) {
 	if ctx == nil || observer == nil {
 		return protocol.TextResult{}, protocol.NewGenerationError(
 			protocol.ErrorInvalidRequest, 0, "", "",
@@ -337,6 +351,16 @@ func (generator *textClient) GenerateStream(
 	httpRequest.Header.Set(authorizationHeaderName, "Bearer "+generator.apiKey.reveal())
 	httpRequest.Header.Set("Content-Type", "application/json")
 	httpRequest.Header.Set("Accept", "text/event-stream")
+	startedAt := time.Now()
+	defer func() {
+		recordTextCall(
+			generator.observer,
+			generator.provider,
+			startedAt,
+			callResult.Usage,
+			callErr,
+		)
+	}()
 	response, err := generator.client.Do(httpRequest)
 	if err != nil {
 		return protocol.TextResult{}, transportError(callContext, err)

--- a/server/internal/providers/spatius/client.go
+++ b/server/internal/providers/spatius/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice/avatar"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 const maxResponseBody = 64 * 1024
@@ -23,12 +24,14 @@ type Config struct {
 	ConsoleBaseURL string
 	APIKey         string
 	Timeout        time.Duration
+	Observer       providerobservability.Recorder
 }
 
 type Client struct {
 	endpoint string
 	apiKey   string
 	client   *http.Client
+	observer providerobservability.Recorder
 }
 
 var _ avatar.TokenProvider = (*Client)(nil)
@@ -64,8 +67,9 @@ func newClient(
 			configuration.ConsoleBaseURL,
 			"/",
 		) + "/session-tokens",
-		apiKey: configuration.APIKey,
-		client: client,
+		apiKey:   configuration.APIKey,
+		client:   client,
+		observer: configuration.Observer,
 	}, nil
 }
 
@@ -98,8 +102,14 @@ func (client *Client) CreateSessionToken(
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("X-Api-Key", client.apiKey)
 
+	startedAt := time.Now()
+	metricKind := providerobservability.ErrorProviderUnavailable
+	defer func() {
+		recordSessionTokenCall(client.observer, startedAt, metricKind)
+	}()
 	response, err := client.client.Do(request)
 	if err != nil {
+		metricKind = sessionTokenTransportKind(ctx, err)
 		return avatar.ProviderSessionToken{}, fmt.Errorf(
 			"create avatar provider session token: %w",
 			avatar.ErrProviderUnavailable,
@@ -110,14 +120,17 @@ func (client *Client) CreateSessionToken(
 	switch {
 	case response.StatusCode == http.StatusTooManyRequests ||
 		response.StatusCode == http.StatusPaymentRequired:
+		metricKind = sessionTokenStatusKind(response.StatusCode)
 		discardResponse(response.Body)
 		return avatar.ProviderSessionToken{}, avatar.ErrProviderQuotaExhausted
 	case response.StatusCode < http.StatusOK ||
 		response.StatusCode >= http.StatusMultipleChoices:
+		metricKind = sessionTokenStatusKind(response.StatusCode)
 		discardResponse(response.Body)
 		return avatar.ProviderSessionToken{}, avatar.ErrProviderUnavailable
 	}
 	if !jsonContentType(response.Header.Get("Content-Type")) {
+		metricKind = providerobservability.ErrorInvalidResponse
 		discardResponse(response.Body)
 		return avatar.ProviderSessionToken{}, avatar.ErrInvalidProviderResponse
 	}
@@ -125,13 +138,20 @@ func (client *Client) CreateSessionToken(
 		response.Body,
 		maxResponseBody+1,
 	))
-	if err != nil || len(body) == 0 || len(body) > maxResponseBody {
+	if err != nil {
+		metricKind = sessionTokenTransportKind(ctx, err)
 		return avatar.ProviderSessionToken{}, avatar.ErrInvalidProviderResponse
 	}
-	token, err := decodeSessionToken(body)
+	if len(body) == 0 || len(body) > maxResponseBody {
+		metricKind = providerobservability.ErrorInvalidResponse
+		return avatar.ProviderSessionToken{}, avatar.ErrInvalidProviderResponse
+	}
+	token, tokenKind, err := decodeSessionToken(body)
+	metricKind = tokenKind
 	if err != nil {
 		return avatar.ProviderSessionToken{}, err
 	}
+	metricKind = providerobservability.ErrorNone
 	return avatar.ProviderSessionToken{
 		Value:     token,
 		ExpiresAt: expiresAt.UTC().Truncate(time.Second),
@@ -151,29 +171,31 @@ type providerError struct {
 	Status int `json:"status"`
 }
 
-func decodeSessionToken(body []byte) (string, error) {
+func decodeSessionToken(
+	body []byte,
+) (string, providerobservability.ErrorKind, error) {
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	var document sessionTokenResponse
 	if err := decoder.Decode(&document); err != nil {
-		return "", avatar.ErrInvalidProviderResponse
+		return "", providerobservability.ErrorInvalidResponse, avatar.ErrInvalidProviderResponse
 	}
 	var trailing any
 	if !errors.Is(decoder.Decode(&trailing), io.EOF) {
-		return "", avatar.ErrInvalidProviderResponse
+		return "", providerobservability.ErrorInvalidResponse, avatar.ErrInvalidProviderResponse
 	}
 	for _, providerError := range document.Errors {
 		if providerError.Status == http.StatusPaymentRequired ||
 			providerError.Status == http.StatusTooManyRequests {
-			return "", avatar.ErrProviderQuotaExhausted
+			return "", sessionTokenStatusKind(providerError.Status), avatar.ErrProviderQuotaExhausted
 		}
 	}
 	if len(document.Errors) > 0 {
-		return "", avatar.ErrProviderUnavailable
+		return "", sessionTokenStatusKind(document.Errors[0].Status), avatar.ErrProviderUnavailable
 	}
 	if !validSessionToken(document.SessionToken) {
-		return "", avatar.ErrInvalidProviderResponse
+		return "", providerobservability.ErrorInvalidResponse, avatar.ErrInvalidProviderResponse
 	}
-	return document.SessionToken, nil
+	return document.SessionToken, providerobservability.ErrorNone, nil
 }
 
 func validConsoleBaseURL(raw string) bool {

--- a/server/internal/providers/spatius/client_test.go
+++ b/server/internal/providers/spatius/client_test.go
@@ -1,0 +1,164 @@
+package spatius
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func TestClientRecordsValidatedSessionTokenCall(t *testing.T) {
+	recorder := &sessionTokenRecorder{}
+	client := newObservedClient(t, recorder, roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodPost || request.URL.Path != "/session-tokens" ||
+			request.Header.Get("X-Api-Key") != "test-api-key" {
+			t.Fatalf("request = %s %s %#v", request.Method, request.URL, request.Header)
+		}
+		return httpSessionTokenResponse(http.StatusOK, `{"sessionToken":"session-token"}`), nil
+	}))
+	result, err := client.CreateSessionToken(
+		context.Background(), "app-id", time.Now().UTC().Add(time.Minute),
+	)
+	if err != nil || result.Value != "session-token" {
+		t.Fatalf("CreateSessionToken() = %#v, %v", result, err)
+	}
+	observation := onlySessionTokenObservation(t, recorder)
+	if observation.Provider != providerobservability.ProviderSpatius ||
+		observation.Capability != providerobservability.CapabilityAvatarSessionToken ||
+		observation.ErrorKind != providerobservability.ErrorNone ||
+		observation.Usage != (providerobservability.Usage{}) {
+		t.Fatalf("observation = %#v", observation)
+	}
+}
+
+func TestClientMapsBoundedHTTPAndDocumentErrors(t *testing.T) {
+	for name, test := range map[string]struct {
+		status int
+		body   string
+		want   providerobservability.ErrorKind
+	}{
+		"bad request":    {status: 400, want: providerobservability.ErrorInvalidRequest},
+		"authentication": {status: 401, want: providerobservability.ErrorAuthentication},
+		"quota":          {status: 402, want: providerobservability.ErrorQuotaExhausted},
+		"authorization":  {status: 403, want: providerobservability.ErrorAuthorization},
+		"rate limited":   {status: 429, want: providerobservability.ErrorRateLimited},
+		"unavailable":    {status: 503, want: providerobservability.ErrorProviderUnavailable},
+		"document error": {
+			status: 200, body: `{"sessionToken":"","errors":[{"status":403}]}`,
+			want: providerobservability.ErrorAuthorization,
+		},
+		"invalid document": {
+			status: 200, body: `{"sessionToken":"short"}`,
+			want: providerobservability.ErrorInvalidResponse,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := &sessionTokenRecorder{}
+			client := newObservedClient(t, recorder, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return httpSessionTokenResponse(test.status, test.body), nil
+			}))
+			_, _ = client.CreateSessionToken(
+				context.Background(), "app-id", time.Now().UTC().Add(time.Minute),
+			)
+			if observation := onlySessionTokenObservation(t, recorder); observation.ErrorKind != test.want {
+				t.Fatalf("observation = %#v", observation)
+			}
+		})
+	}
+}
+
+func TestClientRecordsBoundedTransportOutcome(t *testing.T) {
+	for name, test := range map[string]struct {
+		err  error
+		want providerobservability.ErrorKind
+	}{
+		"cancelled": {err: context.Canceled, want: providerobservability.ErrorCancelled},
+		"timeout":   {err: context.DeadlineExceeded, want: providerobservability.ErrorTimeout},
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := &sessionTokenRecorder{}
+			client := newObservedClient(t, recorder, roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, test.err
+			}))
+			_, _ = client.CreateSessionToken(
+				context.Background(), "app-id", time.Now().UTC().Add(time.Minute),
+			)
+			if observation := onlySessionTokenObservation(t, recorder); observation.ErrorKind != test.want {
+				t.Fatalf("observation = %#v", observation)
+			}
+		})
+	}
+}
+
+func TestClientSkipsInvalidInputBeforeExternalCall(t *testing.T) {
+	recorder := &sessionTokenRecorder{}
+	calls := 0
+	client := newObservedClient(t, recorder, roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, context.Canceled
+	}))
+	_, _ = client.CreateSessionToken(
+		context.Background(), "", time.Now().UTC().Add(time.Minute),
+	)
+	if calls != 0 || len(recorder.observations) != 0 {
+		t.Fatalf("calls = %d observations = %#v", calls, recorder.observations)
+	}
+}
+
+func newObservedClient(
+	t *testing.T,
+	recorder providerobservability.Recorder,
+	transport http.RoundTripper,
+) *Client {
+	t.Helper()
+	client, err := newClient(Config{
+		Enabled: true, ConsoleBaseURL: "https://console.spatius.example",
+		APIKey: "test-api-key", Timeout: time.Second, Observer: recorder,
+	}, &http.Client{Transport: transport})
+	if err != nil {
+		t.Fatalf("newClient: %v", err)
+	}
+	return client
+}
+
+func httpSessionTokenResponse(status int, body string) *http.Response {
+	if body == "" {
+		body = `{}`
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type sessionTokenRecorder struct {
+	observations []providerobservability.Observation
+}
+
+func (recorder *sessionTokenRecorder) Record(
+	observation providerobservability.Observation,
+) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+func onlySessionTokenObservation(
+	t *testing.T,
+	recorder *sessionTokenRecorder,
+) providerobservability.Observation {
+	t.Helper()
+	if len(recorder.observations) != 1 {
+		t.Fatalf("observations = %#v", recorder.observations)
+	}
+	return recorder.observations[0]
+}

--- a/server/internal/providers/spatius/observability.go
+++ b/server/internal/providers/spatius/observability.go
@@ -1,0 +1,67 @@
+package spatius
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+)
+
+func recordSessionTokenCall(
+	recorder providerobservability.Recorder,
+	startedAt time.Time,
+	kind providerobservability.ErrorKind,
+) {
+	if recorder == nil {
+		return
+	}
+	recorder.Record(providerobservability.Observation{
+		Provider:   providerobservability.ProviderSpatius,
+		Capability: providerobservability.CapabilityAvatarSessionToken,
+		Duration:   time.Since(startedAt),
+		ErrorKind:  kind,
+	})
+}
+
+func sessionTokenTransportKind(
+	ctx context.Context,
+	err error,
+) providerobservability.ErrorKind {
+	switch {
+	case errors.Is(err, context.Canceled), ctx != nil && errors.Is(ctx.Err(), context.Canceled):
+		return providerobservability.ErrorCancelled
+	case errors.Is(err, context.DeadlineExceeded), ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return providerobservability.ErrorTimeout
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && networkError.Timeout() {
+		return providerobservability.ErrorTimeout
+	}
+	return providerobservability.ErrorProviderUnavailable
+}
+
+func sessionTokenStatusKind(status int) providerobservability.ErrorKind {
+	switch {
+	case status >= http.StatusOK && status < http.StatusMultipleChoices:
+		return providerobservability.ErrorNone
+	case status >= http.StatusMultipleChoices && status < http.StatusBadRequest:
+		return providerobservability.ErrorInvalidResponse
+	case status == http.StatusBadRequest:
+		return providerobservability.ErrorInvalidRequest
+	case status == http.StatusUnauthorized:
+		return providerobservability.ErrorAuthentication
+	case status == http.StatusPaymentRequired:
+		return providerobservability.ErrorQuotaExhausted
+	case status == http.StatusForbidden:
+		return providerobservability.ErrorAuthorization
+	case status == http.StatusTooManyRequests:
+		return providerobservability.ErrorRateLimited
+	case status >= http.StatusBadRequest && status < http.StatusInternalServerError:
+		return providerobservability.ErrorInvalidRequest
+	default:
+		return providerobservability.ErrorProviderUnavailable
+	}
+}

--- a/server/internal/providers/xfyun/ise.go
+++ b/server/internal/providers/xfyun/ise.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 const (
@@ -30,6 +32,7 @@ const (
 type ISEConfig struct {
 	Endpoint string
 	Timeout  time.Duration
+	Observer providerobservability.Recorder
 }
 
 type EvaluationRequest struct {
@@ -82,6 +85,7 @@ type Evaluator struct {
 	frameInterval time.Duration
 	dial          dialFunc
 	now           func() time.Time
+	observer      providerobservability.Recorder
 }
 
 type secret struct {
@@ -158,7 +162,8 @@ func NewEvaluator(
 		) (websocketConnection, *http.Response, error) {
 			return dialer.DialContext(ctx, target, nil)
 		},
-		now: time.Now,
+		now:      time.Now,
+		observer: config.Observer,
 	}, nil
 }
 
@@ -193,8 +198,14 @@ func (evaluator *Evaluator) Evaluate(
 	if err != nil {
 		return EvaluationResult{}, err
 	}
+	startedAt := time.Now()
+	metricKind := providerobservability.ErrorProviderUnavailable
+	defer func() {
+		recordISECall(evaluator.observer, startedAt, metricKind)
+	}()
 	connection, response, err := evaluator.dial(callContext, target)
 	if err != nil {
+		metricKind = iseHandshakeErrorKind(callContext, response, err)
 		if response != nil {
 			return EvaluationResult{}, fmt.Errorf(
 				"iFlytek ISE handshake failed with HTTP %d: %w",
@@ -207,12 +218,14 @@ func (evaluator *Evaluator) Evaluate(
 	defer connection.Close()
 	if deadline, ok := callContext.Deadline(); ok {
 		if err := connection.SetWriteDeadline(deadline); err != nil {
+			metricKind = iseTransportErrorKind(callContext, err)
 			return EvaluationResult{}, fmt.Errorf(
 				"set iFlytek ISE write deadline: %w",
 				err,
 			)
 		}
 		if err := connection.SetReadDeadline(deadline); err != nil {
+			metricKind = iseTransportErrorKind(callContext, err)
 			return EvaluationResult{}, fmt.Errorf(
 				"set iFlytek ISE read deadline: %w",
 				err,
@@ -244,23 +257,27 @@ func (evaluator *Evaluator) Evaluate(
 		},
 		Data: requestData{Status: 0, Data: ""},
 	}); err != nil {
+		metricKind = iseTransportErrorKind(callContext, err)
 		return EvaluationResult{}, fmt.Errorf(
 			"send iFlytek ISE parameters: %w",
 			err,
 		)
 	}
 	if err := evaluator.sendAudio(callContext, connection, request.Audio); err != nil {
+		metricKind = iseTransportErrorKind(callContext, err)
 		return EvaluationResult{}, err
 	}
 	for {
 		var message responseMessage
 		if err := connection.ReadJSON(&message); err != nil {
+			metricKind = iseTransportErrorKind(callContext, err)
 			return EvaluationResult{}, fmt.Errorf(
 				"read iFlytek ISE response: %w",
 				err,
 			)
 		}
 		if message.Code != 0 {
+			metricKind = iseProviderCodeKind(message.Code)
 			return EvaluationResult{}, fmt.Errorf(
 				"iFlytek ISE rejected request: code=%d message=%s sid=%s",
 				message.Code,
@@ -273,15 +290,18 @@ func (evaluator *Evaluator) Evaluate(
 		}
 		rawXML, err := base64.StdEncoding.DecodeString(message.Data.Data)
 		if err != nil {
+			metricKind = providerobservability.ErrorInvalidResponse
 			return EvaluationResult{}, errors.New(
 				"decode final iFlytek ISE result",
 			)
 		}
 		result, err := parseResult(rawXML)
 		if err != nil {
+			metricKind = providerobservability.ErrorInvalidResponse
 			return EvaluationResult{}, err
 		}
 		result.SessionID = strings.TrimSpace(message.SessionID)
+		metricKind = providerobservability.ErrorNone
 		return result, nil
 	}
 }

--- a/server/internal/providers/xfyun/ise_test.go
+++ b/server/internal/providers/xfyun/ise_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 const testResultXML = `<?xml version="1.0" encoding="UTF-8"?>
@@ -131,6 +133,91 @@ func TestEvaluatorReportsProviderFailureWithoutFallback(t *testing.T) {
 		!strings.Contains(err.Error(), "code=10105") ||
 		!strings.Contains(err.Error(), "ise-failed") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEvaluatorRecordsStableExternalCallOutcome(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		recorder := &iseProviderRecorder{}
+		evaluator := newTestEvaluator(t, &fakeConnection{responses: []responseMessage{{
+			SessionID: "ise-session",
+			Data:      &responseData{Status: 2, Data: base64.StdEncoding.EncodeToString([]byte(testResultXML))},
+		}}})
+		evaluator.frameInterval = 0
+		evaluator.observer = recorder
+		_, err := evaluator.Evaluate(context.Background(), validEvaluationRequest())
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		observation := onlyISEObservation(t, recorder)
+		if observation.Provider != providerobservability.ProviderXFYunISE ||
+			observation.Capability != providerobservability.CapabilitySpeechEvaluation ||
+			observation.ErrorKind != providerobservability.ErrorNone ||
+			observation.Usage != (providerobservability.Usage{}) {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+
+	t.Run("bounded provider code", func(t *testing.T) {
+		recorder := &iseProviderRecorder{}
+		evaluator := newTestEvaluator(t, &fakeConnection{responses: []responseMessage{{
+			Code: 10313, Message: "private provider detail", SessionID: "private-session",
+		}}})
+		evaluator.frameInterval = 0
+		evaluator.observer = recorder
+		_, _ = evaluator.Evaluate(context.Background(), validEvaluationRequest())
+		if observation := onlyISEObservation(t, recorder); observation.ErrorKind !=
+			providerobservability.ErrorAuthentication {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+
+	t.Run("caller cancellation", func(t *testing.T) {
+		recorder := &iseProviderRecorder{}
+		evaluator := newTestEvaluator(t, &fakeConnection{})
+		evaluator.observer = recorder
+		evaluator.dial = func(context.Context, string) (websocketConnection, *http.Response, error) {
+			return nil, nil, context.Canceled
+		}
+		_, _ = evaluator.Evaluate(context.Background(), validEvaluationRequest())
+		if observation := onlyISEObservation(t, recorder); observation.ErrorKind !=
+			providerobservability.ErrorCancelled {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+
+	t.Run("invalid input is not an external call", func(t *testing.T) {
+		recorder := &iseProviderRecorder{}
+		evaluator := newTestEvaluator(t, &fakeConnection{})
+		evaluator.observer = recorder
+		_, _ = evaluator.Evaluate(context.Background(), EvaluationRequest{})
+		if len(recorder.observations) != 0 {
+			t.Fatalf("observations = %#v", recorder.observations)
+		}
+	})
+}
+
+func TestISEErrorMappingsAreBounded(t *testing.T) {
+	for code, want := range map[int]providerobservability.ErrorKind{
+		10313: providerobservability.ErrorAuthentication,
+		11200: providerobservability.ErrorAuthorization,
+		42306: providerobservability.ErrorQuotaExhausted,
+		10200: providerobservability.ErrorTimeout,
+		40007: providerobservability.ErrorInvalidRequest,
+		99999: providerobservability.ErrorProviderUnavailable,
+	} {
+		if got := iseProviderCodeKind(code); got != want {
+			t.Fatalf("iseProviderCodeKind(%d) = %q, want %q", code, got, want)
+		}
+	}
+	if got := iseHandshakeErrorKind(
+		context.Background(), &http.Response{StatusCode: http.StatusForbidden}, errors.New("private"),
+	); got != providerobservability.ErrorAuthorization {
+		t.Fatalf("handshake kind = %q", got)
+	}
+	if got := iseTransportErrorKind(context.Background(), context.DeadlineExceeded); got !=
+		providerobservability.ErrorTimeout {
+		t.Fatalf("transport timeout kind = %q", got)
 	}
 }
 
@@ -334,6 +421,33 @@ func TestEvaluatorNormalizesTypographicPunctuationInTopicPaper(t *testing.T) {
 		"1.1. How would you describe the role you're applying for?" {
 		t.Fatalf("unexpected normalized topic business: %#v", business)
 	}
+}
+
+func validEvaluationRequest() EvaluationRequest {
+	return EvaluationRequest{
+		Audio: []byte{1}, ReferenceText: "Hello.", Category: CategoryReadSentence,
+	}
+}
+
+type iseProviderRecorder struct {
+	observations []providerobservability.Observation
+}
+
+func (recorder *iseProviderRecorder) Record(
+	observation providerobservability.Observation,
+) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+func onlyISEObservation(
+	t *testing.T,
+	recorder *iseProviderRecorder,
+) providerobservability.Observation {
+	t.Helper()
+	if len(recorder.observations) != 1 {
+		t.Fatalf("observations = %#v", recorder.observations)
+	}
+	return recorder.observations[0]
 }
 
 func newTestEvaluator(

--- a/server/internal/providers/xfyun/observability.go
+++ b/server/internal/providers/xfyun/observability.go
@@ -1,0 +1,90 @@
+package xfyun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+)
+
+func recordISECall(
+	recorder providerobservability.Recorder,
+	startedAt time.Time,
+	kind providerobservability.ErrorKind,
+) {
+	if recorder == nil {
+		return
+	}
+	recorder.Record(providerobservability.Observation{
+		Provider:   providerobservability.ProviderXFYunISE,
+		Capability: providerobservability.CapabilitySpeechEvaluation,
+		Duration:   time.Since(startedAt),
+		ErrorKind:  kind,
+	})
+}
+
+func iseTransportErrorKind(
+	ctx context.Context,
+	err error,
+) providerobservability.ErrorKind {
+	switch {
+	case errors.Is(err, context.Canceled), ctx != nil && errors.Is(ctx.Err(), context.Canceled):
+		return providerobservability.ErrorCancelled
+	case errors.Is(err, context.DeadlineExceeded), ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return providerobservability.ErrorTimeout
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && networkError.Timeout() {
+		return providerobservability.ErrorTimeout
+	}
+	var syntaxError *json.SyntaxError
+	var typeError *json.UnmarshalTypeError
+	if errors.As(err, &syntaxError) || errors.As(err, &typeError) {
+		return providerobservability.ErrorInvalidResponse
+	}
+	return providerobservability.ErrorProviderUnavailable
+}
+
+func iseHandshakeErrorKind(
+	ctx context.Context,
+	response *http.Response,
+	err error,
+) providerobservability.ErrorKind {
+	if kind := iseTransportErrorKind(ctx, err); kind != providerobservability.ErrorProviderUnavailable {
+		return kind
+	}
+	if response == nil {
+		return providerobservability.ErrorProviderUnavailable
+	}
+	switch response.StatusCode {
+	case http.StatusUnauthorized:
+		return providerobservability.ErrorAuthentication
+	case http.StatusForbidden:
+		return providerobservability.ErrorAuthorization
+	default:
+		return providerobservability.ErrorProviderUnavailable
+	}
+}
+
+func iseProviderCodeKind(code int) providerobservability.ErrorKind {
+	switch code {
+	case 10313, 10105:
+		return providerobservability.ErrorAuthentication
+	case 11200:
+		return providerobservability.ErrorAuthorization
+	case 11201, 42306:
+		return providerobservability.ErrorQuotaExhausted
+	case 10114, 10200:
+		return providerobservability.ErrorTimeout
+	case 10163, 40007, 10043, 10161, 10160, 60114, 10139, 48196,
+		40006, 40017, 40023, 40034, 40037, 40038, 40040, 68676,
+		30002, 48195, 30011, 68675, 48205:
+		return providerobservability.ErrorInvalidRequest
+	default:
+		return providerobservability.ErrorProviderUnavailable
+	}
+}


### PR DESCRIPTION
## 功能描述

- 在服务组合根建立单一 Prometheus registry，并与现有 HTTP 指标共用内部 /metrics。
- 统一统计 Qianwen 文本、ASR、TTS，PaddleOCR，讯飞 ISE，Spatius session-token，以及 Aliyun OSS、Qiniu Kodo 的真实外部调用结果、耗时、稳定错误类别和可获得的计费用量。
- 指标标签只接受固定枚举，不记录用户、会话、请求、模型、对象键、正文、原始错误或密钥。

## 实现思路

- 新增 providerobservability.Observer，集中注册 calls、duration 与固定单位 usage 指标；生产 ProviderFactory 强制注入同一 recorder。
- 在各 Provider adapter 的真实外部调用边界将类型化错误映射为闭集类别；取消、超时、认证、限流、无效响应等保持可区分。
- 不暴露不可信的 retries_total：SDK 内部重试次数不可观察；对象存储 reconcile 仍按一次逻辑调用结算，避免重复计数和伪造字节数。
- OSS/Kodo Presign 仅为本地签名，不计作外部调用；对象 Open 在 EOF、读取错误或提前 Close 时一次性结算，而不是取得流句柄即记成功。
- 文本 token、OCR 页数和 TTS 字符数按供应商已报告或已提交的实际用量记录，即使后续本地响应校验失败也不丢失。
- HTTP observer 支持显式共享 registry，重复注册或配置冲突时明确失败。

## 可复现测试

- make check-go-coverage
  - go vet ./... 通过
  - 全仓 Go 测试通过
  - 合并覆盖率：47.1%
- go test -race ./internal/platform/providerobservability ./internal/platform/objectstore/... ./internal/providers/qianwen ./internal/providers/paddleocr ./internal/providers/xfyun ./internal/providers/spatius ./internal/app
- 覆盖成功、供应商失败、认证、限流、超时、取消、无效响应、用量保留、对象流完整读取/读错/提前关闭、reconcile 单次计数、Presign 不计外部调用，以及固定低基数标签。

Closes #909