### PR TITLE
ops(observability): 建立隔离的生产监控与告警闭环

### DIFF
--- a/.github/workflows/production-probe.yml
+++ b/.github/workflows/production-probe.yml
@@ -1,0 +1,152 @@
+name: Production probe
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      drill:
+        description: Create or resolve an isolated notification drill incident
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - firing
+          - resolved
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: production-probe
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: Portal, API, and Android release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Probe public endpoints
+        id: public-probe
+        if: github.event_name != 'workflow_dispatch' || inputs.drill == 'none'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          probe() {
+            local name=$1
+            local url=$2
+            local output=$3
+            local started_at elapsed_ms status
+            started_at=$(date +%s%3N)
+            status=$(curl \
+              --silent \
+              --show-error \
+              --location \
+              --max-time 10 \
+              --retry 1 \
+              --retry-delay 1 \
+              --retry-all-errors \
+              --output "$output" \
+              --write-out '%{http_code}' \
+              "$url")
+            elapsed_ms=$(($(date +%s%3N) - started_at))
+            [[ "$status" == 200 ]] || {
+              printf '%s returned HTTP %s\n' "$name" "$status" >&2
+              return 1
+            }
+            printf '| %s | %s | %s ms |\n' "$name" "$status" "$elapsed_ms" \
+              >>"$GITHUB_STEP_SUMMARY"
+          }
+
+          printf '%s\n' '| Target | HTTP | Elapsed |' '|---|---:|---:|' \
+            >>"$GITHUB_STEP_SUMMARY"
+          probe Portal https://speak-up.top/ "$RUNNER_TEMP/portal.html"
+          probe API https://api.speak-up.top/health "$RUNNER_TEMP/health.json"
+          probe Android https://speak-up.top/downloads/android/release.json \
+            "$RUNNER_TEMP/release.json"
+
+          jq --exit-status '
+            type == "object" and
+            keys == [
+              "abis", "apk_certificate_sha256", "apk_sha256", "download_path",
+              "file_name", "metadata_version", "minimum_android_api",
+              "published_at", "size_bytes", "version", "version_code"
+            ] and
+            .metadata_version == 1 and
+            (.version_code | type == "number" and . > 0) and
+            (.size_bytes | type == "number" and . > 0) and
+            (.download_path | test("^/downloads/android/v[0-9]+\\.[0-9]+\\.[0-9]+/speakup-v[0-9]+\\.[0-9]+\\.[0-9]+-production-arm64\\.apk$")) and
+            (.apk_sha256 | test("^[0-9a-f]{64}$")) and
+            (.apk_certificate_sha256 | test("^[0-9a-f]{64}$"))
+          ' "$RUNNER_TEMP/release.json" >/dev/null
+
+          download_path=$(jq -r '.download_path' "$RUNNER_TEMP/release.json")
+          expected_size=$(jq -r '.size_bytes' "$RUNNER_TEMP/release.json")
+          apk_headers="$RUNNER_TEMP/apk.headers"
+          apk_status=$(curl \
+            --silent \
+            --show-error \
+            --head \
+            --max-time 10 \
+            --retry 1 \
+            --retry-delay 1 \
+            --retry-all-errors \
+            --dump-header "$apk_headers" \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            "https://speak-up.top$download_path")
+          [[ "$apk_status" == 200 ]]
+          grep -Eiq '^content-type:[[:space:]]*application/vnd\.android\.package-archive' \
+            "$apk_headers"
+          grep -Eiq "^content-length:[[:space:]]*$expected_size([[:space:]]|$)" \
+            "$apk_headers"
+          printf '| APK | %s | headers only |\n' "$apk_status" \
+            >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Record failure or resolution in GitHub Issues
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRILL_MODE: ${{ inputs.drill || 'none' }}
+          PROBE_OUTCOME: ${{ steps.public-probe.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$DRILL_MODE" in
+            firing)
+              deploy/observability/github-probe-incident.sh firing drill
+              ;;
+            resolved)
+              deploy/observability/github-probe-incident.sh resolved drill
+              ;;
+            none)
+              if [[ "$PROBE_OUTCOME" == success ]]; then
+                deploy/observability/github-probe-incident.sh resolved production
+              else
+                deploy/observability/github-probe-incident.sh firing production
+              fi
+              ;;
+            *)
+              printf 'Unsupported drill mode: %s\n' "$DRILL_MODE" >&2
+              exit 2
+              ;;
+          esac
+
+      - name: Preserve failing probe status
+        if: >-
+          always() &&
+          (inputs.drill == 'firing' ||
+          ((github.event_name != 'workflow_dispatch' || inputs.drill == 'none') &&
+          steps.public-probe.outcome != 'success'))
+        shell: bash
+        run: exit 1

--- a/.github/workflows/production-probe.yml
+++ b/.github/workflows/production-probe.yml
@@ -130,11 +130,8 @@ jobs:
               deploy/observability/github-probe-incident.sh resolved drill
               ;;
             none)
-              if [[ "$PROBE_OUTCOME" == success ]]; then
-                deploy/observability/github-probe-incident.sh resolved production
-              else
-                deploy/observability/github-probe-incident.sh firing production
-              fi
+              deploy/observability/github-probe-incident.sh \
+                "$PROBE_OUTCOME" production
               ;;
             *)
               printf 'Unsupported drill mode: %s\n' "$DRILL_MODE" >&2
@@ -147,6 +144,6 @@ jobs:
           always() &&
           (inputs.drill == 'firing' ||
           ((github.event_name != 'workflow_dispatch' || inputs.drill == 'none') &&
-          steps.public-probe.outcome != 'success'))
+          steps.public-probe.outcome == 'failure'))
         shell: bash
         run: exit 1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -91,6 +91,9 @@ jobs:
                   set_all_checks
                   android_release=true
                   ;;
+                .github/workflows/production-probe.yml)
+                  deploy=true
+                  ;;
                 .github/workflows/database.yml|.github/workflows/coverage-comment.yml|tools/release-candidate/*)
                   set_all_checks
                   ;;
@@ -400,6 +403,42 @@ jobs:
 
       - name: Validate TLS lifecycle contract
         run: make check-tls-lifecycle
+
+      - name: Validate observability and log rotation contracts
+        run: make check-observability
+
+      - name: Validate observability runtime configuration
+        run: |
+          docker run --rm \
+            --volume "$PWD/deploy/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
+            --volume "$PWD/deploy/observability/rules:/etc/prometheus/rules:ro" \
+            --entrypoint promtool \
+            quay.io/prometheus/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893 \
+            check config /etc/prometheus/prometheus.yml
+          docker run --rm \
+            --volume "$PWD/deploy/observability/alertmanager.example.yml:/etc/alertmanager/alertmanager.yml:ro" \
+            --entrypoint amtool \
+            quay.io/prometheus/alertmanager:v0.34.0@sha256:690c7b525f4367aa91f73e2f91c632206d32e97c6384bdbf2fb7a861b420340d \
+            check-config /etc/alertmanager/alertmanager.yml
+          docker run --rm \
+            --volume "$PWD/deploy/observability/blackbox.yml:/etc/blackbox/blackbox.yml:ro" \
+            quay.io/prometheus/blackbox-exporter:v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc \
+            --config.file=/etc/blackbox/blackbox.yml \
+            --config.check
+
+      - name: Validate observability systemd and logrotate configuration
+        run: |
+          sudo install -D -m 0755 \
+            deploy/observability/xe3-speakup-export-metrics \
+            /usr/local/sbin/xe3-speakup-export-metrics
+          sudo install -D -m 0600 \
+            deploy/observability/observability-metrics.env.example \
+            /etc/speakup/observability-metrics.env
+          systemd-analyze verify \
+            deploy/observability/xe3-speakup-observability-metrics.service \
+            deploy/observability/xe3-speakup-observability-metrics.timer
+          sudo logrotate --debug \
+            deploy/observability/xe3-speakup-nginx.logrotate
 
       - name: Validate rendered Nginx configuration
         run: make check-staging-nginx

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SHELL := /bin/bash
 	check-offline-release \
 	check-android-download \
 	check-tls-lifecycle \
+	check-observability \
 	check-production-deploy \
 	check-production-nginx \
 	check-staging-deploy \
@@ -58,6 +59,7 @@ help:
 		'  make check-offline-release  Validate offline image build/load contracts' \
 		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-tls-lifecycle  Validate TLS issuance and renewal contracts' \
+		'  make check-observability  Validate monitoring, alert, and log rotation contracts' \
 		'  make check-production-deploy  Validate the immutable Production contract' \
 		'  make check-production-nginx  Run nginx -t against the Production template' \
 		'  make check-staging-deploy  Validate Staging runtime, schema, lock, and receipt contracts' \
@@ -319,6 +321,10 @@ check-android-download:
 check-tls-lifecycle:
 	./deploy/tls/test.sh
 	./deploy/tls/test-nginx.sh
+
+check-observability:
+	./deploy/observability/test.sh
+	./deploy/observability/test-nginx.sh
 
 check-production-deploy:
 	./deploy/production/test.sh

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -1,0 +1,178 @@
+# SpeakUp observability
+
+This directory defines the isolated production monitoring boundary for SpeakUp.
+It does not expose Prometheus, Alertmanager, node_exporter, blackbox_exporter, or
+application `/metrics` ports to the public network. Only Grafana is published on
+the host loopback interface; Nginx may expose it as `monitor.speak-up.top` after
+DNS and certificate validation.
+
+The shared server remains protected by three scope rules:
+
+- no Docker socket is mounted into an observability container;
+- host container metrics are exported by a fixed script that inspects only the
+  `xe3-speakup-production` and `xe3-speakup-staging` Compose projects;
+- log rotation lists exact SpeakUp files and never rotates another team's logs.
+
+## Components
+
+- Prometheus: 30-day/8-GB bounded retention.
+- Alertmanager: private SMTP configuration supplied by the server operator.
+- Grafana: provisioned Prometheus data source and SpeakUp overview dashboard.
+- blackbox_exporter: Portal, API, and Android release HTTPS probes.
+- node_exporter: only the bounded SpeakUp textfile collector. It has no host
+  root mount; the reviewed host-side exporter emits root disk and inode values.
+- GitHub Actions `Production probe`: an off-host five-minute public endpoint
+  check so a full server outage remains visible when the local stack is down.
+
+The provisioned dashboard keeps Portal, API, Android metadata, container,
+disk/inode, API, and provider status separate. Public probes expose both
+`probe_success` and per-target `probe_duration_seconds`. Safety-unit alerts are
+also time-bounded: the twice-daily TLS renewal becomes stale after 18 hours,
+while each explicitly named PostgreSQL or Portal restore check becomes stale
+after 31 days even when its previous run succeeded.
+
+All container images and runtime limits are explicit. Grafana is the only
+service with a published port, and that port is `127.0.0.1:13000`.
+
+## Application metrics boundary
+
+The production and Staging Server Compose definitions set `METRICS_HOST=0.0.0.0`
+inside their private Docker networks and give the services unique network
+aliases. There is still no host or public port for `9090`; Prometheus reaches it
+only through the existing SpeakUp networks. Nginx continues to return `404` for
+public `/metrics` requests.
+
+The exported HTTP series are bounded by method, route template, status class,
+and environment. Provider series must use only fixed `provider`, `capability`,
+`outcome`, `error_kind`, and `unit` labels. Never use user IDs, request IDs,
+models supplied by a caller, raw errors, text, audio, object keys, credentials,
+or session tokens as metric labels.
+
+## Private files
+
+Create these files on the server; never commit or paste their populated values:
+
+```text
+/etc/speakup/observability.env
+/etc/speakup/observability-metrics.env
+/etc/speakup/alertmanager.yml
+/etc/speakup/grafana-admin-password
+```
+
+Start from `observability.env.example`, `observability-metrics.env.example`, and
+`alertmanager.example.yml`. Standalone Compose bind mounts preserve host
+ownership. Install `observability.env` and `observability-metrics.env` as
+`root:root` mode `0600`, Alertmanager configuration as UID `65534` mode `0400`,
+and the one-line newline-terminated Grafana password as UID `472` mode `0400`.
+The two service UIDs match the pinned container images without making a secret
+group- or world-readable. Validate all four files before Compose reads them:
+
+```bash
+/usr/local/sbin/xe3-speakup-observability-validate-private-files \
+  --environment-file /etc/speakup/observability.env \
+  --metrics-environment-file /etc/speakup/observability-metrics.env
+```
+
+## DNS and TLS prerequisite
+
+Do not install `monitor-nginx.conf` until both conditions are true:
+
+1. `monitor.speak-up.top` resolves to the production server;
+2. the independent `monitor.speak-up.top` certificate lineage has exactly that
+   single SAN and has been activated after `nginx -t`.
+
+The monitor lineage reuses the reviewed Production ACME account and HTTP-01
+webroot but never changes the exact three-SAN `speak-up.top` Production lineage.
+Issue, verify, and activate it through `deploy/tls/manage.sh`:
+
+```bash
+/usr/local/sbin/xe3-speakup-tls issue-monitor --env-file /etc/speakup/tls.env
+/usr/local/sbin/xe3-speakup-tls verify --environment monitor --env-file /etc/speakup/tls.env
+/usr/local/sbin/xe3-speakup-tls activate --environment monitor --env-file /etc/speakup/tls.env
+```
+
+## Installation order
+
+Copy this reviewed directory to `/opt/xe3-speakup-observability/source`, then:
+
+1. Install the private files above, install `validate-private-files` as
+   `/usr/local/sbin/xe3-speakup-observability-validate-private-files`, and run
+   the validator.
+2. Install `xe3-speakup-export-metrics` as
+   `/usr/local/sbin/xe3-speakup-export-metrics` with mode `0755`.
+3. Install the metrics service/timer under `/etc/systemd/system`, reload systemd,
+   and start the timer.
+4. Install `xe3-speakup-nginx.logrotate` as
+   `/etc/logrotate.d/xe3-speakup-nginx` with mode `0644`.
+5. Recreate only the SpeakUp Staging and Production containers so their
+   per-container `json-file` limits and internal metrics listener take effect.
+6. Start the monitoring stack with the private environment file:
+
+   ```bash
+   docker compose \
+     --env-file /etc/speakup/observability.env \
+     --file /opt/xe3-speakup-observability/source/compose.yaml \
+     up --detach --pull always --wait
+   ```
+
+7. Confirm every Prometheus target is up from a loopback Grafana session.
+8. After DNS/TLS validation, install `monitor-nginx.conf`, run
+   `/usr/local/nginx/sbin/nginx -t`, and reload only after it succeeds.
+
+Do not use `docker compose down --volumes`; the three named observability volumes
+contain monitoring history, Alertmanager state, and Grafana configuration.
+
+## Verification
+
+Run repository contracts before touching the server:
+
+```bash
+make check-observability
+make check-staging-deploy
+make check-production-deploy
+```
+
+Then verify the installed runtime:
+
+```bash
+systemctl status xe3-speakup-observability-metrics.timer
+systemctl status xe3-speakup-observability-metrics.service
+docker compose \
+  --env-file /etc/speakup/observability.env \
+  --file /opt/xe3-speakup-observability/source/compose.yaml \
+  ps
+curl --fail http://127.0.0.1:13000/api/health
+curl --fail --location https://monitor.speak-up.top/api/health
+```
+
+Public `/metrics` must still return `404` on Portal, API, and monitor hosts.
+
+## Safe off-host alert drill
+
+The `Production probe` workflow provides two manual drill modes and does not
+stop, restart, or alter a production service:
+
+1. Dispatch `drill=firing`. The workflow intentionally finishes red after it
+   opens and assigns one `[production-probe drill]` GitHub Issue.
+2. Confirm the assignee received GitHub's native notification and record the
+   Issue and workflow-run URLs.
+3. Dispatch `drill=resolved`. The workflow comments with the resolved run and
+   closes the same Issue.
+
+The Issue history is the sanitized firing/resolved receipt and uses only the
+built-in `GITHUB_TOKEN`; no notification secret is required. Scheduled real
+probe failures use a separate Issue and resolve it after a successful run.
+Never make the Portal, API, or APK unavailable to exercise this path. The local
+Alertmanager receiver must be tested separately after its private SMTP settings
+are installed; do not commit those settings.
+
+## Rollback
+
+- If the stack fails, keep its volumes and stop only the
+  `xe3-speakup-observability` Compose project.
+- Restore the previous SpeakUp Compose files and recreate only those services if
+  the metrics-network or logging change is the cause.
+- Remove only the monitor Nginx vhost after `nginx -t` verifies the remaining
+  configuration.
+- Removing observability must not remove Production/Staging networks, databases,
+  Portal data, certificates, or another team's containers.

--- a/deploy/observability/alertmanager.example.yml
+++ b/deploy/observability/alertmanager.example.yml
@@ -1,0 +1,20 @@
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: smtp.example.com:587
+  smtp_from: speakup-alerts@example.com
+  smtp_auth_username: speakup-alerts@example.com
+  smtp_auth_password: replace-with-private-app-password
+  smtp_require_tls: true
+
+route:
+  receiver: production-email
+  group_by: [alertname, environment, severity]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: production-email
+    email_configs:
+      - to: owner@example.com
+        send_resolved: true

--- a/deploy/observability/blackbox.yml
+++ b/deploy/observability/blackbox.yml
@@ -1,0 +1,10 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 8s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      follow_redirects: false
+      fail_if_ssl: false
+      fail_if_not_ssl: true

--- a/deploy/observability/compose.yaml
+++ b/deploy/observability/compose.yaml
@@ -1,0 +1,163 @@
+name: xe3-speakup-observability
+
+x-observability-logging: &observability-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+x-observability-security: &observability-security
+  read_only: true
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+  logging: *observability-logging
+  restart: unless-stopped
+
+services:
+  prometheus:
+    <<: *observability-security
+    image: quay.io/prometheus/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=30d
+      - --storage.tsdb.retention.size=8GB
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./rules:/etc/prometheus/rules:ro
+      - prometheus_data:/prometheus
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    networks:
+      monitor:
+      production_api:
+      staging_api:
+    mem_limit: 768m
+    cpus: 0.75
+    pids_limit: 128
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:9090/-/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  alertmanager:
+    <<: *observability-security
+    image: quay.io/prometheus/alertmanager:v0.34.0@sha256:690c7b525f4367aa91f73e2f91c632206d32e97c6384bdbf2fb7a861b420340d
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    volumes:
+      - ${OBSERVABILITY_ALERTMANAGER_CONFIG:?OBSERVABILITY_ALERTMANAGER_CONFIG is required}:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    networks:
+      - monitor
+    mem_limit: 192m
+    cpus: 0.25
+    pids_limit: 64
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:9093/-/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  grafana:
+    <<: *observability-security
+    image: grafana/grafana:13.2.0@sha256:95a8098fb092130e111b0264a9be4d3a2bd5405e5dba88d4b8f1f630b389614e
+    platform: linux/amd64
+    environment:
+      GF_SERVER_DOMAIN: ${OBSERVABILITY_GRAFANA_HOST:?OBSERVABILITY_GRAFANA_HOST is required}
+      GF_SERVER_ROOT_URL: https://${OBSERVABILITY_GRAFANA_HOST:?OBSERVABILITY_GRAFANA_HOST is required}/
+      GF_SECURITY_ADMIN_USER: ${OBSERVABILITY_GRAFANA_ADMIN_USER:?OBSERVABILITY_GRAFANA_ADMIN_USER is required}
+      GF_SECURITY_ADMIN_PASSWORD__FILE: /run/secrets/grafana_admin_password
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+    secrets:
+      - grafana_admin_password
+    ports:
+      - "127.0.0.1:13000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    networks:
+      - monitor
+    mem_limit: 512m
+    cpus: 0.50
+    pids_limit: 128
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  blackbox:
+    <<: *observability-security
+    image: quay.io/prometheus/blackbox-exporter:v0.28.0@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
+    command:
+      - --config.file=/etc/blackbox/blackbox.yml
+    volumes:
+      - ./blackbox.yml:/etc/blackbox/blackbox.yml:ro
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    networks:
+      - monitor
+    mem_limit: 128m
+    cpus: 0.25
+    pids_limit: 64
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:9115/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+  node-exporter:
+    <<: *observability-security
+    image: quay.io/prometheus/node-exporter:v1.12.1@sha256:1b4e4438faca4dd7e001dd445d161a4a2091b0fededa84093b3a8dfeae1f1be0
+    command:
+      - --collector.disable-defaults
+      - --collector.textfile
+      - --collector.textfile.directory=/textfile
+    volumes:
+      - /var/lib/xe3-speakup-observability/textfile:/textfile:ro
+    networks:
+      - monitor
+    mem_limit: 128m
+    cpus: 0.25
+    pids_limit: 64
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:9100/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+networks:
+  monitor:
+  production_api:
+    external: true
+    name: xe3-speakup-production-server-edge
+  staging_api:
+    external: true
+    name: xe3-speakup-staging_server_edge
+
+volumes:
+  prometheus_data:
+  alertmanager_data:
+  grafana_data:
+
+secrets:
+  grafana_admin_password:
+    file: ${OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE:?OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE is required}

--- a/deploy/observability/github-probe-incident.sh
+++ b/deploy/observability/github-probe-incident.sh
@@ -7,17 +7,33 @@ fail() {
   exit 1
 }
 
-[[ $# == 2 ]] || fail 'usage: github-probe-incident.sh firing|resolved production|drill'
-readonly state=$1
+[[ $# == 2 ]] || fail 'usage: github-probe-incident.sh firing|resolved|success|failure|skipped production|drill'
+readonly requested_state=$1
 readonly kind=$2
-case "$state" in
-  firing | resolved) ;;
-  *) fail 'state must be firing or resolved' ;;
-esac
 case "$kind" in
   production | drill) ;;
   *) fail 'kind must be production or drill' ;;
 esac
+state=''
+case "$requested_state" in
+  firing | resolved)
+    state=$requested_state
+    ;;
+  success)
+    [[ "$kind" == production ]] || fail 'probe outcomes apply only to production'
+    state=resolved
+    ;;
+  failure)
+    [[ "$kind" == production ]] || fail 'probe outcomes apply only to production'
+    state=firing
+    ;;
+  skipped)
+    [[ "$kind" == production ]] || fail 'probe outcomes apply only to production'
+    fail 'production probe did not execute; refusing to create an endpoint incident'
+    ;;
+  *) fail 'state must be firing, resolved, success, failure, or skipped' ;;
+esac
+readonly state
 
 for name in GITHUB_REPOSITORY GITHUB_SERVER_URL GITHUB_RUN_ID GITHUB_RUN_ATTEMPT GITHUB_ACTOR; do
   [[ -n "${!name:-}" && "${!name}" != *$'\n'* && "${!name}" != *$'\r'* ]] ||

--- a/deploy/observability/github-probe-incident.sh
+++ b/deploy/observability/github-probe-incident.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  printf 'production probe incident: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# == 2 ]] || fail 'usage: github-probe-incident.sh firing|resolved production|drill'
+readonly state=$1
+readonly kind=$2
+case "$state" in
+  firing | resolved) ;;
+  *) fail 'state must be firing or resolved' ;;
+esac
+case "$kind" in
+  production | drill) ;;
+  *) fail 'kind must be production or drill' ;;
+esac
+
+for name in GITHUB_REPOSITORY GITHUB_SERVER_URL GITHUB_RUN_ID GITHUB_RUN_ATTEMPT GITHUB_ACTOR; do
+  [[ -n "${!name:-}" && "${!name}" != *$'\n'* && "${!name}" != *$'\r'* ]] ||
+    fail "$name is required and must be single-line"
+done
+[[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+  fail 'GITHUB_REPOSITORY is invalid'
+[[ "$GITHUB_RUN_ID" =~ ^[0-9]+$ && "$GITHUB_RUN_ATTEMPT" =~ ^[0-9]+$ ]] ||
+  fail 'GitHub run identifiers must be numeric'
+
+command -v gh >/dev/null 2>&1 || fail 'gh is required'
+command -v jq >/dev/null 2>&1 || fail 'jq is required'
+
+if [[ "$kind" == production ]]; then
+  readonly title='[production-probe] SpeakUp public endpoint incident'
+else
+  readonly title='[production-probe drill] SpeakUp notification drill'
+fi
+readonly run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT"
+readonly occurred_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+readonly incident_marker='<!-- speakup-production-probe-incident:v1 -->'
+
+issues_json=$(gh api --paginate --slurp \
+  "repos/$GITHUB_REPOSITORY/issues?state=open&per_page=100")
+issue_number=$(jq -er --arg title "$title" --arg marker "$incident_marker" '
+  [.[][] | select(
+    (has("pull_request") | not) and
+    .title == $title and
+    ((.body // "") | contains($marker))
+  )] |
+  if length == 0 then ""
+  elif length == 1 then (.[0].number | tostring)
+  else error("multiple matching probe incidents")
+  end
+' <<<"$issues_json") || fail 'open incident response is invalid or ambiguous'
+
+if [[ "$state" == firing ]]; then
+  if [[ -z "$issue_number" ]]; then
+    body=$(jq -n \
+      --arg title "$title" \
+      --arg run_url "$run_url" \
+      --arg occurred_at "$occurred_at" \
+      --arg actor "$GITHUB_ACTOR" \
+      --arg marker "$incident_marker" \
+      '{
+        title: $title,
+        body: ($marker + "\n\nThe off-host SpeakUp production probe entered **firing** state.\n\n- observed_at: `" + $occurred_at + "`\n- workflow_run: " + $run_url + "\n- actor: `" + $actor + "`\n\nThis issue will be closed automatically after a successful probe or explicit drill resolution."),
+        assignees: ["Lq0412"]
+      }')
+    issue_number=$(gh api --method POST "repos/$GITHUB_REPOSITORY/issues" \
+      --input - --jq '.number' <<<"$body")
+    [[ "$issue_number" =~ ^[0-9]+$ ]] || fail 'created incident number is invalid'
+    printf 'Opened incident #%s: %s\n' "$issue_number" "$run_url" >>"$GITHUB_STEP_SUMMARY"
+  else
+    printf 'Incident #%s remains open: %s\n' "$issue_number" "$run_url" >>"$GITHUB_STEP_SUMMARY"
+  fi
+  exit 0
+fi
+
+if [[ -z "$issue_number" ]]; then
+  [[ "$kind" == production ]] || fail 'drill resolution requires an open drill incident'
+  printf 'No open production incident required resolution.\n' >>"$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+comment=$(jq -n \
+  --arg occurred_at "$occurred_at" \
+  --arg run_url "$run_url" \
+  '{body: ("The off-host probe entered **resolved** state.\n\n- observed_at: `" + $occurred_at + "`\n- workflow_run: " + $run_url)}')
+gh api --method POST \
+  "repos/$GITHUB_REPOSITORY/issues/$issue_number/comments" --input - <<<"$comment" >/dev/null
+gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/$issue_number" \
+  --input - >/dev/null <<'JSON'
+{"state":"closed","state_reason":"completed"}
+JSON
+printf 'Resolved incident #%s: %s\n' "$issue_number" "$run_url" >>"$GITHUB_STEP_SUMMARY"

--- a/deploy/observability/grafana/dashboards/speakup-overview.json
+++ b/deploy/observability/grafana/dashboards/speakup-overview.json
@@ -1,0 +1,177 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [
+            {"options": {"0": {"color": "red", "text": "DOWN"}, "1": {"color": "green", "text": "UP"}}, "type": "value"}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"expr": "probe_success{job=\"blackbox-http\",environment=~\"$environment\"}", "legendFormat": "{{environment}} {{component}}", "refId": "A"}],
+      "title": "Public endpoints",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [{"options": {"0": {"color": "red", "text": "DOWN"}, "1": {"color": "green", "text": "UP"}}, "type": "value"}],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"expr": "speakup_container_up{environment=~\"$environment\"}", "legendFormat": "{{environment}} {{service}}", "refId": "A"}],
+      "title": "SpeakUp containers",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "decimals": 1, "max": 100, "min": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "orange", "value": 8}, {"color": "green", "value": 15}]}, "unit": "percent"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 12, "y": 0},
+      "id": 3,
+      "options": {"minVizHeight": 75, "minVizWidth": 75, "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showThresholdLabels": false, "showThresholdMarkers": true, "sizing": "auto"},
+      "targets": [{"expr": "100 * speakup_host_filesystem_avail_bytes{mountpoint=\"/\"} / speakup_host_filesystem_size_bytes{mountpoint=\"/\"}", "refId": "A"}],
+      "title": "Root disk free",
+      "type": "gauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "decimals": 1, "max": 100, "min": 0, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "orange", "value": 8}, {"color": "green", "value": 15}]}, "unit": "percent"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0},
+      "id": 8,
+      "options": {"minVizHeight": 75, "minVizWidth": 75, "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showThresholdLabels": false, "showThresholdMarkers": true, "sizing": "auto"},
+      "targets": [{"expr": "100 * speakup_host_filesystem_files_free{mountpoint=\"/\"} / speakup_host_filesystem_files{mountpoint=\"/\"}", "refId": "A"}],
+      "title": "Root inodes free",
+      "type": "gauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "reqps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+      "id": 4,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"expr": "sum by (environment) (rate(speakup_http_server_requests_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{environment}}", "refId": "A"}],
+      "title": "API request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+      "id": 5,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"expr": "sum by (environment) (rate(speakup_http_server_requests_total{environment=~\"$environment\",status_class=\"5xx\"}[5m])) / clamp_min(sum by (environment) (rate(speakup_http_server_requests_total{environment=~\"$environment\"}[5m])), 0.001)", "legendFormat": "{{environment}}", "refId": "A"}],
+      "title": "API 5xx ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
+      "id": 6,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"expr": "histogram_quantile(0.95, sum by (environment, le) (rate(speakup_http_server_request_duration_seconds_bucket{environment=~\"$environment\"}[5m])))", "legendFormat": "{{environment}}", "refId": "A"}],
+      "title": "API P95 latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+      "id": 7,
+      "options": {"legend": {"calcs": [], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"expr": "sum by (provider, capability, outcome) (rate(speakup_provider_calls_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{provider}} {{capability}} {{outcome}}", "refId": "A"}],
+      "title": "External provider calls",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 21},
+      "id": 9,
+      "options": {"legend": {"calcs": [], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"expr": "sum by (provider, capability, error_kind) (rate(speakup_provider_calls_total{environment=~\"$environment\",outcome!=\"success\"}[5m]))", "legendFormat": "{{provider}} {{capability}} {{error_kind}}", "refId": "A"}],
+      "title": "External provider errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 21},
+      "id": 10,
+      "options": {"legend": {"calcs": [], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"expr": "histogram_quantile(0.95, sum by (provider, capability, le) (rate(speakup_provider_call_duration_seconds_bucket{environment=~\"$environment\"}[5m])))", "legendFormat": "{{provider}} {{capability}}", "refId": "A"}],
+      "title": "External provider P95 latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 21},
+      "id": 11,
+      "options": {"legend": {"calcs": [], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [
+        {"expr": "sum by (provider, capability) (rate(speakup_provider_usage_tokens_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{provider}} {{capability}} tokens/s", "refId": "A"},
+        {"expr": "sum by (provider, capability) (rate(speakup_provider_usage_audio_seconds_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{provider}} {{capability}} audio-s/s", "refId": "B"},
+        {"expr": "sum by (provider, capability) (rate(speakup_provider_usage_characters_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{provider}} {{capability}} chars/s", "refId": "C"},
+        {"expr": "sum by (provider, capability) (rate(speakup_provider_usage_pages_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{provider}} {{capability}} pages/s", "refId": "D"},
+        {"expr": "sum by (provider, capability) (rate(speakup_provider_usage_bytes_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{provider}} {{capability}} bytes/s", "refId": "E"}
+      ],
+      "title": "External provider usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}}, "unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 29},
+      "id": 12,
+      "options": {"legend": {"calcs": [], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"expr": "probe_duration_seconds{job=\"blackbox-http\",environment=~\"$environment\"}", "legendFormat": "{{environment}} {{component}}", "refId": "A"}],
+      "title": "Public endpoint response time",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": ["speakup", "production"],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {"text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "speakup-prometheus"},
+        "definition": "label_values(speakup_http_server_requests_total, environment)",
+        "includeAll": true,
+        "label": "Environment",
+        "name": "environment",
+        "options": [],
+        "query": {"query": "label_values(speakup_http_server_requests_total, environment)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "browser",
+  "title": "SpeakUp Production Overview",
+  "uid": "speakup-production-overview",
+  "version": 1
+}

--- a/deploy/observability/grafana/provisioning/dashboards/speakup.yml
+++ b/deploy/observability/grafana/provisioning/dashboards/speakup.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: SpeakUp
+    orgId: 1
+    folder: SpeakUp
+    type: file
+    disableDeletion: true
+    editable: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: speakup-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/observability/monitor-nginx.conf
+++ b/deploy/observability/monitor-nginx.conf
@@ -1,0 +1,56 @@
+server {
+    listen 80;
+    server_name monitor.speak-up.top;
+
+    access_log logs/xe3-speakup-monitor.access.log;
+    error_log logs/xe3-speakup-monitor.error.log warn;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /opt/xe3-speakup-portal/certbot/www;
+        default_type text/plain;
+        try_files $uri =404;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name monitor.speak-up.top;
+
+    ssl_certificate /opt/xe3-speakup-portal/certbot/conf/live/monitor.speak-up.top/fullchain.pem;
+    ssl_certificate_key /opt/xe3-speakup-portal/certbot/conf/live/monitor.speak-up.top/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SpeakUpMonitorTLS:10m;
+    ssl_session_tickets off;
+
+    access_log logs/xe3-speakup-monitor.access.log;
+    error_log logs/xe3-speakup-monitor.error.log warn;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy no-referrer always;
+    add_header X-Frame-Options DENY always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    client_max_body_size 1m;
+
+    location ^~ /metrics {
+        return 404;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:13000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+}

--- a/deploy/observability/observability-metrics.env.example
+++ b/deploy/observability/observability-metrics.env.example
@@ -1,0 +1,6 @@
+# Raw KEY=value paths. This file contains no credentials.
+OBSERVABILITY_PRODUCTION_CERTIFICATE=/opt/xe3-speakup-portal/certbot/conf/live/speak-up.top/fullchain.pem
+OBSERVABILITY_STAGING_CERTIFICATE=/opt/xe3-speakup-portal/certbot/conf/live/staging.speak-up.top/fullchain.pem
+OBSERVABILITY_MONITOR_CERTIFICATE=/opt/xe3-speakup-portal/certbot/conf/live/monitor.speak-up.top/fullchain.pem
+OBSERVABILITY_POSTGRES_BACKUP_ROOT=/var/lib/speakup/postgres-backups
+OBSERVABILITY_PORTAL_BACKUP_ROOT=/var/lib/speakup/portal-backups

--- a/deploy/observability/observability.env.example
+++ b/deploy/observability/observability.env.example
@@ -1,0 +1,4 @@
+OBSERVABILITY_ALERTMANAGER_CONFIG=/etc/speakup/alertmanager.yml
+OBSERVABILITY_GRAFANA_HOST=monitor.speak-up.top
+OBSERVABILITY_GRAFANA_ADMIN_USER=speakup-admin
+OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE=/etc/speakup/grafana-admin-password

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -1,0 +1,73 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    product: speakup
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - prometheus:9090
+
+  - job_name: node
+    static_configs:
+      - targets:
+          - node-exporter:9100
+
+  - job_name: speakup-production-api
+    static_configs:
+      - targets:
+          - production-api-metrics:9090
+        labels:
+          environment: production
+
+  - job_name: speakup-staging-api
+    static_configs:
+      - targets:
+          - staging-api-metrics:9090
+        labels:
+          environment: staging
+
+  - job_name: blackbox-http
+    metrics_path: /probe
+    params:
+      module:
+        - http_2xx
+    static_configs:
+      - targets:
+          - https://speak-up.top/
+        labels:
+          environment: production
+          component: portal
+      - targets:
+          - https://api.speak-up.top/health
+        labels:
+          environment: production
+          component: api
+      - targets:
+          - https://speak-up.top/downloads/android/release.json
+        labels:
+          environment: production
+          component: android-release
+      - targets:
+          - https://staging-api.speak-up.top/health
+        labels:
+          environment: staging
+          component: api
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox:9115

--- a/deploy/observability/rules/speakup.yml
+++ b/deploy/observability/rules/speakup.yml
@@ -1,0 +1,298 @@
+groups:
+  - name: speakup-endpoints
+    rules:
+      - alert: SpeakUpScrapeTargetDown
+        expr: up{job=~"prometheus|node|speakup-production-api|speakup-staging-api|blackbox-http"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp scrape target {{ $labels.job }} is down"
+          description: "Prometheus cannot scrape {{ $labels.instance }}."
+
+      - alert: SpeakUpScrapeTargetMissing
+        expr: |
+          absent(up{job="prometheus"})
+          or absent(up{job="node"})
+          or absent(up{job="speakup-production-api"})
+          or absent(up{job="speakup-staging-api"})
+          or absent(up{job="blackbox-http"})
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Required SpeakUp scrape job {{ $labels.job }} is absent"
+          description: "The expected scrape series disappeared instead of reporting a healthy or failed target."
+
+      - alert: SpeakUpEndpointDown
+        expr: probe_success{job="blackbox-http"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} {{ $labels.component }} is unavailable"
+          description: "The HTTPS probe for {{ $labels.instance }} has failed for more than two minutes."
+
+      - alert: SpeakUpEndpointProbeMissing
+        expr: |
+          absent(probe_success{job="blackbox-http",environment="production",component="portal"})
+          or absent(probe_success{job="blackbox-http",environment="production",component="api"})
+          or absent(probe_success{job="blackbox-http",environment="production",component="android-release"})
+          or absent(probe_success{job="blackbox-http",environment="staging",component="api"})
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Required SpeakUp endpoint probe is absent"
+          description: "A configured public endpoint no longer produces probe_success."
+
+      - alert: SpeakUpAPIHigh5xxRate
+        expr: |
+          (
+            sum by (environment) (
+              increase(speakup_http_server_requests_total{status_class="5xx"}[5m])
+            ) >= 5
+          )
+          and
+          (
+            sum by (environment) (
+              increase(speakup_http_server_requests_total{status_class="5xx"}[5m])
+            )
+            /
+            clamp_min(
+              sum by (environment) (
+                increase(speakup_http_server_requests_total[5m])
+              ),
+              1
+            ) > 0.05
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} API 5xx rate is above 5%"
+          description: "At least five server errors were observed and the five-minute error ratio remains above 5%."
+
+      - alert: SpeakUpAPIHighP95Latency
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (environment, le) (
+              rate(speakup_http_server_request_duration_seconds_bucket[5m])
+            )
+          ) > 2
+          and
+          sum by (environment) (
+            increase(speakup_http_server_request_duration_seconds_count[5m])
+          ) >= 20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} API P95 latency is above 2 seconds"
+          description: "The five-minute request P95 has remained above two seconds with sufficient traffic."
+
+  - name: speakup-runtime
+    rules:
+      - alert: SpeakUpContainerDown
+        expr: speakup_container_up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} {{ $labels.service }} container is down"
+          description: "The expected SpeakUp container has not been running for more than two minutes."
+
+      - alert: SpeakUpContainerUnhealthy
+        expr: speakup_container_health == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} {{ $labels.service }} container is unhealthy"
+          description: "The container health check has not reported healthy for more than five minutes."
+
+      - alert: SpeakUpContainerRestarting
+        expr: increase(speakup_container_restarts_total[15m]) >= 3
+        labels:
+          severity: warning
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} {{ $labels.service }} is repeatedly restarting"
+          description: "The container restarted at least three times in fifteen minutes."
+
+      - alert: SpeakUpHostMetricsStale
+        expr: time() - node_textfile_mtime_seconds{file=~".*/speakup\\.prom"} > 180
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp host metrics are stale"
+          description: "The bounded container, backup, and certificate collector has not refreshed for more than three minutes."
+
+      - alert: SpeakUpHostMetricsMissing
+        expr: absent(node_textfile_mtime_seconds{file=~".*/speakup\\.prom"})
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp host metrics file is missing"
+          description: "node_exporter has no textfile series for the reviewed SpeakUp host collector path."
+
+      - alert: SpeakUpDiskSpaceLow
+        expr: |
+          speakup_host_filesystem_avail_bytes{mountpoint="/"}
+          /
+          speakup_host_filesystem_size_bytes{mountpoint="/"} < 0.15
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Server filesystem {{ $labels.mountpoint }} has less than 15% free space"
+          description: "Free space is {{ $value | humanizePercentage }}."
+
+      - alert: SpeakUpDiskSpaceCritical
+        expr: |
+          speakup_host_filesystem_avail_bytes{mountpoint="/"}
+          /
+          speakup_host_filesystem_size_bytes{mountpoint="/"} < 0.08
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Server filesystem {{ $labels.mountpoint }} has less than 8% free space"
+          description: "Free space is {{ $value | humanizePercentage }}."
+
+      - alert: SpeakUpInodesLow
+        expr: |
+          speakup_host_filesystem_files_free{mountpoint="/"}
+          /
+          speakup_host_filesystem_files{mountpoint="/"} < 0.15
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Server filesystem {{ $labels.mountpoint }} has less than 15% free inodes"
+          description: "Free inodes are {{ $value | humanizePercentage }}."
+
+      - alert: SpeakUpInodesCritical
+        expr: |
+          speakup_host_filesystem_files_free{mountpoint="/"}
+          /
+          speakup_host_filesystem_files{mountpoint="/"} < 0.08
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Server filesystem {{ $labels.mountpoint }} has less than 8% free inodes"
+          description: "Free inodes are {{ $value | humanizePercentage }}."
+
+  - name: speakup-certificates-and-backups
+    rules:
+      - alert: SpeakUpCertificateExpiresWithin30Days
+        expr: |
+          speakup_tls_certificate_expiry_timestamp_seconds - time() < 30 * 24 * 60 * 60
+          and
+          speakup_tls_certificate_expiry_timestamp_seconds - time() >= 14 * 24 * 60 * 60
+        labels:
+          severity: warning
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} TLS certificate expires within 30 days"
+          description: "Certificate {{ $labels.lineage }} requires renewal tracking."
+
+      - alert: SpeakUpCertificateExpiresWithin14Days
+        expr: |
+          speakup_tls_certificate_expiry_timestamp_seconds - time() < 14 * 24 * 60 * 60
+          and
+          speakup_tls_certificate_expiry_timestamp_seconds - time() >= 7 * 24 * 60 * 60
+        labels:
+          severity: high
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} TLS certificate expires within 14 days"
+          description: "Certificate {{ $labels.lineage }} requires prompt renewal action."
+
+      - alert: SpeakUpCertificateExpiresWithin7Days
+        expr: speakup_tls_certificate_expiry_timestamp_seconds - time() < 7 * 24 * 60 * 60
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.environment }} TLS certificate expires within 7 days"
+          description: "Certificate {{ $labels.lineage }} is at immediate risk of expiry."
+
+      - alert: SpeakUpBackupStale
+        expr: time() - speakup_backup_last_success_timestamp_seconds > 30 * 60 * 60
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.database }} backup is stale"
+          description: "No verified successful backup has been recorded in the last 30 hours."
+
+      - alert: SpeakUpScheduledSafetyCheckFailed
+        expr: speakup_systemd_unit_last_run_success == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.purpose }} last run failed"
+          description: "Systemd unit {{ $labels.unit }} did not finish successfully."
+
+      - alert: SpeakUpTLSRenewalNotRunRecently
+        expr: |
+          time()
+          - speakup_systemd_unit_last_run_timestamp_seconds{purpose="tls_renewal"}
+          > 18 * 60 * 60
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp TLS renewal has not run within 18 hours"
+          description: "The twice-daily systemd renewal unit {{ $labels.unit }} is stale even if its previous run succeeded."
+
+      - alert: SpeakUpRestoreCheckNotRunMonthly
+        expr: |
+          (
+            time()
+            - speakup_systemd_unit_last_run_timestamp_seconds{purpose="postgres_restore_check"}
+            > 31 * 24 * 60 * 60
+          )
+          or
+          (
+            time()
+            - speakup_systemd_unit_last_run_timestamp_seconds{purpose="portal_restore_check"}
+            > 31 * 24 * 60 * 60
+          )
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.purpose }} has not run within 31 days"
+          description: "The monthly restore verification unit {{ $labels.unit }} is stale even if its previous run succeeded."
+
+  - name: speakup-providers
+    rules:
+      - alert: SpeakUpProviderFailureRateHigh
+        expr: |
+          (
+            sum by (environment, provider, capability) (
+              increase(speakup_provider_calls_total{outcome!="success"}[10m])
+            ) >= 5
+          )
+          and
+          (
+            sum by (environment, provider, capability) (
+              increase(speakup_provider_calls_total{outcome!="success"}[10m])
+            )
+            /
+            clamp_min(
+              sum by (environment, provider, capability) (
+                increase(speakup_provider_calls_total[10m])
+              ),
+              1
+            ) > 0.20
+          )
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SpeakUp {{ $labels.provider }} {{ $labels.capability }} failures exceed 20%"
+          description: "At least five failures occurred and the ten-minute failure ratio remains above 20%."

--- a/deploy/observability/test-nginx.sh
+++ b/deploy/observability/test-nginx.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly observability_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly nginx_configuration="$observability_directory/monitor-nginx.conf"
+readonly nginx_image="nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de"
+
+fail() {
+  printf 'observability Nginx test: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v docker >/dev/null 2>&1 || fail 'docker is required'
+command -v openssl >/dev/null 2>&1 || fail 'openssl is required'
+docker version >/dev/null || fail 'Docker Engine is unavailable'
+
+temporary_directory=$(mktemp -d /tmp/xe3-observability-nginx-test.XXXXXX)
+trap 'rm -rf "$temporary_directory"' EXIT
+certificate_directory="$temporary_directory/certbot/conf/live/monitor.speak-up.top"
+mkdir -p "$certificate_directory" "$temporary_directory/acme" "$temporary_directory/logs"
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -subj /CN=monitor.speak-up.top \
+  -addext subjectAltName=DNS:monitor.speak-up.top \
+  -keyout "$certificate_directory/privkey.pem" \
+  -out "$certificate_directory/fullchain.pem" >/dev/null 2>&1
+chmod 0600 "$certificate_directory/privkey.pem"
+
+docker run \
+  --rm \
+  --name "xe3-observability-nginx-test-$$" \
+  --read-only \
+  --tmpfs /var/cache/nginx:rw,nosuid,nodev,noexec,size=8m \
+  --tmpfs /var/run:rw,nosuid,nodev,noexec,size=1m \
+  --volume "$nginx_configuration:/etc/nginx/conf.d/default.conf:ro" \
+  --volume "$certificate_directory:/opt/xe3-speakup-portal/certbot/conf/live/monitor.speak-up.top:ro" \
+  --volume "$temporary_directory/acme:/opt/xe3-speakup-portal/certbot/www:ro" \
+  --volume "$temporary_directory/logs:/etc/nginx/logs" \
+  "$nginx_image" \
+  nginx -t
+
+printf '%s\n' 'Observability Nginx configuration passed'

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -415,11 +415,30 @@ PATH="$probe_bin:$PATH" "$probe_incident" resolved drill
 [[ ! -e "$probe_state" ]] || fail 'resolved drill incident remained open'
 expect_failure 'resolve missing drill incident' env PATH="$probe_bin:$PATH" \
   "$probe_incident" resolved drill
+
+: >"$probe_log"
+PATH="$probe_bin:$PATH" "$probe_incident" failure production
+grep -Fxq '[production-probe] SpeakUp public endpoint incident' "$probe_state" ||
+  fail 'executed probe failure did not open the Production incident'
+PATH="$probe_bin:$PATH" "$probe_incident" success production
+[[ ! -e "$probe_state" ]] || fail 'executed probe success did not resolve the Production incident'
+: >"$probe_log"
+expect_failure 'skipped Production probe' env PATH="$probe_bin:$PATH" \
+  "$probe_incident" skipped production
+[[ ! -s "$probe_log" && ! -e "$probe_state" ]] ||
+  fail 'skipped probe contacted GitHub or created a Production incident'
+
 grep -Fq 'issues: write' "$probe_workflow" || fail 'off-host probe cannot write incident state'
 grep -Fq 'continue-on-error: true' "$probe_workflow" ||
   fail 'off-host probe cannot notify before preserving failure status'
 grep -Fq 'Preserve failing probe status' "$probe_workflow" ||
   fail 'off-host probe can silently pass after a failed public probe'
+grep -Fq '"$PROBE_OUTCOME" production' "$probe_workflow" ||
+  fail 'off-host probe does not classify the actual step outcome'
+grep -Fq "steps.public-probe.outcome == 'failure'" "$probe_workflow" ||
+  fail 'off-host workflow does not preserve only an executed probe failure'
+! grep -Fq "steps.public-probe.outcome != 'success'" "$probe_workflow" ||
+  fail 'off-host workflow still treats skipped probes as endpoint failures'
 grep -Fq 'inputs:' "$probe_workflow" || fail 'off-host notification drill is not dispatchable'
 [[ $(grep -Fc -- '--max-time 10' "$probe_workflow") -eq 2 ]] ||
   fail 'off-host retries can exhaust the job before incident recording'

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly observability_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly compose_file="$observability_directory/compose.yaml"
+readonly exporter="$observability_directory/xe3-speakup-export-metrics"
+readonly rules_file="$observability_directory/rules/speakup.yml"
+readonly logrotate_file="$observability_directory/xe3-speakup-nginx.logrotate"
+readonly dashboard_file="$observability_directory/grafana/dashboards/speakup-overview.json"
+readonly monitor_nginx="$observability_directory/monitor-nginx.conf"
+readonly private_file_validator="$observability_directory/validate-private-files"
+readonly probe_incident="$observability_directory/github-probe-incident.sh"
+readonly probe_workflow="$observability_directory/../../.github/workflows/production-probe.yml"
+readonly metrics_service="$observability_directory/xe3-speakup-observability-metrics.service"
+readonly metrics_environment_example="$observability_directory/observability-metrics.env.example"
+
+fail() {
+  printf 'observability contract test: %s\n' "$*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  if "$@" >"$temporary_directory/failure.out" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+}
+
+temporary_directory=$(mktemp -d)
+temporary_directory=$(cd "$temporary_directory" && pwd -P)
+readonly temporary_directory
+trap 'rm -rf "$temporary_directory"' EXIT
+
+mkdir -p \
+  "$temporary_directory/fake-bin" \
+  "$temporary_directory/postgres-backups/20260824T010203Z-daily" \
+  "$temporary_directory/portal-backups/20260824T020304Z" \
+  "$temporary_directory/textfile"
+printf '%s\n' 'fixture certificate' >"$temporary_directory/production.pem"
+printf '%s\n' 'fixture certificate' >"$temporary_directory/staging.pem"
+printf '%s\n' 'fixture certificate' >"$temporary_directory/monitor.pem"
+printf '%s\n' 'fixture password' >"$temporary_directory/grafana-password"
+printf '%s\n' \
+  '{"created_at":"2026-08-24T01:02:03Z"}' \
+  >"$temporary_directory/postgres-backups/20260824T010203Z-daily/metadata.json"
+printf '%s\n' \
+  '{"created_at":"2026-08-24T02:03:04Z"}' \
+  >"$temporary_directory/portal-backups/20260824T020304Z/metadata.json"
+
+cat >"$temporary_directory/fake-bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  ps)
+    project=''
+    service=''
+    while (($# > 0)); do
+      if [[ "$1" == --filter ]]; then
+        case "$2" in
+          label=com.docker.compose.project=*)
+            project=${2#label=com.docker.compose.project=}
+            ;;
+          label=com.docker.compose.service=*)
+            service=${2#label=com.docker.compose.service=}
+            ;;
+        esac
+        shift 2
+      else
+        shift
+      fi
+    done
+    if [[ "$service" != "${MISSING_SERVICE:-}" ]]; then
+      printf '%s--%s\n' "$project" "$service"
+    fi
+    ;;
+  inspect)
+    service=${2##*--}
+    restarts=0
+    [[ "$service" != server ]] || restarts=2
+    printf '[{"State":{"Running":true,"Health":{"Status":"healthy"}},"RestartCount":%s}]\n' "$restarts"
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"$temporary_directory/fake-bin/openssl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' 'notAfter=Nov 21 00:00:00 2026 GMT'
+EOF
+
+cat >"$temporary_directory/fake-bin/date" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' '1795219200'
+EOF
+
+cat >"$temporary_directory/fake-bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  *--property=Result*) printf '%s\n' success ;;
+  *--property=ExecMainStatus*) printf '%s\n' 0 ;;
+  *--property=ExecMainExitTimestamp*)
+    [[ "${NEVER_RUN_UNITS:-0}" == 1 ]] || printf '%s\n' 'Sun 2026-08-24 01:02:03 UTC'
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat >"$temporary_directory/fake-bin/df" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  '--block-size=1 --output=size,avail,target /')
+    printf '%s\n' '1B-blocks Avail Mounted on' '1000000 250000 /'
+    ;;
+  '--output=itotal,iavail,target /')
+    printf '%s\n' 'Inodes IFree Mounted on' '2000 500 /'
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod 0755 "$temporary_directory/fake-bin/"*
+
+bash -n "$exporter" "$private_file_validator" "$probe_incident" "$0"
+
+export OBSERVABILITY_PRODUCTION_CERTIFICATE="$temporary_directory/production.pem"
+export OBSERVABILITY_STAGING_CERTIFICATE="$temporary_directory/staging.pem"
+export OBSERVABILITY_MONITOR_CERTIFICATE="$temporary_directory/monitor.pem"
+export OBSERVABILITY_POSTGRES_BACKUP_ROOT="$temporary_directory/postgres-backups"
+export OBSERVABILITY_PORTAL_BACKUP_ROOT="$temporary_directory/portal-backups"
+
+readonly metrics_file="$temporary_directory/textfile/speakup.prom"
+PATH="$temporary_directory/fake-bin:$PATH" "$exporter" --output "$metrics_file"
+
+[[ $(grep -c '^speakup_container_up{' "$metrics_file") -eq 6 ]] ||
+  fail 'expected six bounded container-up series'
+[[ $(grep -c '^speakup_container_health{' "$metrics_file") -eq 6 ]] ||
+  fail 'expected six bounded container-health series'
+grep -Fq 'speakup_container_restarts_total{environment="production",service="server"} 2' \
+  "$metrics_file" || fail 'container restart count was not exported'
+grep -Fq 'speakup_tls_certificate_expiry_timestamp_seconds{environment="production",lineage="speak-up.top"} 1795219200' \
+  "$metrics_file" || fail 'production certificate expiry was not exported'
+grep -Fq 'speakup_tls_certificate_expiry_timestamp_seconds{environment="production",lineage="monitor.speak-up.top"} 1795219200' \
+  "$metrics_file" || fail 'monitor certificate expiry was not exported'
+grep -Fq 'speakup_backup_last_success_timestamp_seconds{database="postgres"} 1787533323' \
+  "$metrics_file" || fail 'PostgreSQL backup time was not exported'
+grep -Fq 'speakup_backup_last_success_timestamp_seconds{database="portal_sqlite"} 1787536984' \
+  "$metrics_file" || fail 'Portal backup time was not exported'
+[[ $(grep -c '^speakup_systemd_unit_last_run_success{' "$metrics_file") -eq 3 ]] ||
+  fail 'expected three bounded systemd safety series'
+[[ $(grep -c '^speakup_systemd_unit_last_run_timestamp_seconds{' "$metrics_file") -eq 3 ]] ||
+  fail 'expected three bounded systemd last-run timestamps'
+grep -Fq 'speakup_host_filesystem_avail_bytes{mountpoint="/"} 250000' "$metrics_file" ||
+  fail 'host root free bytes were not exported'
+grep -Fq 'speakup_host_filesystem_files_free{mountpoint="/"} 500' "$metrics_file" ||
+  fail 'host root free inodes were not exported'
+
+NEVER_RUN_UNITS=1 PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+[[ $(grep -c '^speakup_systemd_unit_last_run_success{.*} 0$' "$metrics_file") -eq 3 ]] ||
+  fail 'never-run systemd units did not fail closed'
+[[ $(grep -c '^speakup_systemd_unit_last_run_timestamp_seconds{.*} 0$' "$metrics_file") -eq 3 ]] ||
+  fail 'never-run systemd unit timestamps were not explicit'
+
+MISSING_SERVICE=portal PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+[[ $(grep -c 'service="portal"} 0$' "$metrics_file") -eq 6 ]] ||
+  fail 'missing Portal containers did not fail closed'
+
+expect_failure 'relative output path' env PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output relative/speakup.prom
+
+OBSERVABILITY_ALERTMANAGER_CONFIG="$observability_directory/alertmanager.example.yml" \
+OBSERVABILITY_GRAFANA_HOST=monitor.speak-up.top \
+OBSERVABILITY_GRAFANA_ADMIN_USER=speakup-admin \
+OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE="$temporary_directory/grafana-password" \
+  docker compose \
+    --env-file /dev/null \
+    --file "$compose_file" \
+    config --format json >"$temporary_directory/compose.json"
+
+jq --exit-status '
+  .name == "xe3-speakup-observability" and
+  (.services | keys | sort) ==
+    ["alertmanager", "blackbox", "grafana", "node-exporter", "prometheus"] and
+  ([.services[] | .read_only == true] | all) and
+  ([.services[] | .restart == "unless-stopped"] | all) and
+  ([.services[] |
+    .logging.driver == "json-file" and
+    .logging.options["max-size"] == "10m" and
+    .logging.options["max-file"] == "5"
+  ] | all) and
+  ([.services[] | (.cap_drop // []) == ["ALL"]] | all) and
+  ([.services[] | (.security_opt // []) == ["no-new-privileges:true"]] | all) and
+  ([.services[] | has("healthcheck")] | all) and
+  ([.services[] | (.volumes // [])[]? | select(.source == "/var/run/docker.sock")] | length) == 0 and
+  ([.services[] | (.volumes // [])[]? | select(.source == "/")] | length) == 0 and
+  .services["node-exporter"].command == [
+    "--collector.disable-defaults",
+    "--collector.textfile",
+    "--collector.textfile.directory=/textfile"
+  ] and
+  .services["node-exporter"].volumes[0].source == "/var/lib/xe3-speakup-observability/textfile" and
+  (.services | to_entries | map(select(.key != "grafana") | (.value | has("ports"))) | any | not) and
+  .services.grafana.ports[0].host_ip == "127.0.0.1" and
+  (.services.grafana.ports[0].published | tostring) == "13000" and
+  .services.grafana.platform == "linux/amd64" and
+  .services.grafana.environment.GF_AUTH_ANONYMOUS_ENABLED == "false" and
+  .networks.production_api.external == true and
+  .networks.production_api.name == "xe3-speakup-production-server-edge" and
+  .networks.staging_api.external == true and
+  .networks.staging_api.name == "xe3-speakup-staging_server_edge" and
+  (.networks.monitor.external // false) == false and
+  ([.services[] | .image | test("@sha256:[0-9a-f]{64}$")] | all)
+' "$temporary_directory/compose.json" >/dev/null ||
+  fail 'resolved observability Compose model violates its isolation contract'
+grep -Fxq 'ExecStart=/usr/local/sbin/xe3-speakup-export-metrics --output /var/lib/xe3-speakup-observability/textfile/speakup.prom' \
+  "$metrics_service" || fail 'systemd and node_exporter textfile paths are not one fixed contract'
+! grep -Fq 'OBSERVABILITY_TEXTFILE_' "$metrics_environment_example" ||
+  fail 'textfile path can still diverge through the metrics environment file'
+
+readonly expected_log_set=$'/usr/local/nginx/logs/xe3-speakup-production-portal.access.log\n/usr/local/nginx/logs/xe3-speakup-production-portal.error.log\n/usr/local/nginx/logs/xe3-speakup-production-api.access.log\n/usr/local/nginx/logs/xe3-speakup-production-api.error.log\n/usr/local/nginx/logs/xe3-speakup-staging-portal.access.log\n/usr/local/nginx/logs/xe3-speakup-staging-portal.error.log\n/usr/local/nginx/logs/xe3-speakup-staging-api.access.log\n/usr/local/nginx/logs/xe3-speakup-staging-api.error.log\n/usr/local/nginx/logs/xe3-speakup-monitor.access.log\n/usr/local/nginx/logs/xe3-speakup-monitor.error.log'
+actual_log_set=$(sed -nE 's|^(/usr/local/nginx/logs/[^[:space:]]+)([[:space:]]+\{)?$|\1|p' \
+  "$logrotate_file")
+[[ "$actual_log_set" == "$expected_log_set" ]] ||
+  fail 'Nginx logrotate scope is not the exact ordered SpeakUp log set'
+[[ $(grep -Ec '[[:space:]]+\{$' "$logrotate_file") -eq 1 ]] ||
+  fail 'Nginx logrotate must open exactly one stanza after the final path'
+! grep -Fq '*' "$logrotate_file" || fail 'Nginx logrotate must not contain globs'
+grep -Fq 'kill -USR1' "$logrotate_file" ||
+  fail 'Nginx logrotate does not reopen file handles'
+[[ $(grep -Fc 'server_name monitor.speak-up.top;' "$monitor_nginx") -eq 2 ]] ||
+  fail 'monitor Nginx host must have exact HTTP and HTTPS blocks'
+grep -Fq 'proxy_pass http://127.0.0.1:13000;' "$monitor_nginx" ||
+  fail 'monitor Nginx upstream is not loopback-only'
+grep -Fq 'live/monitor.speak-up.top/fullchain.pem;' "$monitor_nginx" ||
+  fail 'monitor Nginx does not use its independent certificate lineage'
+grep -Fq 'live/monitor.speak-up.top/privkey.pem;' "$monitor_nginx" ||
+  fail 'monitor Nginx does not use its independent private key lineage'
+! grep -Fq 'live/speak-up.top/' "$monitor_nginx" ||
+  fail 'monitor Nginx would mutate the exact Production certificate SAN contract'
+grep -A2 -F 'location ^~ /metrics {' "$monitor_nginx" | grep -Fq 'return 404;' ||
+  fail 'monitor Nginx does not deny the metrics path'
+if grep -Eq 'proxy_pass http://0\.0\.0\.0|listen 13000' "$monitor_nginx"; then
+  fail 'monitor Nginx exposed an internal listener'
+fi
+
+grep -Fq 'SpeakUpEndpointDown' "$rules_file" || fail 'endpoint alert is missing'
+grep -Fq 'SpeakUpScrapeTargetMissing' "$rules_file" || fail 'absent scrape alert is missing'
+grep -Fq 'SpeakUpEndpointProbeMissing' "$rules_file" || fail 'absent endpoint alert is missing'
+grep -Fq 'SpeakUpHostMetricsMissing' "$rules_file" || fail 'absent textfile alert is missing'
+grep -Fq 'speakup_host_filesystem_files_free' "$rules_file" ||
+  fail 'host inode alerts do not use the bounded host exporter'
+! grep -Fq 'node_filesystem_' "$rules_file" ||
+  fail 'rules still depend on a node_exporter host-root mount'
+grep -Fq 'SpeakUpCertificateExpiresWithin30Days' "$rules_file" ||
+  fail '30-day certificate alert is missing'
+grep -Fq 'SpeakUpCertificateExpiresWithin14Days' "$rules_file" ||
+  fail '14-day certificate alert is missing'
+grep -Fq 'SpeakUpCertificateExpiresWithin7Days' "$rules_file" ||
+  fail '7-day certificate alert is missing'
+grep -Fq 'SpeakUpTLSRenewalNotRunRecently' "$rules_file" ||
+  fail 'twice-daily TLS renewal staleness alert is missing'
+grep -Fq 'purpose="tls_renewal"' "$rules_file" ||
+  fail 'TLS renewal staleness is not scoped to its closed purpose label'
+grep -Fq '> 18 * 60 * 60' "$rules_file" ||
+  fail 'TLS renewal staleness threshold is not explicit'
+grep -Fq 'SpeakUpRestoreCheckNotRunMonthly' "$rules_file" ||
+  fail 'monthly restore-check staleness alert is missing'
+[[ $(grep -Fc 'purpose="postgres_restore_check"' "$rules_file") -eq 1 ]] ||
+  fail 'PostgreSQL restore staleness is not a single closed purpose'
+[[ $(grep -Fc 'purpose="portal_restore_check"' "$rules_file") -eq 1 ]] ||
+  fail 'Portal restore staleness is not a single closed purpose'
+[[ $(grep -Fc '> 31 * 24 * 60 * 60' "$rules_file") -eq 2 ]] ||
+  fail 'monthly restore staleness thresholds are not explicit for both purposes'
+
+jq --exit-status '
+  .uid == "speakup-production-overview" and
+  .editable == false and
+  (.panels | length) >= 12 and
+  ([.panels[].targets[]?.expr // ""] |
+    any(contains("probe_success{job=\"blackbox-http\""))) and
+  ([.panels[].targets[]?.expr // ""] |
+    any(contains("probe_duration_seconds{job=\"blackbox-http\",environment=~\"$environment\"}"))) and
+  ([.panels[].targets[]?.expr // ""] |
+    any(contains("speakup_host_filesystem_files_free"))) and
+  ([.panels[].targets[]?.expr // ""] |
+    any(contains("speakup_provider_calls_total"))) and
+  ([.panels[].targets[]?.expr // ""] |
+    any(contains("speakup_provider_call_duration_seconds_bucket"))) and
+  ([.panels[].targets[]?.expr // ""] |
+    any(contains("speakup_provider_usage_tokens_total"))) and
+  ([.panels[].targets[]?.expr // ""] |
+    any(contains("speakup_http_server_request_duration_seconds_bucket")))
+' "$dashboard_file" >/dev/null || fail 'Grafana dashboard is incomplete'
+
+# Private file validation is fail-closed and accounts for the runtime UIDs of
+# standalone Compose bind mounts.
+private_bin="$temporary_directory/private-bin"
+mkdir -p "$private_bin"
+cat >"$private_bin/stat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+format=$2
+path=$3
+if [[ "${FAKE_BAD_PRIVATE_PATH:-}" == "$path" && "$format" == %a ]]; then
+  printf '%s\n' 644
+  exit
+fi
+case "$path" in
+  */observability.env | */metrics.env)
+    owner=0 mode=600
+    ;;
+  */alertmanager.yml)
+    owner=65534 mode=400
+    ;;
+  */grafana-password)
+    owner=472 mode=400
+    ;;
+  *) exit 2 ;;
+esac
+case "$format" in
+  %u) printf '%s\n' "$owner" ;;
+  %a) printf '%s\n' "$mode" ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod 0755 "$private_bin/stat"
+cp "$observability_directory/alertmanager.example.yml" "$temporary_directory/alertmanager.yml"
+cat >"$temporary_directory/observability.env" <<EOF
+OBSERVABILITY_ALERTMANAGER_CONFIG=$temporary_directory/alertmanager.yml
+OBSERVABILITY_GRAFANA_HOST=monitor.speak-up.top
+OBSERVABILITY_GRAFANA_ADMIN_USER=speakup-admin
+OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE=$temporary_directory/grafana-password
+EOF
+cat >"$temporary_directory/metrics.env" <<EOF
+OBSERVABILITY_PRODUCTION_CERTIFICATE=$temporary_directory/production.pem
+OBSERVABILITY_STAGING_CERTIFICATE=$temporary_directory/staging.pem
+OBSERVABILITY_MONITOR_CERTIFICATE=$temporary_directory/monitor.pem
+OBSERVABILITY_POSTGRES_BACKUP_ROOT=$temporary_directory/postgres-backups
+OBSERVABILITY_PORTAL_BACKUP_ROOT=$temporary_directory/portal-backups
+EOF
+PATH="$private_bin:$PATH" "$private_file_validator" \
+  --environment-file "$temporary_directory/observability.env" \
+  --metrics-environment-file "$temporary_directory/metrics.env" >/dev/null
+expect_failure 'public Grafana password' env \
+  FAKE_BAD_PRIVATE_PATH="$temporary_directory/grafana-password" \
+  PATH="$private_bin:$PATH" \
+  "$private_file_validator" \
+    --environment-file "$temporary_directory/observability.env" \
+    --metrics-environment-file "$temporary_directory/metrics.env"
+
+# The off-host probe opens exactly one assigned incident, then comments and
+# closes it on resolution using only GitHub's built-in token and Issues API.
+probe_bin="$temporary_directory/probe-bin"
+probe_state="$temporary_directory/probe.state"
+probe_log="$temporary_directory/probe.log"
+probe_summary="$temporary_directory/probe.summary"
+mkdir -p "$probe_bin"
+cat >"$probe_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+if [[ "$*" == *'--paginate --slurp'* ]]; then
+  if [[ -s "$FAKE_GH_STATE" ]]; then
+    title=$(<"$FAKE_GH_STATE")
+    jq -n --arg title "$title" '[[{number: 42, title: $title, body: "<!-- speakup-production-probe-incident:v1 -->"}]]'
+  else
+    printf '%s\n' '[[]]'
+  fi
+  exit
+fi
+method=GET
+path=''
+previous=''
+for argument in "$@"; do
+  [[ "$previous" != --method ]] || method=$argument
+  if [[ "$argument" == repos/* ]]; then path=$argument; fi
+  previous=$argument
+done
+case "$method:$path" in
+  POST:*/issues)
+    payload=$(cat)
+    jq -e '.assignees == ["Lq0412"] and (.body | contains("firing"))' \
+      <<<"$payload" >/dev/null
+    jq -r '.title' <<<"$payload" >"$FAKE_GH_STATE"
+    printf '%s\n' 42
+    ;;
+  POST:*/comments)
+    jq -e '.body | contains("resolved")' >/dev/null
+    ;;
+  PATCH:*/issues/42)
+    jq -e '.state == "closed" and .state_reason == "completed"' >/dev/null
+    rm -f "$FAKE_GH_STATE"
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod 0755 "$probe_bin/gh"
+export FAKE_GH_LOG="$probe_log" FAKE_GH_STATE="$probe_state"
+export GITHUB_REPOSITORY=1024XEngineer/XE3-ESL
+export GITHUB_SERVER_URL=https://github.com
+export GITHUB_RUN_ID=123456 GITHUB_RUN_ATTEMPT=1 GITHUB_ACTOR=Lq0412
+export GITHUB_STEP_SUMMARY="$probe_summary"
+PATH="$probe_bin:$PATH" "$probe_incident" firing drill
+PATH="$probe_bin:$PATH" "$probe_incident" firing drill
+[[ $(grep -Fc -- '--method POST repos/1024XEngineer/XE3-ESL/issues ' "$probe_log") -eq 1 ]] ||
+  fail 'repeated firing created duplicate GitHub incidents'
+PATH="$probe_bin:$PATH" "$probe_incident" resolved drill
+[[ ! -e "$probe_state" ]] || fail 'resolved drill incident remained open'
+expect_failure 'resolve missing drill incident' env PATH="$probe_bin:$PATH" \
+  "$probe_incident" resolved drill
+grep -Fq 'issues: write' "$probe_workflow" || fail 'off-host probe cannot write incident state'
+grep -Fq 'continue-on-error: true' "$probe_workflow" ||
+  fail 'off-host probe cannot notify before preserving failure status'
+grep -Fq 'Preserve failing probe status' "$probe_workflow" ||
+  fail 'off-host probe can silently pass after a failed public probe'
+grep -Fq 'inputs:' "$probe_workflow" || fail 'off-host notification drill is not dispatchable'
+[[ $(grep -Fc -- '--max-time 10' "$probe_workflow") -eq 2 ]] ||
+  fail 'off-host retries can exhaust the job before incident recording'
+
+printf '%s\n' 'Observability contract tests passed'

--- a/deploy/observability/validate-private-files
+++ b/deploy/observability/validate-private-files
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  printf 'observability private files: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# == 4 && "$1" == --environment-file && "$3" == --metrics-environment-file ]] ||
+  fail 'usage: validate-private-files --environment-file FILE --metrics-environment-file FILE'
+readonly environment_file=$2
+readonly metrics_environment_file=$4
+
+file_mode() {
+  stat -Lc '%a' "$1"
+}
+
+file_owner() {
+  stat -Lc '%u' "$1"
+}
+
+require_private_file() {
+  local label=$1 path=$2 owner=$3 mode=$4
+  [[ -f "$path" && ! -L "$path" && -s "$path" ]] ||
+    fail "$label must be a non-empty regular file"
+  [[ "$(file_owner "$path")" == "$owner" ]] ||
+    fail "$label must be owned by uid $owner"
+  [[ "$(file_mode "$path")" == "$mode" ]] ||
+    fail "$label must have mode $mode"
+}
+
+valid_absolute_path() {
+  local value=$1
+  [[ "$value" =~ ^/[A-Za-z0-9._/-]+$ ]] &&
+    [[ "$value" != *//* && "$value" != */../* && "$value" != */./* &&
+      "$value" != */.. && "$value" != */. ]]
+}
+
+load_environment() {
+  local line name value line_number=0
+  local seen=$'\n'
+  require_private_file 'observability environment file' "$environment_file" 0 600
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    line=${line%$'\r'}
+    case "$line" in
+      '' | \#*) continue ;;
+    esac
+    [[ "$line" == *=* ]] || fail "invalid environment syntax at line $line_number"
+    name=${line%%=*}
+    value=${line#*=}
+    case "$name" in
+      OBSERVABILITY_ALERTMANAGER_CONFIG | \
+        OBSERVABILITY_GRAFANA_HOST | \
+        OBSERVABILITY_GRAFANA_ADMIN_USER | \
+        OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE)
+        ;;
+      *) fail "unsupported environment key: $name" ;;
+    esac
+    case "$seen" in
+      *$'\n'"$name"$'\n'*) fail "duplicate environment key: $name" ;;
+    esac
+    seen+="$name"$'\n'
+    [[ -n "$value" && "$value" != *$'\n'* && "$value" != *$'\r'* ]] ||
+      fail "$name must be a non-empty single-line value"
+    printf -v "$name" '%s' "$value"
+  done <"$environment_file"
+}
+
+load_metrics_environment() {
+  local line name value line_number=0
+  local seen=$'\n'
+  require_private_file 'metrics environment file' "$metrics_environment_file" 0 600
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    line=${line%$'\r'}
+    case "$line" in
+      '' | \#*) continue ;;
+    esac
+    [[ "$line" == *=* ]] || fail "invalid metrics environment syntax at line $line_number"
+    name=${line%%=*}
+    value=${line#*=}
+    case "$name" in
+      OBSERVABILITY_PRODUCTION_CERTIFICATE | \
+        OBSERVABILITY_STAGING_CERTIFICATE | \
+        OBSERVABILITY_MONITOR_CERTIFICATE | \
+        OBSERVABILITY_POSTGRES_BACKUP_ROOT | \
+        OBSERVABILITY_PORTAL_BACKUP_ROOT)
+        ;;
+      *) fail "unsupported metrics environment key: $name" ;;
+    esac
+    case "$seen" in
+      *$'\n'"$name"$'\n'*) fail "duplicate metrics environment key: $name" ;;
+    esac
+    seen+="$name"$'\n'
+    valid_absolute_path "$value" || fail "$name must be a safe absolute path"
+    printf -v "$name" '%s' "$value"
+  done <"$metrics_environment_file"
+}
+
+load_environment
+load_metrics_environment
+for name in \
+  OBSERVABILITY_ALERTMANAGER_CONFIG \
+  OBSERVABILITY_GRAFANA_HOST \
+  OBSERVABILITY_GRAFANA_ADMIN_USER \
+  OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE; do
+  [[ -n "${!name:-}" ]] || fail "$name is required"
+done
+for name in \
+  OBSERVABILITY_PRODUCTION_CERTIFICATE \
+  OBSERVABILITY_STAGING_CERTIFICATE \
+  OBSERVABILITY_MONITOR_CERTIFICATE \
+  OBSERVABILITY_POSTGRES_BACKUP_ROOT \
+  OBSERVABILITY_PORTAL_BACKUP_ROOT; do
+  [[ -n "${!name:-}" ]] || fail "$name is required"
+done
+valid_absolute_path "$OBSERVABILITY_ALERTMANAGER_CONFIG" ||
+  fail 'OBSERVABILITY_ALERTMANAGER_CONFIG must be a safe absolute path'
+valid_absolute_path "$OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE" ||
+  fail 'OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE must be a safe absolute path'
+[[ "$OBSERVABILITY_GRAFANA_HOST" == monitor.speak-up.top ]] ||
+  fail 'OBSERVABILITY_GRAFANA_HOST must be monitor.speak-up.top'
+[[ "$OBSERVABILITY_GRAFANA_ADMIN_USER" =~ ^[A-Za-z0-9_.-]{3,64}$ ]] ||
+  fail 'OBSERVABILITY_GRAFANA_ADMIN_USER is invalid'
+
+# Standalone Compose bind mounts preserve host ownership. Match each image's
+# non-root runtime UID while denying group and other access.
+require_private_file 'Alertmanager configuration' "$OBSERVABILITY_ALERTMANAGER_CONFIG" 65534 400
+require_private_file 'Grafana admin password' "$OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE" 472 400
+[[ $(wc -l <"$OBSERVABILITY_GRAFANA_ADMIN_PASSWORD_FILE" | tr -d '[:space:]') == 1 ]] ||
+  fail 'Grafana admin password must contain exactly one newline-terminated line'
+
+printf 'observability private files valid=true\n'

--- a/deploy/observability/xe3-speakup-export-metrics
+++ b/deploy/observability/xe3-speakup-export-metrics
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly required_environment=(
+  OBSERVABILITY_PRODUCTION_CERTIFICATE
+  OBSERVABILITY_STAGING_CERTIFICATE
+  OBSERVABILITY_MONITOR_CERTIFICATE
+  OBSERVABILITY_POSTGRES_BACKUP_ROOT
+  OBSERVABILITY_PORTAL_BACKUP_ROOT
+)
+
+fail() {
+  printf 'speakup metrics export: %s\n' "$*" >&2
+  exit 1
+}
+
+require_absolute_path() {
+  local name=$1
+  local value=${!name:-}
+  [[ -n "$value" ]] || fail "$name is required"
+  [[ "$value" == /* && "$value" != *$'\n'* && "$value" != *$'\r'* ]] ||
+    fail "$name must be an absolute single-line path"
+}
+
+for name in "${required_environment[@]}"; do
+  require_absolute_path "$name"
+done
+
+[[ $# == 2 && "$1" == --output ]] ||
+  fail 'usage: xe3-speakup-export-metrics --output FILE'
+readonly output_path=$2
+[[ "$output_path" == /* && "$output_path" != *$'\n'* && "$output_path" != *$'\r'* ]] ||
+  fail '--output must be an absolute single-line path'
+readonly output_directory=${output_path%/*}
+[[ "$output_directory" != "$output_path" ]] || fail '--output must include a directory'
+install -d -m 0755 "$output_directory"
+
+temporary_file=$(mktemp "$output_directory/.speakup.prom.XXXXXX")
+readonly temporary_file
+trap 'rm -f "$temporary_file"' EXIT
+chmod 0644 "$temporary_file"
+
+emit_container_metrics() {
+  local environment=$1
+  local project=$2
+  local service ids id inspect_json running health restarts
+
+  for service in portal server postgres; do
+    ids=()
+    while IFS= read -r id; do
+      [[ -z "$id" ]] || ids+=("$id")
+    done < <(
+        docker ps --all --quiet \
+          --filter "label=com.docker.compose.project=$project" \
+          --filter "label=com.docker.compose.service=$service"
+      )
+    running=0
+    health=0
+    restarts=0
+    if ((${#ids[@]} == 1)); then
+      id=${ids[0]}
+      inspect_json=$(docker inspect "$id")
+      running=$(jq -r 'if .[0].State.Running == true then 1 else 0 end' <<<"$inspect_json")
+      health=$(jq -r 'if .[0].State.Health.Status == "healthy" then 1 else 0 end' <<<"$inspect_json")
+      restarts=$(jq -r '.[0].RestartCount // 0' <<<"$inspect_json")
+      [[ "$running" =~ ^[01]$ && "$health" =~ ^[01]$ && "$restarts" =~ ^[0-9]+$ ]] ||
+        fail "invalid Docker state for $environment/$service"
+    fi
+    printf 'speakup_container_up{environment="%s",service="%s"} %s\n' \
+      "$environment" "$service" "$running" >>"$temporary_file"
+    printf 'speakup_container_health{environment="%s",service="%s"} %s\n' \
+      "$environment" "$service" "$health" >>"$temporary_file"
+    printf 'speakup_container_restarts_total{environment="%s",service="%s"} %s\n' \
+      "$environment" "$service" "$restarts" >>"$temporary_file"
+  done
+}
+
+certificate_expiry() {
+  local environment=$1
+  local lineage=$2
+  local certificate=$3
+  local not_after timestamp
+
+  timestamp=0
+  if [[ -f "$certificate" ]]; then
+    not_after=$(openssl x509 -in "$certificate" -noout -enddate)
+    not_after=${not_after#notAfter=}
+    timestamp=$(date --utc --date="$not_after" +%s)
+    [[ "$timestamp" =~ ^[0-9]+$ ]] || fail "invalid TLS expiry for $lineage"
+  fi
+  printf 'speakup_tls_certificate_expiry_timestamp_seconds{environment="%s",lineage="%s"} %s\n' \
+    "$environment" "$lineage" "$timestamp" >>"$temporary_file"
+}
+
+latest_backup_timestamp() {
+  local database=$1
+  local root=$2
+  local metadata timestamp candidate
+
+  timestamp=0
+  if [[ -d "$root" ]]; then
+    while IFS= read -r metadata; do
+      candidate=$(jq -er '.created_at | fromdateiso8601' "$metadata")
+      [[ "$candidate" =~ ^[0-9]+$ ]] ||
+        fail "invalid backup timestamp for $database"
+      if ((candidate > timestamp)); then
+        timestamp=$candidate
+      fi
+    done < <(find "$root" -mindepth 2 -maxdepth 2 -type f -name metadata.json -print)
+  fi
+  printf 'speakup_backup_last_success_timestamp_seconds{database="%s"} %s\n' \
+    "$database" "$timestamp" >>"$temporary_file"
+}
+
+unit_success() {
+  local purpose=$1
+  local unit=$2
+  local result status last_run last_run_timestamp=0 success=0
+
+  result=$(systemctl show --property=Result --value "$unit" 2>/dev/null || true)
+  status=$(systemctl show --property=ExecMainStatus --value "$unit" 2>/dev/null || true)
+  last_run=$(systemctl show --property=ExecMainExitTimestamp --value "$unit" 2>/dev/null || true)
+  if [[ -n "$last_run" && "$last_run" != n/a ]]; then
+    last_run_timestamp=$(date --utc --date="$last_run" +%s)
+    [[ "$last_run_timestamp" =~ ^[0-9]+$ ]] || fail "invalid last-run time for $unit"
+  fi
+  if [[ "$result" == success && "$status" == 0 && "$last_run_timestamp" -gt 0 ]]; then
+    success=1
+  fi
+  printf 'speakup_systemd_unit_last_run_success{purpose="%s",unit="%s"} %s\n' \
+    "$purpose" "$unit" "$success" >>"$temporary_file"
+  printf 'speakup_systemd_unit_last_run_timestamp_seconds{purpose="%s",unit="%s"} %s\n' \
+    "$purpose" "$unit" "$last_run_timestamp" >>"$temporary_file"
+}
+
+emit_host_filesystem_metrics() {
+  local size available mountpoint files files_free inode_mountpoint
+
+  read -r size available mountpoint < <(df --block-size=1 --output=size,avail,target / | tail -n 1)
+  read -r files files_free inode_mountpoint < <(df --output=itotal,iavail,target / | tail -n 1)
+  [[ "$size" =~ ^[0-9]+$ && "$available" =~ ^[0-9]+$ && "$mountpoint" == / ]] ||
+    fail 'invalid root filesystem capacity from df'
+  [[ "$files" =~ ^[0-9]+$ && "$files_free" =~ ^[0-9]+$ && "$inode_mountpoint" == / ]] ||
+    fail 'invalid root filesystem inode capacity from df'
+  ((size > 0 && available <= size && files > 0 && files_free <= files)) ||
+    fail 'root filesystem metrics are outside their valid range'
+
+  printf 'speakup_host_filesystem_size_bytes{mountpoint="/"} %s\n' "$size" >>"$temporary_file"
+  printf 'speakup_host_filesystem_avail_bytes{mountpoint="/"} %s\n' "$available" >>"$temporary_file"
+  printf 'speakup_host_filesystem_files{mountpoint="/"} %s\n' "$files" >>"$temporary_file"
+  printf 'speakup_host_filesystem_files_free{mountpoint="/"} %s\n' "$files_free" >>"$temporary_file"
+}
+
+cat >>"$temporary_file" <<'EOF'
+# HELP speakup_container_up Whether the expected SpeakUp container is running.
+# TYPE speakup_container_up gauge
+# HELP speakup_container_health Whether the expected SpeakUp container is healthy.
+# TYPE speakup_container_health gauge
+# HELP speakup_container_restarts_total Docker restart count for the expected SpeakUp container.
+# TYPE speakup_container_restarts_total counter
+# HELP speakup_tls_certificate_expiry_timestamp_seconds Unix timestamp when a SpeakUp TLS certificate expires.
+# TYPE speakup_tls_certificate_expiry_timestamp_seconds gauge
+# HELP speakup_backup_last_success_timestamp_seconds Unix timestamp of the newest verified SpeakUp backup metadata.
+# TYPE speakup_backup_last_success_timestamp_seconds gauge
+# HELP speakup_systemd_unit_last_run_success Whether the last relevant systemd unit run succeeded.
+# TYPE speakup_systemd_unit_last_run_success gauge
+# HELP speakup_systemd_unit_last_run_timestamp_seconds Unix timestamp when the relevant systemd unit last exited.
+# TYPE speakup_systemd_unit_last_run_timestamp_seconds gauge
+# HELP speakup_host_filesystem_size_bytes Total bytes on the host root filesystem.
+# TYPE speakup_host_filesystem_size_bytes gauge
+# HELP speakup_host_filesystem_avail_bytes Available bytes on the host root filesystem.
+# TYPE speakup_host_filesystem_avail_bytes gauge
+# HELP speakup_host_filesystem_files Total inodes on the host root filesystem.
+# TYPE speakup_host_filesystem_files gauge
+# HELP speakup_host_filesystem_files_free Free inodes on the host root filesystem.
+# TYPE speakup_host_filesystem_files_free gauge
+EOF
+
+emit_container_metrics production xe3-speakup-production
+emit_container_metrics staging xe3-speakup-staging
+certificate_expiry production speak-up.top "$OBSERVABILITY_PRODUCTION_CERTIFICATE"
+certificate_expiry staging staging.speak-up.top "$OBSERVABILITY_STAGING_CERTIFICATE"
+certificate_expiry production monitor.speak-up.top "$OBSERVABILITY_MONITOR_CERTIFICATE"
+latest_backup_timestamp postgres "$OBSERVABILITY_POSTGRES_BACKUP_ROOT"
+latest_backup_timestamp portal_sqlite "$OBSERVABILITY_PORTAL_BACKUP_ROOT"
+emit_host_filesystem_metrics
+unit_success postgres_restore_check xe3-postgres-restore-check.service
+unit_success portal_restore_check xe3-portal-sqlite-restore-check.service
+unit_success tls_renewal xe3-speakup-tls-renew.service
+
+mv -f "$temporary_file" "$output_path"
+trap - EXIT

--- a/deploy/observability/xe3-speakup-nginx.logrotate
+++ b/deploy/observability/xe3-speakup-nginx.logrotate
@@ -1,0 +1,26 @@
+/usr/local/nginx/logs/xe3-speakup-production-portal.access.log
+/usr/local/nginx/logs/xe3-speakup-production-portal.error.log
+/usr/local/nginx/logs/xe3-speakup-production-api.access.log
+/usr/local/nginx/logs/xe3-speakup-production-api.error.log
+/usr/local/nginx/logs/xe3-speakup-staging-portal.access.log
+/usr/local/nginx/logs/xe3-speakup-staging-portal.error.log
+/usr/local/nginx/logs/xe3-speakup-staging-api.access.log
+/usr/local/nginx/logs/xe3-speakup-staging-api.error.log
+/usr/local/nginx/logs/xe3-speakup-monitor.access.log
+/usr/local/nginx/logs/xe3-speakup-monitor.error.log {
+    daily
+    rotate 14
+    maxsize 50M
+    missingok
+    notifempty
+    compress
+    delaycompress
+    dateext
+    create 0600 root root
+    sharedscripts
+    postrotate
+        if [ -s /usr/local/nginx/logs/nginx.pid ]; then
+            kill -USR1 "$(cat /usr/local/nginx/logs/nginx.pid)"
+        fi
+    endscript
+}

--- a/deploy/observability/xe3-speakup-observability-metrics.service
+++ b/deploy/observability/xe3-speakup-observability-metrics.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Export bounded SpeakUp production metrics for node_exporter
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+UMask=0022
+EnvironmentFile=/etc/speakup/observability-metrics.env
+StateDirectory=xe3-speakup-observability
+ExecStart=/usr/local/sbin/xe3-speakup-export-metrics --output /var/lib/xe3-speakup-observability/textfile/speakup.prom
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/xe3-speakup-observability
+RestrictSUIDSGID=true

--- a/deploy/observability/xe3-speakup-observability-metrics.timer
+++ b/deploy/observability/xe3-speakup-observability-metrics.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Refresh SpeakUp production metrics every minute
+
+[Timer]
+OnBootSec=2m
+OnUnitActiveSec=1m
+AccuracySec=10s
+Persistent=true
+Unit=xe3-speakup-observability-metrics.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/production/compose.yaml
+++ b/deploy/production/compose.yaml
@@ -1,10 +1,17 @@
 name: xe3-speakup-production
 
+x-speakup-logging: &speakup-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   postgres:
     image: postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108
     pull_policy: always
     restart: unless-stopped
+    logging: *speakup-logging
     environment:
       POSTGRES_DB: ${PRODUCTION_POSTGRES_DB:?PRODUCTION_POSTGRES_DB is required}
       POSTGRES_USER: ${PRODUCTION_POSTGRES_USER:?PRODUCTION_POSTGRES_USER is required}
@@ -30,6 +37,7 @@ services:
     profiles:
       - migration
     restart: "no"
+    logging: *speakup-logging
     command:
       - /usr/local/bin/speakup-migrate
       - up
@@ -46,12 +54,14 @@ services:
     pull_policy: always
     restart: unless-stopped
     init: true
+    logging: *speakup-logging
     env_file:
       - ${PRODUCTION_SERVER_ENV_FILE:?PRODUCTION_SERVER_ENV_FILE is required}
     environment:
       DATABASE_URL: postgres://${PRODUCTION_POSTGRES_USER:?PRODUCTION_POSTGRES_USER is required}:${PRODUCTION_POSTGRES_PASSWORD:?PRODUCTION_POSTGRES_PASSWORD is required}@postgres:5432/${PRODUCTION_POSTGRES_DB:?PRODUCTION_POSTGRES_DB is required}?sslmode=disable
       SERVER_HOST: 0.0.0.0
       SERVER_PORT: "8080"
+      METRICS_HOST: 0.0.0.0
       TRUSTED_PROXY_CIDRS: ${PRODUCTION_SERVER_EDGE_GATEWAY_CIDR:?PRODUCTION_SERVER_EDGE_GATEWAY_CIDR is required}
       TRUSTED_PROXY_HEADER: x-forwarded-for
     ports:
@@ -60,8 +70,10 @@ services:
       postgres:
         condition: service_healthy
     networks:
-      - server_edge
-      - database
+      server_edge:
+        aliases:
+          - production-api-metrics
+      database:
     healthcheck:
       test:
         [
@@ -83,6 +95,7 @@ services:
     pull_policy: always
     restart: unless-stopped
     init: true
+    logging: *speakup-logging
     environment:
       PORTAL_ADMIN_PASSWORD: ${PORTAL_ADMIN_PASSWORD:?PORTAL_ADMIN_PASSWORD is required}
       PORTAL_SQLITE_PATH: /app/.wrangler/portal.sqlite

--- a/deploy/production/test.sh
+++ b/deploy/production/test.sh
@@ -791,6 +791,11 @@ jq --exit-status \
       ("ghcr.io/1024xengineer/xe3-esl-server@" + $server_digest) and
     ([.services[] | has("build")] | any | not) and
     ([.services[] | has("container_name")] | any | not) and
+    ([.services[] |
+      .logging.driver == "json-file" and
+      .logging.options["max-size"] == "10m" and
+      .logging.options["max-file"] == "5"
+    ] | all) and
     .services.portal.ports[0].host_ip == "127.0.0.1" and
     (.services.portal.ports[0].published | tostring) == "18082" and
     .services.server.ports[0].host_ip == "127.0.0.1" and
@@ -803,6 +808,9 @@ jq --exit-status \
     (.services.postgres.networks | keys) == ["database"] and
     (.services.migrate.networks | keys) == ["database"] and
     (.services.server.networks | keys | sort) == ["database", "server_edge"] and
+    .services.server.networks.server_edge.aliases ==
+      ["production-api-metrics"] and
+    .services.server.environment.METRICS_HOST == "0.0.0.0" and
     .services.server.environment.TRUSTED_PROXY_CIDRS == "172.31.0.1/32" and
     .services.server.environment.TRUSTED_PROXY_HEADER == "x-forwarded-for" and
     .services.portal.healthcheck.test == [

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -1,10 +1,17 @@
 name: xe3-speakup-staging
 
+x-speakup-logging: &speakup-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   postgres:
     image: postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108
     pull_policy: always
     restart: unless-stopped
+    logging: *speakup-logging
     environment:
       POSTGRES_DB: ${STAGING_POSTGRES_DB:?STAGING_POSTGRES_DB is required}
       POSTGRES_USER: ${STAGING_POSTGRES_USER:?STAGING_POSTGRES_USER is required}
@@ -30,6 +37,7 @@ services:
     profiles:
       - migration
     restart: "no"
+    logging: *speakup-logging
     command:
       - /usr/local/bin/speakup-migrate
       - up
@@ -46,20 +54,24 @@ services:
     pull_policy: always
     restart: unless-stopped
     init: true
+    logging: *speakup-logging
     env_file:
       - ${STAGING_SERVER_ENV_FILE:?STAGING_SERVER_ENV_FILE is required}
     environment:
       DATABASE_URL: postgres://${STAGING_POSTGRES_USER:?STAGING_POSTGRES_USER is required}:${STAGING_POSTGRES_PASSWORD:?STAGING_POSTGRES_PASSWORD is required}@postgres:5432/${STAGING_POSTGRES_DB:?STAGING_POSTGRES_DB is required}?sslmode=disable
       SERVER_HOST: 0.0.0.0
       SERVER_PORT: "8080"
+      METRICS_HOST: 0.0.0.0
     ports:
       - "127.0.0.1:28083:8080"
     depends_on:
       postgres:
         condition: service_healthy
     networks:
-      - server_edge
-      - database
+      server_edge:
+        aliases:
+          - staging-api-metrics
+      database:
     healthcheck:
       test:
         [
@@ -81,6 +93,7 @@ services:
     pull_policy: always
     restart: unless-stopped
     init: true
+    logging: *speakup-logging
     environment:
       PORTAL_ADMIN_PASSWORD: ${PORTAL_ADMIN_PASSWORD:?PORTAL_ADMIN_PASSWORD is required}
       PORTAL_SQLITE_PATH: /app/.wrangler/portal.sqlite

--- a/deploy/staging/test.sh
+++ b/deploy/staging/test.sh
@@ -582,6 +582,11 @@ jq --exit-status \
       ("ghcr.io/1024xengineer/xe3-esl-server@" + $server_digest) and
     ([.services[] | has("build")] | any | not) and
     ([.services[] | has("container_name")] | any | not) and
+    ([.services[] |
+      .logging.driver == "json-file" and
+      .logging.options["max-size"] == "10m" and
+      .logging.options["max-file"] == "5"
+    ] | all) and
     .services.portal.ports[0].host_ip == "127.0.0.1" and
     (.services.portal.ports[0].published | tostring) == "28082" and
     .services.server.ports[0].host_ip == "127.0.0.1" and
@@ -592,6 +597,9 @@ jq --exit-status \
     (.services.postgres.networks | keys) == ["database"] and
     (.services.migrate.networks | keys) == ["database"] and
     (.services.server.networks | keys | sort) == ["database", "server_edge"] and
+    .services.server.networks.server_edge.aliases ==
+      ["staging-api-metrics"] and
+    .services.server.environment.METRICS_HOST == "0.0.0.0" and
     (.volumes | keys | sort) == ["portal_data", "postgres_data"]
   ' "$temporary_directory/compose.json" >/dev/null ||
   fail "resolved Compose model violates the isolation contract"

--- a/deploy/tls/README.md
+++ b/deploy/tls/README.md
@@ -1,7 +1,7 @@
 # SpeakUp TLS lifecycle contract
 
 This directory defines the audited HTTP-01 issuance, verification, activation,
-and renewal path for the two SpeakUp certificate lineages. Committing or merging
+and renewal path for the three SpeakUp certificate lineages. Committing or merging
 these files does **not** connect to a server, contact a certificate authority,
 change DNS, install Nginx configuration, or switch any traffic.
 
@@ -24,11 +24,14 @@ change DNS, install Nginx configuration, or switch any traffic.
   expanded exact three-name certificate is accepted idempotently. A missing
   lineage, a partial lineage, or any other SAN is rejected. The result must
   contain exactly `speak-up.top`, `www.speak-up.top`, and `api.speak-up.top`.
-- New issuance never registers or guesses an ACME account. Both Staging issue
-  and Production expansion reuse the exact account referenced by the existing
+- Monitor is a separate lineage named `monitor.speak-up.top` with exactly that
+  one SAN. It reuses the reviewed Production ACME account and webroot but never
+  expands or otherwise changes the Production three-name lineage.
+- New issuance never registers or guesses an ACME account. Staging and monitor
+  issuance plus Production expansion reuse the exact account referenced by the existing
   Production renewal configuration, validate its fixed Let's Encrypt storage
   path and file permissions, pass it explicitly with `--account`, and require
-  both saved renewal configurations to retain that same account.
+  all three saved renewal configurations to retain that same account.
 - Both Production's existing Portal hosts and its new API host use the same
   operator-provided Production webroot during expansion and renewal.
 - A certificate is usable only when the Certbot live paths resolve inside the
@@ -40,13 +43,13 @@ change DNS, install Nginx configuration, or switch any traffic.
   at least five minutes remain. This fail-closed clock-skew window never treats
   an expired or imminently expiring certificate as valid. Any certificate checked
   after a live renewal must again have at least seven days remaining.
-- Before activation, every final Staging or Production hostname must occur in
+- Before activation, every final Staging, Production, or monitor hostname must occur in
   exactly one `443 ssl` server block. That block itself must contain exactly one
   direct certificate and key directive for the current lineage; directives in
   nested or unrelated blocks cannot satisfy the check. A still-installed HTTP
   bootstrap or legacy Portal-only vhost therefore cannot be recorded as the
   final activated state.
-- `renew` validates both lineages before and after Certbot runs. Nginx reloads
+- `renew` validates all three lineages before and after Certbot runs. Nginx reloads
   once only when a verified certificate differs from the last successfully
   activated SHA-256 and `nginx -t` succeeds. A dry-run never reloads.
 - Renewal configuration must still use the webroot authenticator and Let's
@@ -104,12 +107,13 @@ result unless `docker image inspect` reports `linux/amd64` and includes that
 exact digest in `RepoDigests`. Repeat it only after an approved digest update;
 scheduled renewal never upgrades software implicitly.
 
-The final Staging and Production deployment environment files must reference
-the same live paths derived from this root:
+The final Staging, Production, and monitor configurations must reference the
+live paths derived from this root:
 
 ```text
 <TLS_CERTBOT_CONFIG_ROOT>/live/staging.speak-up.top/{fullchain,privkey}.pem
 <TLS_CERTBOT_CONFIG_ROOT>/live/speak-up.top/{fullchain,privkey}.pem
+<TLS_CERTBOT_CONFIG_ROOT>/live/monitor.speak-up.top/{fullchain,privkey}.pem
 ```
 
 ## 2. Install HTTP-01 bootstrap vhosts
@@ -143,18 +147,32 @@ blocks; those existing blocks must already serve the same Production webroot.
 /usr/local/nginx/sbin/nginx -s reload
 ```
 
+Monitor has one independent hostname but uses the reviewed Production webroot:
+
+```sh
+/usr/local/sbin/xe3-speakup-tls render-bootstrap \
+  --environment monitor \
+  --env-file /etc/speakup/tls.env \
+  --output /usr/local/nginx/conf/vhost/xe3-speakup-monitor-bootstrap.conf
+/usr/local/nginx/sbin/nginx -t
+/usr/local/nginx/sbin/nginx -s reload
+```
+
 Before contacting the CA, place a temporary non-secret file below each
 webroot's `.well-known/acme-challenge/` directory and verify that every selected
 hostname returns that exact file on HTTP while an unrelated path returns `404`.
 Remove the file after verification. Do not issue while an AAAA record points to
 an unreachable or differently configured host.
 
-## 3. Issue Staging and expand Production
+## 3. Issue Staging and monitor, then expand Production
 
 After DNS and public port 80 have been independently verified:
 
 ```sh
 /usr/local/sbin/xe3-speakup-tls issue-staging \
+  --env-file /etc/speakup/tls.env
+
+/usr/local/sbin/xe3-speakup-tls issue-monitor \
   --env-file /etc/speakup/tls.env
 
 /usr/local/sbin/xe3-speakup-tls expand-production \
@@ -168,11 +186,10 @@ certificate and persisted renewal account and prints a small audit record
 containing its environment, lineage, SHA-256, expiry, and `reload=false`. It does
 not print the environment file, account identifier, account key, or private key.
 
-If `issue-staging` exits after Certbot has already reported a saved certificate,
-do not rerun it blindly: the exact Staging lineage may now exist and rate limits
-still apply. Record hashes and permissions for
-`live/staging.speak-up.top`, `archive/staging.speak-up.top`, and
-`renewal/staging.speak-up.top.conf`, then run `verify --environment staging`.
+If either issue command exits after Certbot has already reported a saved
+certificate, do not rerun it blindly: the exact new lineage may now exist and
+rate limits still apply. Record hashes and permissions for its exact `live`,
+`archive`, and `renewal` paths, then run `verify` for that environment.
 Repair a local permission or renewal-account mismatch in place when the
 certificate itself is valid. If the lineage is incomplete or irreparably wrong,
 move only those three exact Staging paths to a root-owned timestamped quarantine
@@ -205,6 +222,10 @@ the same `server_name`. Test and atomically activate each verified certificate:
 /usr/local/sbin/xe3-speakup-tls activate \
   --environment production \
   --env-file /etc/speakup/tls.env
+
+/usr/local/sbin/xe3-speakup-tls activate \
+  --environment monitor \
+  --env-file /etc/speakup/tls.env
 ```
 
 `activate` runs all certificate and renewal checks, `nginx -t`, and a private
@@ -218,7 +239,7 @@ Production cutover. This Issue and its PR stop at the tested host-side contract.
 
 ## 4. Dry-run and automatic renewal
 
-Only after both final HTTPS vhosts have been activated, test both lineages
+Only after all final HTTPS vhosts have been activated, test all three lineages
 against Certbot's renewal staging flow:
 
 ```sh
@@ -260,7 +281,7 @@ failure and certificate validity before the seven-day release threshold.
 
 ## 5. Verification, evidence, and recovery
 
-After activation, verify all five public HTTPS hostnames from outside the server,
+After activation, verify all six public HTTPS hostnames from outside the server,
 including their expected redirects, Portal/API health behavior, certificate SANs,
 and expiry. Record only non-secret evidence:
 
@@ -270,6 +291,7 @@ curl --fail https://staging-api.speak-up.top/health
 curl --fail --location https://speak-up.top/
 curl --silent --show-error --head https://www.speak-up.top/
 curl --fail https://api.speak-up.top/health
+curl --fail https://monitor.speak-up.top/api/health
 
 openssl s_client \
   -connect staging.speak-up.top:443 \
@@ -281,17 +303,24 @@ openssl s_client \
   -servername speak-up.top \
   -verify_return_error </dev/null 2>/dev/null |
   openssl x509 -noout -ext subjectAltName -dates -fingerprint -sha256
+openssl s_client \
+  -connect monitor.speak-up.top:443 \
+  -servername monitor.speak-up.top \
+  -verify_return_error </dev/null 2>/dev/null |
+  openssl x509 -noout -ext subjectAltName -dates -fingerprint -sha256
 
 /usr/local/sbin/xe3-speakup-tls verify \
   --environment staging --env-file /etc/speakup/tls.env
 /usr/local/sbin/xe3-speakup-tls verify \
   --environment production --env-file /etc/speakup/tls.env
+/usr/local/sbin/xe3-speakup-tls verify \
+  --environment monitor --env-file /etc/speakup/tls.env
 systemctl list-timers xe3-speakup-tls-renew.timer
 systemctl status xe3-speakup-tls-renew.service
 journalctl -u xe3-speakup-tls-renew.service --since today
 ```
 
-If Certbot fails, either lineage fails verification, or `nginx -t` fails,
+If Certbot fails, any lineage fails verification, or `nginx -t` fails,
 `renew` exits nonzero without a reload and the existing Nginx workers continue
 using their previously loaded certificate. Fix the CA, DNS, file permission,
 certificate, or Nginx error and run `renew` again. If Certbot had already updated
@@ -301,7 +330,7 @@ certificate rather than silently skipping it.
 
 Local and CI verification never contacts a real CA or writes a server. It runs
 the lifecycle boundaries against fake Docker/OpenSSL/Nginx tools, then syntax
-checks both rendered bootstrap fragments in the same pinned Docker Official
+checks all three rendered bootstrap fragments in the same pinned Docker Official
 Nginx image used by the deployment contracts:
 
 ```sh

--- a/deploy/tls/manage.sh
+++ b/deploy/tls/manage.sh
@@ -16,11 +16,12 @@ usage() {
   cat >&2 <<'EOF'
 Usage:
   manage.sh prepare-image --env-file FILE
-  manage.sh render-bootstrap --environment staging|production --env-file FILE --output FILE
+  manage.sh render-bootstrap --environment staging|production|monitor --env-file FILE --output FILE
   manage.sh issue-staging --env-file FILE
+  manage.sh issue-monitor --env-file FILE
   manage.sh expand-production --env-file FILE
-  manage.sh verify --environment staging|production --env-file FILE
-  manage.sh activate --environment staging|production --env-file FILE
+  manage.sh verify --environment staging|production|monitor --env-file FILE
+  manage.sh activate --environment staging|production|monitor --env-file FILE
   manage.sh renew --env-file FILE
   manage.sh renew-dry-run --env-file FILE
 EOF
@@ -341,8 +342,15 @@ select_environment() {
       # The temporary bootstrap include must not duplicate those server names.
       bootstrap_domains=(api.speak-up.top)
       ;;
+    monitor)
+      certificate_name="monitor.speak-up.top"
+      acme_root=$TLS_PRODUCTION_ACME_ROOT
+      expected_domains=(monitor.speak-up.top)
+      exact_webroot_map='{"monitor.speak-up.top":"/var/www/acme"}'
+      bootstrap_domains=(monitor.speak-up.top)
+      ;;
     *)
-      fail "environment must be staging or production"
+      fail "environment must be staging, production, or monitor"
       ;;
   esac
   certificate="$TLS_CERTBOT_CONFIG_ROOT/live/$certificate_name/fullchain.pem"
@@ -860,7 +868,7 @@ issue_certificate() {
   production_account_id=$(resolve_production_acme_account_id)
   if lineage_exists; then
     [[ "$selected_environment" == production ]] ||
-      fail "Staging certificate lineage already exists; use renew"
+      fail "$selected_environment certificate lineage already exists; use renew"
     [[ (-e "$certificate" || -L "$certificate") &&
       (-e "$certificate_key" || -L "$certificate_key") ]] ||
       fail "Production certificate lineage is incomplete"
@@ -1143,7 +1151,7 @@ activate_selected_certificate() {
 
 renew_all_certificates() {
   local environment
-  local -a environments=(staging production)
+  local -a environments=(staging production monitor)
   local -a changed_environments=()
   local -a changed_shas=()
   local -a final_shas=()
@@ -1187,16 +1195,16 @@ renew_all_certificates() {
   done
 
   if ((${#changed_environments[@]} == 0)); then
-    printf 'certificates=staging,production renewed=true reload=false\n'
+    printf 'certificates=staging,production,monitor renewed=true reload=false\n'
     return
   fi
 
-  test_and_reload_nginx staging production
+  test_and_reload_nginx staging production monitor
   for ((index = 0; index < ${#changed_environments[@]}; index++)); do
     select_environment "${changed_environments[$index]}"
     write_deployed_sha "${changed_shas[$index]}"
   done
-  printf 'certificates=staging,production renewed=true reload=true\n'
+  printf 'certificates=staging,production,monitor renewed=true reload=true\n'
 }
 
 renew_dry_run_selected() {
@@ -1221,7 +1229,7 @@ renew_dry_run_selected() {
 
 renew_dry_run_all() {
   local environment
-  for environment in staging production; do
+  for environment in staging production monitor; do
     select_environment "$environment"
     renew_dry_run_selected
   done
@@ -1282,7 +1290,7 @@ main() {
   validate_configuration
 
   case "$command" in
-    prepare-image | issue-staging | expand-production | renew | renew-dry-run)
+    prepare-image | issue-staging | issue-monitor | expand-production | renew | renew-dry-run)
       [[ -z "$environment" ]] || fail "$command does not accept --environment"
       ;;
     render-bootstrap | verify | activate)
@@ -1308,6 +1316,12 @@ main() {
     issue-staging)
       [[ -z "$output" ]] || fail "issue-staging does not accept --output"
       select_environment staging
+      acquire_lock
+      issue_certificate
+      ;;
+    issue-monitor)
+      [[ -z "$output" ]] || fail "issue-monitor does not accept --output"
+      select_environment monitor
       acquire_lock
       issue_certificate
       ;;

--- a/deploy/tls/test-nginx.sh
+++ b/deploy/tls/test-nginx.sh
@@ -34,7 +34,7 @@ printf '%s\n' \
   >"$temporary_directory/tls.env"
 chmod 0600 "$temporary_directory/tls.env"
 
-for environment in staging production; do
+for environment in staging production monitor; do
   rendered="$temporary_directory/$environment.conf"
   "$manage" render-bootstrap \
     --environment "$environment" \

--- a/deploy/tls/test.sh
+++ b/deploy/tls/test.sh
@@ -365,6 +365,12 @@ server {
     ssl_certificate $certbot_root/live/speak-up.top/fullchain.pem;
     ssl_certificate_key $certbot_root/live/speak-up.top/privkey.pem;
 }
+server {
+    listen 443 ssl;
+    server_name monitor.speak-up.top;
+    ssl_certificate $certbot_root/live/monitor.speak-up.top/fullchain.pem;
+    ssl_certificate_key $certbot_root/live/monitor.speak-up.top/privkey.pem;
+}
 EOF
 
   if [[ -n "$unrelated_certificate" || -n "$unrelated_key" ]]; then
@@ -513,6 +519,17 @@ grep -Fq 'set $speakup_tls_bootstrap production;' "$temporary_directory/producti
 ! grep -Fq 'server_name www.speak-up.top' "$temporary_directory/production-http.conf" ||
   fail "Production bootstrap duplicates the legacy redirect hostname"
 
+"$manage" render-bootstrap \
+  --environment monitor \
+  --env-file "$environment_file" \
+  --output "$temporary_directory/monitor-http.conf" >"$command_output"
+grep -Fq 'server_name monitor.speak-up.top;' "$temporary_directory/monitor-http.conf" ||
+  fail "Monitor bootstrap hostname is wrong"
+grep -Fq "root $production_webroot;" "$temporary_directory/monitor-http.conf" ||
+  fail "Monitor bootstrap webroot is wrong"
+grep -Fq 'set $speakup_tls_bootstrap monitor;' "$temporary_directory/monitor-http.conf" ||
+  fail "Monitor bootstrap has no removable runtime marker"
+
 # Configuration parsing is strict and never prints values from rejected lines.
 cp "$environment_file" "$temporary_directory/secret.env"
 printf '%s\n' 'PORTAL_ADMIN_PASSWORD=do-not-print-this-value' >>"$temporary_directory/secret.env"
@@ -625,6 +642,15 @@ assert_no_reload "Staging issuance"
 expect_failure "duplicate Staging issuance" \
   "$manage" issue-staging --env-file "$environment_file"
 
+"$manage" issue-monitor --env-file "$environment_file" >"$command_output"
+grep -Fq 'environment=monitor certificate_name=monitor.speak-up.top' "$command_output" ||
+  fail "Monitor issue audit is missing"
+grep -Fxq "account = $production_account_id" \
+  "$certbot_root/renewal/monitor.speak-up.top.conf" ||
+  fail "Monitor renewal did not persist the Production account"
+expect_failure "duplicate Monitor issuance" \
+  "$manage" issue-monitor --env-file "$environment_file"
+
 cp "$certbot_root/renewal/speak-up.top.conf" "$temporary_directory/legacy-production-renewal.conf"
 sed '/^www\.speak-up\.top = /d' \
   "$temporary_directory/legacy-production-renewal.conf" \
@@ -671,6 +697,7 @@ grep -Fq -- 'reconfigure --non-interactive --cert-name speak-up.top --webroot-pa
   fail "Production renewal configuration still contains the legacy webroot"
 "$manage" verify --environment staging --env-file "$environment_file" >"$command_output"
 "$manage" verify --environment production --env-file "$environment_file" >"$command_output"
+"$manage" verify --environment monitor --env-file "$environment_file" >"$command_output"
 grep -Fq 'verified=true' "$command_output" || fail "Production verification audit is missing"
 
 staging_renewal="$certbot_root/renewal/staging.speak-up.top.conf"
@@ -705,6 +732,10 @@ grep -Fq -- '--domains speak-up.top --domains www.speak-up.top --domains api.spe
   "$docker_log" || fail "Production Certbot SAN arguments are not exact"
 grep -Fq -- '--webroot-map {"speak-up.top":"/var/www/acme","www.speak-up.top":"/var/www/acme","api.speak-up.top":"/var/www/acme"}' \
   "$docker_log" || fail "Production Certbot webroot map argument is not exact"
+grep -Fq -- '--domains monitor.speak-up.top' "$docker_log" ||
+  fail "Monitor Certbot SAN argument is not exact"
+grep -Fq -- '--webroot-map {"monitor.speak-up.top":"/var/www/acme"}' \
+  "$docker_log" || fail "Monitor Certbot webroot map argument is not exact"
 grep -Fxq "account = $production_account_id" \
   "$certbot_root/renewal/speak-up.top.conf" ||
   fail "Production renewal did not retain the selected account"
@@ -749,8 +780,13 @@ reset_nginx_log
 "$manage" activate --environment production --env-file "$environment_file" >"$command_output"
 grep -Fxq -- '-t' "$nginx_log" || fail "Production activation did not test Nginx"
 grep -Fxq -- '-s reload' "$nginx_log" || fail "Production activation did not gracefully reload"
+reset_nginx_log
+"$manage" activate --environment monitor --env-file "$environment_file" >"$command_output"
+grep -Fxq -- '-t' "$nginx_log" || fail "Monitor activation did not test Nginx"
+grep -Fxq -- '-s reload' "$nginx_log" || fail "Monitor activation did not gracefully reload"
 [[ -s "$state_root/staging.deployed.sha256" ]] || fail "Staging activation state is missing"
 [[ -s "$state_root/production.deployed.sha256" ]] || fail "Production activation state is missing"
+[[ -s "$state_root/monitor.deployed.sha256" ]] || fail "Monitor activation state is missing"
 
 # A certificate with six days left is rejected for serving but may still reach Certbot renewal.
 staging_certificate=$(realpath "$certbot_root/live/staging.speak-up.top/fullchain.pem")
@@ -794,7 +830,7 @@ docker_calls_after=$(wc -l <"$docker_log" | tr -d '[:space:]')
   fail "Expired certificate was rejected only after Docker ran"
 cp "$temporary_directory/production-expired.backup" "$production_certificate"
 
-# A successful no-op renewal verifies both lineages and never reloads.
+# A successful no-op renewal verifies all three lineages and never reloads.
 reset_nginx_log
 "$manage" renew --env-file "$environment_file" >"$command_output"
 grep -Fq 'renewed=true reload=false' "$command_output" || fail "No-op renewal audit is wrong"
@@ -851,7 +887,7 @@ docker_calls_after=$(wc -l <"$docker_log" | tr -d '[:space:]')
 sed -i.bak '/^renew_hook = /d' "$certbot_root/renewal/speak-up.top.conf"
 rm -f "$certbot_root/renewal/speak-up.top.conf.bak"
 
-# One changed lineage triggers one reload, but only after both lineages verify.
+# One changed lineage triggers one reload, but only after all lineages verify.
 reset_nginx_log
 FAKE_DOCKER_RENEW_CHANGE=staging.speak-up.top \
   "$manage" renew --env-file "$environment_file" >"$command_output"
@@ -912,9 +948,10 @@ assert_no_reload "still-loaded Staging bootstrap"
 sed -i.bak '/speakup_tls_bootstrap staging/d' "$nginx_dump"
 rm -f "$nginx_dump.bak"
 
-# Dry-run checks both renewal lineages and can neither change state nor reload.
+# Dry-run checks all renewal lineages and can neither change state nor reload.
 staging_state_before=$(<"$state_root/staging.deployed.sha256")
 production_state_before=$(<"$state_root/production.deployed.sha256")
+monitor_state_before=$(<"$state_root/monitor.deployed.sha256")
 reset_nginx_log
 FAKE_DOCKER_RENEW_CHANGE=staging.speak-up.top \
   "$manage" renew-dry-run --env-file "$environment_file" >"$command_output"
@@ -923,7 +960,9 @@ assert_no_reload "renewal dry-run"
   fail "Dry-run changed Staging deployed state"
 [[ "$(<"$state_root/production.deployed.sha256")" == "$production_state_before" ]] ||
   fail "Dry-run changed Production deployed state"
-[[ $(grep -Fc -- '--dry-run' "$docker_log") -ge 2 ]] || fail "Dry-run did not cover both lineages"
+[[ "$(<"$state_root/monitor.deployed.sha256")" == "$monitor_state_before" ]] ||
+  fail "Dry-run changed Monitor deployed state"
+[[ $(grep -Fc -- '--dry-run' "$docker_log") -ge 3 ]] || fail "Dry-run did not cover all lineages"
 
 # Key mismatch, unsafe key permissions, bad validity, Docker failure, and wrong host all fail closed.
 staging_key=$(realpath "$certbot_root/live/staging.speak-up.top/privkey.pem")


### PR DESCRIPTION
## 功能描述

为 SpeakUp 建立与共享服务器其他项目隔离的生产监控边界，覆盖公开入口、API、容器、磁盘/inode、证书、备份、外部服务指标展示、日志轮转和服务器外部探测。

Refs #905
Related #909

## 实现思路

- 新增独立 `xe3-speakup-observability` Compose 项目，使用固定镜像摘要、独立网络/数据卷/端口和资源限制；仅 Grafana 绑定 `127.0.0.1:13000`。
- Prometheus 通过 Docker 内网抓取 Production/Staging API 指标，`/metrics`、Alertmanager、Prometheus、node_exporter 和 blackbox exporter 均不开放公网。
- 主机侧固定脚本只读取 SpeakUp 两个 Compose 项目、根磁盘/inode、三条证书、两类备份与三个安全检查 unit；不挂载宿主根目录或 Docker socket到监控容器。
- 新增 Portal/API/APK 的同机 blackbox 探测和 GitHub Actions 服务器外探测；失败/恢复使用单一 GitHub Issue 留下可审计回执，并提供不停止生产的 firing/resolved 演练。
- 为 SpeakUp Production/Staging 容器设置 Docker JSON 日志上限，并以十个精确 Nginx 日志路径轮转，不使用通配符、不触碰其他团队日志。
- 新增 `monitor.speak-up.top` 独立 exact-SAN TLS lineage，不修改现有 Production 三 SAN 证书。
- Grafana 展示公开入口可用性/响应耗时、API 5xx/P95、容器、磁盘/inode和外部服务调用/错误/耗时/用量；Prometheus 包含 23 条可验证告警规则。

## 可复现测试

```bash
make check-observability
make check-tls-lifecycle
make check-staging-deploy
make check-production-deploy
```

结果：

- Observability 与 monitor Nginx 合同通过
- 三条 TLS lineage 合同通过
- Staging / Production 部署合同通过
- Prometheus 23 条规则、Alertmanager 与 blackbox 配置校验通过
- Shell、YAML、JSON、敏感模式和 `git diff --check` 通过

## 范围与上线说明

- 本 PR 未连接生产服务器、未签发证书、未安装 Nginx、未启动容器，也未修改 DNS。
- AI/ASR/TTS/OCR/OSS 指标的服务端采集由 #909 / #916 提供；本 PR 只提供统一抓取、规则和展示。
- #905 在合并后仍需完成服务器安装、HTTPS 验收、Alertmanager 通知和 firing/resolved 演练，运行态验收完成前不关闭 Issue。
