### PR TITLE
fix(mobile): 修复 Android 系统返回绕过内层路由栈

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -383,7 +383,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
 
   @override
   Widget build(BuildContext context) {
-    return Navigator(
+    final navigator = Navigator(
       key: _navigatorKey,
       observers: [_routeObserver],
       initialRoute: AppRoutes.home,
@@ -487,6 +487,15 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
           builder: (_) => page,
         );
       },
+    );
+    return NavigatorPopHandler<Object?>(
+      onPopWithResult: (result) {
+        final navigatorState = _navigatorKey.currentState;
+        if (navigatorState != null) {
+          unawaited(navigatorState.maybePop<Object?>(result));
+        }
+      },
+      child: navigator,
     );
   }
 

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1172,6 +1172,67 @@ void main() {
     );
   });
 
+  testWidgets('system back pops an authenticated nested route first', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp.preview());
+
+    final shellContext = tester.element(find.byType(SpeakUpShell));
+    Navigator.of(shellContext).pushNamed(AppRoutes.conversation);
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('conversation-route-back-button')),
+      findsOneWidget,
+    );
+
+    expect(await tester.binding.handlePopRoute(), isTrue);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('conversation-route-back-button')),
+      findsNothing,
+    );
+    expect(find.byKey(const Key('agent-home-page')), findsOneWidget);
+    expect(await tester.binding.handlePopRoute(), isFalse);
+  });
+
+  testWidgets('system back leaves a nested PopScope in control', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const SpeakUpApp.preview());
+    var intercepted = false;
+
+    final shellContext = tester.element(find.byType(SpeakUpShell));
+    Navigator.of(shellContext).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => PopScope<void>(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, _) {
+            if (!didPop) {
+              intercepted = true;
+            }
+          },
+          child: const Scaffold(
+            body: Center(
+              child: Text(
+                'Active practice',
+                key: Key('blocking-practice-route'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(intercepted, isTrue);
+    expect(find.byKey(const Key('blocking-practice-route')), findsOneWidget);
+    expect(find.byKey(const Key('agent-home-page')), findsNothing);
+  });
+
   testWidgets('keeps primary tabs root-styled from the conversation route', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

- 修复登录后内层 Navigator 未接管 Android 系统返回的问题。
- 二级页面的系统返回先回到 SpeakUp 一级页面，不再直接退出 Activity。
- 内层路由已在根页面时，返回事件继续交给外层系统处理。
- 保留练习页现有 `PopScope` 保存和退出拦截语义。

## 实现思路

- 使用 Flutter 官方面向嵌套 Navigator 的 `NavigatorPopHandler` 包裹认证后的内层 Navigator。
- 回调通过 `maybePop` 交给内层路由处理，确保顶部路由的 `PopScope` 仍能阻止退出或展示确认流程。
- 不增加 Tab 历史，不调整现有路由结构或业务页面。

## 可复现测试

```bash
cd mobile
flutter pub get --enforce-lockfile
flutter test test/speak_up_app_test.dart --plain-name 'system back'
flutter test test/speak_up_app_test.dart
flutter analyze
```

结果：2 个系统返回回归测试、35 个 App 测试和静态分析全部通过。

Closes #917
