### PR TITLE
fix(observability): 兼容备份时间中的小数秒

### DIFF
--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -46,7 +46,7 @@ printf '%s\n' \
   '{"created_at":"2026-08-24T01:02:03Z"}' \
   >"$temporary_directory/postgres-backups/20260824T010203Z-daily/metadata.json"
 printf '%s\n' \
-  '{"created_at":"2026-08-24T02:03:04Z"}' \
+  '{"created_at":"2026-08-24T02:03:04.110Z"}' \
   >"$temporary_directory/portal-backups/20260824T020304Z/metadata.json"
 
 cat >"$temporary_directory/fake-bin/docker" <<'EOF'
@@ -174,6 +174,11 @@ MISSING_SERVICE=portal PATH="$temporary_directory/fake-bin:$PATH" \
 
 expect_failure 'relative output path' env PATH="$temporary_directory/fake-bin:$PATH" \
   "$exporter" --output relative/speakup.prom
+
+printf '%s\n' '{"created_at":"not-an-rfc3339-time"}' \
+  >"$temporary_directory/portal-backups/20260824T020304Z/metadata.json"
+expect_failure 'invalid backup timestamp' env PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
 
 OBSERVABILITY_ALERTMANAGER_CONFIG="$observability_directory/alertmanager.example.yml" \
 OBSERVABILITY_GRAFANA_HOST=monitor.speak-up.top \

--- a/deploy/observability/xe3-speakup-export-metrics
+++ b/deploy/observability/xe3-speakup-export-metrics
@@ -101,7 +101,11 @@ latest_backup_timestamp() {
   timestamp=0
   if [[ -d "$root" ]]; then
     while IFS= read -r metadata; do
-      candidate=$(jq -er '.created_at | fromdateiso8601' "$metadata")
+      candidate=$(jq -er '
+        .created_at
+        | sub("\\.[0-9]+Z$"; "Z")
+        | fromdateiso8601
+      ' "$metadata")
       [[ "$candidate" =~ ^[0-9]+$ ]] ||
         fail "invalid backup timestamp for $database"
       if ((candidate > timestamp)); then


### PR DESCRIPTION
## 功能描述

修复生产观测指标导出器无法解析 Portal 备份元数据 RFC3339 小数秒时间的问题，避免 `xe3-speakup-observability-metrics.service` 因合法的 `created_at`（如 `2026-08-23T19:47:42.110Z`）失败。

Fixes #923
Related #905

## 实现思路

- 在交给 `jq fromdateiso8601` 前，仅移除 UTC RFC3339 时间末尾的小数秒部分，按秒导出备份成功时间。
- 无小数秒格式保持不变。
- 非法时间仍由解析器 fail closed，不会静默输出 `0` 或错误时间。

## 可复现测试

```bash
make check-observability
bash -n deploy/observability/xe3-speakup-export-metrics deploy/observability/test.sh
git diff --check
```

结果：Observability 合同与 Nginx 配置测试通过；并已用生产服务器现有 PostgreSQL/Portal 备份元数据进行只读导出验证，两个备份时间戳均成功生成。

## 范围说明

- 只修改备份元数据时间解析及其合同测试。
- 不修改备份内容、应用容器、数据库、证书或其他团队项目。
