### PR TITLE
feat(ielts): 增量评估完整模考并加速最终报告

### DIFF
--- a/server/cmd/server/evaluation_worker.go
+++ b/server/cmd/server/evaluation_worker.go
@@ -10,12 +10,14 @@ import (
 )
 
 const (
-	evaluationPollInterval      = 500 * time.Millisecond
-	evaluationSpeechConcurrency = 4
+	evaluationPollInterval       = 500 * time.Millisecond
+	evaluationProfileConcurrency = 2
+	evaluationSpeechConcurrency  = 4
 )
 
 type evaluationProcessor interface {
 	ProcessSession(context.Context) (bool, error)
+	ProcessProfile(context.Context) (bool, error)
 	ProcessSpeech(context.Context) (bool, error)
 }
 
@@ -36,12 +38,18 @@ func buildEvaluationRuntime(
 	if processor == nil || logger == nil {
 		return nil, errors.New("evaluation worker dependencies are required")
 	}
-	workers := make([]*evaluationLaneWorker, 0, 1+evaluationSpeechConcurrency)
+	workers := make([]*evaluationLaneWorker, 0,
+		1+evaluationProfileConcurrency+evaluationSpeechConcurrency)
 	workers = append(workers, &evaluationLaneWorker{
 		name:    "session",
 		process: processor.ProcessSession,
 		logger:  logger,
 	})
+	for range evaluationProfileConcurrency {
+		workers = append(workers, &evaluationLaneWorker{
+			name: "profile", process: processor.ProcessProfile, logger: logger,
+		})
+	}
 	for range evaluationSpeechConcurrency {
 		workers = append(workers, &evaluationLaneWorker{
 			name:    "speech",

--- a/server/cmd/server/evaluation_worker_test.go
+++ b/server/cmd/server/evaluation_worker_test.go
@@ -17,7 +17,8 @@ func TestEvaluationRuntimeUsesIndependentSpeechWorkers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(runtime.workers) != 1+evaluationSpeechConcurrency {
+	if len(runtime.workers) != 1+evaluationProfileConcurrency+
+		evaluationSpeechConcurrency {
 		t.Fatalf("workers = %d", len(runtime.workers))
 	}
 	speechWorkers := 0
@@ -57,6 +58,10 @@ func TestEvaluationFailureAttributesExposeSafeDiagnosticMetadata(t *testing.T) {
 type evaluationProcessorStub struct{}
 
 func (evaluationProcessorStub) ProcessSession(context.Context) (bool, error) {
+	return false, nil
+}
+
+func (evaluationProcessorStub) ProcessProfile(context.Context) (bool, error) {
 	return false, nil
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -93,6 +93,12 @@ func run() int {
 		logger.Error("evaluation scoring startup failed")
 		return 1
 	}
+	evaluationProfileGenerator, err :=
+		providerFactory.EvaluationProfileGenerator(textConfig)
+	if err != nil {
+		logger.Error("evaluation profile startup failed")
+		return 1
+	}
 	evaluationSpeechFeedbackGenerator, err :=
 		providerFactory.EvaluationSpeechFeedbackGenerator(textConfig)
 	if err != nil {
@@ -365,17 +371,27 @@ func run() int {
 	evaluationComposition, err := app.NewEvaluationComposition(
 		databasePool.Native(),
 		evaluationScoringGenerator,
+		evaluationProfileGenerator,
 		evaluationSpeechFeedbackGenerator,
 		acousticEvaluator,
 		app.EvaluationConfiguration{
 			Provider:     textConfig.Provider,
 			SessionModel: textConfig.EvaluationModel,
+			ProfileModel: textConfig.EvaluationModel,
 			SpeechModel:  textConfig.SpeechFeedbackModel,
 			Worker: evaluation.WorkerConfiguration{
 				SessionLane: evaluation.ClaimLane{
 					Kinds:         []evaluation.Kind{evaluation.KindSessionReport},
 					LeaseDuration: sessionLease,
 					MaxAttempts:   3,
+				},
+				ProfileLane: evaluation.ClaimLane{
+					Kinds: []evaluation.Kind{
+						evaluation.KindIELTSPart1Profile,
+						evaluation.KindIELTSPart2Profile,
+					},
+					LeaseDuration: 90 * time.Second,
+					MaxAttempts:   2,
 				},
 				SpeechLane: evaluation.ClaimLane{
 					Kinds: []evaluation.Kind{
@@ -385,14 +401,16 @@ func run() int {
 					LeaseDuration: speechLease,
 					MaxAttempts:   3,
 				},
-				AcousticsEnabled:  acousticsEnabled,
-				InterviewDeadline: singleRoundDeadline,
-				IELTSDeadline:     ieltsDeadline,
-				GeneralDeadline:   singleRoundDeadline,
-				SpeechDeadline:    speechDeadline,
-				RetryDelay:        time.Second,
-				DependencyDelay:   5 * time.Second,
-				FinalizeTimeout:   5 * time.Second,
+				AcousticsEnabled:         acousticsEnabled,
+				InterviewDeadline:        singleRoundDeadline,
+				IELTSDeadline:            ieltsDeadline,
+				GeneralDeadline:          singleRoundDeadline,
+				SpeechDeadline:           speechDeadline,
+				ProfileDeadline:          45 * time.Second,
+				RetryDelay:               time.Second,
+				DependencyDelay:          5 * time.Second,
+				ProfileDependencyMaxWait: 20 * time.Second,
+				FinalizeTimeout:          5 * time.Second,
 			},
 		},
 	)

--- a/server/internal/app/agent_data.go
+++ b/server/internal/app/agent_data.go
@@ -371,6 +371,7 @@ func buildIdentityAgentComposition(
 				voiceConfigurations[0].PracticeInteraction,
 				schedulers.Completion,
 				schedulers.TurnFeedback,
+				schedulers.IELTSProfile,
 				schedulers.FeedbackReader,
 				ids,
 				agentMedia,

--- a/server/internal/app/ai_text.go
+++ b/server/internal/app/ai_text.go
@@ -160,6 +160,17 @@ func newEvaluationScoringGenerator(
 	return qianwen.NewEvaluationScoringGenerator(providerConfig, apiKey)
 }
 
+func (factory *ProviderFactory) EvaluationProfileGenerator(
+	configuration config.TextGenerationConfig,
+) (textgeneration.Generator, error) {
+	providerConfig, apiKey, err := textProvider(configuration, factory.observer)
+	if err != nil {
+		return nil, err
+	}
+	providerConfig.Model = configuration.EvaluationModel
+	return qianwen.NewEvaluationProfileGenerator(providerConfig, apiKey)
+}
+
 func NewEvaluationSpeechFeedbackGenerator(
 	configuration config.TextGenerationConfig,
 ) (speechfeedback.TextGenerator, error) {

--- a/server/internal/app/evaluation.go
+++ b/server/internal/app/evaluation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	evaluationapi "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/api"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/ieltsprofile"
 	evaluationpostgres "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/postgres"
 	evaluationpracticeinteraction "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/practiceturn"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/sessionevaluation"
@@ -18,6 +19,7 @@ import (
 type EvaluationConfiguration struct {
 	Provider     string
 	SessionModel string
+	ProfileModel string
 	SpeechModel  string
 	Worker       evaluation.WorkerConfiguration
 }
@@ -25,11 +27,13 @@ type EvaluationConfiguration struct {
 type PracticeEvaluationSchedulers struct {
 	Completion     practicepostgres.CompletionScheduler
 	TurnFeedback   practicepostgres.TurnFeedbackScheduler
+	IELTSProfile   practicepostgres.IELTSProfileScheduler
 	FeedbackReader practiceinteraction.TurnFeedbackStatusReader
 }
 
 func (schedulers PracticeEvaluationSchedulers) valid() bool {
 	return schedulers.Completion != nil && schedulers.TurnFeedback != nil &&
+		schedulers.IELTSProfile != nil &&
 		schedulers.FeedbackReader != nil
 }
 
@@ -46,12 +50,15 @@ type EvaluationComposition struct {
 func NewEvaluationComposition(
 	database *pgxpool.Pool,
 	sessionGenerator textgeneration.Generator,
+	profileGenerator textgeneration.Generator,
 	speechGenerator speechfeedback.TextGenerator,
 	acoustics evaluation.AcousticEvaluator,
 	configuration EvaluationConfiguration,
 ) (*EvaluationComposition, error) {
-	if database == nil || sessionGenerator == nil || speechGenerator == nil ||
+	if database == nil || sessionGenerator == nil || profileGenerator == nil ||
+		speechGenerator == nil ||
 		configuration.Provider == "" || configuration.SessionModel == "" ||
+		configuration.ProfileModel == "" ||
 		configuration.SpeechModel == "" ||
 		!configuration.Worker.Valid() ||
 		(configuration.Worker.AcousticsEnabled && acoustics == nil) {
@@ -75,6 +82,12 @@ func NewEvaluationComposition(
 	if err != nil {
 		return nil, err
 	}
+	profileLineage, err := ieltsprofile.Lineage(
+		configuration.Provider, configuration.ProfileModel,
+	)
+	if err != nil {
+		return nil, err
+	}
 	sessionBuilder, err := evaluation.NewSessionCommandBuilder(
 		sessionLineages,
 		configuration.Worker.AcousticsEnabled,
@@ -83,6 +96,18 @@ func NewEvaluationComposition(
 		return nil, err
 	}
 	completion, err := evaluationpostgres.NewSessionScheduler(store, sessionBuilder)
+	if err != nil {
+		return nil, err
+	}
+	profileBuilder, err := evaluation.NewIELTSProfileCommandBuilder(
+		profileLineage, configuration.Worker.AcousticsEnabled,
+	)
+	if err != nil {
+		return nil, err
+	}
+	profileScheduler, err := evaluationpostgres.NewIELTSProfileScheduler(
+		store, profileBuilder,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -115,6 +140,10 @@ func NewEvaluationComposition(
 	if err != nil {
 		return nil, err
 	}
+	profileEvaluator, err := ieltsprofile.New(profileGenerator)
+	if err != nil {
+		return nil, err
+	}
 	speechEvaluator, err := speechfeedback.NewCompactEvaluator(speechGenerator)
 	if err != nil {
 		return nil, err
@@ -122,6 +151,7 @@ func NewEvaluationComposition(
 	worker, err := evaluation.NewWorker(
 		store,
 		sessionEvaluator,
+		profileEvaluator,
 		speechEvaluator,
 		acoustics,
 		store,
@@ -141,6 +171,7 @@ func NewEvaluationComposition(
 	schedulers := PracticeEvaluationSchedulers{
 		Completion:     completion,
 		TurnFeedback:   turnFeedback,
+		IELTSProfile:   profileScheduler,
 		FeedbackReader: feedbackReader,
 	}
 	if !schedulers.valid() {

--- a/server/internal/app/practice_context.go
+++ b/server/internal/app/practice_context.go
@@ -281,6 +281,7 @@ func newIdentityAgentAndPracticeComposition(
 		database,
 		evaluationSchedulers.Completion,
 		evaluationSchedulers.TurnFeedback,
+		evaluationSchedulers.IELTSProfile,
 		base.ids,
 	)
 	if err != nil {

--- a/server/internal/app/voice.go
+++ b/server/internal/app/voice.go
@@ -80,6 +80,7 @@ func buildPracticeInteractionApplication(
 	configuration PracticeInteractionConfiguration,
 	completion practicepostgres.CompletionScheduler,
 	turnFeedback practicepostgres.TurnFeedbackScheduler,
+	profile practicepostgres.IELTSProfileScheduler,
 	feedbackReader practiceinteraction.TurnFeedbackStatusReader,
 	ids practice.PracticeResourceIDGenerator,
 	mediaService *sharedmedia.Service,
@@ -97,7 +98,7 @@ func buildPracticeInteractionApplication(
 		configuration.QuestionGenerator == nil ||
 		configuration.TemporaryAudio == nil ||
 		configuration.ASRLease <= 0 || completion == nil ||
-		turnFeedback == nil || feedbackReader == nil || ids == nil {
+		turnFeedback == nil || profile == nil || feedbackReader == nil || ids == nil {
 		return nil, nil, nil,
 			errors.New("bootstrap: Practice Interaction dependencies are required")
 	}
@@ -106,6 +107,7 @@ func buildPracticeInteractionApplication(
 		database,
 		completion,
 		turnFeedback,
+		profile,
 		ids,
 	)
 	if err != nil {

--- a/server/internal/app/voice_integration_test.go
+++ b/server/internal/app/voice_integration_test.go
@@ -1252,6 +1252,14 @@ func (voiceTestEvaluationBoundary) ScheduleConfirmedTurn(
 	return nil
 }
 
+func (voiceTestEvaluationBoundary) ScheduleCompletedPart(
+	context.Context,
+	pgx.Tx,
+	practice.IELTSPartProfileEvidence,
+) error {
+	return nil
+}
+
 func (voiceTestEvaluationBoundary) StatusURLForTurn(
 	context.Context,
 	requestcontext.Actor,
@@ -1265,6 +1273,7 @@ func voiceTestPracticeEvaluationSchedulers() PracticeEvaluationSchedulers {
 	return PracticeEvaluationSchedulers{
 		Completion:     boundary,
 		TurnFeedback:   boundary,
+		IELTSProfile:   boundary,
 		FeedbackReader: boundary,
 	}
 }

--- a/server/internal/coaching/evaluation/completion.go
+++ b/server/internal/coaching/evaluation/completion.go
@@ -20,14 +20,17 @@ const (
 )
 
 type SessionLineages struct {
-	Interview ConfigLineage
-	IELTS     ConfigLineage
-	General   ConfigLineage
+	Interview     ConfigLineage
+	IELTSPractice ConfigLineage
+	IELTS         ConfigLineage
+	General       ConfigLineage
 }
 
 func (lineages SessionLineages) Valid() bool {
 	return lineages.Interview.Valid() &&
 		lineages.Interview.StrategyRef == InterviewStrategyRef &&
+		lineages.IELTSPractice.Valid() &&
+		lineages.IELTSPractice.StrategyRef == IELTSStrategyRef &&
 		lineages.IELTS.Valid() && lineages.IELTS.StrategyRef == IELTSStrategyRef &&
 		lineages.General.Valid() && lineages.General.StrategyRef == GeneralStrategyRef
 }
@@ -129,8 +132,9 @@ func (builder *SessionCommandBuilder) lineageFor(
 	switch policyRef {
 	case InterviewEvaluationPolicyRef:
 		return builder.lineages.Interview, nil
-	case IELTSSpeakingPracticeEvaluationPolicyRef,
-		IELTSSpeakingFullMockEvaluationPolicyRef:
+	case IELTSSpeakingPracticeEvaluationPolicyRef:
+		return builder.lineages.IELTSPractice, nil
+	case IELTSSpeakingFullMockEvaluationPolicyRef:
 		return builder.lineages.IELTS, nil
 	case WorkplaceEvaluationPolicyRef, DailyEvaluationPolicyRef:
 		return builder.lineages.General, nil

--- a/server/internal/coaching/evaluation/ielts_profile.go
+++ b/server/internal/coaching/evaluation/ielts_profile.go
@@ -1,0 +1,192 @@
+package evaluation
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	IELTSProfileInputSchemaVersion      = "ielts-cumulative-profile-input/v1"
+	IELTSCumulativeProfileSchemaVersion = "ielts-cumulative-profile/v1"
+)
+
+type IELTSProfileStage string
+
+const (
+	IELTSProfileStagePart1 IELTSProfileStage = "PART_1"
+	IELTSProfileStagePart2 IELTSProfileStage = "PART_2"
+)
+
+type IELTSProfileDependencyResolution string
+
+const (
+	IELTSProfileDependencyPending  IELTSProfileDependencyResolution = "PENDING"
+	IELTSProfileDependencyResolved IELTSProfileDependencyResolution = "RESOLVED"
+	IELTSProfileDependencyFallback IELTSProfileDependencyResolution = "FALLBACK"
+)
+
+type IELTSFinalProfileResolution string
+
+const (
+	IELTSFinalProfileResolved IELTSFinalProfileResolution = "RESOLVED"
+	IELTSFinalProfileFallback IELTSFinalProfileResolution = "FALLBACK"
+)
+
+type IELTSProfileInputSnapshot struct {
+	SchemaVersion        string                           `json:"schema_version"`
+	SessionID            string                           `json:"session_id"`
+	SessionVersion       int                              `json:"session_version"`
+	Stage                IELTSProfileStage                `json:"stage"`
+	CompletedAt          time.Time                        `json:"completed_at"`
+	Part1Boundary        int                              `json:"part_1_boundary"`
+	Part2Boundary        int                              `json:"part_2_boundary"`
+	AcousticCapability   AcousticCapabilityStatus         `json:"acoustic_capability"`
+	Questions            []SessionEvidenceQuestion        `json:"questions"`
+	Turns                []SessionEvidenceTurn            `json:"turns"`
+	PreviousProfile      *IELTSCumulativeProfile          `json:"previous_profile,omitempty"`
+	DependencyResolution IELTSProfileDependencyResolution `json:"dependency_resolution"`
+}
+
+func (snapshot IELTSProfileInputSnapshot) Valid() bool {
+	if snapshot.SchemaVersion != IELTSProfileInputSchemaVersion ||
+		!validUUID(snapshot.SessionID) || snapshot.SessionVersion < 1 ||
+		snapshot.CompletedAt.IsZero() || snapshot.Part1Boundary < 1 ||
+		snapshot.Part2Boundary <= snapshot.Part1Boundary ||
+		(snapshot.AcousticCapability != AcousticCapabilityEnabled &&
+			snapshot.AcousticCapability != AcousticCapabilityNotConfigured) ||
+		(snapshot.Stage != IELTSProfileStagePart1 && snapshot.Stage != IELTSProfileStagePart2) ||
+		(snapshot.DependencyResolution != IELTSProfileDependencyPending &&
+			snapshot.DependencyResolution != IELTSProfileDependencyResolved &&
+			snapshot.DependencyResolution != IELTSProfileDependencyFallback) ||
+		len(snapshot.Questions) == 0 || len(snapshot.Turns) == 0 {
+		return false
+	}
+	expectedTurns := snapshot.Part1Boundary
+	if snapshot.Stage == IELTSProfileStagePart2 {
+		expectedTurns = snapshot.Part2Boundary
+	}
+	if len(snapshot.Turns) != expectedTurns ||
+		(snapshot.Stage == IELTSProfileStagePart1 && snapshot.PreviousProfile != nil) ||
+		(snapshot.DependencyResolution == IELTSProfileDependencyResolved && snapshot.PreviousProfile == nil) ||
+		(snapshot.PreviousProfile != nil && (!snapshot.PreviousProfile.Valid() ||
+			snapshot.PreviousProfile.SessionID != snapshot.SessionID)) {
+		return false
+	}
+	questionIDs := make(map[string]struct{}, len(snapshot.Questions))
+	for _, question := range snapshot.Questions {
+		if !validSessionEvidenceQuestion(question) {
+			return false
+		}
+		questionIDs[question.ID] = struct{}{}
+	}
+	seenTurns := make(map[string]struct{}, len(snapshot.Turns))
+	for _, turn := range snapshot.Turns {
+		if !turn.Effective || !validSessionEvidenceTurn(turn) {
+			return false
+		}
+		if _, exists := questionIDs[turn.QuestionID]; !exists {
+			return false
+		}
+		if _, duplicate := seenTurns[turn.ID]; duplicate {
+			return false
+		}
+		seenTurns[turn.ID] = struct{}{}
+	}
+	return true
+}
+
+type IELTSCumulativeProfile struct {
+	SchemaVersion  string                  `json:"schema_version"`
+	SessionID      string                  `json:"session_id"`
+	CompletedParts []int                   `json:"completed_parts"`
+	Dimensions     []IELTSProfileDimension `json:"dimensions"`
+	Provider       string                  `json:"provider"`
+	Model          string                  `json:"model"`
+}
+
+func (profile IELTSCumulativeProfile) Valid() bool {
+	if profile.SchemaVersion != IELTSCumulativeProfileSchemaVersion ||
+		!validUUID(profile.SessionID) ||
+		(len(profile.CompletedParts) != 1 && len(profile.CompletedParts) != 2) ||
+		profile.CompletedParts[0] != 1 ||
+		(len(profile.CompletedParts) == 2 && profile.CompletedParts[1] != 2) ||
+		len(profile.Dimensions) != 4 || !validIdentifier(profile.Provider) ||
+		!validIdentifier(profile.Model) {
+		return false
+	}
+	expected := []string{
+		"FLUENCY_COHERENCE", "LEXICAL_RESOURCE",
+		"GRAMMATICAL_RANGE_ACCURACY", "PRONUNCIATION",
+	}
+	for index, dimension := range profile.Dimensions {
+		if dimension.Key != expected[index] || !dimension.Valid() {
+			return false
+		}
+	}
+	return true
+}
+
+type IELTSProfileDimension struct {
+	Key                 string                    `json:"key"`
+	ProvisionalBandLow  float64                   `json:"provisional_band_low"`
+	ProvisionalBandHigh float64                   `json:"provisional_band_high"`
+	Coverage            float64                   `json:"coverage"`
+	Confidence          float64                   `json:"confidence"`
+	Observations        []IELTSProfileObservation `json:"observations"`
+}
+
+func (dimension IELTSProfileDimension) Valid() bool {
+	return validIdentifier(dimension.Key) && validIELTSBand(dimension.ProvisionalBandLow) &&
+		validIELTSBand(dimension.ProvisionalBandHigh) &&
+		dimension.ProvisionalBandLow <= dimension.ProvisionalBandHigh &&
+		dimension.Coverage >= 0 && dimension.Coverage <= 1 &&
+		dimension.Confidence >= 0 && dimension.Confidence <= 1 &&
+		dimension.Observations != nil && len(dimension.Observations) <= 3 &&
+		allValidProfileObservations(dimension.Observations)
+}
+
+type IELTSProfileObservation struct {
+	Kind       string                 `json:"kind"`
+	ReasonCode string                 `json:"reason_code"`
+	Evidence   []IELTSProfileEvidence `json:"evidence"`
+}
+
+func (observation IELTSProfileObservation) Valid() bool {
+	if (observation.Kind != "STRENGTH" && observation.Kind != "IMPROVEMENT") ||
+		!validIdentifier(observation.ReasonCode) || len(observation.Evidence) == 0 ||
+		len(observation.Evidence) > 2 {
+		return false
+	}
+	for _, evidence := range observation.Evidence {
+		if !evidence.Valid() {
+			return false
+		}
+	}
+	return true
+}
+
+type IELTSProfileEvidence struct {
+	TurnID     string `json:"turn_id"`
+	Quote      string `json:"quote"`
+	Occurrence int    `json:"occurrence"`
+	Part       int    `json:"part"`
+}
+
+func (evidence IELTSProfileEvidence) Valid() bool {
+	return validUUID(evidence.TurnID) && strings.TrimSpace(evidence.Quote) != "" &&
+		len(evidence.Quote) <= 4096 && evidence.Occurrence > 0 &&
+		(evidence.Part == 1 || evidence.Part == 2)
+}
+
+func validIELTSBand(value float64) bool {
+	return value >= 0 && value <= 9 && value*2 == float64(int(value*2))
+}
+
+func allValidProfileObservations(values []IELTSProfileObservation) bool {
+	for _, value := range values {
+		if !value.Valid() {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/coaching/evaluation/ielts_profile_completion.go
+++ b/server/internal/coaching/evaluation/ielts_profile_completion.go
@@ -1,0 +1,86 @@
+package evaluation
+
+import (
+	"slices"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+)
+
+type IELTSProfileCommandBuilder struct {
+	lineage          ConfigLineage
+	acousticsEnabled bool
+}
+
+func NewIELTSProfileCommandBuilder(
+	lineage ConfigLineage,
+	acousticsEnabled bool,
+) (*IELTSProfileCommandBuilder, error) {
+	if !lineage.Valid() || lineage.StrategyRef != "ielts-cumulative-profile/v1" {
+		return nil, ErrInvalidRequest
+	}
+	return &IELTSProfileCommandBuilder{
+		lineage: lineage, acousticsEnabled: acousticsEnabled,
+	}, nil
+}
+
+func (builder *IELTSProfileCommandBuilder) Build(
+	source practice.IELTSPartProfileEvidence,
+) (QueueCommand, error) {
+	if builder == nil {
+		return QueueCommand{}, ErrInvalidRequest
+	}
+	stage := IELTSProfileStage(source.Stage)
+	kind := KindIELTSPart1Profile
+	if stage == IELTSProfileStagePart2 {
+		kind = KindIELTSPart2Profile
+	} else if stage != IELTSProfileStagePart1 {
+		return QueueCommand{}, ErrInvalidRequest
+	}
+	snapshot := IELTSProfileInputSnapshot{
+		SchemaVersion: IELTSProfileInputSchemaVersion,
+		SessionID:     source.SessionID, SessionVersion: source.SessionVersion,
+		Stage: stage, CompletedAt: source.CompletedAt.UTC(),
+		Part1Boundary: source.Part1Boundary, Part2Boundary: source.Part2Boundary,
+		AcousticCapability:   AcousticCapabilityEnabled,
+		Questions:            make([]SessionEvidenceQuestion, len(source.Questions)),
+		Turns:                make([]SessionEvidenceTurn, 0, len(source.Turns)),
+		DependencyResolution: IELTSProfileDependencyPending,
+	}
+	if !builder.acousticsEnabled {
+		snapshot.AcousticCapability = AcousticCapabilityNotConfigured
+	}
+	for index, question := range source.Questions {
+		snapshot.Questions[index] = SessionEvidenceQuestion{
+			ID: question.ID, Position: question.Position,
+			ParentQuestionID: question.ParentQuestionID, Text: question.Text,
+			SpeakerParticipantID:    question.SpeakerParticipantID,
+			AddresseeParticipantIDs: slices.Clone(question.AddresseeParticipantIDs),
+		}
+	}
+	for _, turn := range source.Turns {
+		snapshot.Turns = append(snapshot.Turns, SessionEvidenceTurn{
+			ID: turn.ID, Position: turn.Position, QuestionID: turn.QuestionID,
+			RespondentParticipantID: turn.RespondentParticipantID,
+			Transcript:              turn.Transcript, Effective: true,
+			ConfirmedAt: turn.ConfirmedAt.UTC(), AudioAssetID: turn.AudioAssetID,
+		})
+	}
+	if !snapshot.Valid() || source.UserID == "" {
+		return QueueCommand{}, ErrInvalidRequest
+	}
+	inputJSON, inputHash, err := EncodeStrict(snapshot)
+	if err != nil {
+		return QueueCommand{}, err
+	}
+	configJSON, configHash, err := EncodeStrict(builder.lineage)
+	if err != nil {
+		return QueueCommand{}, err
+	}
+	return QueueCommand{
+		UserID: source.UserID, Kind: kind,
+		SourceID: source.SessionID, ContextID: source.SessionID,
+		InputSnapshot: inputJSON, InputHash: inputHash,
+		ConfigLineage: configJSON, ConfigHash: configHash,
+		AvailableAt: source.CompletedAt.UTC(),
+	}, nil
+}

--- a/server/internal/coaching/evaluation/ielts_profile_completion_test.go
+++ b/server/internal/coaching/evaluation/ielts_profile_completion_test.go
@@ -121,3 +121,31 @@ func TestIELTSProfileEvidenceValidation(t *testing.T) {
 		t.Fatal("Part 3 evidence was accepted in a Part 1/2 profile")
 	}
 }
+
+func TestSessionCommandBuilderKeepsStandaloneIELTSOnV2(t *testing.T) {
+	lineage := func(strategy string, prompt string) ConfigLineage {
+		return ConfigLineage{
+			SchemaVersion: ConfigLineageSchemaVersion,
+			StrategyRef:   strategy, PipelineVersion: "session-evaluation/v1",
+			PromptVersion: prompt, ResultSchema: "report/v1",
+			Provider: "qianwen", Model: "qwen-plus",
+		}
+	}
+	builder, err := NewSessionCommandBuilder(SessionLineages{
+		Interview:     lineage(InterviewStrategyRef, "interview-report/v2"),
+		IELTSPractice: lineage(IELTSStrategyRef, "ielts-report/v2"),
+		IELTS:         lineage(IELTSStrategyRef, "ielts-report/v3"),
+		General:       lineage(GeneralStrategyRef, "general-report/v2"),
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	standalone, err := builder.lineageFor(IELTSSpeakingPracticeEvaluationPolicyRef)
+	if err != nil || standalone.PromptVersion != "ielts-report/v2" {
+		t.Fatalf("standalone IELTS lineage = %#v, %v", standalone, err)
+	}
+	fullMock, err := builder.lineageFor(IELTSSpeakingFullMockEvaluationPolicyRef)
+	if err != nil || fullMock.PromptVersion != "ielts-report/v3" {
+		t.Fatalf("full mock IELTS lineage = %#v, %v", fullMock, err)
+	}
+}

--- a/server/internal/coaching/evaluation/ielts_profile_completion_test.go
+++ b/server/internal/coaching/evaluation/ielts_profile_completion_test.go
@@ -1,0 +1,123 @@
+package evaluation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+)
+
+func TestIELTSProfileCommandBuilderFreezesPart2Evidence(t *testing.T) {
+	lineage := ConfigLineage{
+		SchemaVersion:   ConfigLineageSchemaVersion,
+		StrategyRef:     "ielts-cumulative-profile/v1",
+		PipelineVersion: "ielts-cumulative-profile/v1",
+		PromptVersion:   "ielts-cumulative-profile/v1",
+		ResultSchema:    IELTSCumulativeProfileSchemaVersion,
+		Provider:        "qianwen", Model: "qwen-plus",
+	}
+	builder, err := NewIELTSProfileCommandBuilder(lineage, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	source := practice.IELTSPartProfileEvidence{
+		UserID:         "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		SessionID:      "20000000-0000-4000-8000-000000000001",
+		SessionVersion: 3, Stage: practice.IELTSProfileStagePart2,
+		CompletedAt: now, Part1Boundary: 1, Part2Boundary: 2,
+		Questions: []practice.EvidenceQuestion{
+			{ID: "40000000-0000-4000-8000-000000000001", Position: 1,
+				Text: "Part 1", SpeakerParticipantID: "assistant",
+				AddresseeParticipantIDs: []string{"learner"}},
+			{ID: "40000000-0000-4000-8000-000000000002", Position: 2,
+				Text: "Part 2", SpeakerParticipantID: "assistant",
+				AddresseeParticipantIDs: []string{"learner"}},
+		},
+		Turns: []practice.EvidenceTurn{
+			{ID: "30000000-0000-4000-8000-000000000001", Position: 1,
+				QuestionID:              "40000000-0000-4000-8000-000000000001",
+				RespondentParticipantID: "learner", Transcript: "Part 1 answer",
+				Effective: true, ConfirmedAt: now},
+			{ID: "30000000-0000-4000-8000-000000000002", Position: 2,
+				QuestionID:              "40000000-0000-4000-8000-000000000002",
+				RespondentParticipantID: "learner", Transcript: "Part 2 answer",
+				Effective: true, ConfirmedAt: now},
+		},
+	}
+
+	command, err := builder.Build(source)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if command.Kind != KindIELTSPart2Profile ||
+		command.SourceID != source.SessionID || command.ContextID != source.SessionID ||
+		command.UserID != source.UserID || command.AvailableAt != now {
+		t.Fatalf("command = %#v", command)
+	}
+	var snapshot IELTSProfileInputSnapshot
+	if DecodeStrict(command.InputSnapshot, &snapshot) != nil || !snapshot.Valid() ||
+		snapshot.Stage != IELTSProfileStagePart2 || len(snapshot.Turns) != 2 ||
+		snapshot.AcousticCapability != AcousticCapabilityNotConfigured ||
+		snapshot.DependencyResolution != IELTSProfileDependencyPending {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+	if string(command.ConfigLineage) == "" || command.InputHash == ([32]byte{}) ||
+		command.ConfigHash == ([32]byte{}) {
+		t.Fatal("builder omitted immutable hashes or lineage")
+	}
+}
+
+func TestIELTSProfileCommandBuilderRejectsInvalidStage(t *testing.T) {
+	lineage := ConfigLineage{
+		SchemaVersion:   ConfigLineageSchemaVersion,
+		StrategyRef:     "ielts-cumulative-profile/v1",
+		PipelineVersion: "ielts-cumulative-profile/v1",
+		PromptVersion:   "ielts-cumulative-profile/v1",
+		ResultSchema:    IELTSCumulativeProfileSchemaVersion,
+		Provider:        "qianwen", Model: "qwen-plus",
+	}
+	builder, err := NewIELTSProfileCommandBuilder(lineage, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := builder.Build(practice.IELTSPartProfileEvidence{
+		Stage: "PART_3",
+	}); err == nil {
+		t.Fatal("Build accepted an unsupported Part 3 profile")
+	}
+	if _, err := builder.Build(practice.IELTSPartProfileEvidence{
+		Stage: practice.IELTSProfileStagePart1,
+	}); err == nil {
+		t.Fatal("Build accepted incomplete Part 1 evidence")
+	}
+	var nilBuilder *IELTSProfileCommandBuilder
+	if _, err := nilBuilder.Build(practice.IELTSPartProfileEvidence{}); err == nil {
+		t.Fatal("nil builder accepted evidence")
+	}
+}
+
+func TestIELTSProfileEvidenceValidation(t *testing.T) {
+	evidence := IELTSProfileEvidence{
+		TurnID: "30000000-0000-4000-8000-000000000001",
+		Quote:  "exact evidence", Occurrence: 1, Part: 1,
+	}
+	if !evidence.Valid() {
+		t.Fatal("valid IELTS profile evidence was rejected")
+	}
+	observation := IELTSProfileObservation{
+		Kind: "STRENGTH", ReasonCode: "CLEAR_LINKING",
+		Evidence: []IELTSProfileEvidence{evidence},
+	}
+	if !observation.Valid() {
+		t.Fatal("valid IELTS profile observation was rejected")
+	}
+	observation.Kind = "GUESS"
+	if observation.Valid() {
+		t.Fatal("invalid IELTS profile observation was accepted")
+	}
+	evidence.Part = 3
+	if evidence.Valid() {
+		t.Fatal("Part 3 evidence was accepted in a Part 1/2 profile")
+	}
+}

--- a/server/internal/coaching/evaluation/ielts_profile_test.go
+++ b/server/internal/coaching/evaluation/ielts_profile_test.go
@@ -1,0 +1,34 @@
+package evaluation
+
+import "testing"
+
+func TestIELTSProfileDimensionValidatesHalfBands(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		low  float64
+		high float64
+		want bool
+	}{
+		{name: "whole bands", low: 6, high: 7, want: true},
+		{name: "half bands", low: 6.5, high: 7.5, want: true},
+		{name: "non half low", low: 6.3, high: 7.5, want: false},
+		{name: "non half high", low: 6.5, high: 7.3, want: false},
+		{name: "below range", low: -0.5, high: 1, want: false},
+		{name: "above range", low: 8.5, high: 9.5, want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dimension := IELTSProfileDimension{
+				Key: "FLUENCY_COHERENCE", ProvisionalBandLow: test.low,
+				ProvisionalBandHigh: test.high, Coverage: 0.5, Confidence: 0.5,
+				Observations: []IELTSProfileObservation{},
+			}
+			if got := dimension.Valid(); got != test.want {
+				t.Fatalf("Valid() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}

--- a/server/internal/coaching/evaluation/ieltsprofile/evaluator.go
+++ b/server/internal/coaching/evaluation/ieltsprofile/evaluator.go
@@ -68,9 +68,46 @@ func (evaluator *Evaluator) EvaluateProfile(
 	if err != nil {
 		return nil, err
 	}
+	profile, normalizeErr := normalizeGeneratedProfile(generated, snapshot)
+	if normalizeErr == nil {
+		return encodeProfile(profile)
+	}
+	repairPayload, err := json.Marshal(struct {
+		Input          json.RawMessage `json:"input"`
+		RejectedOutput string          `json:"rejected_output"`
+		Instruction    string          `json:"instruction"`
+	}{
+		Input:          payload,
+		RejectedOutput: generated.Content,
+		Instruction: "Return a complete corrected JSON object that obeys the " +
+			"contract exactly. Every provisional band must be one of " +
+			"0, 0.5, 1, 1.5, ..., 8.5, 9.",
+	})
+	if err != nil {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	repaired, err := evaluator.generator.Generate(ctx, textgeneration.Request{
+		SystemPrompt: profileSystemPrompt, UserPrompt: string(repairPayload),
+	})
+	if err != nil {
+		return nil, err
+	}
+	profile, err = normalizeGeneratedProfile(repaired, snapshot)
+	if err != nil {
+		return nil, errors.Join(normalizeErr, err)
+	}
+	return encodeProfile(profile)
+}
+
+func normalizeGeneratedProfile(
+	generated textgeneration.Result,
+	snapshot evaluation.IELTSProfileInputSnapshot,
+) (evaluation.IELTSCumulativeProfile, error) {
 	var provider providerProfile
 	if evaluation.DecodeStrict([]byte(generated.Content), &provider) != nil {
-		return nil, errors.New("ielts profile: provider response invalid")
+		return evaluation.IELTSCumulativeProfile{}, errors.New(
+			"ielts profile: provider response invalid",
+		)
 	}
 	profile := evaluation.IELTSCumulativeProfile{
 		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
@@ -79,8 +116,14 @@ func (evaluator *Evaluator) EvaluateProfile(
 		Provider:   generated.Provider, Model: generated.Model,
 	}
 	if !profile.Valid() || !profileMatchesSnapshot(profile, snapshot) {
-		return nil, errors.New("ielts profile: normalized response invalid")
+		return evaluation.IELTSCumulativeProfile{}, errors.New(
+			"ielts profile: normalized response invalid",
+		)
 	}
+	return profile, nil
+}
+
+func encodeProfile(profile evaluation.IELTSCumulativeProfile) (json.RawMessage, error) {
 	encoded, _, err := evaluation.EncodeStrict(profile)
 	return encoded, err
 }
@@ -150,7 +193,7 @@ func profileMatchesSnapshot(
 	return true
 }
 
-const profileSystemPrompt = `You maintain an internal provisional cumulative IELTS Speaking profile. Return one JSON object only with exactly completed_parts and dimensions. completed_parts is [1] for PART_1 and [1,2] for PART_2. dimensions must be ordered FLUENCY_COHERENCE, LEXICAL_RESOURCE, GRAMMATICAL_RANGE_ACCURACY, PRONUNCIATION. Each dimension contains key, provisional_band_low, provisional_band_high, coverage, confidence, observations. Bands use 0.5 increments from 0 to 9 and are provisional ranges, never official Part scores. Each observation contains kind (STRENGTH or IMPROVEMENT), reason_code and one or two evidence items. Evidence contains turn_id, an exact quote, its 1-based occurrence and part. Use at most three observations per dimension. When previous_profile is present, preserve valid earlier evidence and update conclusions using the new Part. Do not mechanically average Parts. Base pronunciation only on acoustic checkpoints; when coverage is insufficient, use a broad low-confidence range and no invented evidence.`
+const profileSystemPrompt = `You maintain an internal provisional cumulative IELTS Speaking profile. Return one JSON object only with exactly completed_parts and dimensions. completed_parts is [1] for PART_1 and [1,2] for PART_2. dimensions must be ordered FLUENCY_COHERENCE, LEXICAL_RESOURCE, GRAMMATICAL_RANGE_ACCURACY, PRONUNCIATION. Each dimension contains key, provisional_band_low, provisional_band_high, coverage, confidence, observations. Every band must be one of 0, 0.5, 1, 1.5, ..., 8.5, 9 and is a provisional range, never an official Part score. Each observation contains kind (STRENGTH or IMPROVEMENT), reason_code and one or two evidence items. Evidence contains turn_id, an exact quote, its 1-based occurrence and part. Use at most three observations per dimension. When previous_profile is present, preserve valid earlier evidence and update conclusions using the new Part. Do not mechanically average Parts. Base pronunciation only on acoustic checkpoints; when coverage is insufficient, use a broad low-confidence range and no invented evidence.`
 
 var _ interface {
 	EvaluateProfile(context.Context, evaluation.Record, evaluation.IELTSProfileInputSnapshot, evaluation.ConfigLineage) (json.RawMessage, error)

--- a/server/internal/coaching/evaluation/ieltsprofile/evaluator.go
+++ b/server/internal/coaching/evaluation/ieltsprofile/evaluator.go
@@ -1,0 +1,157 @@
+package ieltsprofile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
+)
+
+const (
+	StrategyRef     = "ielts-cumulative-profile/v1"
+	PipelineVersion = "ielts-cumulative-profile/v1"
+	PromptVersion   = "ielts-cumulative-profile/v1"
+)
+
+type Evaluator struct{ generator textgeneration.Generator }
+
+func New(generator textgeneration.Generator) (*Evaluator, error) {
+	if generator == nil {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	return &Evaluator{generator: generator}, nil
+}
+
+func Lineage(provider string, model string) (evaluation.ConfigLineage, error) {
+	lineage := evaluation.ConfigLineage{
+		SchemaVersion: evaluation.ConfigLineageSchemaVersion,
+		StrategyRef:   StrategyRef, PipelineVersion: PipelineVersion,
+		PromptVersion: PromptVersion,
+		ResultSchema:  evaluation.IELTSCumulativeProfileSchemaVersion,
+		Provider:      provider, Model: model,
+	}
+	if !lineage.Valid() {
+		return evaluation.ConfigLineage{}, evaluation.ErrInvalidRequest
+	}
+	return lineage, nil
+}
+
+func (evaluator *Evaluator) EvaluateProfile(
+	ctx context.Context,
+	_ evaluation.Record,
+	snapshot evaluation.IELTSProfileInputSnapshot,
+	lineage evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	if evaluator == nil || evaluator.generator == nil || ctx == nil ||
+		!snapshot.Valid() || !lineage.Valid() || lineage.StrategyRef != StrategyRef {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	questions, turns := profileDelta(snapshot)
+	payload, err := json.Marshal(struct {
+		Stage           evaluation.IELTSProfileStage         `json:"stage"`
+		PreviousProfile *evaluation.IELTSCumulativeProfile   `json:"previous_profile"`
+		Questions       []evaluation.SessionEvidenceQuestion `json:"questions"`
+		Turns           []evaluation.SessionEvidenceTurn     `json:"turns"`
+	}{
+		Stage: snapshot.Stage, PreviousProfile: snapshot.PreviousProfile,
+		Questions: questions, Turns: turns,
+	})
+	if err != nil {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	generated, err := evaluator.generator.Generate(ctx, textgeneration.Request{
+		SystemPrompt: profileSystemPrompt, UserPrompt: string(payload),
+	})
+	if err != nil {
+		return nil, err
+	}
+	var provider providerProfile
+	if evaluation.DecodeStrict([]byte(generated.Content), &provider) != nil {
+		return nil, errors.New("ielts profile: provider response invalid")
+	}
+	profile := evaluation.IELTSCumulativeProfile{
+		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
+		SessionID:     snapshot.SessionID, CompletedParts: provider.CompletedParts,
+		Dimensions: provider.Dimensions,
+		Provider:   generated.Provider, Model: generated.Model,
+	}
+	if !profile.Valid() || !profileMatchesSnapshot(profile, snapshot) {
+		return nil, errors.New("ielts profile: normalized response invalid")
+	}
+	encoded, _, err := evaluation.EncodeStrict(profile)
+	return encoded, err
+}
+
+type providerProfile struct {
+	CompletedParts []int                              `json:"completed_parts"`
+	Dimensions     []evaluation.IELTSProfileDimension `json:"dimensions"`
+}
+
+func profileDelta(snapshot evaluation.IELTSProfileInputSnapshot) (
+	[]evaluation.SessionEvidenceQuestion,
+	[]evaluation.SessionEvidenceTurn,
+) {
+	start := 0
+	if snapshot.Stage == evaluation.IELTSProfileStagePart2 &&
+		snapshot.PreviousProfile != nil {
+		start = snapshot.Part1Boundary
+	}
+	turns := append([]evaluation.SessionEvidenceTurn(nil), snapshot.Turns[start:]...)
+	questionIDs := make(map[string]struct{}, len(turns))
+	for _, turn := range turns {
+		questionIDs[turn.QuestionID] = struct{}{}
+	}
+	questions := make([]evaluation.SessionEvidenceQuestion, 0, len(questionIDs))
+	for _, question := range snapshot.Questions {
+		if _, exists := questionIDs[question.ID]; exists {
+			questions = append(questions, question)
+		}
+	}
+	return questions, turns
+}
+
+func profileMatchesSnapshot(
+	profile evaluation.IELTSCumulativeProfile,
+	snapshot evaluation.IELTSProfileInputSnapshot,
+) bool {
+	wantParts := 1
+	if snapshot.Stage == evaluation.IELTSProfileStagePart2 {
+		wantParts = 2
+	}
+	if len(profile.CompletedParts) != wantParts {
+		return false
+	}
+	turns := make(map[string]evaluation.SessionEvidenceTurn, len(snapshot.Turns))
+	for _, turn := range snapshot.Turns {
+		turns[turn.ID] = turn
+	}
+	for _, dimension := range profile.Dimensions {
+		for _, observation := range dimension.Observations {
+			for _, evidence := range observation.Evidence {
+				turn, exists := turns[evidence.TurnID]
+				if !exists || strings.Count(turn.Transcript, evidence.Quote) < evidence.Occurrence {
+					return false
+				}
+				part := 1
+				for index, candidate := range snapshot.Turns {
+					if candidate.ID == evidence.TurnID && index >= snapshot.Part1Boundary {
+						part = 2
+					}
+				}
+				if evidence.Part != part {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+const profileSystemPrompt = `You maintain an internal provisional cumulative IELTS Speaking profile. Return one JSON object only with exactly completed_parts and dimensions. completed_parts is [1] for PART_1 and [1,2] for PART_2. dimensions must be ordered FLUENCY_COHERENCE, LEXICAL_RESOURCE, GRAMMATICAL_RANGE_ACCURACY, PRONUNCIATION. Each dimension contains key, provisional_band_low, provisional_band_high, coverage, confidence, observations. Bands use 0.5 increments from 0 to 9 and are provisional ranges, never official Part scores. Each observation contains kind (STRENGTH or IMPROVEMENT), reason_code and one or two evidence items. Evidence contains turn_id, an exact quote, its 1-based occurrence and part. Use at most three observations per dimension. When previous_profile is present, preserve valid earlier evidence and update conclusions using the new Part. Do not mechanically average Parts. Base pronunciation only on acoustic checkpoints; when coverage is insufficient, use a broad low-confidence range and no invented evidence.`
+
+var _ interface {
+	EvaluateProfile(context.Context, evaluation.Record, evaluation.IELTSProfileInputSnapshot, evaluation.ConfigLineage) (json.RawMessage, error)
+} = (*Evaluator)(nil)

--- a/server/internal/coaching/evaluation/ieltsprofile/evaluator_test.go
+++ b/server/internal/coaching/evaluation/ieltsprofile/evaluator_test.go
@@ -1,0 +1,117 @@
+package ieltsprofile
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
+)
+
+func TestPart2EvaluationSendsPreviousProfileAndOnlyPart2Delta(t *testing.T) {
+	generator := &profileGeneratorFake{}
+	evaluator, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage, err := Lineage("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := profileSnapshotFixture()
+
+	if _, err := evaluator.EvaluateProfile(
+		context.Background(), evaluation.Record{}, snapshot, lineage,
+	); err != nil {
+		t.Fatalf("EvaluateProfile() error = %v", err)
+	}
+	if strings.Contains(generator.last.UserPrompt, "PART_ONE_PRIVATE_TRANSCRIPT") ||
+		!strings.Contains(generator.last.UserPrompt, "PART_TWO_NEW_TRANSCRIPT") ||
+		!strings.Contains(generator.last.UserPrompt, `"previous_profile"`) {
+		t.Fatalf("Part 2 incremental payload = %s", generator.last.UserPrompt)
+	}
+}
+
+type profileGeneratorFake struct{ last textgeneration.Request }
+
+func (generator *profileGeneratorFake) Generate(
+	_ context.Context,
+	request textgeneration.Request,
+) (textgeneration.Result, error) {
+	generator.last = request
+	dimensions := make([]map[string]any, 0, 4)
+	for _, key := range []string{
+		"FLUENCY_COHERENCE", "LEXICAL_RESOURCE",
+		"GRAMMATICAL_RANGE_ACCURACY", "PRONUNCIATION",
+	} {
+		dimensions = append(dimensions, map[string]any{
+			"key": key, "provisional_band_low": 6.0,
+			"provisional_band_high": 7.0, "coverage": 0.7,
+			"confidence": 0.6, "observations": []any{},
+		})
+	}
+	content, err := json.Marshal(map[string]any{
+		"completed_parts": []int{1, 2}, "dimensions": dimensions,
+	})
+	return textgeneration.Result{
+		RequestID: "profile-request-1", Content: string(content),
+		Provider: "qianwen", Model: "qwen-plus",
+	}, err
+}
+
+func profileSnapshotFixture() evaluation.IELTSProfileInputSnapshot {
+	now := time.Now().UTC()
+	sessionID := "20000000-0000-4000-8000-000000000001"
+	profile := &evaluation.IELTSCumulativeProfile{
+		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
+		SessionID:     sessionID, CompletedParts: []int{1},
+		Dimensions: profileDimensions(), Provider: "qianwen", Model: "qwen-plus",
+	}
+	return evaluation.IELTSProfileInputSnapshot{
+		SchemaVersion: evaluation.IELTSProfileInputSchemaVersion,
+		SessionID:     sessionID, SessionVersion: 3,
+		Stage: evaluation.IELTSProfileStagePart2, CompletedAt: now,
+		Part1Boundary: 1, Part2Boundary: 2,
+		AcousticCapability:   evaluation.AcousticCapabilityNotConfigured,
+		DependencyResolution: evaluation.IELTSProfileDependencyResolved,
+		PreviousProfile:      profile,
+		Questions: []evaluation.SessionEvidenceQuestion{
+			{ID: "40000000-0000-4000-8000-000000000001", Position: 1,
+				Text: "Part 1", SpeakerParticipantID: "assistant",
+				AddresseeParticipantIDs: []string{"learner"}},
+			{ID: "40000000-0000-4000-8000-000000000002", Position: 2,
+				Text: "Part 2", SpeakerParticipantID: "assistant",
+				AddresseeParticipantIDs: []string{"learner"}},
+		},
+		Turns: []evaluation.SessionEvidenceTurn{
+			{ID: "30000000-0000-4000-8000-000000000001", Position: 1,
+				QuestionID:              "40000000-0000-4000-8000-000000000001",
+				RespondentParticipantID: "learner", Transcript: "PART_ONE_PRIVATE_TRANSCRIPT",
+				Effective: true, ConfirmedAt: now},
+			{ID: "30000000-0000-4000-8000-000000000002", Position: 2,
+				QuestionID:              "40000000-0000-4000-8000-000000000002",
+				RespondentParticipantID: "learner", Transcript: "PART_TWO_NEW_TRANSCRIPT",
+				Effective: true, ConfirmedAt: now},
+		},
+	}
+}
+
+func profileDimensions() []evaluation.IELTSProfileDimension {
+	result := make([]evaluation.IELTSProfileDimension, 0, 4)
+	for _, key := range []string{
+		"FLUENCY_COHERENCE", "LEXICAL_RESOURCE",
+		"GRAMMATICAL_RANGE_ACCURACY", "PRONUNCIATION",
+	} {
+		result = append(result, evaluation.IELTSProfileDimension{
+			Key: key, ProvisionalBandLow: 6, ProvisionalBandHigh: 7,
+			Coverage: 0.5, Confidence: 0.5,
+			Observations: []evaluation.IELTSProfileObservation{},
+		})
+	}
+	return result
+}
+
+var _ textgeneration.Generator = (*profileGeneratorFake)(nil)

--- a/server/internal/coaching/evaluation/ieltsprofile/evaluator_test.go
+++ b/server/internal/coaching/evaluation/ieltsprofile/evaluator_test.go
@@ -35,6 +35,53 @@ func TestPart2EvaluationSendsPreviousProfileAndOnlyPart2Delta(t *testing.T) {
 	}
 }
 
+func TestProfileEvaluationRepairsInvalidHalfBand(t *testing.T) {
+	generator := &sequencedProfileGenerator{bands: []float64{6.3, 6.5}}
+	evaluator, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage, err := Lineage("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := evaluator.EvaluateProfile(
+		context.Background(), evaluation.Record{}, profileSnapshotFixture(), lineage,
+	)
+	if err != nil {
+		t.Fatalf("EvaluateProfile() error = %v", err)
+	}
+	if generator.calls != 2 || !strings.Contains(
+		generator.requests[1].UserPrompt, "Every provisional band must be one of",
+	) {
+		t.Fatalf("repair requests = %#v", generator.requests)
+	}
+	var profile evaluation.IELTSCumulativeProfile
+	if evaluation.DecodeStrict(result, &profile) != nil || !profile.Valid() ||
+		profile.Dimensions[0].ProvisionalBandLow != 6.5 {
+		t.Fatalf("repaired profile = %#v", profile)
+	}
+}
+
+func TestProfileEvaluationRejectsRepeatedInvalidHalfBands(t *testing.T) {
+	generator := &sequencedProfileGenerator{bands: []float64{6.3, 6.3}}
+	evaluator, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage, err := Lineage("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := evaluator.EvaluateProfile(
+		context.Background(), evaluation.Record{}, profileSnapshotFixture(), lineage,
+	); err == nil || generator.calls != 2 {
+		t.Fatalf("EvaluateProfile() error = %v, calls = %d", err, generator.calls)
+	}
+}
+
 type profileGeneratorFake struct{ last textgeneration.Request }
 
 func (generator *profileGeneratorFake) Generate(
@@ -115,3 +162,38 @@ func profileDimensions() []evaluation.IELTSProfileDimension {
 }
 
 var _ textgeneration.Generator = (*profileGeneratorFake)(nil)
+
+type sequencedProfileGenerator struct {
+	bands    []float64
+	calls    int
+	requests []textgeneration.Request
+}
+
+func (generator *sequencedProfileGenerator) Generate(
+	_ context.Context,
+	request textgeneration.Request,
+) (textgeneration.Result, error) {
+	generator.requests = append(generator.requests, request)
+	band := generator.bands[generator.calls]
+	generator.calls++
+	dimensions := make([]map[string]any, 0, 4)
+	for _, key := range []string{
+		"FLUENCY_COHERENCE", "LEXICAL_RESOURCE",
+		"GRAMMATICAL_RANGE_ACCURACY", "PRONUNCIATION",
+	} {
+		dimensions = append(dimensions, map[string]any{
+			"key": key, "provisional_band_low": band,
+			"provisional_band_high": band, "coverage": 0.7,
+			"confidence": 0.6, "observations": []any{},
+		})
+	}
+	content, err := json.Marshal(map[string]any{
+		"completed_parts": []int{1, 2}, "dimensions": dimensions,
+	})
+	return textgeneration.Result{
+		RequestID: "profile-request", Content: string(content),
+		Provider: "qianwen", Model: "qwen-plus",
+	}, err
+}
+
+var _ textgeneration.Generator = (*sequencedProfileGenerator)(nil)

--- a/server/internal/coaching/evaluation/job.go
+++ b/server/internal/coaching/evaluation/job.go
@@ -34,11 +34,14 @@ const (
 	KindSessionReport        Kind = "SESSION_REPORT"
 	KindPracticeTurnFeedback Kind = "PRACTICE_TURN_FEEDBACK"
 	KindAgentMessageFeedback Kind = "AGENT_MESSAGE_FEEDBACK"
+	KindIELTSPart1Profile    Kind = "IELTS_PART1_PROFILE"
+	KindIELTSPart2Profile    Kind = "IELTS_PART2_PROFILE"
 )
 
 func (kind Kind) Valid() bool {
 	switch kind {
-	case KindSessionReport, KindPracticeTurnFeedback, KindAgentMessageFeedback:
+	case KindSessionReport, KindPracticeTurnFeedback, KindAgentMessageFeedback,
+		KindIELTSPart1Profile, KindIELTSPart2Profile:
 		return true
 	default:
 		return false
@@ -98,19 +101,21 @@ func (failure JobError) Valid() bool {
 }
 
 type SessionInputSnapshot struct {
-	SchemaVersion       string                    `json:"schema_version"`
-	SessionID           string                    `json:"session_id"`
-	SessionVersion      int                       `json:"session_version"`
-	EvaluationPolicyRef string                    `json:"evaluation_policy_ref"`
-	PracticeExperience  string                    `json:"practice_experience"`
-	SceneCategory       string                    `json:"scene_category"`
-	PracticeMode        string                    `json:"practice_mode"`
-	CompletedAt         time.Time                 `json:"completed_at"`
-	AcousticCapability  AcousticCapabilityStatus  `json:"acoustic_capability"`
-	PlanSnapshot        json.RawMessage           `json:"plan_snapshot"`
-	Participants        json.RawMessage           `json:"participants"`
-	Questions           []SessionEvidenceQuestion `json:"questions"`
-	Turns               []SessionEvidenceTurn     `json:"turns"`
+	SchemaVersion       string                      `json:"schema_version"`
+	SessionID           string                      `json:"session_id"`
+	SessionVersion      int                         `json:"session_version"`
+	EvaluationPolicyRef string                      `json:"evaluation_policy_ref"`
+	PracticeExperience  string                      `json:"practice_experience"`
+	SceneCategory       string                      `json:"scene_category"`
+	PracticeMode        string                      `json:"practice_mode"`
+	CompletedAt         time.Time                   `json:"completed_at"`
+	AcousticCapability  AcousticCapabilityStatus    `json:"acoustic_capability"`
+	PlanSnapshot        json.RawMessage             `json:"plan_snapshot"`
+	Participants        json.RawMessage             `json:"participants"`
+	Questions           []SessionEvidenceQuestion   `json:"questions"`
+	Turns               []SessionEvidenceTurn       `json:"turns"`
+	CumulativeProfile   *IELTSCumulativeProfile     `json:"cumulative_profile,omitempty"`
+	ProfileResolution   IELTSFinalProfileResolution `json:"profile_resolution,omitempty"`
 }
 
 type SessionEvidenceQuestion struct {
@@ -148,6 +153,19 @@ func (snapshot SessionInputSnapshot) Valid() bool {
 		!validJSONArray(snapshot.Participants) ||
 		len(snapshot.Questions) == 0 || len(snapshot.Questions) > 128 ||
 		len(snapshot.Turns) == 0 || len(snapshot.Turns) > 128 {
+		return false
+	}
+	if snapshot.ProfileResolution != "" &&
+		snapshot.ProfileResolution != IELTSFinalProfileResolved &&
+		snapshot.ProfileResolution != IELTSFinalProfileFallback {
+		return false
+	}
+	if (snapshot.ProfileResolution == IELTSFinalProfileResolved) !=
+		(snapshot.CumulativeProfile != nil) ||
+		(snapshot.CumulativeProfile != nil &&
+			(!snapshot.CumulativeProfile.Valid() ||
+				snapshot.CumulativeProfile.SessionID != snapshot.SessionID ||
+				len(snapshot.CumulativeProfile.CompletedParts) != 2)) {
 		return false
 	}
 	questionIDs := make(map[string]struct{}, len(snapshot.Questions))
@@ -417,6 +435,15 @@ func validateRecordJSON(record Record) error {
 		if err := DecodeStrict(record.InputSnapshot, &snapshot); err != nil ||
 			!snapshot.Valid(record.Kind) ||
 			snapshot.EvidenceRefID != record.SourceID {
+			return ErrInvalidRequest
+		}
+	case KindIELTSPart1Profile, KindIELTSPart2Profile:
+		var snapshot IELTSProfileInputSnapshot
+		if err := DecodeStrict(record.InputSnapshot, &snapshot); err != nil ||
+			!snapshot.Valid() || snapshot.SessionID != record.SourceID ||
+			snapshot.SessionID != record.ContextID ||
+			(record.Kind == KindIELTSPart1Profile && snapshot.Stage != IELTSProfileStagePart1) ||
+			(record.Kind == KindIELTSPart2Profile && snapshot.Stage != IELTSProfileStagePart2) {
 			return ErrInvalidRequest
 		}
 	default:

--- a/server/internal/coaching/evaluation/postgres/practice_scheduler.go
+++ b/server/internal/coaching/evaluation/postgres/practice_scheduler.go
@@ -46,6 +46,38 @@ type TurnFeedbackScheduler struct {
 	builder *evaluation.TurnFeedbackCommandBuilder
 }
 
+type IELTSProfileScheduler struct {
+	store   *Store
+	builder *evaluation.IELTSProfileCommandBuilder
+}
+
+func NewIELTSProfileScheduler(
+	store *Store,
+	builder *evaluation.IELTSProfileCommandBuilder,
+) (*IELTSProfileScheduler, error) {
+	if store == nil || builder == nil {
+		return nil, evaluation.ErrInvalidRequest
+	}
+	return &IELTSProfileScheduler{store: store, builder: builder}, nil
+}
+
+func (scheduler *IELTSProfileScheduler) ScheduleCompletedPart(
+	ctx context.Context,
+	tx pgx.Tx,
+	evidence practice.IELTSPartProfileEvidence,
+) error {
+	if scheduler == nil || scheduler.store == nil || scheduler.builder == nil ||
+		ctx == nil || tx == nil {
+		return evaluation.ErrInvalidRequest
+	}
+	command, err := scheduler.builder.Build(evidence)
+	if err != nil {
+		return err
+	}
+	_, _, err = scheduler.store.QueueInTx(ctx, tx, command)
+	return err
+}
+
 func NewTurnFeedbackScheduler(
 	store *Store,
 	builder *evaluation.TurnFeedbackCommandBuilder,
@@ -75,3 +107,4 @@ func (scheduler *TurnFeedbackScheduler) ScheduleConfirmedTurn(
 
 var _ practicepostgres.CompletionScheduler = (*SessionScheduler)(nil)
 var _ practicepostgres.TurnFeedbackScheduler = (*TurnFeedbackScheduler)(nil)
+var _ practicepostgres.IELTSProfileScheduler = (*IELTSProfileScheduler)(nil)

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -57,6 +57,15 @@ func Lineages(
 			Provider:        provider,
 			Model:           model,
 		},
+		IELTSPractice: evaluation.ConfigLineage{
+			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
+			StrategyRef:     evaluation.IELTSStrategyRef,
+			PipelineVersion: pipelineVersion,
+			PromptVersion:   ieltsPromptVersionV2,
+			ResultSchema:    report.FormalReportSchemaVersion,
+			Provider:        provider,
+			Model:           model,
+		},
 		General: evaluation.ConfigLineage{
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.GeneralStrategyRef,

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -29,6 +29,7 @@ const (
 	interviewPromptVersionV2 = "interview-report/v2"
 	ieltsPromptVersionV1     = "ielts-report/v1"
 	ieltsPromptVersionV2     = "ielts-report/v2"
+	ieltsPromptVersionV3     = "ielts-report/v3"
 	generalPromptVersionV1   = "general-report/v1"
 	generalPromptVersionV2   = "general-report/v2"
 )
@@ -51,7 +52,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.IELTSStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   ieltsPromptVersionV2,
+			PromptVersion:   ieltsPromptVersionV3,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -156,7 +157,7 @@ func (evaluator *InterviewEvaluator) Evaluate(
 			"INTERVIEW_EVIDENCE",
 			"INTERVIEW_PROFESSIONAL",
 			"INTERVIEW_INTERACTION",
-		}, report.ReportScalePercentage100, false)
+		}, report.ReportScalePercentage100, false, nil)
 }
 
 func (evaluator *IELTSEvaluator) Evaluate(
@@ -172,6 +173,13 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		ieltsPromptVersionV2,
 		ieltsSystemPromptV2,
 	)
+	if lineage.PromptVersion == ieltsPromptVersionV3 {
+		prompt = reportPrompt{
+			system:              ieltsSystemPromptV3,
+			insufficientSummary: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		}
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -184,9 +192,16 @@ func (evaluator *IELTSEvaluator) Evaluate(
 	if pronunciationAssessed {
 		dimensions = append(dimensions, "PRONUNCIATION")
 	}
+	var payloadOverride any
+	if snapshot.CumulativeProfile != nil {
+		payloadOverride, err = incrementalIELTSPayload(snapshot, dimensions)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return evaluate(ctx, evaluator.generator, snapshot, lineage,
 		prompt.system, prompt.insufficientSummary, evaluation.SceneIELTSSpeaking,
-		dimensions, report.ReportScaleIELTSBand, true)
+		dimensions, report.ReportScaleIELTSBand, true, payloadOverride)
 }
 
 func (evaluator *GeneralEvaluator) Evaluate(
@@ -228,7 +243,7 @@ func (evaluator *GeneralEvaluator) Evaluate(
 			"CLARITY_COHERENCE",
 			"LANGUAGE_CONTROL",
 			"INTERACTION",
-		}, report.ReportScalePercentage100, false)
+		}, report.ReportScalePercentage100, false, nil)
 }
 
 func evaluate(
@@ -242,6 +257,7 @@ func evaluate(
 	dimensionKeys []string,
 	scale report.ReportScoreScale,
 	allowRepair bool,
+	payloadOverride any,
 ) (json.RawMessage, error) {
 	if generator == nil || ctx == nil || strings.TrimSpace(systemPrompt) == "" ||
 		strings.TrimSpace(insufficientSummary) == "" ||
@@ -259,13 +275,15 @@ func evaluate(
 			snapshot, sceneType, dimensionKeys, scale, insufficientSummary,
 		))
 	}
-	payload, err := json.Marshal(providerInput{
-		SceneType:     sceneType,
-		PracticeMode:  snapshot.PracticeMode,
-		DimensionKeys: dimensionKeys,
-		Questions:     snapshot.Questions,
-		Turns:         effectiveTurns,
-	})
+	payloadSource := payloadOverride
+	if payloadSource == nil {
+		payloadSource = providerInput{
+			SceneType: sceneType, PracticeMode: snapshot.PracticeMode,
+			DimensionKeys: dimensionKeys, Questions: snapshot.Questions,
+			Turns: effectiveTurns,
+		}
+	}
+	payload, err := json.Marshal(payloadSource)
 	if err != nil {
 		return nil, evaluation.ErrInvalidRequest
 	}
@@ -321,6 +339,68 @@ type providerInput struct {
 	DimensionKeys []string                             `json:"dimension_keys"`
 	Questions     []evaluation.SessionEvidenceQuestion `json:"questions"`
 	Turns         []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
+}
+
+type incrementalIELTSProviderInput struct {
+	SceneType         evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode      string                               `json:"practice_mode"`
+	DimensionKeys     []string                             `json:"dimension_keys"`
+	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
+	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
+	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+}
+
+func incrementalIELTSPayload(
+	snapshot evaluation.SessionInputSnapshot,
+	dimensionKeys []string,
+) (incrementalIELTSProviderInput, error) {
+	if snapshot.CumulativeProfile == nil ||
+		!snapshot.CumulativeProfile.Valid() {
+		return incrementalIELTSProviderInput{}, evaluation.ErrInvalidRequest
+	}
+	var plan struct {
+		IELTSAssignment *struct {
+			Parts []struct {
+				TurnBlueprints []string `json:"turn_blueprints"`
+			} `json:"parts"`
+		} `json:"ielts_assignment"`
+	}
+	if json.Unmarshal(snapshot.PlanSnapshot, &plan) != nil ||
+		plan.IELTSAssignment == nil || len(plan.IELTSAssignment.Parts) != 3 {
+		return incrementalIELTSProviderInput{}, evaluation.ErrInvalidRequest
+	}
+	part2Boundary := len(plan.IELTSAssignment.Parts[0].TurnBlueprints) +
+		len(plan.IELTSAssignment.Parts[1].TurnBlueprints)
+	effectivePosition := 0
+	turns := make([]evaluation.SessionEvidenceTurn, 0)
+	questionIDs := make(map[string]struct{})
+	for _, turn := range snapshot.Turns {
+		if !turn.Effective {
+			continue
+		}
+		effectivePosition++
+		if effectivePosition <= part2Boundary {
+			continue
+		}
+		turns = append(turns, turn)
+		questionIDs[turn.QuestionID] = struct{}{}
+	}
+	if len(turns) == 0 {
+		return incrementalIELTSProviderInput{}, evaluation.ErrInvalidRequest
+	}
+	questions := make([]evaluation.SessionEvidenceQuestion, 0, len(questionIDs))
+	for _, question := range snapshot.Questions {
+		if _, exists := questionIDs[question.ID]; exists {
+			questions = append(questions, question)
+		}
+	}
+	return incrementalIELTSProviderInput{
+		SceneType:         evaluation.SceneIELTSSpeaking,
+		PracticeMode:      snapshot.PracticeMode,
+		DimensionKeys:     dimensionKeys,
+		CumulativeProfile: *snapshot.CumulativeProfile,
+		Questions:         questions, Turns: turns,
+	}, nil
 }
 
 type providerReport struct {
@@ -728,6 +808,8 @@ const interviewSystemPromptV2 = `You are an evidence-bound job interview English
 const ieltsSystemPromptV1 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
 
 const ieltsSystemPromptV2 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
+
+const ieltsSystemPromptV3 = `You are an evidence-bound IELTS Speaking practice evaluator. Score the candidate's average performance across the whole test, not separate Part scores. The input may contain a provisional cumulative_profile for Parts 1 and 2 plus raw Part 3 evidence. Treat the profile as provisional evidence: preserve its exact cited quotes, then recalibrate every requested dimension using Part 3. Never mechanically average Parts or copy provisional bands without reconsideration. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote present either in cumulative_profile evidence or Part 3 turns, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Base PRONUNCIATION only on acoustic checkpoints and the provisional pronunciation profile, never on transcript spelling.`
 
 const generalSystemPromptV1 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -106,6 +106,70 @@ func TestIELTSEvaluatorMarksPronunciationNotAssessedWhenCapabilityDisabled(t *te
 	}
 }
 
+func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := sessionSnapshotFixture()
+	now := snapshot.CompletedAt
+	snapshot.PlanSnapshot = json.RawMessage(`{"ielts_assignment":{"parts":[{"turn_blueprints":["p1"]},{"turn_blueprints":["p2"]},{"turn_blueprints":["p3"]}]}}`)
+	snapshot.Questions[0].Text = "Part 1 question"
+	snapshot.Turns[0].Transcript = "PART_ONE_RAW_TRANSCRIPT"
+	for index, transcript := range []string{"PART_TWO_RAW_TRANSCRIPT", "PART_THREE_RAW_TRANSCRIPT"} {
+		position := index + 2
+		questionID := fmt.Sprintf("40000000-0000-4000-8000-%012d", position)
+		turnID := fmt.Sprintf("30000000-0000-4000-8000-%012d", position)
+		snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
+			ID: questionID, Position: position, Text: fmt.Sprintf("Part %d question", position),
+			SpeakerParticipantID: "assistant-1", AddresseeParticipantIDs: []string{"user-1"},
+		})
+		snapshot.Turns = append(snapshot.Turns, evaluation.SessionEvidenceTurn{
+			ID: turnID, Position: position, QuestionID: questionID,
+			RespondentParticipantID: "user-1", Transcript: transcript,
+			Effective: true, ConfirmedAt: now,
+		})
+	}
+	snapshot.CumulativeProfile = &evaluation.IELTSCumulativeProfile{
+		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
+		SessionID:     snapshot.SessionID, CompletedParts: []int{1, 2},
+		Dimensions: cumulativeProfileDimensions(), Provider: "qianwen", Model: "qwen-plus",
+	}
+	snapshot.ProfileResolution = evaluation.IELTSFinalProfileResolved
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	if strings.Contains(generator.last.UserPrompt, "PART_ONE_RAW_TRANSCRIPT") ||
+		strings.Contains(generator.last.UserPrompt, "PART_TWO_RAW_TRANSCRIPT") ||
+		!strings.Contains(generator.last.UserPrompt, "PART_THREE_RAW_TRANSCRIPT") ||
+		!strings.Contains(generator.last.UserPrompt, `"cumulative_profile"`) {
+		t.Fatalf("final incremental payload = %s", generator.last.UserPrompt)
+	}
+}
+
+func cumulativeProfileDimensions() []evaluation.IELTSProfileDimension {
+	result := make([]evaluation.IELTSProfileDimension, 0, 4)
+	for _, key := range []string{
+		"FLUENCY_COHERENCE", "LEXICAL_RESOURCE",
+		"GRAMMATICAL_RANGE_ACCURACY", "PRONUNCIATION",
+	} {
+		result = append(result, evaluation.IELTSProfileDimension{
+			Key: key, ProvisionalBandLow: 6, ProvisionalBandHigh: 7,
+			Coverage: 0.6, Confidence: 0.6,
+			Observations: []evaluation.IELTSProfileObservation{},
+		})
+	}
+	return result
+}
+
 func TestIELTSEvaluatorDoesNotScorePronunciationBelowMinimumCoverage(t *testing.T) {
 	generator := &reportGeneratorFake{}
 	evaluators, err := New(generator)
@@ -262,7 +326,7 @@ func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *te
 		version string
 	}{
 		{name: "interview", prompt: interviewSystemPromptV2, version: interviewPromptVersionV2},
-		{name: "IELTS", prompt: ieltsSystemPromptV2, version: ieltsPromptVersionV2},
+		{name: "IELTS", prompt: ieltsSystemPromptV3, version: ieltsPromptVersionV3},
 		{name: "general", prompt: generalSystemPromptV2, version: generalPromptVersionV2},
 	}
 	lineages, err := Lineages("qianwen", "qwen-plus")

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -48,6 +48,15 @@ type SessionEvaluators interface {
 	EvaluateGeneral(context.Context, Record, SessionInputSnapshot, ConfigLineage) (json.RawMessage, error)
 }
 
+type IELTSProfileEvaluators interface {
+	EvaluateProfile(
+		context.Context,
+		Record,
+		IELTSProfileInputSnapshot,
+		ConfigLineage,
+	) (json.RawMessage, error)
+}
+
 type SpeechEvaluators interface {
 	EvaluatePracticeTurn(
 		context.Context,
@@ -80,22 +89,29 @@ type SessionAcousticSource interface {
 }
 
 type WorkerConfiguration struct {
-	SessionLane       ClaimLane
-	SpeechLane        ClaimLane
-	AcousticsEnabled  bool
-	InterviewDeadline time.Duration
-	IELTSDeadline     time.Duration
-	GeneralDeadline   time.Duration
-	SpeechDeadline    time.Duration
-	RetryDelay        time.Duration
-	DependencyDelay   time.Duration
-	FinalizeTimeout   time.Duration
+	SessionLane              ClaimLane
+	ProfileLane              ClaimLane
+	SpeechLane               ClaimLane
+	AcousticsEnabled         bool
+	InterviewDeadline        time.Duration
+	IELTSDeadline            time.Duration
+	GeneralDeadline          time.Duration
+	SpeechDeadline           time.Duration
+	ProfileDeadline          time.Duration
+	RetryDelay               time.Duration
+	DependencyDelay          time.Duration
+	ProfileDependencyMaxWait time.Duration
+	FinalizeTimeout          time.Duration
 }
 
 func (configuration WorkerConfiguration) Valid() bool {
 	return configuration.SessionLane.Valid() &&
 		len(configuration.SessionLane.Kinds) == 1 &&
 		configuration.SessionLane.Kinds[0] == KindSessionReport &&
+		configuration.ProfileLane.Valid() &&
+		len(configuration.ProfileLane.Kinds) == 2 &&
+		containsKind(configuration.ProfileLane.Kinds, KindIELTSPart1Profile) &&
+		containsKind(configuration.ProfileLane.Kinds, KindIELTSPart2Profile) &&
 		configuration.SpeechLane.Valid() &&
 		len(configuration.SpeechLane.Kinds) == 2 &&
 		containsKind(configuration.SpeechLane.Kinds, KindPracticeTurnFeedback) &&
@@ -108,9 +124,13 @@ func (configuration WorkerConfiguration) Valid() bool {
 		configuration.GeneralDeadline < configuration.SessionLane.LeaseDuration &&
 		configuration.SpeechDeadline > 0 &&
 		configuration.SpeechDeadline < configuration.SpeechLane.LeaseDuration &&
+		configuration.ProfileDeadline > 0 &&
+		configuration.ProfileDeadline < configuration.ProfileLane.LeaseDuration &&
 		configuration.RetryDelay >= 0 && configuration.RetryDelay <= time.Hour &&
 		configuration.DependencyDelay >= time.Second &&
 		configuration.DependencyDelay <= time.Minute &&
+		configuration.ProfileDependencyMaxWait >= configuration.DependencyDelay &&
+		configuration.ProfileDependencyMaxWait <= 5*time.Minute &&
 		configuration.FinalizeTimeout >= time.Second &&
 		configuration.FinalizeTimeout <= 30*time.Second
 }
@@ -118,6 +138,7 @@ func (configuration WorkerConfiguration) Valid() bool {
 type Worker struct {
 	store         Store
 	sessions      SessionEvaluators
+	profiles      IELTSProfileEvaluators
 	speech        SpeechEvaluators
 	acoustics     AcousticEvaluator
 	sessionAudio  SessionAcousticSource
@@ -127,12 +148,13 @@ type Worker struct {
 func NewWorker(
 	store Store,
 	sessions SessionEvaluators,
+	profiles IELTSProfileEvaluators,
 	speech SpeechEvaluators,
 	acoustics AcousticEvaluator,
 	sessionAudio SessionAcousticSource,
 	configuration WorkerConfiguration,
 ) (*Worker, error) {
-	if store == nil || sessions == nil || speech == nil ||
+	if store == nil || sessions == nil || profiles == nil || speech == nil ||
 		(configuration.AcousticsEnabled &&
 			(acoustics == nil || sessionAudio == nil)) ||
 		!configuration.Valid() {
@@ -141,11 +163,171 @@ func NewWorker(
 	return &Worker{
 		store:         store,
 		sessions:      sessions,
+		profiles:      profiles,
 		speech:        speech,
 		acoustics:     acoustics,
 		sessionAudio:  sessionAudio,
 		configuration: configuration,
 	}, nil
+}
+
+func (worker *Worker) ProcessProfile(ctx context.Context) (bool, error) {
+	if worker == nil || worker.store == nil || ctx == nil {
+		return false, ErrInvalidRequest
+	}
+	claim, err := worker.store.ClaimNext(ctx, worker.configuration.ProfileLane)
+	if errors.Is(err, ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	result, deferred, err := worker.evaluateProfile(ctx, &claim)
+	if deferred {
+		return true, err
+	}
+	if err != nil {
+		return true, worker.fail(ctx, claim, err)
+	}
+	if err := worker.complete(ctx, claim, result, nil); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func (worker *Worker) evaluateProfile(
+	ctx context.Context,
+	claim *Claim,
+) (json.RawMessage, bool, error) {
+	if claim == nil || (claim.Kind != KindIELTSPart1Profile &&
+		claim.Kind != KindIELTSPart2Profile) {
+		return nil, false, ErrInvalidRequest
+	}
+	var snapshot IELTSProfileInputSnapshot
+	var lineage ConfigLineage
+	if DecodeStrict(claim.InputSnapshot, &snapshot) != nil || !snapshot.Valid() ||
+		DecodeStrict(claim.ConfigLineage, &lineage) != nil || !lineage.Valid() {
+		return nil, false, ErrInvalidRequest
+	}
+	if snapshot.Stage == IELTSProfileStagePart2 &&
+		snapshot.DependencyResolution == IELTSProfileDependencyPending {
+		deferred, err := worker.resolvePreviousProfile(ctx, claim, &snapshot)
+		if err != nil || deferred {
+			return nil, deferred, err
+		}
+	}
+	if worker.configuration.AcousticsEnabled {
+		deferred, err := worker.resolveProfileAcoustics(ctx, claim, &snapshot)
+		if err != nil || deferred {
+			return nil, deferred, err
+		}
+	}
+	evaluationContext, cancel := context.WithTimeout(
+		ctx, worker.configuration.ProfileDeadline,
+	)
+	defer cancel()
+	result, err := worker.profiles.EvaluateProfile(
+		evaluationContext, claim.Record, snapshot, lineage,
+	)
+	return result, false, err
+}
+
+func (worker *Worker) resolvePreviousProfile(
+	ctx context.Context,
+	claim *Claim,
+	snapshot *IELTSProfileInputSnapshot,
+) (bool, error) {
+	record, err := worker.store.GetRecordBySource(
+		ctx, claim.UserID, KindIELTSPart1Profile, snapshot.SessionID,
+	)
+	if err == nil && (record.Status == JobQueued || record.Status == JobRunning) &&
+		time.Since(claim.CreatedAt) < worker.configuration.ProfileDependencyMaxWait {
+		finalizeContext, cancel := worker.finalizeContext(ctx)
+		defer cancel()
+		return true, worker.store.DeferClaim(finalizeContext, Deferral{
+			UserID: claim.UserID, ID: claim.ID, LeaseToken: claim.LeaseToken,
+			AvailableAt: time.Now().UTC().Add(worker.configuration.DependencyDelay),
+		})
+	}
+	if err == nil && record.Status == JobReady {
+		var profile IELTSCumulativeProfile
+		if DecodeStrict(record.Result, &profile) == nil && profile.Valid() &&
+			profile.SessionID == snapshot.SessionID && len(profile.CompletedParts) == 1 {
+			snapshot.PreviousProfile = &profile
+			snapshot.DependencyResolution = IELTSProfileDependencyResolved
+		} else {
+			snapshot.DependencyResolution = IELTSProfileDependencyFallback
+		}
+	} else if errors.Is(err, ErrNotFound) || err == nil {
+		snapshot.DependencyResolution = IELTSProfileDependencyFallback
+	} else {
+		return false, err
+	}
+	return false, worker.checkpointProfileSnapshot(ctx, claim, *snapshot)
+}
+
+func (worker *Worker) resolveProfileAcoustics(
+	ctx context.Context,
+	claim *Claim,
+	snapshot *IELTSProfileInputSnapshot,
+) (bool, error) {
+	turnIDs := make([]string, 0, len(snapshot.Turns))
+	for _, turn := range snapshot.Turns {
+		if turn.AudioAssetID != "" && turn.Acoustic == nil {
+			turnIDs = append(turnIDs, turn.ID)
+		}
+	}
+	if len(turnIDs) == 0 {
+		return false, nil
+	}
+	read, err := worker.sessionAudio.ReadSessionAcoustics(
+		ctx, claim.UserID, snapshot.SessionID, turnIDs,
+	)
+	if err != nil {
+		return false, err
+	}
+	if read.Pending {
+		finalizeContext, cancel := worker.finalizeContext(ctx)
+		defer cancel()
+		return true, worker.store.DeferClaim(finalizeContext, Deferral{
+			UserID: claim.UserID, ID: claim.ID, LeaseToken: claim.LeaseToken,
+			AvailableAt: time.Now().UTC().Add(worker.configuration.DependencyDelay),
+		})
+	}
+	if len(read.Checkpoints) != len(turnIDs) {
+		return false, ErrInvalidRequest
+	}
+	for index := range snapshot.Turns {
+		checkpoint, exists := read.Checkpoints[snapshot.Turns[index].ID]
+		if exists {
+			snapshot.Turns[index].Acoustic = &checkpoint
+		}
+	}
+	return false, worker.checkpointProfileSnapshot(ctx, claim, *snapshot)
+}
+
+func (worker *Worker) checkpointProfileSnapshot(
+	ctx context.Context,
+	claim *Claim,
+	snapshot IELTSProfileInputSnapshot,
+) error {
+	if !snapshot.Valid() {
+		return ErrInvalidRequest
+	}
+	encoded, digest, err := EncodeStrict(snapshot)
+	if err != nil {
+		return err
+	}
+	finalizeContext, cancel := worker.finalizeContext(ctx)
+	updated, err := worker.store.CheckpointSnapshot(finalizeContext, SnapshotCheckpoint{
+		UserID: claim.UserID, ID: claim.ID, LeaseToken: claim.LeaseToken,
+		InputSnapshot: encoded, InputHash: digest,
+	})
+	cancel()
+	if err == nil {
+		claim.Record = updated
+	}
+	return err
 }
 
 func (worker *Worker) ProcessSession(ctx context.Context) (bool, error) {
@@ -216,6 +398,13 @@ func (worker *Worker) evaluateSession(
 			return nil, deferred, err
 		}
 	}
+	if lineage.StrategyRef == IELTSStrategyRef &&
+		snapshot.PracticeMode == "FULL_MOCK" && snapshot.ProfileResolution == "" {
+		deferred, err := worker.resolveFinalProfile(ctx, claim, &snapshot)
+		if err != nil || deferred {
+			return nil, deferred, err
+		}
+	}
 	var deadline time.Duration
 	var evaluate func(context.Context) (json.RawMessage, error)
 	switch lineage.StrategyRef {
@@ -247,6 +436,56 @@ func (worker *Worker) evaluateSession(
 		return nil, false, ErrInvalidRequest
 	}
 	return result, false, nil
+}
+
+func (worker *Worker) resolveFinalProfile(
+	ctx context.Context,
+	claim *Claim,
+	snapshot *SessionInputSnapshot,
+) (bool, error) {
+	record, err := worker.store.GetRecordBySource(
+		ctx, claim.UserID, KindIELTSPart2Profile, snapshot.SessionID,
+	)
+	if err == nil && (record.Status == JobQueued || record.Status == JobRunning) &&
+		time.Since(claim.CreatedAt) < worker.configuration.ProfileDependencyMaxWait {
+		finalizeContext, cancel := worker.finalizeContext(ctx)
+		defer cancel()
+		return true, worker.store.DeferClaim(finalizeContext, Deferral{
+			UserID: claim.UserID, ID: claim.ID, LeaseToken: claim.LeaseToken,
+			AvailableAt: time.Now().UTC().Add(worker.configuration.DependencyDelay),
+		})
+	}
+	if err == nil && record.Status == JobReady {
+		var profile IELTSCumulativeProfile
+		if DecodeStrict(record.Result, &profile) == nil && profile.Valid() &&
+			profile.SessionID == snapshot.SessionID && len(profile.CompletedParts) == 2 {
+			snapshot.CumulativeProfile = &profile
+			snapshot.ProfileResolution = IELTSFinalProfileResolved
+		} else {
+			snapshot.ProfileResolution = IELTSFinalProfileFallback
+		}
+	} else if errors.Is(err, ErrNotFound) || err == nil {
+		snapshot.ProfileResolution = IELTSFinalProfileFallback
+	} else {
+		return false, err
+	}
+	if !snapshot.Valid() {
+		return false, ErrInvalidRequest
+	}
+	encoded, digest, err := EncodeStrict(*snapshot)
+	if err != nil {
+		return false, err
+	}
+	finalizeContext, cancel := worker.finalizeContext(ctx)
+	updated, err := worker.store.CheckpointSnapshot(finalizeContext, SnapshotCheckpoint{
+		UserID: claim.UserID, ID: claim.ID, LeaseToken: claim.LeaseToken,
+		InputSnapshot: encoded, InputHash: digest,
+	})
+	cancel()
+	if err == nil {
+		claim.Record = updated
+	}
+	return false, err
 }
 
 func (worker *Worker) resolveSessionAcoustics(

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -40,6 +40,70 @@ func TestWorkerConfigurationRejectsIELTSDeadlineThatCutsRepairRound(t *testing.T
 	}
 }
 
+func TestWorkerPart2ProfileReusesReadyPart1Profile(t *testing.T) {
+	now := time.Now().UTC()
+	claim := profileClaimFixture(t, now, IELTSProfileStagePart2)
+	part1 := cumulativeProfileFixture(claim.SourceID, []int{1})
+	part1Result, _, err := EncodeStrict(part1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &workerStoreFake{
+		claims: []Claim{claim},
+		records: map[Kind]Record{
+			KindIELTSPart1Profile: {Status: JobReady, Result: part1Result},
+		},
+	}
+	profiles := &profileEvaluatorsFake{}
+	worker, err := NewWorker(
+		store, &sessionEvaluatorsFake{}, profiles, &speechEvaluatorsFake{},
+		&acousticEvaluatorFake{}, store, workerConfigurationFixture(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	processed, err := worker.ProcessProfile(context.Background())
+	if err != nil || !processed || profiles.calls != 1 ||
+		profiles.last.DependencyResolution != IELTSProfileDependencyResolved ||
+		profiles.last.PreviousProfile == nil || len(store.checkpoints) != 1 ||
+		len(store.completions) != 1 {
+		t.Fatalf("ProcessProfile=(%t,%v), calls=%d snapshot=%#v checkpoints=%d completions=%d",
+			processed, err, profiles.calls, profiles.last,
+			len(store.checkpoints), len(store.completions))
+	}
+}
+
+func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
+	now := time.Now().UTC()
+	claim := sessionClaimFixture(t, now, IELTSStrategyRef)
+	part2 := cumulativeProfileFixture(claim.SourceID, []int{1, 2})
+	part2Result, _, err := EncodeStrict(part2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &workerStoreFake{
+		claims: []Claim{claim},
+		records: map[Kind]Record{
+			KindIELTSPart2Profile: {Status: JobReady, Result: part2Result},
+		},
+	}
+	sessions := &sessionEvaluatorsFake{}
+	worker := workerFixture(
+		t, store, sessions, &speechEvaluatorsFake{}, &acousticEvaluatorFake{},
+	)
+
+	processed, err := worker.ProcessSession(context.Background())
+	if err != nil || !processed || sessions.ieltsCalls != 1 ||
+		sessions.lastIELTSSnapshot.ProfileResolution != IELTSFinalProfileResolved ||
+		sessions.lastIELTSSnapshot.CumulativeProfile == nil ||
+		len(store.checkpoints) != 1 || len(store.completions) != 1 {
+		t.Fatalf("ProcessSession=(%t,%v), calls=%d snapshot=%#v checkpoints=%d completions=%d",
+			processed, err, sessions.ieltsCalls, sessions.lastIELTSSnapshot,
+			len(store.checkpoints), len(store.completions))
+	}
+}
+
 func TestWorkerReusesAcousticCheckpointAfterTextEvaluationRetry(t *testing.T) {
 	now := time.Now().UTC()
 	first := speechClaimFixture(t, now, KindPracticeTurnFeedback, nil)
@@ -191,15 +255,16 @@ func TestWorkerIELTSReportReusesTurnAcousticsAfterTextRetry(t *testing.T) {
 	)
 
 	processed, err := worker.ProcessSession(context.Background())
-	if !processed || err == nil || len(store.checkpoints) != 1 ||
+	if !processed || err == nil || len(store.checkpoints) != 2 ||
 		store.sessionAcousticCalls != 1 {
 		t.Fatalf(
 			"first ProcessSession = (%v, %v), checkpoints=%d reads=%d",
 			processed, err, len(store.checkpoints), store.sessionAcousticCalls,
 		)
 	}
-	store.claims[1].InputSnapshot = store.checkpoints[0].InputSnapshot
-	store.claims[1].InputHash = store.checkpoints[0].InputHash
+	latestCheckpoint := store.checkpoints[len(store.checkpoints)-1]
+	store.claims[1].InputSnapshot = latestCheckpoint.InputSnapshot
+	store.claims[1].InputHash = latestCheckpoint.InputHash
 
 	processed, err = worker.ProcessSession(context.Background())
 	if err != nil {
@@ -333,6 +398,7 @@ type workerStoreFake struct {
 	deferrals            []Deferral
 	sessionAcoustics     SessionAcousticRead
 	sessionAcousticCalls int
+	records              map[Kind]Record
 }
 
 func (store *workerStoreFake) DeferClaim(_ context.Context, deferral Deferral) error {
@@ -355,11 +421,17 @@ func (store *workerStoreFake) Queue(context.Context, QueueCommand) (Record, bool
 }
 
 func (store *workerStoreFake) GetRecordBySource(
-	context.Context,
-	string,
-	Kind,
-	string,
+	_ context.Context,
+	_ string,
+	kind Kind,
+	_ string,
 ) (Record, error) {
+	if record, exists := store.records[kind]; exists {
+		return record, nil
+	}
+	if kind == KindIELTSPart1Profile || kind == KindIELTSPart2Profile {
+		return Record{}, ErrNotFound
+	}
 	return Record{}, errors.New("unexpected GetRecordBySource")
 }
 
@@ -523,6 +595,7 @@ func workerFixture(
 	worker, err := NewWorker(
 		store,
 		sessions,
+		&profileEvaluatorsFake{},
 		speech,
 		acoustics,
 		store.(*workerStoreFake),
@@ -541,6 +614,11 @@ func workerConfigurationFixture() WorkerConfiguration {
 			LeaseDuration: 3 * time.Minute,
 			MaxAttempts:   3,
 		},
+		ProfileLane: ClaimLane{
+			Kinds:         []Kind{KindIELTSPart1Profile, KindIELTSPart2Profile},
+			LeaseDuration: 90 * time.Second,
+			MaxAttempts:   2,
+		},
 		SpeechLane: ClaimLane{
 			Kinds: []Kind{
 				KindPracticeTurnFeedback,
@@ -549,14 +627,123 @@ func workerConfigurationFixture() WorkerConfiguration {
 			LeaseDuration: 13 * time.Minute,
 			MaxAttempts:   3,
 		},
-		AcousticsEnabled:  true,
-		InterviewDeadline: 45 * time.Second,
-		IELTSDeadline:     110 * time.Second,
-		GeneralDeadline:   45 * time.Second,
-		SpeechDeadline:    11*time.Minute + 30*time.Second,
-		RetryDelay:        time.Second,
-		DependencyDelay:   5 * time.Second,
-		FinalizeTimeout:   5 * time.Second,
+		AcousticsEnabled:         true,
+		InterviewDeadline:        45 * time.Second,
+		IELTSDeadline:            110 * time.Second,
+		GeneralDeadline:          45 * time.Second,
+		SpeechDeadline:           11*time.Minute + 30*time.Second,
+		ProfileDeadline:          45 * time.Second,
+		RetryDelay:               time.Second,
+		DependencyDelay:          5 * time.Second,
+		ProfileDependencyMaxWait: 20 * time.Second,
+		FinalizeTimeout:          5 * time.Second,
+	}
+}
+
+type profileEvaluatorsFake struct {
+	calls int
+	last  IELTSProfileInputSnapshot
+}
+
+func (evaluator *profileEvaluatorsFake) EvaluateProfile(
+	_ context.Context,
+	_ Record,
+	snapshot IELTSProfileInputSnapshot,
+	_ ConfigLineage,
+) (json.RawMessage, error) {
+	evaluator.calls++
+	evaluator.last = snapshot
+	return json.RawMessage(`{"schema_version":"ielts-cumulative-profile/v1"}`), nil
+}
+
+func profileClaimFixture(
+	t *testing.T,
+	now time.Time,
+	stage IELTSProfileStage,
+) Claim {
+	t.Helper()
+	snapshot := IELTSProfileInputSnapshot{
+		SchemaVersion: IELTSProfileInputSchemaVersion,
+		SessionID:     "20000000-0000-4000-8000-000000000001", SessionVersion: 3,
+		Stage: stage, CompletedAt: now.Add(-time.Minute),
+		Part1Boundary: 1, Part2Boundary: 2,
+		AcousticCapability:   AcousticCapabilityEnabled,
+		DependencyResolution: IELTSProfileDependencyPending,
+		Questions: []SessionEvidenceQuestion{
+			{ID: "40000000-0000-4000-8000-000000000001", Position: 1,
+				Text: "Part 1", SpeakerParticipantID: "assistant",
+				AddresseeParticipantIDs: []string{"learner"}},
+		},
+		Turns: []SessionEvidenceTurn{
+			{ID: "30000000-0000-4000-8000-000000000001", Position: 1,
+				QuestionID:              "40000000-0000-4000-8000-000000000001",
+				RespondentParticipantID: "learner", Transcript: "Part 1 answer",
+				Effective: true, ConfirmedAt: now.Add(-time.Minute)},
+		},
+	}
+	if stage == IELTSProfileStagePart2 {
+		snapshot.Questions = append(snapshot.Questions, SessionEvidenceQuestion{
+			ID: "40000000-0000-4000-8000-000000000002", Position: 2,
+			Text: "Part 2", SpeakerParticipantID: "assistant",
+			AddresseeParticipantIDs: []string{"learner"},
+		})
+		snapshot.Turns = append(snapshot.Turns, SessionEvidenceTurn{
+			ID: "30000000-0000-4000-8000-000000000002", Position: 2,
+			QuestionID:              "40000000-0000-4000-8000-000000000002",
+			RespondentParticipantID: "learner", Transcript: "Part 2 answer",
+			Effective: true, ConfirmedAt: now.Add(-time.Minute),
+		})
+	}
+	input, inputHash, err := EncodeStrict(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage := ConfigLineage{
+		SchemaVersion:   ConfigLineageSchemaVersion,
+		StrategyRef:     "ielts-cumulative-profile/v1",
+		PipelineVersion: "ielts-cumulative-profile/v1",
+		PromptVersion:   "ielts-cumulative-profile/v1",
+		ResultSchema:    IELTSCumulativeProfileSchemaVersion,
+		Provider:        "qianwen", Model: "qwen-plus",
+	}
+	config, configHash, err := EncodeStrict(lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaseExpiry := now.Add(90 * time.Second)
+	started := now
+	kind := KindIELTSPart1Profile
+	if stage == IELTSProfileStagePart2 {
+		kind = KindIELTSPart2Profile
+	}
+	return Claim{Record: Record{
+		ID:     "11111111-1111-4111-8111-111111111119",
+		UserID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		Kind:   kind, SourceID: snapshot.SessionID, ContextID: snapshot.SessionID,
+		Status: JobRunning, InputSnapshot: input, InputHash: inputHash,
+		ConfigLineage: config, ConfigHash: configHash, AttemptCount: 1,
+		LeaseToken:     "11111111-1111-4111-8111-111111111120",
+		LeaseExpiresAt: &leaseExpiry, AvailableAt: now.Add(-time.Minute),
+		CreatedAt: now.Add(-time.Minute), UpdatedAt: now, StartedAt: &started,
+	}, LeaseDuration: 90 * time.Second}
+}
+
+func cumulativeProfileFixture(sessionID string, parts []int) IELTSCumulativeProfile {
+	dimensions := make([]IELTSProfileDimension, 0, 4)
+	for _, key := range []string{
+		"FLUENCY_COHERENCE", "LEXICAL_RESOURCE",
+		"GRAMMATICAL_RANGE_ACCURACY", "PRONUNCIATION",
+	} {
+		dimensions = append(dimensions, IELTSProfileDimension{
+			Key: key, ProvisionalBandLow: 6, ProvisionalBandHigh: 7,
+			Coverage: 0.5, Confidence: 0.5,
+			Observations: []IELTSProfileObservation{},
+		})
+	}
+	return IELTSCumulativeProfile{
+		SchemaVersion: IELTSCumulativeProfileSchemaVersion,
+		SessionID:     sessionID, CompletedParts: parts, Dimensions: dimensions,
+		Provider: "qianwen", Model: "qwen-plus",
 	}
 }
 

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -74,6 +74,59 @@ func TestWorkerPart2ProfileReusesReadyPart1Profile(t *testing.T) {
 	}
 }
 
+func TestWorkerPart2ProfileDefersWhilePart1IsRunning(t *testing.T) {
+	now := time.Now().UTC()
+	claim := profileClaimFixture(t, now, IELTSProfileStagePart2)
+	claim.CreatedAt = now
+	store := &workerStoreFake{
+		claims: []Claim{claim},
+		records: map[Kind]Record{
+			KindIELTSPart1Profile: {Status: JobRunning},
+		},
+	}
+	profiles := &profileEvaluatorsFake{}
+	worker, err := NewWorker(
+		store, &sessionEvaluatorsFake{}, profiles, &speechEvaluatorsFake{},
+		&acousticEvaluatorFake{}, store, workerConfigurationFixture(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	processed, err := worker.ProcessProfile(context.Background())
+	if err != nil || !processed || profiles.calls != 0 ||
+		len(store.deferrals) != 1 || len(store.checkpoints) != 0 ||
+		len(store.completions) != 0 {
+		t.Fatalf("ProcessProfile=(%t,%v), calls=%d deferrals=%d checkpoints=%d completions=%d",
+			processed, err, profiles.calls, len(store.deferrals),
+			len(store.checkpoints), len(store.completions))
+	}
+}
+
+func TestWorkerPart2ProfileFallsBackWhenPart1IsMissing(t *testing.T) {
+	now := time.Now().UTC()
+	claim := profileClaimFixture(t, now, IELTSProfileStagePart2)
+	store := &workerStoreFake{claims: []Claim{claim}}
+	profiles := &profileEvaluatorsFake{}
+	worker, err := NewWorker(
+		store, &sessionEvaluatorsFake{}, profiles, &speechEvaluatorsFake{},
+		&acousticEvaluatorFake{}, store, workerConfigurationFixture(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	processed, err := worker.ProcessProfile(context.Background())
+	if err != nil || !processed || profiles.calls != 1 ||
+		profiles.last.DependencyResolution != IELTSProfileDependencyFallback ||
+		profiles.last.PreviousProfile != nil || len(store.checkpoints) != 1 ||
+		len(store.completions) != 1 {
+		t.Fatalf("ProcessProfile=(%t,%v), calls=%d snapshot=%#v checkpoints=%d completions=%d",
+			processed, err, profiles.calls, profiles.last,
+			len(store.checkpoints), len(store.completions))
+	}
+}
+
 func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
 	now := time.Now().UTC()
 	claim := sessionClaimFixture(t, now, IELTSStrategyRef)

--- a/server/internal/coaching/practice/evidence.go
+++ b/server/internal/coaching/practice/evidence.go
@@ -58,3 +58,25 @@ type TurnFeedbackEvidence struct {
 	SceneCategory           string
 	PracticeMode            string
 }
+
+type IELTSProfileStage string
+
+const (
+	IELTSProfileStagePart1 IELTSProfileStage = "PART_1"
+	IELTSProfileStagePart2 IELTSProfileStage = "PART_2"
+)
+
+// IELTSPartProfileEvidence is cumulative confirmed FULL_MOCK evidence frozen
+// at a Part boundary. Part 2 deliberately includes Part 1 so Evaluation can
+// rebuild when the earlier profile is unavailable.
+type IELTSPartProfileEvidence struct {
+	UserID         string
+	SessionID      string
+	SessionVersion int
+	Stage          IELTSProfileStage
+	CompletedAt    time.Time
+	Part1Boundary  int
+	Part2Boundary  int
+	Questions      []EvidenceQuestion
+	Turns          []EvidenceTurn
+}

--- a/server/internal/coaching/practice/interaction/postgres/repository.go
+++ b/server/internal/coaching/practice/interaction/postgres/repository.go
@@ -25,12 +25,14 @@ func New(
 	pool *pgxpool.Pool,
 	completion practicepostgres.CompletionScheduler,
 	turnFeedback practicepostgres.TurnFeedbackScheduler,
+	profile practicepostgres.IELTSProfileScheduler,
 	ids practice.PracticeResourceIDGenerator,
 ) (*Repository, error) {
 	practiceRepository, err := practicepostgres.New(
 		pool,
 		completion,
 		turnFeedback,
+		profile,
 		ids,
 	)
 	if err != nil {

--- a/server/internal/coaching/practice/postgres/context_integration_test.go
+++ b/server/internal/coaching/practice/postgres/context_integration_test.go
@@ -33,6 +33,7 @@ func TestCreateSessionReplaysOnlyTheSameIdempotencyIntent(t *testing.T) {
 		pool,
 		contextCompletionScheduler{},
 		contextTurnFeedbackScheduler{},
+		contextIELTSProfileScheduler{},
 		contextIDGenerator{},
 	)
 	if err != nil {
@@ -185,6 +186,16 @@ func (contextTurnFeedbackScheduler) ScheduleConfirmedTurn(
 	context.Context,
 	pgx.Tx,
 	practice.TurnFeedbackEvidence,
+) error {
+	return nil
+}
+
+type contextIELTSProfileScheduler struct{}
+
+func (contextIELTSProfileScheduler) ScheduleCompletedPart(
+	context.Context,
+	pgx.Tx,
+	practice.IELTSPartProfileEvidence,
 ) error {
 	return nil
 }

--- a/server/internal/coaching/practice/postgres/context_voice.go
+++ b/server/internal/coaching/practice/postgres/context_voice.go
@@ -112,6 +112,20 @@ func (r *Repository) advanceTurnInTransaction(ctx context.Context, tx pgx.Tx, ac
 	if tag.RowsAffected() != 1 {
 		return practice.TurnResult{}, practice.ErrConflict
 	}
+	if stage, part1Boundary, part2Boundary, ok := ieltsProfileBoundary(
+		snapshot, nextEffective,
+	); ok {
+		evidence, err := r.ReadIELTSPartProfileEvidence(
+			ctx, tx, actor.UserID, command.SessionID,
+			stage, part1Boundary, part2Boundary,
+		)
+		if err != nil {
+			return practice.TurnResult{}, err
+		}
+		if err := r.profile.ScheduleCompletedPart(ctx, tx, evidence); err != nil {
+			return practice.TurnResult{}, err
+		}
+	}
 	if completed {
 		evidence, err := r.ReadSessionEvidence(ctx, tx, actor.UserID, command.SessionID)
 		if err != nil {
@@ -122,4 +136,27 @@ func (r *Repository) advanceTurnInTransaction(ctx context.Context, tx pgx.Tx, ac
 		}
 	}
 	return practice.TurnResult{SessionID: command.SessionID, TurnID: command.TurnID, Round: nextEffective, EffectiveTurns: nextEffective, SessionVersion: version + 1, TurnLimit: turnLimit, Completed: completed, CreatedAt: progressed.UTC()}, nil
+}
+
+func ieltsProfileBoundary(
+	snapshot practice.SessionSnapshot,
+	nextEffective int,
+) (practice.IELTSProfileStage, int, int, bool) {
+	assignment := snapshot.IELTSAssignment
+	if snapshot.PracticeMode != practice.PracticeModeFullMock ||
+		assignment == nil || len(assignment.Parts) != 3 {
+		return "", 0, 0, false
+	}
+	part1Boundary := len(assignment.Parts[0].TurnBlueprints)
+	part2Boundary := part1Boundary + len(assignment.Parts[1].TurnBlueprints)
+	switch nextEffective {
+	case part1Boundary:
+		return practice.IELTSProfileStagePart1,
+			part1Boundary, part2Boundary, true
+	case part2Boundary:
+		return practice.IELTSProfileStagePart2,
+			part1Boundary, part2Boundary, true
+	default:
+		return "", part1Boundary, part2Boundary, false
+	}
 }

--- a/server/internal/coaching/practice/postgres/context_voice_test.go
+++ b/server/internal/coaching/practice/postgres/context_voice_test.go
@@ -1,0 +1,41 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+)
+
+func TestIELTSProfileBoundarySchedulesOnlyFullMockPartBoundaries(t *testing.T) {
+	snapshot := practice.SessionSnapshot{
+		PracticeMode: practice.PracticeModeFullMock,
+		IELTSAssignment: &practice.IELTSAssignment{Parts: []practice.IELTSPart{
+			{TurnBlueprints: []string{"p1-1", "p1-2"}},
+			{TurnBlueprints: []string{"p2-1"}},
+			{TurnBlueprints: []string{"p3-1", "p3-2"}},
+		}},
+	}
+
+	tests := []struct {
+		turn  int
+		stage practice.IELTSProfileStage
+		ok    bool
+	}{
+		{turn: 1},
+		{turn: 2, stage: practice.IELTSProfileStagePart1, ok: true},
+		{turn: 3, stage: practice.IELTSProfileStagePart2, ok: true},
+		{turn: 5},
+	}
+	for _, test := range tests {
+		stage, part1, part2, ok := ieltsProfileBoundary(snapshot, test.turn)
+		if ok != test.ok || stage != test.stage || part1 != 2 || part2 != 3 {
+			t.Fatalf("turn %d boundary = (%q,%d,%d,%t)",
+				test.turn, stage, part1, part2, ok)
+		}
+	}
+
+	snapshot.PracticeMode = practice.PracticeModePart1
+	if _, _, _, ok := ieltsProfileBoundary(snapshot, 2); ok {
+		t.Fatal("standalone Part 1 must not schedule a cumulative profile")
+	}
+}

--- a/server/internal/coaching/practice/postgres/ielts_profile_evidence.go
+++ b/server/internal/coaching/practice/postgres/ielts_profile_evidence.go
@@ -1,0 +1,119 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/practice"
+	"github.com/jackc/pgx/v5"
+)
+
+func (r *Repository) ReadIELTSPartProfileEvidence(
+	ctx context.Context,
+	tx pgx.Tx,
+	ownerID string,
+	sessionID string,
+	stage practice.IELTSProfileStage,
+	part1Boundary int,
+	part2Boundary int,
+) (practice.IELTSPartProfileEvidence, error) {
+	if r == nil || tx == nil || ctx == nil || !validUserID(ownerID) ||
+		!validResourceID(sessionID) || part1Boundary < 1 ||
+		part2Boundary <= part1Boundary ||
+		(stage != practice.IELTSProfileStagePart1 &&
+			stage != practice.IELTSProfileStagePart2) {
+		return practice.IELTSPartProfileEvidence{}, practice.ErrInvalidArgument
+	}
+	boundary := part1Boundary
+	if stage == practice.IELTSProfileStagePart2 {
+		boundary = part2Boundary
+	}
+	value := practice.IELTSPartProfileEvidence{
+		Stage: stage, Part1Boundary: part1Boundary, Part2Boundary: part2Boundary,
+	}
+	var status practice.SessionStatus
+	var effectiveTurns int
+	err := tx.QueryRow(ctx, `SELECT user_id::text, session_id, version, status,
+			effective_turns
+		FROM practice_sessions
+		WHERE user_id=$1 AND session_id=$2`, ownerID, sessionID).Scan(
+		&value.UserID, &value.SessionID, &value.SessionVersion,
+		&status, &effectiveTurns,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return practice.IELTSPartProfileEvidence{}, practice.ErrNotFound
+	}
+	if err != nil {
+		return practice.IELTSPartProfileEvidence{}, err
+	}
+	if (status != practice.SessionInProgress && status != practice.SessionCompleted) ||
+		effectiveTurns < boundary {
+		return practice.IELTSPartProfileEvidence{}, practice.ErrConflict
+	}
+	rows, err := tx.Query(ctx, `SELECT DISTINCT q.question_id, q.sequence,
+			COALESCE(q.parent_question_id::text,''), q.content,
+			q.speaker_participant_id, q.addressee_participant_ids
+		FROM practice_questions q
+		JOIN practice_turns t
+		  ON t.session_id=q.session_id AND t.question_id=q.question_id
+		WHERE q.session_id=$1 AND t.status='confirmed'
+		  AND t.turn_kind='EFFECTIVE' AND t.effective_turns_after <= $2
+		ORDER BY q.sequence, q.question_id`, sessionID, boundary)
+	if err != nil {
+		return practice.IELTSPartProfileEvidence{}, err
+	}
+	for rows.Next() {
+		var question practice.EvidenceQuestion
+		if err := rows.Scan(
+			&question.ID, &question.Position, &question.ParentQuestionID,
+			&question.Text, &question.SpeakerParticipantID,
+			&question.AddresseeParticipantIDs,
+		); err != nil {
+			rows.Close()
+			return practice.IELTSPartProfileEvidence{}, err
+		}
+		value.Questions = append(value.Questions, question)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return practice.IELTSPartProfileEvidence{}, err
+	}
+	rows.Close()
+	turnRows, err := tx.Query(ctx, `SELECT t.turn_id, t.sequence,
+			t.question_id, t.respondent_participant_id, t.transcript,
+			t.confirmed_at, COALESCE(t.audio_asset_id::text,''), t.progressed_at
+		FROM practice_turns t
+		WHERE t.session_id=$1 AND t.status='confirmed'
+		  AND t.turn_kind='EFFECTIVE' AND t.effective_turns_after <= $2
+		ORDER BY t.effective_turns_after, t.sequence`, sessionID, boundary)
+	if err != nil {
+		return practice.IELTSPartProfileEvidence{}, err
+	}
+	defer turnRows.Close()
+	for turnRows.Next() {
+		var turn practice.EvidenceTurn
+		var progressedAt *time.Time
+		if err := turnRows.Scan(
+			&turn.ID, &turn.Position, &turn.QuestionID,
+			&turn.RespondentParticipantID, &turn.Transcript,
+			&turn.ConfirmedAt, &turn.AudioAssetID, &progressedAt,
+		); err != nil {
+			return practice.IELTSPartProfileEvidence{}, err
+		}
+		if progressedAt == nil {
+			return practice.IELTSPartProfileEvidence{}, practice.ErrConflict
+		}
+		turn.Effective = true
+		value.Turns = append(value.Turns, turn)
+		value.CompletedAt = progressedAt.UTC()
+	}
+	if err := turnRows.Err(); err != nil {
+		return practice.IELTSPartProfileEvidence{}, err
+	}
+	if len(value.Turns) != boundary || len(value.Questions) == 0 ||
+		value.CompletedAt.IsZero() {
+		return practice.IELTSPartProfileEvidence{}, practice.ErrConflict
+	}
+	return value, nil
+}

--- a/server/internal/coaching/practice/postgres/repository.go
+++ b/server/internal/coaching/practice/postgres/repository.go
@@ -21,6 +21,7 @@ type Repository struct {
 	afterRecordingLock func()
 	completion         CompletionScheduler
 	turnFeedback       TurnFeedbackScheduler
+	profile            IELTSProfileScheduler
 	ids                practice.PracticeResourceIDGenerator
 }
 
@@ -34,13 +35,23 @@ type TurnFeedbackScheduler interface {
 	ScheduleConfirmedTurn(context.Context, pgx.Tx, practice.TurnFeedbackEvidence) error
 }
 
+type IELTSProfileScheduler interface {
+	ScheduleCompletedPart(
+		context.Context,
+		pgx.Tx,
+		practice.IELTSPartProfileEvidence,
+	) error
+}
+
 func New(
 	pool *pgxpool.Pool,
 	completion CompletionScheduler,
 	turnFeedback TurnFeedbackScheduler,
+	profile IELTSProfileScheduler,
 	ids practice.PracticeResourceIDGenerator,
 ) (*Repository, error) {
-	if pool == nil || completion == nil || turnFeedback == nil || ids == nil {
+	if pool == nil || completion == nil || turnFeedback == nil ||
+		profile == nil || ids == nil {
 		return nil, errors.New("practice postgres dependencies are required")
 	}
 	return &Repository{
@@ -48,6 +59,7 @@ func New(
 		now:          time.Now,
 		completion:   completion,
 		turnFeedback: turnFeedback,
+		profile:      profile,
 		ids:          ids,
 	}, nil
 }

--- a/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
+++ b/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
@@ -113,6 +113,7 @@ INSERT INTO agent_threads (id,user_id) VALUES ($2,$1)
 		pool,
 		completionScheduler,
 		noopTurnFeedbackScheduler{},
+		noopIELTSProfileScheduler{},
 		identity.NewUUIDv4Generator(nil),
 	)
 	if err != nil {
@@ -261,6 +262,7 @@ func customLifecycleEvaluationRuntime(
 	worker, err := evaluation.NewWorker(
 		store,
 		sessionEvaluator,
+		customLifecycleProfileEvaluator{},
 		speechEvaluator,
 		nil,
 		nil,
@@ -270,6 +272,17 @@ func customLifecycleEvaluationRuntime(
 		t.Fatalf("compose Custom Evaluation worker: %v", err)
 	}
 	return store, scheduler, worker
+}
+
+type customLifecycleProfileEvaluator struct{}
+
+func (customLifecycleProfileEvaluator) EvaluateProfile(
+	context.Context,
+	evaluation.Record,
+	evaluation.IELTSProfileInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected IELTS profile evaluation")
 }
 
 type customLifecycleReportGenerator struct{}
@@ -336,6 +349,14 @@ func customLifecycleWorkerConfiguration() evaluation.WorkerConfiguration {
 			LeaseDuration: 3 * time.Minute,
 			MaxAttempts:   3,
 		},
+		ProfileLane: evaluation.ClaimLane{
+			Kinds: []evaluation.Kind{
+				evaluation.KindIELTSPart1Profile,
+				evaluation.KindIELTSPart2Profile,
+			},
+			LeaseDuration: 3 * time.Minute,
+			MaxAttempts:   3,
+		},
 		SpeechLane: evaluation.ClaimLane{
 			Kinds: []evaluation.Kind{
 				evaluation.KindPracticeTurnFeedback,
@@ -344,13 +365,15 @@ func customLifecycleWorkerConfiguration() evaluation.WorkerConfiguration {
 			LeaseDuration: 3 * time.Minute,
 			MaxAttempts:   3,
 		},
-		InterviewDeadline: 30 * time.Second,
-		IELTSDeadline:     110 * time.Second,
-		GeneralDeadline:   30 * time.Second,
-		SpeechDeadline:    30 * time.Second,
-		RetryDelay:        time.Second,
-		DependencyDelay:   time.Second,
-		FinalizeTimeout:   5 * time.Second,
+		InterviewDeadline:        30 * time.Second,
+		IELTSDeadline:            110 * time.Second,
+		GeneralDeadline:          30 * time.Second,
+		SpeechDeadline:           30 * time.Second,
+		ProfileDeadline:          30 * time.Second,
+		RetryDelay:               time.Second,
+		DependencyDelay:          time.Second,
+		ProfileDependencyMaxWait: 20 * time.Second,
+		FinalizeTimeout:          5 * time.Second,
 	}
 }
 

--- a/server/internal/coaching/review/postgres/retry_integration_test.go
+++ b/server/internal/coaching/review/postgres/retry_integration_test.go
@@ -42,6 +42,7 @@ func TestServiceRetryReplayAndFeedbackScopedIdempotency(t *testing.T) {
 		pool,
 		noopCompletionScheduler{},
 		noopTurnFeedbackScheduler{},
+		noopIELTSProfileScheduler{},
 		identity.NewUUIDv4Generator(nil),
 	)
 	if err != nil {
@@ -311,6 +312,16 @@ func (noopTurnFeedbackScheduler) ScheduleConfirmedTurn(
 	context.Context,
 	pgx.Tx,
 	practice.TurnFeedbackEvidence,
+) error {
+	return nil
+}
+
+type noopIELTSProfileScheduler struct{}
+
+func (noopIELTSProfileScheduler) ScheduleCompletedPart(
+	context.Context,
+	pgx.Tx,
+	practice.IELTSPartProfileEvidence,
 ) error {
 	return nil
 }

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -417,11 +417,13 @@ INSERT INTO practice_plans (
 	evaluationComposition, err := app.NewEvaluationComposition(
 		pool,
 		migrationReportGenerator{},
+		migrationReportGenerator{},
 		migrationSpeechFeedbackGenerator{},
 		nil,
 		app.EvaluationConfiguration{
 			Provider:     "qianwen",
 			SessionModel: "qwen-plus",
+			ProfileModel: "qwen-plus",
 			SpeechModel:  "qwen-plus",
 			Worker:       migrationEvaluationWorkerConfiguration(),
 		},
@@ -434,6 +436,7 @@ INSERT INTO practice_plans (
 		pool,
 		schedulers.Completion,
 		schedulers.TurnFeedback,
+		schedulers.IELTSProfile,
 		ids,
 	)
 	if err != nil {
@@ -937,6 +940,14 @@ func migrationEvaluationWorkerConfiguration() evaluation.WorkerConfiguration {
 			LeaseDuration: 3 * time.Minute,
 			MaxAttempts:   3,
 		},
+		ProfileLane: evaluation.ClaimLane{
+			Kinds: []evaluation.Kind{
+				evaluation.KindIELTSPart1Profile,
+				evaluation.KindIELTSPart2Profile,
+			},
+			LeaseDuration: 3 * time.Minute,
+			MaxAttempts:   3,
+		},
 		SpeechLane: evaluation.ClaimLane{
 			Kinds: []evaluation.Kind{
 				evaluation.KindPracticeTurnFeedback,
@@ -945,13 +956,15 @@ func migrationEvaluationWorkerConfiguration() evaluation.WorkerConfiguration {
 			LeaseDuration: 3 * time.Minute,
 			MaxAttempts:   3,
 		},
-		InterviewDeadline: 30 * time.Second,
-		IELTSDeadline:     110 * time.Second,
-		GeneralDeadline:   30 * time.Second,
-		SpeechDeadline:    30 * time.Second,
-		RetryDelay:        time.Second,
-		DependencyDelay:   time.Second,
-		FinalizeTimeout:   5 * time.Second,
+		InterviewDeadline:        30 * time.Second,
+		IELTSDeadline:            110 * time.Second,
+		GeneralDeadline:          30 * time.Second,
+		SpeechDeadline:           30 * time.Second,
+		ProfileDeadline:          30 * time.Second,
+		RetryDelay:               time.Second,
+		DependencyDelay:          time.Second,
+		ProfileDependencyMaxWait: 20 * time.Second,
+		FinalizeTimeout:          5 * time.Second,
 	}
 }
 

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -74,6 +74,12 @@ func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 
 	changed, err = runner.DownOne()
 	if err != nil || !changed {
+		t.Fatalf("DownOne to v8 Product health views = %t, %v", changed, err)
+	}
+	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
+
+	changed, err = runner.DownOne()
+	if err != nil || !changed {
 		t.Fatalf("DownOne to v7 Pending Practice actions = %t, %v", changed, err)
 	}
 	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
@@ -138,6 +144,9 @@ func TestSceneSelectionSourceMigrationTransformsPlansAndPreservesSessions(
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v8 Product health views = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v7 Pending Practice actions = %t, %v", changed, downErr)
@@ -276,6 +285,9 @@ FROM practice_sessions WHERE session_id = $1
 	}
 
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("roll back v9 = %t, %v", changed, downErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("roll back v8 = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
@@ -316,6 +328,9 @@ func TestMigratedLegacyCatalogPlanCompletesThroughFormalReport(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v8 Product health views = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v7 Pending Practice actions = %t, %v", changed, downErr)
@@ -578,6 +593,9 @@ func TestSceneSelectionSourceMigrationRejectsDownWithCustomPlan(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v8 Product health views = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v7 Pending Practice actions = %t, %v", changed, downErr)

--- a/server/internal/platform/migration/product_health_migration_integration_test.go
+++ b/server/internal/platform/migration/product_health_migration_integration_test.go
@@ -43,6 +43,10 @@ func TestProductHealthViewsAreAnonymousAccurateAndReadOnly(t *testing.T) {
 	assertProductHealthReaderPrivileges(t, admin, database, schema)
 
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("IELTS profile DownOne = %t, %v", changed, downErr)
+	}
+	assertProductHealthViewSet(t, admin, schema)
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("product health DownOne = %t, %v", changed, downErr)
 	}
 	assertProductHealthViewCount(t, admin, schema, 0)

--- a/server/internal/providers/qianwen/business_generation_test.go
+++ b/server/internal/providers/qianwen/business_generation_test.go
@@ -47,6 +47,25 @@ func TestBusinessGeneratorsMapOwnedRequests(t *testing.T) {
 			},
 		},
 		{
+			name:           "IELTS profile JSON",
+			systemPrompt:   "update provisional IELTS profile",
+			userPrompt:     "frozen Part evidence",
+			responseFormat: protocol.TextResponseFormatJSONSchema,
+			schemaName:     "ielts_cumulative_profile",
+			generate: func(client *textClient) (string, string, string, error) {
+				result, err := (&EvaluationProfileGenerator{
+					generator: client,
+				}).Generate(
+					context.Background(),
+					textgeneration.Request{
+						SystemPrompt: "update provisional IELTS profile",
+						UserPrompt:   "frozen Part evidence",
+					},
+				)
+				return result.Provider, result.Model, result.Content, err
+			},
+		},
+		{
 			name:           "Summary JSON",
 			systemPrompt:   "summarize the thread",
 			userPrompt:     "thread transcript",

--- a/server/internal/providers/qianwen/evaluation_profile.go
+++ b/server/internal/providers/qianwen/evaluation_profile.go
@@ -1,0 +1,96 @@
+package qianwen
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
+	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
+)
+
+type EvaluationProfileGenerator struct{ generator *textClient }
+
+func NewEvaluationProfileGenerator(
+	configuration TextConfig,
+	apiKey string,
+) (*EvaluationProfileGenerator, error) {
+	generator, err := newTextClient(configuration, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &EvaluationProfileGenerator{generator: generator}, nil
+}
+
+func (generator *EvaluationProfileGenerator) Generate(
+	ctx context.Context,
+	request textgeneration.Request,
+) (textgeneration.Result, error) {
+	if generator == nil || generator.generator == nil || ctx == nil ||
+		strings.TrimSpace(request.SystemPrompt) == "" ||
+		strings.TrimSpace(request.UserPrompt) == "" {
+		return textgeneration.Result{}, errors.New("qianwen: invalid Evaluation profile request")
+	}
+	generated, err := generator.generator.Generate(ctx, protocol.TextRequest{
+		Messages: []protocol.TextMessage{
+			{Role: protocol.TextRoleSystem, Content: request.SystemPrompt},
+			{Role: protocol.TextRoleUser, Content: request.UserPrompt},
+		},
+		ResponseFormat: protocol.TextResponseFormatJSONSchema,
+		ResponseSchema: &protocol.JSONSchemaDefinition{
+			Name: "ielts_cumulative_profile", Strict: true,
+			Schema: ieltsCumulativeProfileSchema(),
+		},
+	})
+	if err != nil {
+		return textgeneration.Result{}, err
+	}
+	return textgeneration.Result{
+		RequestID: generated.ID, Content: generated.Content,
+		Provider: generated.Provider, Model: generated.Model,
+	}, nil
+}
+
+func ieltsCumulativeProfileSchema() map[string]any {
+	evidence := map[string]any{
+		"type": "object", "additionalProperties": false,
+		"required": []any{"turn_id", "quote", "occurrence", "part"},
+		"properties": map[string]any{
+			"turn_id":    map[string]any{"type": "string"},
+			"quote":      map[string]any{"type": "string", "maxLength": 4096},
+			"occurrence": map[string]any{"type": "integer", "minimum": 1},
+			"part":       map[string]any{"type": "integer", "enum": []any{1, 2}},
+		},
+	}
+	observation := map[string]any{
+		"type": "object", "additionalProperties": false,
+		"required": []any{"kind", "reason_code", "evidence"},
+		"properties": map[string]any{
+			"kind":        map[string]any{"type": "string", "enum": []any{"STRENGTH", "IMPROVEMENT"}},
+			"reason_code": map[string]any{"type": "string"},
+			"evidence":    map[string]any{"type": "array", "minItems": 1, "maxItems": 2, "items": evidence},
+		},
+	}
+	dimension := map[string]any{
+		"type": "object", "additionalProperties": false,
+		"required": []any{"key", "provisional_band_low", "provisional_band_high", "coverage", "confidence", "observations"},
+		"properties": map[string]any{
+			"key":                   map[string]any{"type": "string"},
+			"provisional_band_low":  map[string]any{"type": "number", "minimum": 0, "maximum": 9, "multipleOf": 0.5},
+			"provisional_band_high": map[string]any{"type": "number", "minimum": 0, "maximum": 9, "multipleOf": 0.5},
+			"coverage":              map[string]any{"type": "number", "minimum": 0, "maximum": 1},
+			"confidence":            map[string]any{"type": "number", "minimum": 0, "maximum": 1},
+			"observations":          map[string]any{"type": "array", "maxItems": 3, "items": observation},
+		},
+	}
+	return map[string]any{
+		"type": "object", "additionalProperties": false,
+		"required": []any{"completed_parts", "dimensions"},
+		"properties": map[string]any{
+			"completed_parts": map[string]any{"type": "array", "minItems": 1, "maxItems": 2, "items": map[string]any{"type": "integer", "enum": []any{1, 2}}},
+			"dimensions":      map[string]any{"type": "array", "minItems": 4, "maxItems": 4, "items": dimension},
+		},
+	}
+}
+
+var _ textgeneration.Generator = (*EvaluationProfileGenerator)(nil)

--- a/server/internal/providers/qianwen/evaluation_profile.go
+++ b/server/internal/providers/qianwen/evaluation_profile.go
@@ -76,8 +76,8 @@ func ieltsCumulativeProfileSchema() map[string]any {
 		"required": []any{"key", "provisional_band_low", "provisional_band_high", "coverage", "confidence", "observations"},
 		"properties": map[string]any{
 			"key":                   map[string]any{"type": "string"},
-			"provisional_band_low":  map[string]any{"type": "number", "minimum": 0, "maximum": 9, "multipleOf": 0.5},
-			"provisional_band_high": map[string]any{"type": "number", "minimum": 0, "maximum": 9, "multipleOf": 0.5},
+			"provisional_band_low":  map[string]any{"type": "number", "minimum": 0, "maximum": 9},
+			"provisional_band_high": map[string]any{"type": "number", "minimum": 0, "maximum": 9},
 			"coverage":              map[string]any{"type": "number", "minimum": 0, "maximum": 1},
 			"confidence":            map[string]any{"type": "number", "minimum": 0, "maximum": 1},
 			"observations":          map[string]any{"type": "array", "maxItems": 3, "items": observation},

--- a/server/internal/providers/qianwen/evaluation_profile_test.go
+++ b/server/internal/providers/qianwen/evaluation_profile_test.go
@@ -1,0 +1,23 @@
+package qianwen
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestIELTSCumulativeProfileSchemaUsesCompatibleBandConstraints(t *testing.T) {
+	encoded, err := json.Marshal(ieltsCumulativeProfileSchema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := string(encoded)
+	if strings.Contains(schema, `"multipleOf"`) {
+		t.Fatalf("profile schema contains unsupported multipleOf: %s", schema)
+	}
+	for _, field := range []string{"provisional_band_low", "provisional_band_high"} {
+		if !strings.Contains(schema, `"`+field+`":{"maximum":9,"minimum":0,"type":"number"}`) {
+			t.Fatalf("profile schema does not constrain %s to a 0-9 number: %s", field, schema)
+		}
+	}
+}

--- a/server/migrations/000009_ielts_incremental_profile.down.sql
+++ b/server/migrations/000009_ielts_incremental_profile.down.sql
@@ -1,5 +1,16 @@
 BEGIN;
 
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM evaluations
+        WHERE kind IN ('IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE')
+    ) THEN
+        RAISE EXCEPTION 'cannot roll back IELTS incremental profiles while profile evaluations exist';
+    END IF;
+END
+$$;
+
 ALTER TABLE evaluations DROP CONSTRAINT evaluations_kind_check;
 
 ALTER TABLE evaluations ADD CONSTRAINT evaluations_kind_check CHECK (

--- a/server/migrations/000009_ielts_incremental_profile.down.sql
+++ b/server/migrations/000009_ielts_incremental_profile.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE evaluations DROP CONSTRAINT evaluations_kind_check;
+
+ALTER TABLE evaluations ADD CONSTRAINT evaluations_kind_check CHECK (
+    kind IN (
+        'SESSION_REPORT',
+        'PRACTICE_TURN_FEEDBACK',
+        'AGENT_MESSAGE_FEEDBACK'
+    )
+);
+
+COMMIT;

--- a/server/migrations/000009_ielts_incremental_profile.up.sql
+++ b/server/migrations/000009_ielts_incremental_profile.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE evaluations DROP CONSTRAINT evaluations_kind_check;
+
+ALTER TABLE evaluations ADD CONSTRAINT evaluations_kind_check CHECK (
+    kind IN (
+        'SESSION_REPORT',
+        'PRACTICE_TURN_FEEDBACK',
+        'AGENT_MESSAGE_FEEDBACK',
+        'IELTS_PART1_PROFILE',
+        'IELTS_PART2_PROFILE'
+    )
+);
+
+COMMIT;

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -209,6 +209,18 @@ func TestProductHealthMigrationKeepsAnonymousUTCViewsFailClosed(t *testing.T) {
 	}
 }
 
+func TestIELTSIncrementalProfileRollbackProtectsExistingRows(t *testing.T) {
+	down := readMigration(t, "000009_ielts_incremental_profile.down.sql")
+	for _, required := range []string{
+		"kind IN ('IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE')",
+		"cannot roll back IELTS incremental profiles while profile evaluations exist",
+	} {
+		if !strings.Contains(down, required) {
+			t.Errorf("IELTS incremental profile rollback is missing %q", required)
+		}
+	}
+}
+
 func readMigration(t *testing.T, name string) string {
 	t.Helper()
 	content, err := Files.ReadFile(name)

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -50,6 +50,8 @@ func TestEveryMigrationPairIsEmbedded(t *testing.T) {
 		"000007_pending_practice_actions.up.sql",
 		"000008_product_health_views.down.sql",
 		"000008_product_health_views.up.sql",
+		"000009_ielts_incremental_profile.down.sql",
+		"000009_ielts_incremental_profile.up.sql",
 	}
 	slices.Sort(files)
 	if !slices.Equal(files, want) {
@@ -75,6 +77,8 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		"000007_pending_practice_actions.down.sql",
 		"000008_product_health_views.up.sql",
 		"000008_product_health_views.down.sql",
+		"000009_ielts_incremental_profile.up.sql",
+		"000009_ielts_incremental_profile.down.sql",
 	} {
 		sql := readMigration(t, name)
 		if !strings.HasPrefix(sql, "BEGIN;") {


### PR DESCRIPTION
## 功能描述

将 IELTS 完整模考报告生成改为增量评估：

- Part 1 完成后异步生成暂定能力画像 v1。
- Part 2 完成后复用 v1，仅用 Part 2 新证据更新为 v2。
- Part 3 完成后复用 v2，并结合 Part 3 原始证据生成最终四项评分和总报告。
- 单项 Part 1/2/3 练习保持原逻辑；本 PR 不涉及 Android 报告加载问题。

Closes #922

## 实现思路

- 在 Practice 的事务边界识别完整模考 Part 1/2 完成点，并持久化两类独立 evaluation job。
- 新增严格版本化的累计画像输入/输出协议和千问 JSON Schema 适配器。
- 增加独立 profile worker lane（2 并发），避免画像任务阻塞最终报告和逐题语音反馈。
- Part 2 最多等待 Part 1 画像 20 秒；最终报告最多等待 Part 2 画像 20 秒。依赖缺失、失败或超时后回退到原始全量证据流程，保证仍会生成报告。
- 最终报告有 v2 画像时只向模型发送累计画像和 Part 3 原始证据；正式报告归一化仍使用完整冻结快照校验引用。
- 新增数据库迁移，扩展 evaluations.kind 约束。

## 可复现测试

```bash
make check-go
```

已在本分支执行通过，包括：

- `go vet ./...`
- `go test -count=1 ./...`
- 完整模考 Part 1/2 边界触发测试
- Part 2 只发送新增证据测试
- 最终报告只发送 Part 3 原始证据测试
- worker 画像依赖复用与最终快路径测试
- migration 嵌入与集成测试
