### PR TITLE
fix(mobile): 修复冷启动首页误显示回复中

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -714,6 +714,7 @@ class _SpeakUpShellState extends State<SpeakUpShell>
         isLoadingEarlierMessages:
             widget.conversationController.isLoadingEarlierMessages,
         isBusy: widget.conversationController.isBusy,
+        isRestoring: widget.conversationController.isRestoring,
         errorMessage:
             widget.conversationController.errorMessage ??
             widget.conversationController.threadHistoryErrorMessage,

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -64,6 +64,7 @@ class ConversationPage extends StatefulWidget {
     this.hasEarlierMessages = false,
     this.isLoadingEarlierMessages = false,
     this.isBusy = false,
+    this.isRestoring = false,
     this.errorMessage,
     this.onSubmitText,
     this.onRetryOperation,
@@ -104,6 +105,7 @@ class ConversationPage extends StatefulWidget {
   final bool hasEarlierMessages;
   final bool isLoadingEarlierMessages;
   final bool isBusy;
+  final bool isRestoring;
   final String? errorMessage;
   final Future<bool> Function(String)? onSubmitText;
   final VoidCallback? onRetryOperation;
@@ -290,21 +292,22 @@ class ConversationPage extends StatefulWidget {
                             const SizedBox(height: 14),
                             Center(
                               child: Semantics(
-                                label: 'SpeakUp 正在处理',
-                                child: const Wrap(
-                                  key: Key('agent-operation-progress'),
+                                excludeSemantics: true,
+                                label: isRestoring ? '正在加载对话' : 'SpeakUp 正在处理',
+                                child: Wrap(
+                                  key: const Key('agent-operation-progress'),
                                   alignment: WrapAlignment.center,
                                   crossAxisAlignment: WrapCrossAlignment.center,
                                   spacing: 10,
                                   children: [
-                                    SizedBox.square(
+                                    const SizedBox.square(
                                       dimension: 18,
                                       child: CircularProgressIndicator(
                                         strokeWidth: 2,
                                       ),
                                     ),
                                     Text(
-                                      'SpeakUp 正在回复…',
+                                      isRestoring ? '正在加载对话…' : 'SpeakUp 正在回复…',
                                       style: SpeakUpDesign.meta,
                                     ),
                                   ],

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -79,6 +79,7 @@ final class ConversationController extends ChangeNotifier {
   bool get isLoadingEarlierMessages => _loadingEarlierMessages;
   String? get errorMessage => _errorMessage;
   bool get isBusy => _busy || _threadTransitionInFlight;
+  bool get isRestoring => !_initialized && _busy;
   bool get canRetry => _retry != null;
 
   Future<void> initialize() async {

--- a/mobile/test/agent/conversation_controller_test.dart
+++ b/mobile/test/agent/conversation_controller_test.dart
@@ -133,6 +133,31 @@ void main() {
   });
 
   test(
+    'exposes conversation restoration separately from generic busy work',
+    () async {
+      final gate = Completer<void>();
+      final client = _HistoryAgentClient(
+        startsWithoutHistory: true,
+        initializationGate: gate,
+      );
+      final controller = ConversationController(client: client);
+      addTearDown(controller.dispose);
+
+      final restoration = controller.initialize();
+      await client.initialListStarted.future;
+
+      expect(controller.isBusy, isTrue);
+      expect(controller.isRestoring, isTrue);
+
+      gate.complete();
+      await restoration;
+
+      expect(controller.isBusy, isFalse);
+      expect(controller.isRestoring, isFalse);
+    },
+  );
+
+  test(
     'Fake client cancels old account work and reuses stable write IDs',
     () async {
       final client = FakeAgentClient(delay: const Duration(milliseconds: 20));

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -585,6 +585,23 @@ void main() {
     expect(find.byKey(const Key('agent-assistant-streaming')), findsNothing);
   });
 
+  testWidgets('conversation restore is not presented as an Agent reply', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ConversationPage(isBusy: true, isRestoring: true),
+      ),
+    );
+
+    expect(find.text('正在加载对话…'), findsOneWidget);
+    expect(find.text('SpeakUp 正在回复…'), findsNothing);
+    expect(
+      tester.getSemantics(find.byKey(const Key('agent-operation-progress'))),
+      isSemantics(label: '正在加载对话'),
+    );
+  });
+
   testWidgets('older Message pagination is visible and accessible', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

- 冷启动恢复对话历史时显示“正在加载对话…”，不再误报“SpeakUp 正在回复…”。
- 真实 Agent 消息发送期间继续显示原有回复进度。
- 恢复进度使用单一无障碍语义标签，避免重复朗读。

## 实现思路

- 在 `ConversationController` 上显式暴露恢复态，将其与通用 `isBusy` 区分。
- 由 `SpeakUpShell` 把恢复态传给 `ConversationPage`。
- 页面根据恢复态选择正确的可见文案和 Semantics 文案，不改变现有并发互斥与输入禁用规则。

## 可复现测试

```bash
cd mobile
dart analyze
flutter test --no-pub
```

结果：静态分析通过；Flutter 全量测试 797/797 通过。

Android 真机（Xiaomi 2211133C，Android 16）验证：强制退出后重新打开，恢复阶段显示“正在加载对话…”，恢复完成后正常展示会话。

Closes #920
