### PR TITLE
fix(mobile): 冷启动恢复期间保持录音可用

### DIFF
--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -715,6 +715,8 @@ class _SpeakUpShellState extends State<SpeakUpShell>
             widget.conversationController.isLoadingEarlierMessages,
         isBusy: widget.conversationController.isBusy,
         isRestoring: widget.conversationController.isRestoring,
+        isReplyPending: widget.conversationController.isReplyPending,
+        isComposerBlocked: widget.conversationController.isComposerBlocked,
         errorMessage:
             widget.conversationController.errorMessage ??
             widget.conversationController.threadHistoryErrorMessage,

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -65,6 +65,8 @@ class ConversationPage extends StatefulWidget {
     this.isLoadingEarlierMessages = false,
     this.isBusy = false,
     this.isRestoring = false,
+    this.isReplyPending = false,
+    this.isComposerBlocked = false,
     this.errorMessage,
     this.onSubmitText,
     this.onRetryOperation,
@@ -106,6 +108,8 @@ class ConversationPage extends StatefulWidget {
   final bool isLoadingEarlierMessages;
   final bool isBusy;
   final bool isRestoring;
+  final bool isReplyPending;
+  final bool isComposerBlocked;
   final String? errorMessage;
   final Future<bool> Function(String)? onSubmitText;
   final VoidCallback? onRetryOperation;
@@ -150,7 +154,7 @@ class ConversationPage extends StatefulWidget {
       AgentVoiceComposerState.awaitingAssistant => true,
       _ => false,
     };
-    final replyPending = isBusy || voiceShowsReplyProgress;
+    final replyPending = isReplyPending || voiceShowsReplyProgress;
     const topContentInset = 65.0;
     const topOverlayExtent = 76.0;
     final bottomOverlayExtent = composerBottom + composerHeight + 16;
@@ -288,7 +292,8 @@ class ConversationPage extends StatefulWidget {
                                   : null,
                             ),
                           ],
-                          if (isBusy && !voiceShowsReplyProgress) ...[
+                          if ((isRestoring || isReplyPending) &&
+                              !voiceShowsReplyProgress) ...[
                             const SizedBox(height: 14),
                             Center(
                               child: Semantics(
@@ -407,10 +412,11 @@ class ConversationPage extends StatefulWidget {
                             acceptedUserMessageText: acceptedUserMessage?.text,
                             onStartVoice: onStartVoice,
                             voiceController: voiceController,
-                            voiceEnabled: voiceController != null && !isBusy,
+                            voiceEnabled:
+                                voiceController != null && !isComposerBlocked,
                             onSubmitText: onSubmitText,
                             enabled: canCompose,
-                            isBusy: isBusy,
+                            isBusy: isComposerBlocked,
                             pendingImages: pendingImages,
                             imageErrorMessage: imageErrorMessage,
                             imageSelectionInFlight: imageSelectionInFlight,

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -55,6 +55,7 @@ final class ConversationController extends ChangeNotifier {
   _ConversationRetry? _retry;
   bool _initialized = false;
   bool _busy = false;
+  bool _replyPending = false;
   bool _disposed = false;
   int _epoch = 0;
   Future<void>? _initializationFuture;
@@ -78,8 +79,11 @@ final class ConversationController extends ChangeNotifier {
   bool get hasEarlierMessages => _nextMessageCursor != null;
   bool get isLoadingEarlierMessages => _loadingEarlierMessages;
   String? get errorMessage => _errorMessage;
-  bool get isBusy => _busy || _threadTransitionInFlight;
-  bool get isRestoring => !_initialized && _busy;
+  bool get isBusy => _busy || _replyPending || _threadTransitionInFlight;
+  bool get isRestoring => !_initialized && _busy && !_replyPending;
+  bool get isReplyPending => _replyPending;
+  bool get isComposerBlocked =>
+      _replyPending || _threadTransitionInFlight || (_busy && !isRestoring);
   bool get canRetry => _retry != null;
 
   Future<void> initialize() async {
@@ -657,7 +661,7 @@ final class ConversationController extends ChangeNotifier {
     final fence = _captureOperationFence(threadId: threadId);
     _retry = null;
     _errorMessage = null;
-    _setBusy(true);
+    _setReplyPending(true);
     if (operation.imageAssetIds.isEmpty && client is AgentStreamingTextClient) {
       final streamingClient = client as AgentStreamingTextClient;
       final committedUserMessageID = operation.committedUserMessageID;
@@ -739,7 +743,7 @@ final class ConversationController extends ChangeNotifier {
       return false;
     } finally {
       if (_isOperationCurrent(fence)) {
-        _setBusy(false);
+        _setReplyPending(false);
       }
     }
   }
@@ -914,7 +918,7 @@ final class ConversationController extends ChangeNotifier {
     } finally {
       frameTimer?.cancel();
       if (_isOperationCurrent(fence)) {
-        _setBusy(false);
+        _setReplyPending(false);
       }
     }
   }
@@ -1264,8 +1268,7 @@ final class ConversationController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<bool> prepareToLeaveConversation() async =>
-      !_disposed && !_busy && !_threadTransitionInFlight;
+  Future<bool> prepareToLeaveConversation() async => !_disposed && !isBusy;
 
   Future<void> clearPrivateState() async {
     _epoch++;
@@ -1287,6 +1290,7 @@ final class ConversationController extends ChangeNotifier {
     _retry = null;
     _initialized = false;
     _busy = false;
+    _replyPending = false;
     if (!_disposed) {
       notifyListeners();
     }
@@ -1382,6 +1386,14 @@ final class ConversationController extends ChangeNotifier {
       return;
     }
     _busy = value;
+    notifyListeners();
+  }
+
+  void _setReplyPending(bool value) {
+    if (_disposed) {
+      return;
+    }
+    _replyPending = value;
     notifyListeners();
   }
 

--- a/mobile/test/agent/agent_voice_flow_test.dart
+++ b/mobile/test/agent/agent_voice_flow_test.dart
@@ -19,6 +19,57 @@ import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 
 void main() {
+  testWidgets(
+    'cold-start restore keeps recording available without reply progress',
+    (tester) async {
+      final conversationController = ConversationController(
+        client: FakeAgentClient(delay: const Duration(milliseconds: 100)),
+      );
+      final composerController = ComposerController(
+        conversationController: conversationController,
+        voiceClient: FakeAgentVoiceClient(),
+      );
+      addTearDown(() {
+        composerController.dispose();
+        conversationController.dispose();
+      });
+
+      await tester.pumpWidget(
+        SpeakUpApp.preview(
+          conversationController: conversationController,
+          composerController: composerController,
+        ),
+      );
+
+      expect(conversationController.isBusy, isTrue);
+      expect(conversationController.isRestoring, isTrue);
+      expect(conversationController.isReplyPending, isFalse);
+      expect(conversationController.isComposerBlocked, isFalse);
+      expect(find.byKey(const Key('agent-operation-progress')), findsOneWidget);
+      expect(find.text('正在加载对话…'), findsOneWidget);
+      expect(find.text('SpeakUp 正在回复…'), findsNothing);
+      expect(find.text('点击或长按说话'), findsOneWidget);
+      expect(find.text('暂时无法录音'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('agent-mic-placeholder')));
+      await _pumpUntil(
+        tester,
+        () =>
+            composerController.voiceController?.state ==
+            AgentVoiceComposerState.recording,
+      );
+
+      expect(
+        composerController.voiceController?.state,
+        AgentVoiceComposerState.recording,
+      );
+      expect(find.byKey(const Key('agent-operation-progress')), findsNothing);
+
+      await composerController.voiceController!.cancel();
+      await tester.pump();
+    },
+  );
+
   testWidgets('home microphone commits a playable voice Message', (
     tester,
   ) async {

--- a/mobile/test/agent/conversation_controller_test.dart
+++ b/mobile/test/agent/conversation_controller_test.dart
@@ -8,6 +8,40 @@ import 'package:speakup/features/agent/conversation/agent_models.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('a real text Run is exposed as reply pending', () async {
+    final client = _HistoryAgentClient(controlOldSend: true);
+    final controller = ConversationController(client: client);
+    addTearDown(controller.dispose);
+    await controller.initialize();
+
+    final sending = controller.sendText('real user message');
+    await client.sendStarted.future;
+
+    expect(controller.isBusy, isTrue);
+    expect(controller.isRestoring, isFalse);
+    expect(controller.isReplyPending, isTrue);
+    expect(controller.isComposerBlocked, isTrue);
+
+    client.sendResult.complete(
+      const AgentExchange(
+        userMessage: AgentMessage(
+          id: 'message_real_user',
+          role: AgentMessageRole.user,
+          text: 'real user message',
+        ),
+        assistantMessage: AgentMessage(
+          id: 'message_real_assistant',
+          role: AgentMessageRole.assistant,
+          text: 'real assistant reply',
+        ),
+      ),
+    );
+    expect(await sending, isTrue);
+    expect(controller.isBusy, isFalse);
+    expect(controller.isReplyPending, isFalse);
+    expect(controller.isComposerBlocked, isFalse);
+  });
+
   test(
     'clears UI before awaiting client cleanup and discards a late response',
     () async {
@@ -148,12 +182,16 @@ void main() {
 
       expect(controller.isBusy, isTrue);
       expect(controller.isRestoring, isTrue);
+      expect(controller.isReplyPending, isFalse);
+      expect(controller.isComposerBlocked, isFalse);
 
       gate.complete();
       await restoration;
 
       expect(controller.isBusy, isFalse);
       expect(controller.isRestoring, isFalse);
+      expect(controller.isReplyPending, isFalse);
+      expect(controller.isComposerBlocked, isFalse);
     },
   );
 
@@ -324,6 +362,7 @@ void main() {
     await client.createStarted.future;
 
     expect(controller.isThreadTransitionInFlight, isTrue);
+    expect(controller.isComposerBlocked, isTrue);
     expect(await controller.createThread(), isFalse);
     expect(client.createCalls, 1);
 
@@ -331,6 +370,7 @@ void main() {
     expect(await firstCreate, isTrue);
     expect(client.createCalls, 1);
     expect(controller.isThreadTransitionInFlight, isFalse);
+    expect(controller.isComposerBlocked, isFalse);
   });
 
   test(

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -542,6 +542,8 @@ void main() {
         home: ConversationPage(
           hasFocusedThread: false,
           isBusy: true,
+          isReplyPending: true,
+          isComposerBlocked: true,
           onCreateConversation: () {},
           onSubmitText: (_) async => true,
         ),
@@ -564,6 +566,8 @@ void main() {
       const MaterialApp(
         home: ConversationPage(
           isBusy: true,
+          isReplyPending: true,
+          isComposerBlocked: true,
           messages: <AgentMessage>[
             AgentMessage(
               id: 'user-message',


### PR DESCRIPTION
## 功能描述

- 保留 #926 的“正在加载对话…”恢复提示，不再把恢复误报为 Agent 回复。
- 纯会话恢复期间保持首页录音入口可用；用户点击后，现有 Composer 流程会等待恢复完成再安全开始录音。
- 真实文本 Run 和线程切换等冲突操作仍禁用 Composer 操作。

## 实现思路

- `ConversationController` 单独暴露真实文本 Run 的 `isReplyPending`，并基于恢复、回复与线程切换状态给出 `isComposerBlocked`。
- `ConversationPage` 分别使用恢复态渲染加载提示、使用回复态渲染回复提示、使用 Composer 门禁控制输入和录音。
- 不修改 Agent Client 协议，也不增加兜底或新依赖。

## 可复现测试

```bash
cd mobile
flutter test test/agent/conversation_controller_test.dart test/agent/agent_voice_flow_test.dart test/speak_up_app_test.dart
flutter analyze
```

结果：相关整文件测试 75/75 通过；静态分析无问题。

当前执行环境没有 Android 设备，Android 真机的“强制退出 → 重开 → 恢复阶段点击录音”将在 Staging 验收时补做。

Closes #929
Related #920
Follow-up to #926