### PR TITLE
fix(observability): 持久化安全检查成功时间

### DIFF
--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -38,7 +38,9 @@ Safety-check success time comes only from the mtime of three fixed markers under
 on systemd's volatile exit timestamps. The directory must be `root:root` mode
 `0700`, and each empty marker must be `root:root` mode `0600`. A missing marker,
 non-regular file, ownership or mode mismatch, or future mtime exports both
-success and timestamp as zero for that check.
+success and timestamp as zero for that check. Each producer removes only its
+own marker before a new attempt and recreates it only after success, so an
+in-progress or failed later run cannot inherit an older success.
 
 All container images and runtime limits are explicit. Grafana is the only
 service with a published port, and that port is `127.0.0.1:13000`.

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -33,6 +33,13 @@ also time-bounded: the twice-daily TLS renewal becomes stale after 18 hours,
 while each explicitly named PostgreSQL or Portal restore check becomes stale
 after 31 days even when its previous run succeeded.
 
+Safety-check success time comes only from the mtime of three fixed markers under
+`/var/lib/speakup/safety-checks`; the exporter does not parse journals or depend
+on systemd's volatile exit timestamps. The directory must be `root:root` mode
+`0700`, and each empty marker must be `root:root` mode `0600`. A missing marker,
+non-regular file, ownership or mode mismatch, or future mtime exports both
+success and timestamp as zero for that check.
+
 All container images and runtime limits are explicit. Grafana is the only
 service with a published port, and that port is `127.0.0.1:13000`.
 
@@ -195,15 +202,18 @@ switching it so rollback selects an exact source. Then:
      --pgpass-file /etc/speakup/product-health-reader.pgpass
    ```
 
-3. Install `xe3-speakup-export-metrics` as
+3. Install the current PostgreSQL restore-check, Portal SQLite restore-check,
+   and TLS renewal units from their deployment directories. Reload systemd and
+   successfully run each check once so systemd creates its persistent marker.
+4. Install `xe3-speakup-export-metrics` as
    `/usr/local/sbin/xe3-speakup-export-metrics` with mode `0755`.
-4. Install the metrics service/timer under `/etc/systemd/system`, reload systemd,
+5. Install the metrics service/timer under `/etc/systemd/system`, reload systemd,
    and start the timer.
-5. Install `xe3-speakup-nginx.logrotate` as
+6. Install `xe3-speakup-nginx.logrotate` as
    `/etc/logrotate.d/xe3-speakup-nginx` with mode `0644`.
-6. Recreate only the SpeakUp Staging and Production containers so their
+7. Recreate only the SpeakUp Staging and Production containers so their
    per-container `json-file` limits and internal metrics listener take effect.
-7. Start the monitoring stack with the private environment file:
+8. Start the monitoring stack with the private environment file:
 
    ```bash
    docker compose \
@@ -212,10 +222,17 @@ switching it so rollback selects an exact source. Then:
      up --detach --pull always --wait
    ```
 
-8. Confirm every Prometheus target is up and the Product Health datasource can
+9. Confirm every Prometheus target is up and the Product Health datasource can
    query only its five views from a loopback Grafana session.
-9. After DNS/TLS validation, install `monitor-nginx.conf`, run
+10. After DNS/TLS validation, install `monitor-nginx.conf`, run
    `/usr/local/nginx/sbin/nginx -t`, and reload only after it succeeds.
+
+For an existing installation, reinstall all three producer units before the
+new exporter, run `systemctl daemon-reload`, then start each check manually.
+Previous journal or unit timestamps are intentionally not migrated or inferred;
+until a check completes successfully, its metrics remain `0/0`. Do not create
+or touch a marker by hand. The `StateDirectory=` contract keeps valid markers
+across later daemon reloads and host reboots.
 
 Do not use `docker compose down --volumes`; the three named observability volumes
 contain monitoring history, Alertmanager state, and Grafana configuration.

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -216,11 +216,28 @@ grep -Fq 'speakup_host_filesystem_avail_bytes{mountpoint="/"} 250000' "$metrics_
 grep -Fq 'speakup_host_filesystem_files_free{mountpoint="/"} 500' "$metrics_file" ||
   fail 'host root free inodes were not exported'
 
+# Each unit removes only its own previous success marker before a later run.
+# If that run fails, its metric fails closed while the other successes remain.
 MISSING_SAFETY_MARKER=postgres-restore-check.success \
   PATH="$temporary_directory/fake-bin:$PATH" \
   "$exporter" --output "$metrics_file"
 assert_safety_metric postgres_restore_check xe3-postgres-restore-check.service 0 0
 assert_safety_metric portal_restore_check xe3-portal-sqlite-restore-check.service 1 1787536984
+assert_safety_metric tls_renewal xe3-speakup-tls-renew.service 1 1787540585
+
+MISSING_SAFETY_MARKER=portal-sqlite-restore-check.success \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+assert_safety_metric postgres_restore_check xe3-postgres-restore-check.service 1 1787533323
+assert_safety_metric portal_restore_check xe3-portal-sqlite-restore-check.service 0 0
+assert_safety_metric tls_renewal xe3-speakup-tls-renew.service 1 1787540585
+
+MISSING_SAFETY_MARKER=tls-renewal.success \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+assert_safety_metric postgres_restore_check xe3-postgres-restore-check.service 1 1787533323
+assert_safety_metric portal_restore_check xe3-portal-sqlite-restore-check.service 1 1787536984
+assert_safety_metric tls_renewal xe3-speakup-tls-renew.service 0 0
 
 UNSAFE_SAFETY_MARKER=portal-sqlite-restore-check.success \
   PATH="$temporary_directory/fake-bin:$PATH" \

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -104,17 +104,48 @@ set -euo pipefail
 printf '%s\n' '1795219200'
 EOF
 
-cat >"$temporary_directory/fake-bin/systemctl" <<'EOF'
+cat >"$temporary_directory/fake-bin/stat" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-case "$*" in
-  *--property=Result*) printf '%s\n' success ;;
-  *--property=ExecMainStatus*) printf '%s\n' 0 ;;
-  *--property=ExecMainExitTimestamp*)
-    [[ "${NEVER_RUN_UNITS:-0}" == 1 ]] || printf '%s\n' 'Sun 2026-08-24 01:02:03 UTC'
-    ;;
+
+[[ $# == 4 && "$1" == -c && "$3" == -- ]] || exit 2
+readonly format=$2
+readonly path=$4
+readonly state_directory=/var/lib/speakup/safety-checks
+
+if [[ "$path" == "$state_directory" && "$format" == '%f:%u:%g:%a' ]]; then
+  [[ "${MISSING_SAFETY_DIRECTORY:-0}" != 1 ]] || exit 1
+  if [[ "${UNSAFE_SAFETY_DIRECTORY:-0}" == 1 ]]; then
+    printf '%s\n' '41ed:0:0:755'
+  else
+    printf '%s\n' '41c0:0:0:700'
+  fi
+  exit
+fi
+
+[[ "$path" == "$state_directory/"* && "$format" == '%f:%u:%g:%a:%Y' ]] || exit 2
+readonly marker=${path##*/}
+[[ "$marker" != "${MISSING_SAFETY_MARKER:-}" ]] || exit 1
+
+case "$marker" in
+  postgres-restore-check.success) timestamp=1787533323 ;;
+  portal-sqlite-restore-check.success) timestamp=1787536984 ;;
+  tls-renewal.success) timestamp=1787540585 ;;
   *) exit 2 ;;
 esac
+
+if [[ "$marker" == "${UNSAFE_SAFETY_MARKER:-}" ]]; then
+  printf '81b6:0:0:666:'
+elif [[ "$marker" == "${NONREGULAR_SAFETY_MARKER:-}" ]]; then
+  printf 'a1ff:0:0:777:'
+else
+  printf '8180:0:0:600:'
+fi
+if [[ "$marker" == "${FUTURE_SAFETY_MARKER:-}" ]]; then
+  printf '%s\n' '1893456000'
+else
+  printf '%s\n' "$timestamp"
+fi
 EOF
 
 cat >"$temporary_directory/fake-bin/df" <<'EOF'
@@ -144,6 +175,19 @@ export OBSERVABILITY_PORTAL_BACKUP_ROOT="$temporary_directory/portal-backups"
 readonly metrics_file="$temporary_directory/textfile/speakup.prom"
 PATH="$temporary_directory/fake-bin:$PATH" "$exporter" --output "$metrics_file"
 
+assert_safety_metric() {
+  local purpose=$1
+  local unit=$2
+  local success=$3
+  local timestamp=$4
+  grep -Fq \
+    "speakup_systemd_unit_last_run_success{purpose=\"$purpose\",unit=\"$unit\"} $success" \
+    "$metrics_file" || fail "$purpose success metric is wrong"
+  grep -Fq \
+    "speakup_systemd_unit_last_run_timestamp_seconds{purpose=\"$purpose\",unit=\"$unit\"} $timestamp" \
+    "$metrics_file" || fail "$purpose timestamp metric is wrong"
+}
+
 [[ $(grep -c '^speakup_container_up{' "$metrics_file") -eq 6 ]] ||
   fail 'expected six bounded container-up series'
 [[ $(grep -c '^speakup_container_health{' "$metrics_file") -eq 6 ]] ||
@@ -162,17 +206,43 @@ grep -Fq 'speakup_backup_last_success_timestamp_seconds{database="portal_sqlite"
   fail 'expected three bounded systemd safety series'
 [[ $(grep -c '^speakup_systemd_unit_last_run_timestamp_seconds{' "$metrics_file") -eq 3 ]] ||
   fail 'expected three bounded systemd last-run timestamps'
+assert_safety_metric postgres_restore_check xe3-postgres-restore-check.service 1 1787533323
+assert_safety_metric portal_restore_check xe3-portal-sqlite-restore-check.service 1 1787536984
+assert_safety_metric tls_renewal xe3-speakup-tls-renew.service 1 1787540585
+! grep -Eq 'systemctl|journalctl' "$exporter" ||
+  fail 'safety-check metrics still depend on volatile systemd state or logs'
 grep -Fq 'speakup_host_filesystem_avail_bytes{mountpoint="/"} 250000' "$metrics_file" ||
   fail 'host root free bytes were not exported'
 grep -Fq 'speakup_host_filesystem_files_free{mountpoint="/"} 500' "$metrics_file" ||
   fail 'host root free inodes were not exported'
 
-NEVER_RUN_UNITS=1 PATH="$temporary_directory/fake-bin:$PATH" \
+MISSING_SAFETY_MARKER=postgres-restore-check.success \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+assert_safety_metric postgres_restore_check xe3-postgres-restore-check.service 0 0
+assert_safety_metric portal_restore_check xe3-portal-sqlite-restore-check.service 1 1787536984
+
+UNSAFE_SAFETY_MARKER=portal-sqlite-restore-check.success \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+assert_safety_metric portal_restore_check xe3-portal-sqlite-restore-check.service 0 0
+
+NONREGULAR_SAFETY_MARKER=postgres-restore-check.success \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+assert_safety_metric postgres_restore_check xe3-postgres-restore-check.service 0 0
+
+FUTURE_SAFETY_MARKER=tls-renewal.success \
+  PATH="$temporary_directory/fake-bin:$PATH" \
+  "$exporter" --output "$metrics_file"
+assert_safety_metric tls_renewal xe3-speakup-tls-renew.service 0 0
+
+UNSAFE_SAFETY_DIRECTORY=1 PATH="$temporary_directory/fake-bin:$PATH" \
   "$exporter" --output "$metrics_file"
 [[ $(grep -c '^speakup_systemd_unit_last_run_success{.*} 0$' "$metrics_file") -eq 3 ]] ||
-  fail 'never-run systemd units did not fail closed'
+  fail 'unsafe safety-check state directory did not fail closed'
 [[ $(grep -c '^speakup_systemd_unit_last_run_timestamp_seconds{.*} 0$' "$metrics_file") -eq 3 ]] ||
-  fail 'never-run systemd unit timestamps were not explicit'
+  fail 'unsafe safety-check state directory timestamps were not explicit'
 
 MISSING_SERVICE=portal PATH="$temporary_directory/fake-bin:$PATH" \
   "$exporter" --output "$metrics_file"

--- a/deploy/observability/xe3-speakup-export-metrics
+++ b/deploy/observability/xe3-speakup-export-metrics
@@ -9,6 +9,7 @@ readonly required_environment=(
   OBSERVABILITY_POSTGRES_BACKUP_ROOT
   OBSERVABILITY_PORTAL_BACKUP_ROOT
 )
+readonly safety_check_state_directory=/var/lib/speakup/safety-checks
 
 fail() {
   printf 'speakup metrics export: %s\n' "$*" >&2
@@ -117,20 +118,37 @@ latest_backup_timestamp() {
     "$database" "$timestamp" >>"$temporary_file"
 }
 
-unit_success() {
+safety_check_success() {
   local purpose=$1
   local unit=$2
-  local result status last_run last_run_timestamp=0 success=0
+  local marker_name=$3
+  local marker="$safety_check_state_directory/$marker_name"
+  local directory_attributes directory_raw_mode directory_owner directory_group directory_mode
+  local directory_mode_value marker_attributes marker_raw_mode
+  local marker_owner marker_group marker_mode marker_timestamp now
+  local marker_mode_value
+  local last_run_timestamp=0 success=0
 
-  result=$(systemctl show --property=Result --value "$unit" 2>/dev/null || true)
-  status=$(systemctl show --property=ExecMainStatus --value "$unit" 2>/dev/null || true)
-  last_run=$(systemctl show --property=ExecMainExitTimestamp --value "$unit" 2>/dev/null || true)
-  if [[ -n "$last_run" && "$last_run" != n/a ]]; then
-    last_run_timestamp=$(date --utc --date="$last_run" +%s)
-    [[ "$last_run_timestamp" =~ ^[0-9]+$ ]] || fail "invalid last-run time for $unit"
-  fi
-  if [[ "$result" == success && "$status" == 0 && "$last_run_timestamp" -gt 0 ]]; then
+  if directory_attributes=$(stat -c '%f:%u:%g:%a' -- "$safety_check_state_directory" 2>/dev/null) &&
+    IFS=: read -r directory_raw_mode directory_owner directory_group directory_mode \
+      <<<"$directory_attributes" &&
+    [[ "$directory_raw_mode" =~ ^[0-9a-fA-F]+$ ]] &&
+    directory_mode_value=$((16#$directory_raw_mode)) &&
+    (((directory_mode_value & 0170000) == 0040000)) &&
+    [[ "$directory_owner" == 0 && "$directory_group" == 0 && "$directory_mode" == 700 ]] &&
+    marker_attributes=$(stat -c '%f:%u:%g:%a:%Y' -- "$marker" 2>/dev/null) &&
+    IFS=: read -r marker_raw_mode marker_owner marker_group marker_mode marker_timestamp \
+      <<<"$marker_attributes" &&
+    [[ "$marker_raw_mode" =~ ^[0-9a-fA-F]+$ ]] &&
+    marker_mode_value=$((16#$marker_raw_mode)) &&
+    (((marker_mode_value & 0170000) == 0100000)) &&
+    [[ "$marker_owner" == 0 && "$marker_group" == 0 && "$marker_mode" == 600 ]] &&
+    [[ "$marker_timestamp" =~ ^[0-9]+$ ]] &&
+    now=$(date --utc +%s) &&
+    [[ "$now" =~ ^[0-9]+$ ]] &&
+    ((marker_timestamp > 0 && marker_timestamp <= now)); then
     success=1
+    last_run_timestamp=$marker_timestamp
   fi
   printf 'speakup_systemd_unit_last_run_success{purpose="%s",unit="%s"} %s\n' \
     "$purpose" "$unit" "$success" >>"$temporary_file"
@@ -167,9 +185,9 @@ cat >>"$temporary_file" <<'EOF'
 # TYPE speakup_tls_certificate_expiry_timestamp_seconds gauge
 # HELP speakup_backup_last_success_timestamp_seconds Unix timestamp of the newest verified SpeakUp backup metadata.
 # TYPE speakup_backup_last_success_timestamp_seconds gauge
-# HELP speakup_systemd_unit_last_run_success Whether the last relevant systemd unit run succeeded.
+# HELP speakup_systemd_unit_last_run_success Whether the last relevant safety check completed successfully.
 # TYPE speakup_systemd_unit_last_run_success gauge
-# HELP speakup_systemd_unit_last_run_timestamp_seconds Unix timestamp when the relevant systemd unit last exited.
+# HELP speakup_systemd_unit_last_run_timestamp_seconds Unix timestamp from the relevant persistent success marker.
 # TYPE speakup_systemd_unit_last_run_timestamp_seconds gauge
 # HELP speakup_host_filesystem_size_bytes Total bytes on the host root filesystem.
 # TYPE speakup_host_filesystem_size_bytes gauge
@@ -189,9 +207,9 @@ certificate_expiry production monitor.speak-up.top "$OBSERVABILITY_MONITOR_CERTI
 latest_backup_timestamp postgres "$OBSERVABILITY_POSTGRES_BACKUP_ROOT"
 latest_backup_timestamp portal_sqlite "$OBSERVABILITY_PORTAL_BACKUP_ROOT"
 emit_host_filesystem_metrics
-unit_success postgres_restore_check xe3-postgres-restore-check.service
-unit_success portal_restore_check xe3-portal-sqlite-restore-check.service
-unit_success tls_renewal xe3-speakup-tls-renew.service
+safety_check_success postgres_restore_check xe3-postgres-restore-check.service postgres-restore-check.success
+safety_check_success portal_restore_check xe3-portal-sqlite-restore-check.service portal-sqlite-restore-check.success
+safety_check_success tls_renewal xe3-speakup-tls-renew.service tls-renewal.success
 
 mv -f "$temporary_file" "$output_path"
 trap - EXIT

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -487,12 +487,13 @@ is private and only `AF_UNIX` is permitted so the Docker Unix socket remains
 usable without granting the unit IP network access.
 
 The restore-check unit additionally creates the root-only persistent state
-directory `/var/lib/speakup/safety-checks`. Only after the isolated check exits
-successfully does `ExecStartPost=` replace
-`postgres-restore-check.success` as a `root:root` mode `0600` empty marker. A
-failed check cannot refresh its mtime. `StateDirectory=` remains writable under
-this unit's `ProtectSystem=strict` sandbox and persists across daemon reloads and
-host reboots.
+directory `/var/lib/speakup/safety-checks`. `ExecStartPre=` removes only
+`postgres-restore-check.success` before each attempt, so the marker remains
+absent while the check runs or after it fails. Only after the isolated check
+exits successfully does `ExecStartPost=` replace it as a `root:root` mode `0600`
+empty marker. `StateDirectory=` remains writable under this unit's
+`ProtectSystem=strict` sandbox and persists across daemon reloads and host
+reboots.
 
 When upgrading an existing host, reinstall the restore-check unit, run
 `systemctl daemon-reload`, and start the check once before relying on its

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -486,6 +486,20 @@ use a `0077` umask and a two-hour start timeout. Their process network namespace
 is private and only `AF_UNIX` is permitted so the Docker Unix socket remains
 usable without granting the unit IP network access.
 
+The restore-check unit additionally creates the root-only persistent state
+directory `/var/lib/speakup/safety-checks`. Only after the isolated check exits
+successfully does `ExecStartPost=` replace
+`postgres-restore-check.success` as a `root:root` mode `0600` empty marker. A
+failed check cannot refresh its mtime. `StateDirectory=` remains writable under
+this unit's `ProtectSystem=strict` sandbox and persists across daemon reloads and
+host reboots.
+
+When upgrading an existing host, reinstall the restore-check unit, run
+`systemctl daemon-reload`, and start the check once before relying on its
+observability series. The old journal/systemd exit time is deliberately not
+converted into a marker; monitoring remains fail-closed until a real check
+succeeds. Never create or touch the marker manually.
+
 The configured application database user is also the owner of objects created
 by the migration command. Dumps and isolated restores both use
 `--no-owner --no-privileges`: they preserve the application schema and data

--- a/deploy/production/test-backup.sh
+++ b/deploy/production/test-backup.sh
@@ -83,6 +83,9 @@ assert_unit_contracts() {
   done
 
   assert_unit_directive \
+    "$restore_check_service" Service ExecStartPre \
+    '/usr/bin/rm --force -- /var/lib/speakup/safety-checks/postgres-restore-check.success'
+  assert_unit_directive \
     "$restore_check_service" Service ExecStartPost \
     '/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/postgres-restore-check.success'
   ! grep -Fq 'safety-checks' "$backup_service" ||

--- a/deploy/production/test-backup.sh
+++ b/deploy/production/test-backup.sh
@@ -60,17 +60,19 @@ assert_unit_directive() {
 }
 
 assert_unit_contracts() {
-  local service command
+  local service command state_directories
   for service in "$backup_service" "$restore_check_service"; do
     if [[ "$service" == "$backup_service" ]]; then
       command='backup daily'
+      state_directories='speakup/postgres-backups'
     else
       command='check'
+      state_directories='speakup/postgres-backups speakup/safety-checks'
     fi
     assert_unit_directive "$service" Service TimeoutStartSec 2h
     assert_unit_directive \
       "$service" Service EnvironmentFile /etc/speakup/postgres-backup.env
-    assert_unit_directive "$service" Service StateDirectory speakup/postgres-backups
+    assert_unit_directive "$service" Service StateDirectory "$state_directories"
     assert_unit_directive "$service" Service StateDirectoryMode 0700
     assert_unit_directive "$service" Service UMask 0077
     assert_unit_directive \
@@ -79,6 +81,12 @@ assert_unit_contracts() {
     assert_unit_directive "$service" Service PrivateNetwork true
     assert_unit_directive "$service" Service RestrictAddressFamilies AF_UNIX
   done
+
+  assert_unit_directive \
+    "$restore_check_service" Service ExecStartPost \
+    '/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/postgres-restore-check.success'
+  ! grep -Fq 'safety-checks' "$backup_service" ||
+    fail 'the backup unit must not write the restore-check success marker'
 
   assert_unit_directive "$backup_timer" Timer OnCalendar daily
   assert_unit_directive "$backup_timer" Timer Persistent true

--- a/deploy/production/xe3-postgres-restore-check.service
+++ b/deploy/production/xe3-postgres-restore-check.service
@@ -7,10 +7,11 @@ After=docker.service
 Type=oneshot
 TimeoutStartSec=2h
 EnvironmentFile=/etc/speakup/postgres-backup.env
-StateDirectory=speakup/postgres-backups
+StateDirectory=speakup/postgres-backups speakup/safety-checks
 StateDirectoryMode=0700
 UMask=0077
 ExecStart=/usr/bin/flock --nonblock /run/lock/xe3-postgres-backup.lock /usr/bin/env POSTGRES_BACKUP_ROOT=/var/lib/speakup/postgres-backups /usr/local/sbin/xe3-postgres-backup check
+ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/postgres-restore-check.success
 PrivateTmp=true
 PrivateDevices=true
 PrivateNetwork=true

--- a/deploy/production/xe3-postgres-restore-check.service
+++ b/deploy/production/xe3-postgres-restore-check.service
@@ -10,6 +10,7 @@ EnvironmentFile=/etc/speakup/postgres-backup.env
 StateDirectory=speakup/postgres-backups speakup/safety-checks
 StateDirectoryMode=0700
 UMask=0077
+ExecStartPre=/usr/bin/rm --force -- /var/lib/speakup/safety-checks/postgres-restore-check.success
 ExecStart=/usr/bin/flock --nonblock /run/lock/xe3-postgres-backup.lock /usr/bin/env POSTGRES_BACKUP_ROOT=/var/lib/speakup/postgres-backups /usr/local/sbin/xe3-postgres-backup check
 ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/postgres-restore-check.success
 PrivateTmp=true

--- a/deploy/tls/README.md
+++ b/deploy/tls/README.md
@@ -269,6 +269,19 @@ systemctl start xe3-speakup-tls-renew.service
 systemctl enable --now xe3-speakup-tls-renew.timer
 ```
 
+The renewal unit uses `StateDirectory=speakup/safety-checks` to create the
+shared `/var/lib/speakup/safety-checks` directory as `root:root` mode `0700`.
+Only after the complete three-lineage renewal and verification command succeeds
+does `ExecStartPost=` replace the empty `tls-renewal.success` marker as
+`root:root` mode `0600`; a failure cannot refresh its mtime. The marker persists
+across daemon reloads and host reboots.
+
+For an existing installation, reinstall the service and timer, run
+`systemctl daemon-reload`, and manually start the renewal service once before
+relying on the new observability series. No previous journal/systemd timestamp
+is migrated, so monitoring remains fail-closed until a real renewal check
+succeeds. Never create or touch the marker manually.
+
 The timer runs twice daily with up to 30 minutes of randomized delay and catches
 up after downtime. The script uses a non-blocking `flock`, while Certbot's own
 random sleep is disabled because scheduling jitter belongs to systemd. The unit

--- a/deploy/tls/README.md
+++ b/deploy/tls/README.md
@@ -271,10 +271,11 @@ systemctl enable --now xe3-speakup-tls-renew.timer
 
 The renewal unit uses `StateDirectory=speakup/safety-checks` to create the
 shared `/var/lib/speakup/safety-checks` directory as `root:root` mode `0700`.
-Only after the complete three-lineage renewal and verification command succeeds
-does `ExecStartPost=` replace the empty `tls-renewal.success` marker as
-`root:root` mode `0600`; a failure cannot refresh its mtime. The marker persists
-across daemon reloads and host reboots.
+Before each attempt, `ExecStartPre=` removes only `tls-renewal.success`, leaving
+it absent while renewal runs or after it fails. Only after the complete
+three-lineage renewal and verification command succeeds does `ExecStartPost=`
+replace the empty marker as `root:root` mode `0600`. The marker persists across
+daemon reloads and host reboots.
 
 For an existing installation, reinstall the service and timer, run
 `systemctl daemon-reload`, and manually start the renewal service once before

--- a/deploy/tls/test.sh
+++ b/deploy/tls/test.sh
@@ -999,6 +999,11 @@ grep -Fxq 'StateDirectory=speakup/safety-checks' \
   "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd renewal state directory is wrong"
 grep -Fxq 'StateDirectoryMode=0700' \
   "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd renewal state directory is not root-only"
+[[ $(grep -c '^ExecStartPre=' "$tls_directory/xe3-speakup-tls-renew.service") -eq 1 ]] ||
+  fail "systemd renewal must invalidate exactly one success marker"
+grep -Fxq \
+  'ExecStartPre=/usr/bin/rm --force -- /var/lib/speakup/safety-checks/tls-renewal.success' \
+  "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd renewal marker invalidation is wrong"
 grep -Fxq \
   'ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/tls-renewal.success' \
   "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd renewal success marker is wrong"

--- a/deploy/tls/test.sh
+++ b/deploy/tls/test.sh
@@ -995,6 +995,13 @@ FAKE_UNAME_MACHINE=arm64 expect_failure "non-amd64 host" \
 # The unit is deterministic, locked by the script, and scheduled twice daily.
 grep -Fq 'ExecStart=/usr/local/sbin/xe3-speakup-tls renew --env-file /etc/speakup/tls.env' \
   "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd service entry point is wrong"
+grep -Fxq 'StateDirectory=speakup/safety-checks' \
+  "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd renewal state directory is wrong"
+grep -Fxq 'StateDirectoryMode=0700' \
+  "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd renewal state directory is not root-only"
+grep -Fxq \
+  'ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/tls-renewal.success' \
+  "$tls_directory/xe3-speakup-tls-renew.service" || fail "systemd renewal success marker is wrong"
 ! grep -Eq 'prepare-image|docker[[:space:]]+pull' \
   "$tls_directory/xe3-speakup-tls-renew.service" ||
   fail "systemd renewal can prepare or pull the Certbot image"

--- a/deploy/tls/xe3-speakup-tls-renew.service
+++ b/deploy/tls/xe3-speakup-tls-renew.service
@@ -10,7 +10,10 @@ User=root
 Group=root
 UMask=0077
 TimeoutStartSec=15min
+StateDirectory=speakup/safety-checks
+StateDirectoryMode=0700
 ExecStart=/usr/local/sbin/xe3-speakup-tls renew --env-file /etc/speakup/tls.env
+ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/tls-renewal.success
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true

--- a/deploy/tls/xe3-speakup-tls-renew.service
+++ b/deploy/tls/xe3-speakup-tls-renew.service
@@ -12,6 +12,7 @@ UMask=0077
 TimeoutStartSec=15min
 StateDirectory=speakup/safety-checks
 StateDirectoryMode=0700
+ExecStartPre=/usr/bin/rm --force -- /var/lib/speakup/safety-checks/tls-renewal.success
 ExecStart=/usr/local/sbin/xe3-speakup-tls renew --env-file /etc/speakup/tls.env
 ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/tls-renewal.success
 NoNewPrivileges=true

--- a/portal/deploy/README.md
+++ b/portal/deploy/README.md
@@ -86,10 +86,11 @@ systemd units 会在启动命令中把备份根目录固定为
 `/var/lib/speakup/portal-backups`；环境文件不能覆盖该路径。
 
 恢复检查 unit 还会由 `StateDirectory=` 创建 `root:root`、`0700` 的固定目录
-`/var/lib/speakup/safety-checks`。只有隔离恢复检查成功退出后，
-`ExecStartPost=` 才会以 `root:root`、`0600` 替换空标记
-`portal-sqlite-restore-check.success`；检查失败不会刷新 mtime。该状态目录在
-`ProtectSystem=strict` 下仍由 systemd 保持可写，并跨 `daemon-reload` 和主机重启保留。
+`/var/lib/speakup/safety-checks`。每次开始前，`ExecStartPre=` 只删除自己的
+`portal-sqlite-restore-check.success`，因此检查进行中或失败后标记保持缺失；只有
+隔离恢复检查成功退出后，`ExecStartPost=` 才会以 `root:root`、`0600` 替换空标记。
+该状态目录在 `ProtectSystem=strict` 下仍由 systemd 保持可写，并跨
+`daemon-reload` 和主机重启保留。
 
 已有安装升级时，重新安装 restore-check unit、执行 `systemctl daemon-reload`，再手动
 成功运行一次恢复检查后才能依赖相应监控。旧 journal/systemd 退出时间不会推断或迁移；

--- a/portal/deploy/README.md
+++ b/portal/deploy/README.md
@@ -85,6 +85,16 @@ fi
 systemd units 会在启动命令中把备份根目录固定为
 `/var/lib/speakup/portal-backups`；环境文件不能覆盖该路径。
 
+恢复检查 unit 还会由 `StateDirectory=` 创建 `root:root`、`0700` 的固定目录
+`/var/lib/speakup/safety-checks`。只有隔离恢复检查成功退出后，
+`ExecStartPost=` 才会以 `root:root`、`0600` 替换空标记
+`portal-sqlite-restore-check.success`；检查失败不会刷新 mtime。该状态目录在
+`ProtectSystem=strict` 下仍由 systemd 保持可写，并跨 `daemon-reload` 和主机重启保留。
+
+已有安装升级时，重新安装 restore-check unit、执行 `systemctl daemon-reload`，再手动
+成功运行一次恢复检查后才能依赖相应监控。旧 journal/systemd 退出时间不会推断或迁移；
+首次真实成功前指标保持 fail-closed。禁止人工创建或 `touch` 该标记。
+
 本地 image ID 可只读查询，不需要打开容器环境变量：
 
 ```sh

--- a/portal/deploy/xe3-portal-sqlite-restore-check.service
+++ b/portal/deploy/xe3-portal-sqlite-restore-check.service
@@ -6,10 +6,11 @@ After=docker.service
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/speakup/portal-backup.env
-StateDirectory=speakup/portal-backups
+StateDirectory=speakup/portal-backups speakup/safety-checks
 StateDirectoryMode=0700
 UMask=0077
 ExecStart=/usr/bin/flock --nonblock /run/lock/xe3-portal-sqlite-backup.lock /usr/bin/env PORTAL_BACKUP_ROOT=/var/lib/speakup/portal-backups /usr/local/sbin/xe3-portal-sqlite-backup check
+ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/portal-sqlite-restore-check.success
 PrivateTmp=true
 PrivateDevices=true
 PrivateNetwork=true

--- a/portal/deploy/xe3-portal-sqlite-restore-check.service
+++ b/portal/deploy/xe3-portal-sqlite-restore-check.service
@@ -9,6 +9,7 @@ EnvironmentFile=/etc/speakup/portal-backup.env
 StateDirectory=speakup/portal-backups speakup/safety-checks
 StateDirectoryMode=0700
 UMask=0077
+ExecStartPre=/usr/bin/rm --force -- /var/lib/speakup/safety-checks/portal-sqlite-restore-check.success
 ExecStart=/usr/bin/flock --nonblock /run/lock/xe3-portal-sqlite-backup.lock /usr/bin/env PORTAL_BACKUP_ROOT=/var/lib/speakup/portal-backups /usr/local/sbin/xe3-portal-sqlite-backup check
 ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/portal-sqlite-restore-check.success
 PrivateTmp=true

--- a/portal/tests/portal-sqlite-backup.test.mjs
+++ b/portal/tests/portal-sqlite-backup.test.mjs
@@ -278,6 +278,9 @@ test("deployment units expose timer, failure, and isolated-check contracts", asy
     /^StateDirectory=speakup\/portal-backups speakup\/safety-checks$/m,
   );
   assert.match(restoreService, /^StateDirectoryMode=0700$/m);
+  assert.deepEqual(restoreService.match(/^ExecStartPre=.*$/gm), [
+    "ExecStartPre=/usr/bin/rm --force -- /var/lib/speakup/safety-checks/portal-sqlite-restore-check.success",
+  ]);
   assert.ok(
     restoreService.includes(
       "ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/portal-sqlite-restore-check.success",

--- a/portal/tests/portal-sqlite-backup.test.mjs
+++ b/portal/tests/portal-sqlite-backup.test.mjs
@@ -273,6 +273,17 @@ test("deployment units expose timer, failure, and isolated-check contracts", asy
     /\/usr\/bin\/env PORTAL_BACKUP_ROOT=\/var\/lib\/speakup\/portal-backups .* check$/m,
   );
   assert.match(restoreService, /xe3-portal-sqlite-backup check/);
+  assert.match(
+    restoreService,
+    /^StateDirectory=speakup\/portal-backups speakup\/safety-checks$/m,
+  );
+  assert.match(restoreService, /^StateDirectoryMode=0700$/m);
+  assert.ok(
+    restoreService.includes(
+      "ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup/safety-checks/portal-sqlite-restore-check.success",
+    ),
+  );
+  assert.doesNotMatch(backupService, /safety-checks/);
   assert.match(timer, /^OnCalendar=daily$/m);
   assert.match(timer, /^Persistent=true$/m);
   assert.match(wrapperContent, /dst=\/source,readonly,volume-nocopy/);


### PR DESCRIPTION
## 功能描述

- PostgreSQL 恢复检查、Portal SQLite 恢复检查和 TLS 续期仅在完整命令成功后写入各自的持久成功标记。
- 每次新检查开始前只失效自身旧标记，因此进行中或后续失败立即 fail closed，不会误删另外两项状态。
- exporter 从固定 root-only StateDirectory 的标记 mtime 导出成功状态与时间，不再依赖易失的 systemd 退出时间，也不解析日志。
- 标记缺失、非普通文件、所有权或权限不安全、mtime 位于未来时按项输出 `success=0`、`timestamp=0`。
- 补充 systemd/exporter 合同测试及新装、升级说明。

## 实现思路

- 三个 oneshot unit 共用 `/var/lib/speakup/safety-checks`，由 `StateDirectory=` 以 `root:root`、`0700` 管理；原有 PostgreSQL/Portal 备份目录保持不变。
- 每个 unit 使用一条固定路径的 `ExecStartPre=/usr/bin/rm --force -- <自身标记>` 失效旧成功；主命令成功后再由 `ExecStartPost=` 以单条 `install --no-target-directory` 写入独立 `root:root`、`0600` 空标记。
- exporter 只读取三个固定路径，使用数值文件类型、UID/GID、mode 与 mtime 校验，并保留现有指标名和 label 契约。
- 升级不从 journal 或 systemd 状态推断历史；每项检查首次真实成功前以及失败后保持 fail closed。

## 可复现测试

- `make check-observability`（覆盖 PostgreSQL、Portal、TLS 各自先成功、后失败，且其余标记不受影响）
- `make check-production-backup`
- `make check-tls-lifecycle`
- `node --test portal/tests/portal-sqlite-backup.test.mjs`
- Ubuntu 24.04 中对三个生产 unit 与 exporter unit 运行 `systemd-analyze verify`
- `git diff --check`

Closes #927