### PR TITLE
fix(mobile): 修复 IELTS 回答输入状态卡死

### DIFF
--- a/mobile/lib/design/voice_capture_control.dart
+++ b/mobile/lib/design/voice_capture_control.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -120,12 +121,14 @@ class _VoiceCaptureControlState extends State<VoiceCaptureControl> {
 
   @override
   void dispose() {
+    _removePointerRoute();
     _holdTimer?.cancel();
     _operationGeneration++;
     super.dispose();
   }
 
   void _resetInteraction() {
+    _removePointerRoute();
     _holdTimer?.cancel();
     _holdTimer = null;
     _pointerOrigin = null;
@@ -184,6 +187,10 @@ class _VoiceCaptureControlState extends State<VoiceCaptureControl> {
       _pointerOrigin = event.position;
       _pointerPosition = event.position;
     });
+    GestureBinding.instance.pointerRouter.addRoute(
+      event.pointer,
+      _handleTrackedPointerEvent,
+    );
     if (!startingCapture || widget.mode == VoiceCaptureMode.tapToToggle) {
       return;
     }
@@ -235,12 +242,43 @@ class _VoiceCaptureControlState extends State<VoiceCaptureControl> {
     _finishPointer(VoiceCaptureReleaseIntent.cancel);
   }
 
+  void _handleTrackedPointerEvent(PointerEvent event) {
+    if (event.pointer != _activePointer) {
+      return;
+    }
+    switch (event) {
+      case final PointerMoveEvent move:
+        _handlePointerMove(move);
+        return;
+      case final PointerUpEvent up:
+        _handlePointerUp(up);
+        return;
+      case final PointerCancelEvent cancel:
+        _handlePointerCancel(cancel);
+        return;
+      default:
+        return;
+    }
+  }
+
+  void _removePointerRoute() {
+    final pointer = _activePointer;
+    if (pointer == null) {
+      return;
+    }
+    GestureBinding.instance.pointerRouter.removeRoute(
+      pointer,
+      _handleTrackedPointerEvent,
+    );
+  }
+
   void _finishPointer(VoiceCaptureReleaseIntent intent) {
     if (!mounted || !_pointerActive) {
       return;
     }
     _holdTimer?.cancel();
     _holdTimer = null;
+    _removePointerRoute();
     final holdStarted = _holdStarted;
     final endingTapCapture = _tapMode && _isCapturing;
     setState(() {

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -1888,6 +1888,8 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       onSendVoice: _sendShortVoice,
       onConvertToText: _convertShortVoice,
       onCancelRecording: _cancelShortVoice,
+      onRetryConfirmation: _confirmPendingTranscript,
+      onRerecord: widget.controller.rerecord,
       onSubmitConvertedAnswer: _submitConvertedAnswer,
       onCancelConvertedAnswer: _cancelConvertedAnswer,
       onOpenTextAnswer: _openTextAnswer,

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
@@ -263,6 +263,8 @@ class _RecorderDock extends StatelessWidget {
     required this.onSendVoice,
     required this.onConvertToText,
     required this.onCancelRecording,
+    required this.onRetryConfirmation,
+    required this.onRerecord,
     required this.onSubmitConvertedAnswer,
     required this.onCancelConvertedAnswer,
     required this.onOpenTextAnswer,
@@ -282,6 +284,8 @@ class _RecorderDock extends StatelessWidget {
   final FutureOr<void> Function() onSendVoice;
   final FutureOr<void> Function() onConvertToText;
   final FutureOr<void> Function() onCancelRecording;
+  final VoidCallback onRetryConfirmation;
+  final VoidCallback onRerecord;
   final FutureOr<void> Function() onSubmitConvertedAnswer;
   final VoidCallback onCancelConvertedAnswer;
   final VoidCallback onOpenTextAnswer;
@@ -298,7 +302,6 @@ class _RecorderDock extends StatelessWidget {
     };
     final working =
         state == PracticeRecordingState.transcribing ||
-        state == PracticeRecordingState.awaitingConfirmation ||
         state == PracticeRecordingState.submitting;
     final control = VoiceCaptureControl(
       phase: phase,
@@ -306,6 +309,7 @@ class _RecorderDock extends StatelessWidget {
           enabledOverride ??
           (!convertedAnswerMode &&
               !controller.hasPendingPracticeAudio &&
+              state != PracticeRecordingState.awaitingConfirmation &&
               !working),
       onStart: onStart,
       onSendVoice: onSendVoice,
@@ -320,6 +324,14 @@ class _RecorderDock extends StatelessWidget {
                 submitting: convertedAnswerSubmitting,
                 onSubmit: onSubmitConvertedAnswer,
                 onCancel: onCancelConvertedAnswer,
+              )
+            : state == PracticeRecordingState.awaitingConfirmation
+            ? PracticeTranscriptComposer(
+                transcript: controller.transcript ?? '',
+                keyPrefix: 'ielts-mock',
+                onRerecord: onRerecord,
+                onConfirm: onRetryConfirmation,
+                confirmLabel: controller.errorMessage == null ? '发送回答' : '重试提交',
               )
             : working
             ? _IeltsRecorderWorkingState(state: state)
@@ -404,8 +416,7 @@ class _IeltsRecorderWorkingState extends StatelessWidget {
   Widget build(BuildContext context) {
     final label = switch (state) {
       PracticeRecordingState.transcribing => '正在识别你的回答…',
-      PracticeRecordingState.awaitingConfirmation => '正在提交你的回答…',
-      PracticeRecordingState.submitting => '回答已发送，正在进入下一题…',
+      PracticeRecordingState.submitting => '正在提交你的回答…',
       _ => '正在处理…',
     };
     return KeyedSubtree(

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -2071,6 +2071,95 @@ void main() {
     expect(find.text('1 题'), findsOneWidget);
   });
 
+  testWidgets('Part 3 confirmation failure exposes a recoverable retry', (
+    tester,
+  ) async {
+    final practice = _IeltsPracticeClient(initialCompleted: 0, turnLimit: 2)
+      ..confirmFailure = const PracticeClientException(
+        kind: PracticeClientFailureKind.network,
+        retryable: true,
+      );
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    addTearDown(controller.dispose);
+    await _activatePractice(
+      controller,
+      practice,
+      _ieltsScene,
+      mode: PracticeMode.part3,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: _MemoryProgressStore(),
+          examinerSpeaker: _ImmediateExaminerSpeaker(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('ielts-mock-record')));
+    for (
+      var attempt = 0;
+      attempt < 20 &&
+          controller.recordingState != PracticeRecordingState.recording;
+      attempt++
+    ) {
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+    await tester.tap(find.byKey(const Key('ielts-mock-record')));
+    for (
+      var attempt = 0;
+      attempt < 20 && controller.errorMessage == null;
+      attempt++
+    ) {
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+
+    expect(
+      controller.recordingState,
+      PracticeRecordingState.awaitingConfirmation,
+    );
+    expect(find.text('网络连接不稳定，这一轮尚未确认，请重试。'), findsOneWidget);
+    expect(find.text('正在提交你的回答…'), findsNothing);
+    expect(find.byKey(const Key('ielts-mock-confirm-turn')), findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.byKey(const Key('ielts-mock-confirm-turn')),
+          )
+          .onPressed,
+      isNotNull,
+    );
+    expect(find.text('重试提交'), findsOneWidget);
+    expect(find.byKey(const Key('ielts-mock-rerecord')), findsOneWidget);
+    expect(
+      tester
+          .widget<OutlinedButton>(find.byKey(const Key('ielts-mock-rerecord')))
+          .onPressed,
+      isNotNull,
+    );
+    expect(practice.confirmationIdempotencyKeys, hasLength(1));
+
+    practice.confirmFailure = null;
+    await tester.tap(find.byKey(const Key('ielts-mock-confirm-turn')));
+    for (
+      var attempt = 0;
+      attempt < 20 && controller.completedTurns == 0;
+      attempt++
+    ) {
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+
+    expect(controller.completedTurns, 1);
+    expect(practice.confirmationIdempotencyKeys, hasLength(2));
+    expect(practice.confirmationIdempotencyKeys.toSet(), hasLength(1));
+  });
+
   testWidgets('section PracticeOption modes open the matching IELTS flow', (
     tester,
   ) async {

--- a/mobile/test/design/voice_capture_control_test.dart
+++ b/mobile/test/design/voice_capture_control_test.dart
@@ -227,6 +227,30 @@ void main() {
     expect(harness.currentState?.sends, 1);
   });
 
+  testWidgets('release survives the wrapped target rebuilding away', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(key: harness, detachTargetWhileRecording: true),
+    );
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await tester.pump(const Duration(milliseconds: 180));
+
+    expect(harness.currentState?.starts, 1);
+    expect(find.byKey(const Key('voice-capture-target')), findsNothing);
+    expect(find.byKey(const Key('detached-capture-target')), findsOneWidget);
+
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.sends, 1);
+    expect(harness.currentState?.cancels, 0);
+  });
+
   testWidgets('one release action fences later taps until it completes', (
     tester,
   ) async {
@@ -293,12 +317,14 @@ class _VoiceCaptureHarness extends StatefulWidget {
     this.beforeStartCompleter,
     this.sendCompleter,
     this.showTapActions = false,
+    this.detachTargetWhileRecording = false,
   });
 
   final Completer<void>? startCompleter;
   final Completer<void>? beforeStartCompleter;
   final Completer<void>? sendCompleter;
   final bool showTapActions;
+  final bool detachTargetWhileRecording;
 
   @override
   State<_VoiceCaptureHarness> createState() => _VoiceCaptureHarnessState();
@@ -362,6 +388,14 @@ class _VoiceCaptureHarnessState extends State<_VoiceCaptureHarness> {
             onConvertToText: _convert,
             onCancel: _cancel,
             builder: (context, capture) {
+              if (widget.detachTargetWhileRecording &&
+                  phase == VoiceCapturePhase.recording) {
+                return const SizedBox(
+                  key: Key('detached-capture-target'),
+                  width: 180,
+                  height: 64,
+                );
+              }
               final target = capture.wrapTarget(
                 key: const Key('voice-capture-target'),
                 semanticsLabel: phase == VoiceCapturePhase.idle


### PR DESCRIPTION
## 功能描述

- 修复 IELTS 语音回答确认失败后底部栏持续显示加载、无法操作的问题。
- 修复录音目标重绘时局部指针监听丢失，导致松手后仍停留在录音态的问题。
- 不新增按钮，不改变按住录音、松开发送、上滑取消的用户操作逻辑。

## 实现思路

- 将 `awaitingConfirmation` 作为可操作的待确认状态，复用现有转写确认组件，失败后提供重试提交或重录。
- 仅在真实 `submitting` 请求期间显示提交加载状态。
- 在 `VoiceCaptureControl` 内通过 Flutter 全局 pointer route 跟踪当前指针，并在完成、重置和销毁时成对清理，确保组件重绘后仍能收到 move/up/cancel。
- 重试确认沿用原 idempotency key，避免重复计入进度。

## 可复现测试

1. 进入 IELTS Part 1 或 Part 3，录音并提交。
2. 在确认请求阶段断网；失败后应显示保留的转写以及“重试提交 / 重录”，不能持续转圈。
3. 恢复网络后点击重试；进度只增加一次。
4. 长按录音并在录音控件重绘后松手；仍应正常发送，不停留在录音态。

已执行：
- `dart analyze`
- `flutter test --no-pub`（799/799）
- Android arm64 staging debug APK 构建、真机安装与本地后端连接验证

Closes #928