### PR TITLE
chore(release): 准备 v0.1.5 候选版本

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.4+5
+version: 0.1.5+6
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## 功能描述

将 SpeakUp 移动端候选版本更新为 0.1.5+6，为本轮已经合入 dev 的 Android 更新、数字人嘴型、冷启动恢复录音和可观测能力生成下一份可追溯候选制品。

## 实现思路

- 只更新 mobile/pubspec.yaml 的 version。
- versionName 从 0.1.4 更新为 0.1.5。
- versionCode 从 5 单调递增为 6。
- 不创建 Tag、不部署 Staging/Production，也不更新公开 APK 链接。

## 可复现测试

- make check-release-candidate
- cd mobile && flutter pub get --enforce-lockfile
- git diff --check upstream/dev...HEAD

本地 Release Candidate 工具测试 31/31 通过，Android 签名与 APK 校验脚本测试通过。

Closes #934