### PR TITLE
fix(mobile): 统一我的页卡片圆角

### DIFF
--- a/mobile/lib/features/coaching/profile/coaching_profile.dart
+++ b/mobile/lib/features/coaching/profile/coaching_profile.dart
@@ -274,7 +274,7 @@ class _CoachingProfileCardState extends State<CoachingProfileCard> {
         final profile = widget.controller.profile;
         return InkWell(
           key: const Key('coaching-profile-card'),
-          borderRadius: BorderRadius.circular(22),
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
           onTap: profile == null
               ? widget.controller.load
               : () => Navigator.of(context).push(
@@ -287,7 +287,7 @@ class _CoachingProfileCardState extends State<CoachingProfileCard> {
             padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
               border: Border.all(color: const Color(0xFFE5E5E5)),
-              borderRadius: BorderRadius.circular(22),
+              borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
             ),
             child: Row(
               children: [

--- a/mobile/test/coaching/profile/coaching_profile_test.dart
+++ b/mobile/test/coaching/profile/coaching_profile_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 
 void main() {
@@ -14,6 +15,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Alex · 工程师 · 音乐'), findsOneWidget);
+    expect(
+      tester
+          .widget<InkWell>(find.byKey(const Key('coaching-profile-card')))
+          .borderRadius,
+      BorderRadius.circular(SpeakUpDesign.radiusCard),
+    );
     await tester.tap(find.byKey(const Key('coaching-profile-card')));
     await tester.pumpAndSettle();
     expect(find.text('教练记忆'), findsWidgets);


### PR DESCRIPTION
## 功能描述

统一“我的”页面中“教练记忆”和“当前 IELTS 能力”卡片的圆角，全部遵循全局卡片圆角 token。

Closes #936

## 实现思路

- 将教练记忆卡片容器的硬编码圆角 `22` 替换为 `SpeakUpDesign.radiusCard`。
- 同步让 `InkWell` 使用相同 token，确保点击水波纹边界与卡片一致。
- 增加组件断言，防止教练记忆卡片重新偏离全局圆角。
- 不改变页面布局、内容或用户操作逻辑。

## 可复现测试

1. `cd mobile && dart analyze`
2. `cd mobile && flutter test --no-pub test/coaching/profile/coaching_profile_test.dart`
3. `cd mobile && flutter test --no-pub`（801 项通过）
4. `SPEAKUP_DEV_PORT=18082 IOS_SIMULATOR_ID=C3F00DDB-A017-4A12-ABB7-234CB16B2037 make dev-ios-simulator`
5. 登录后进入“我的”，确认“教练记忆”和“当前 IELTS 能力”卡片圆角一致；真实本地后端运行，数字人禁用。

## 验证结果

- 静态分析通过。
- 相关测试通过。
- Flutter 全量 801 项测试通过。
- iPhone 17 Pro / iOS 26.5 模拟器视觉验证通过。