### PR TITLE
fix(mobile): 稳定数字人连接回退并补充失败诊断

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -572,6 +572,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       reportStatusController: widget.sessionEvaluationController,
       speechFeedbackController: widget.speechFeedbackController,
       avatarSurfaceBuilder: avatar?.surfaceBuilder,
+      avatarSurfaceVisible: avatar?.surfaceVisible ?? true,
       avatarStatusLabel: avatar?.statusLabel,
       onBeforeUserTurn: avatar?.interruptForUserTurn,
       onReplayQuestionWithAvatar: avatar?.onReplayQuestion,

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -79,6 +79,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
     this.speechFeedbackController,
     this.examinerSpeaker,
     this.avatarSurfaceBuilder,
+    this.avatarSurfaceVisible = true,
     this.avatarStatusLabel,
     this.onBeforeUserTurn,
     this.onReplayQuestionWithAvatar,
@@ -97,6 +98,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
   final SpeechFeedbackController? speechFeedbackController;
   final PracticePromptSpeaker? examinerSpeaker;
   final WidgetBuilder? avatarSurfaceBuilder;
+  final bool avatarSurfaceVisible;
   final String? avatarStatusLabel;
   final Future<void> Function()? onBeforeUserTurn;
   final Future<void> Function()? onReplayQuestionWithAvatar;
@@ -1606,6 +1608,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
                       imageKey: Key('ielts-avatar-placeholder'),
                     ),
                     surfaceBuilder: widget.avatarSurfaceBuilder,
+                    surfaceVisible: widget.avatarSurfaceVisible,
                     statusLabel: widget.avatarStatusLabel,
                     exitInFlight: _exitInFlight,
                     exitButtonKey: const Key('ielts-mock-exit'),

--- a/mobile/lib/features/coaching/practice/avatar/avatar_controller.dart
+++ b/mobile/lib/features/coaching/practice/avatar/avatar_controller.dart
@@ -547,7 +547,9 @@ final class AvatarController extends ChangeNotifier {
       AvatarControllerState(
         phase: phase,
         renderer: rendererState,
-        failure: rendererState.failure ?? _state.failure,
+        failure: rendererState.connection == AvatarRendererConnection.connected
+            ? rendererState.failure
+            : rendererState.failure ?? _state.failure,
       ),
     );
   }

--- a/mobile/lib/features/coaching/practice/avatar/spatius_avatar_renderer.dart
+++ b/mobile/lib/features/coaching/practice/avatar/spatius_avatar_renderer.dart
@@ -139,7 +139,7 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
         );
       }
     };
-    controller.onConnectionState = (connection, _) {
+    controller.onConnectionState = (connection, errorMessage) {
       if (_closed || !identical(_controller, controller)) {
         return;
       }
@@ -163,7 +163,7 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
             ),
           );
         case kit.ConnectionState.failed:
-          _fail(AvatarRendererFailure.network);
+          _fail(_mapConnectionFailure(errorMessage));
       }
     };
     controller.onConversationState = (conversation) {
@@ -437,6 +437,40 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
       kit.AvatarError.failedToDownloadAvatarAssets ||
       kit.AvatarError.serverError => AvatarRendererFailure.network,
     };
+  }
+
+  static AvatarRendererFailure _mapConnectionFailure(String? errorMessage) {
+    final normalized = errorMessage?.toLowerCase();
+    if (normalized == null || normalized.isEmpty) {
+      return AvatarRendererFailure.network;
+    }
+    if (normalized.contains('sessiontokenexpired') ||
+        normalized.contains('session token expired') ||
+        normalized.contains('sessiontimeout') ||
+        normalized.contains('session timeout')) {
+      return AvatarRendererFailure.sessionExpired;
+    }
+    if (normalized.contains('appidunrecognized') ||
+        normalized.contains('avataridunrecognized') ||
+        normalized.contains('avatarassetmissing')) {
+      return AvatarRendererFailure.invalidConfiguration;
+    }
+    if (normalized.contains('insufficientbalance') ||
+        normalized.contains('insufficient balance')) {
+      return AvatarRendererFailure.insufficientBalance;
+    }
+    if (normalized.contains('concurrentlimitexceeded') ||
+        normalized.contains('concurrent limit')) {
+      return AvatarRendererFailure.sessionLimit;
+    }
+    if (normalized.contains('sessiontokeninvalid') ||
+        normalized.contains('session token invalid') ||
+        normalized.contains('authentication') ||
+        normalized.contains('unauthorized') ||
+        normalized.contains('forbidden')) {
+      return AvatarRendererFailure.authentication;
+    }
+    return AvatarRendererFailure.network;
   }
 }
 

--- a/mobile/lib/features/coaching/practice/avatar/spatius_avatar_renderer.dart
+++ b/mobile/lib/features/coaching/practice/avatar/spatius_avatar_renderer.dart
@@ -24,6 +24,9 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
   static int _nextTokenLease = 0;
   static int _activeTokenLease = 0;
   static Future<void> _tokenLeaseTail = Future<void>.value();
+  static Future<void>? _sdkInitializationFuture;
+  static String? _initializedAppId;
+  static int? _initializedSampleRateHz;
 
   AvatarRendererState _state = const AvatarRendererState();
   kit.Avatar? _avatar;
@@ -31,6 +34,7 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
   String? _loadingAvatarId;
   bool _closed = false;
   bool _prepared = false;
+  bool _startRequested = false;
   int? _tokenLease;
   Completer<void>? _tokenLeaseRelease;
   Future<void>? _sdkConfigurationFuture;
@@ -75,7 +79,10 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
       final avatarId = grant.avatarId;
       _loadingAvatarId = avatarId;
       try {
-        _avatar = await kit.AvatarManager.shared.load(id: avatarId);
+        _avatar = await kit.AvatarManager.shared.load(
+          id: avatarId,
+          useCompressedModel: true,
+        );
       } finally {
         if (_loadingAvatarId == avatarId) {
           _loadingAvatarId = null;
@@ -128,16 +135,21 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
     if (previous != null && !identical(previous, controller)) {
       unawaited(previous.close().catchError((_) {}));
     }
+    if (!identical(previous, controller)) {
+      _startRequested = false;
+    }
     _controller = controller;
     controller.onFirstRendering = () {
-      if (!_closed && _state.connection == AvatarRendererConnection.preparing) {
-        _setState(
-          _state.copyWith(
-            connection: AvatarRendererConnection.surfaceReady,
-            clearFailure: true,
-          ),
-        );
+      if (_closed || _startRequested || !identical(_controller, controller)) {
+        return;
       }
+      _setState(
+        _state.copyWith(
+          connection: AvatarRendererConnection.connecting,
+          clearFailure: true,
+        ),
+      );
+      _startOnce(controller);
     };
     controller.onConnectionState = (connection, errorMessage) {
       if (_closed || !identical(_controller, controller)) {
@@ -146,20 +158,17 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
       switch (connection) {
         case kit.ConnectionState.disconnected:
           _setState(
-            const AvatarRendererState(
-              connection: AvatarRendererConnection.surfaceReady,
-            ),
+            _state.copyWith(connection: AvatarRendererConnection.surfaceReady),
           );
         case kit.ConnectionState.connecting:
           _setState(
-            const AvatarRendererState(
-              connection: AvatarRendererConnection.connecting,
-            ),
+            _state.copyWith(connection: AvatarRendererConnection.connecting),
           );
         case kit.ConnectionState.connected:
           _setState(
-            const AvatarRendererState(
+            _state.copyWith(
               connection: AvatarRendererConnection.connected,
+              clearFailure: true,
             ),
           );
         case kit.ConnectionState.failed:
@@ -182,11 +191,13 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
         _fail(_mapError(error));
       }
     };
-    _setState(
-      const AvatarRendererState(
-        connection: AvatarRendererConnection.connecting,
-      ),
-    );
+  }
+
+  void _startOnce(kit.AvatarController controller) {
+    if (_startRequested || _closed || !identical(_controller, controller)) {
+      return;
+    }
+    _startRequested = true;
     unawaited(_start(controller));
   }
 
@@ -283,6 +294,7 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
     }
     final controller = _controller;
     _controller = null;
+    _startRequested = false;
     var nativeCloseFailed = false;
     if (controller != null) {
       controller.onFirstRendering = null;
@@ -327,17 +339,7 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
     _tokenLease = lease;
     _tokenLeaseRelease = release;
     try {
-      await kit.AvatarSDK.initialize(
-        appID: grant.appId,
-        configuration: kit.Configuration(
-          environment: kit.Environment.intl,
-          audioFormat: kit.AudioFormat(
-            sampleRate: grant.audioFormat.sampleRateHz,
-          ),
-          drivingServiceMode: kit.DrivingServiceMode.sdk,
-          logLevel: kit.LogLevel.off,
-        ),
-      );
+      await _ensureSdkInitialized(grant);
       if (_closed || _activeTokenLease != lease) {
         throw const AvatarRendererException(AvatarRendererFailure.unavailable);
       }
@@ -347,6 +349,45 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
       }
     } catch (_) {
       await _clearSdkTokenIfOwned();
+      rethrow;
+    }
+  }
+
+  static Future<void> _ensureSdkInitialized(AvatarSessionGrant grant) async {
+    final existing = _sdkInitializationFuture;
+    if (existing != null) {
+      await existing;
+      if (_initializedAppId != grant.appId ||
+          _initializedSampleRateHz != grant.audioFormat.sampleRateHz) {
+        throw const AvatarRendererException(
+          AvatarRendererFailure.invalidConfiguration,
+        );
+      }
+      return;
+    }
+
+    _initializedAppId = grant.appId;
+    _initializedSampleRateHz = grant.audioFormat.sampleRateHz;
+    final initialization = kit.AvatarSDK.initialize(
+      appID: grant.appId,
+      configuration: kit.Configuration(
+        environment: kit.Environment.intl,
+        audioFormat: kit.AudioFormat(
+          sampleRate: grant.audioFormat.sampleRateHz,
+        ),
+        drivingServiceMode: kit.DrivingServiceMode.sdk,
+        logLevel: kit.LogLevel.off,
+      ),
+    );
+    _sdkInitializationFuture = initialization;
+    try {
+      await initialization;
+    } catch (_) {
+      if (identical(_sdkInitializationFuture, initialization)) {
+        _sdkInitializationFuture = null;
+        _initializedAppId = null;
+        _initializedSampleRateHz = null;
+      }
       rethrow;
     }
   }
@@ -456,7 +497,8 @@ final class SpatiusAvatarRenderer implements AvatarRenderer {
       return AvatarRendererFailure.invalidConfiguration;
     }
     if (normalized.contains('insufficientbalance') ||
-        normalized.contains('insufficient balance')) {
+        normalized.contains('insufficient balance') ||
+        normalized.contains('insufficient credits')) {
       return AvatarRendererFailure.insufficientBalance;
     }
     if (normalized.contains('concurrentlimitexceeded') ||

--- a/mobile/lib/features/coaching/practice/practice_stage.dart
+++ b/mobile/lib/features/coaching/practice/practice_stage.dart
@@ -45,14 +45,15 @@ class PracticeStageLayout extends StatelessWidget {
   );
 }
 
-/// Stable stage chrome. A live renderer may replace [fallback] later without
-/// changing the surrounding practice experience.
+/// Stable stage chrome. A live renderer stays mounted behind [fallback] until
+/// it is ready to be shown, so connecting and replacement do not flash.
 class PracticeRoleStage extends StatelessWidget {
   const PracticeRoleStage({
     required this.title,
     required this.fallback,
     required this.onExit,
     this.surfaceBuilder,
+    this.surfaceVisible = true,
     this.statusLabel,
     this.exitInFlight = false,
     this.exitButtonKey,
@@ -63,6 +64,7 @@ class PracticeRoleStage extends StatelessWidget {
   final Widget fallback;
   final VoidCallback onExit;
   final WidgetBuilder? surfaceBuilder;
+  final bool surfaceVisible;
   final String? statusLabel;
   final bool exitInFlight;
   final Key? exitButtonKey;
@@ -73,7 +75,8 @@ class PracticeRoleStage extends StatelessWidget {
     child: Stack(
       fit: StackFit.expand,
       children: [
-        if (surfaceBuilder case final builder?) builder(context) else fallback,
+        if (surfaceBuilder case final builder?) builder(context),
+        if (surfaceBuilder == null || !surfaceVisible) fallback,
         const Positioned.fill(
           child: IgnorePointer(
             child: DecoratedBox(

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -26,6 +26,7 @@ class ScenarioPracticePage extends StatefulWidget {
   const ScenarioPracticePage({
     required this.practiceController,
     this.avatarSurfaceBuilder,
+    this.avatarSurfaceVisible = true,
     this.avatarStatusLabel,
     this.onBeforeStartRecording,
     this.onBeforeSubmitText,
@@ -43,6 +44,7 @@ class ScenarioPracticePage extends StatefulWidget {
 
   final PracticeController practiceController;
   final ScenarioAvatarSurfaceBuilder? avatarSurfaceBuilder;
+  final bool avatarSurfaceVisible;
   final String? avatarStatusLabel;
   final ScenarioAsyncAction? onBeforeStartRecording;
   final ScenarioAsyncAction? onBeforeSubmitText;
@@ -637,6 +639,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
                       imageKey: const Key('scenario-role-placeholder'),
                     ),
                     surfaceBuilder: widget.avatarSurfaceBuilder,
+                    surfaceVisible: widget.avatarSurfaceVisible,
                     statusLabel: widget.avatarStatusLabel,
                     exitInFlight: _exitInFlight,
                     exitButtonKey: const Key('scenario-exit'),

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -131,6 +131,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
   int _connectionOperationId = 0;
   int _generation = 0;
   int _lastExhaustedAttemptSequence = 0;
+  String? _connectionBudgetSessionId;
   String? _lastConnectionDiagnostic;
   Future<void> _lifecycleTail = Future<void>.value();
   Future<void> _controllerReplacementTail = Future<void>.value();
@@ -194,7 +195,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       return;
     }
     if (replaceController || !_foreground || !_hasLiveAvatarController) {
-      await _replaceAvatarController(resetConnectionAttempts: true);
+      await _replaceAvatarController(resetConnectionAttempts: false);
     }
     if (!_disposed && _foreground && _hasLiveAvatarController) {
       _scheduleSync();
@@ -288,7 +289,6 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       _hasUsableAvatarSurface = true;
     }
     if (avatarState.canUseAvatar) {
-      _connectionAttempts = 0;
       _reconnecting = false;
       _readinessTimer?.cancel();
       _readinessTimer = null;
@@ -301,6 +301,8 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       if (!_isRetryableAvatarFailure(avatarState.failure) ||
           _connectionAttempts >= _maximumConnectionAttempts) {
         _reconnecting = false;
+        _reconnectTimer?.cancel();
+        _reconnectTimer = null;
       }
     }
     final sessionId = widget.practiceController.practiceSessionId;
@@ -347,6 +349,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     if (sessionId == null || sessionId.isEmpty) {
       return;
     }
+    _resetConnectionBudgetForNewSession(sessionId);
     if (!_hasLiveAvatarController) {
       _queueLifecycleReconciliation();
       return;
@@ -452,8 +455,10 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
         operationId: operationId,
         sessionId: sessionId,
       )) {
-        retry = true;
-        _readinessExpired = false;
+        // AvatarKit model loading is not cancellable through Future.timeout.
+        // Keep the original load alive and allow audio fallback instead of
+        // launching an overlapping download with a replacement renderer.
+        _readinessExpired = true;
       }
     } catch (_) {
       if (_connectionFenceMatches(
@@ -475,6 +480,19 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
         }
       }
     }
+  }
+
+  void _resetConnectionBudgetForNewSession(String sessionId) {
+    if (_connectionBudgetSessionId == sessionId) {
+      return;
+    }
+    _connectionBudgetSessionId = sessionId;
+    _connectionAttempts = 0;
+    _connectionAttemptSequence = 0;
+    _lastExhaustedAttemptSequence = 0;
+    _reconnecting = false;
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
   }
 
   bool _connectionFenceMatches({
@@ -534,6 +552,11 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       if (_disposed ||
           !_foreground ||
           widget.practiceController.practiceSessionId != sessionId) {
+        return;
+      }
+      final failure = _avatarController.state.failure;
+      if (failure != null && !_isRetryableAvatarFailure(failure)) {
+        _reconnecting = false;
         return;
       }
       await _replaceAvatarController(resetConnectionAttempts: false);

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -18,6 +18,7 @@ typedef PracticeAvatarSessionBuilder =
 final class PracticeAvatarSessionView {
   const PracticeAvatarSessionView({
     required this.surfaceBuilder,
+    required this.surfaceVisible,
     required this.statusLabel,
     required this.interruptForUserTurn,
     required this.onReplayQuestion,
@@ -26,6 +27,7 @@ final class PracticeAvatarSessionView {
   });
 
   final WidgetBuilder? surfaceBuilder;
+  final bool surfaceVisible;
   final String? statusLabel;
   final Future<void> Function() interruptForUserTurn;
   final Future<void> Function()? onReplayQuestion;
@@ -85,6 +87,7 @@ class ScenarioPracticeSession extends StatelessWidget {
         practiceController: practiceController,
         questionSpeaker: practiceController.promptSpeaker,
         avatarSurfaceBuilder: avatar.surfaceBuilder,
+        avatarSurfaceVisible: avatar.surfaceVisible,
         avatarStatusLabel: avatar.statusLabel,
         onBeforeStartRecording: avatar.interruptForUserTurn,
         onBeforeSubmitText: avatar.interruptForUserTurn,
@@ -121,10 +124,14 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
   bool _foreground = true;
   bool _hasLiveAvatarController = true;
   bool _hasUsableAvatarSurface = false;
+  bool _reconnecting = false;
   bool _disposed = false;
   int _connectionAttempts = 0;
+  int _connectionAttemptSequence = 0;
   int _connectionOperationId = 0;
   int _generation = 0;
+  int _lastExhaustedAttemptSequence = 0;
+  String? _lastConnectionDiagnostic;
   Future<void> _lifecycleTail = Future<void>.value();
   Future<void> _controllerReplacementTail = Future<void>.value();
 
@@ -142,7 +149,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       if (_foreground) {
         _scheduleSync();
       } else {
-        _queueLifecycleReconciliation();
+        _queueLifecycleReconciliation(replaceController: true);
       }
     });
   }
@@ -170,23 +177,23 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       // Never replay an interrupted question just because the App resumes.
       _autoHandledQuestionId = widget.practiceController.questionId;
     }
-    _queueLifecycleReconciliation();
+    _queueLifecycleReconciliation(replaceController: !_foreground);
   }
 
-  void _queueLifecycleReconciliation() {
+  void _queueLifecycleReconciliation({bool replaceController = false}) {
     final previous = _lifecycleTail;
     final operation = previous
         .catchError((_) {})
-        .then((_) => _reconcileLifecycle());
+        .then((_) => _reconcileLifecycle(replaceController: replaceController));
     _lifecycleTail = operation;
     unawaited(operation);
   }
 
-  Future<void> _reconcileLifecycle() async {
+  Future<void> _reconcileLifecycle({required bool replaceController}) async {
     if (_disposed) {
       return;
     }
-    if (!_foreground || !_hasLiveAvatarController) {
+    if (replaceController || !_foreground || !_hasLiveAvatarController) {
       await _replaceAvatarController(resetConnectionAttempts: true);
     }
     if (!_disposed && _foreground && _hasLiveAvatarController) {
@@ -217,6 +224,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       _hasUsableAvatarSurface = false;
       if (resetConnectionAttempts) {
         _connectionAttempts = 0;
+        _reconnecting = false;
       }
 
       if (_hasLiveAvatarController) {
@@ -270,6 +278,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       return;
     }
     final avatarState = _avatarController.state;
+    _logConnectionState(avatarState);
     if (switch (avatarState.renderer.connection) {
       AvatarRendererConnection.surfaceReady ||
       AvatarRendererConnection.connecting ||
@@ -280,13 +289,25 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     }
     if (avatarState.canUseAvatar) {
       _connectionAttempts = 0;
+      _reconnecting = false;
       _readinessTimer?.cancel();
       _readinessTimer = null;
+      _reconnectTimer?.cancel();
+      _reconnectTimer = null;
+    }
+    if (avatarState.failure != null) {
+      _readinessTimer?.cancel();
+      _readinessTimer = null;
+      if (!_isRetryableAvatarFailure(avatarState.failure) ||
+          _connectionAttempts >= _maximumConnectionAttempts) {
+        _reconnecting = false;
+      }
     }
     final sessionId = widget.practiceController.practiceSessionId;
     if (sessionId != null &&
         !_connectionInFlight &&
-        _isRetryableAvatarFailure(_avatarController.state.failure)) {
+        !avatarState.canUseAvatar &&
+        _isRetryableAvatarFailure(avatarState.failure)) {
       _scheduleReconnect(sessionId);
     }
     if (mounted) {
@@ -375,6 +396,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     _connectionInFlight = true;
     _connectionAttemptedSessionId = sessionId;
     _connectionAttempts++;
+    _connectionAttemptSequence++;
     _readinessExpired = false;
     _readinessTimer?.cancel();
     _readinessTimer = null;
@@ -395,9 +417,18 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
         _readinessExpired = !retry;
         return;
       }
-      _reconnectTimer?.cancel();
-      _reconnectTimer = null;
       if (controller.state.canUseAvatar) {
+        _reconnectTimer?.cancel();
+        _reconnectTimer = null;
+        return;
+      }
+      final failure = controller.state.failure;
+      if (_isRetryableAvatarFailure(failure)) {
+        retry = true;
+        return;
+      }
+      if (failure != null) {
+        _readinessExpired = true;
         return;
       }
       _readinessTimer = Timer(_avatarReadinessTimeout, () {
@@ -410,6 +441,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
           return;
         }
         _readinessExpired = true;
+        _reconnecting = false;
         _scheduleSync();
         if (mounted) {
           setState(() {});
@@ -422,6 +454,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
         sessionId: sessionId,
       )) {
         _readinessExpired = true;
+        _reconnecting = false;
       }
     } catch (_) {
       if (_connectionFenceMatches(
@@ -469,12 +502,33 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     if (_disposed ||
         !_foreground ||
         !_hasLiveAvatarController ||
-        _reconnectTimer != null ||
-        _connectionAttempts >= _maximumConnectionAttempts ||
         widget.practiceController.practiceSessionId != sessionId) {
       return;
     }
+    if (_connectionAttempts >= _maximumConnectionAttempts) {
+      _reconnecting = false;
+      if (_lastExhaustedAttemptSequence != _connectionAttemptSequence) {
+        _lastExhaustedAttemptSequence = _connectionAttemptSequence;
+        developer.log(
+          'avatar_connection attempt=$_connectionAttemptSequence '
+          'state=exhausted mapped_failure='
+          '${_avatarController.state.failure?.name ?? 'none'}',
+          name: 'speakup.avatar',
+        );
+      }
+      return;
+    }
+    if (_reconnectTimer != null) {
+      return;
+    }
+    _reconnecting = true;
     final delay = Duration(milliseconds: 500 * (_connectionAttempts + 1));
+    developer.log(
+      'avatar_connection attempt=$_connectionAttemptSequence '
+      'state=reconnect_scheduled mapped_failure='
+      '${_avatarController.state.failure?.name ?? 'none'}',
+      name: 'speakup.avatar',
+    );
     _reconnectTimer = Timer(delay, () async {
       _reconnectTimer = null;
       if (_disposed ||
@@ -669,6 +723,11 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       return _foreground ? '正在重新连接情景角色' : '情景角色已暂停';
     }
     final state = _avatarController.state;
+    if (_reconnecting ||
+        (_isRetryableAvatarFailure(state.failure) &&
+            _connectionAttempts < _maximumConnectionAttempts)) {
+      return '正在重新连接情景角色';
+    }
     if (state.phase == AvatarControllerPhase.idle ||
         state.phase == AvatarControllerPhase.preparing) {
       return _readinessExpired ? '画面暂不可用，语音仍可继续' : '正在准备情景角色';
@@ -680,14 +739,32 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     return null;
   }
 
+  void _logConnectionState(AvatarControllerState state) {
+    final diagnostic =
+        'avatar_connection attempt=$_connectionAttemptSequence '
+        'state=${state.renderer.connection.name} '
+        'mapped_failure=${state.failure?.name ?? 'none'}';
+    if (_lastConnectionDiagnostic == diagnostic) {
+      return;
+    }
+    _lastConnectionDiagnostic = diagnostic;
+    developer.log(diagnostic, name: 'speakup.avatar');
+  }
+
   @override
   Widget build(BuildContext context) {
+    final avatarController = _avatarController;
     return widget.builder(
       context,
       PracticeAvatarSessionView(
         surfaceBuilder: _hasLiveAvatarController && _hasUsableAvatarSurface
-            ? (_) => _avatarController.buildSurface(key: widget.surfaceKey)
+            ? (_) => KeyedSubtree(
+                key: ObjectKey(avatarController),
+                child: avatarController.buildSurface(key: widget.surfaceKey),
+              )
             : null,
+        surfaceVisible:
+            _hasLiveAvatarController && avatarController.state.canUseAvatar,
         statusLabel: _avatarStatusLabel,
         interruptForUserTurn: _interruptForUserTurn,
         onReplayQuestion: !widget.practiceController.canPlayQuestionAudio

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -440,8 +440,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
             controller.state.canUseAvatar) {
           return;
         }
-        _readinessExpired = true;
-        _reconnecting = false;
+        _scheduleReconnect(sessionId);
         _scheduleSync();
         if (mounted) {
           setState(() {});
@@ -453,8 +452,8 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
         operationId: operationId,
         sessionId: sessionId,
       )) {
-        _readinessExpired = true;
-        _reconnecting = false;
+        retry = true;
+        _readinessExpired = false;
       }
     } catch (_) {
       if (_connectionFenceMatches(
@@ -507,6 +506,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     }
     if (_connectionAttempts >= _maximumConnectionAttempts) {
       _reconnecting = false;
+      _readinessExpired = true;
       if (_lastExhaustedAttemptSequence != _connectionAttemptSequence) {
         _lastExhaustedAttemptSequence = _connectionAttemptSequence;
         developer.log(

--- a/mobile/test/coaching/practice/avatar/avatar_test_fakes.dart
+++ b/mobile/test/coaching/practice/avatar/avatar_test_fakes.dart
@@ -9,11 +9,13 @@ final class FakeAvatarRenderer implements AvatarRenderer {
     this.connectOnPrepare = true,
     this.prepareFailure,
     this.prepareGate,
+    this.surfaceBuilder,
   });
 
   final bool connectOnPrepare;
   final AvatarRendererFailure? prepareFailure;
   final Completer<void>? prepareGate;
+  final Widget Function(Key? key)? surfaceBuilder;
   final StreamController<AvatarRendererState> _states =
       StreamController<AvatarRendererState>.broadcast(sync: true);
 
@@ -65,7 +67,8 @@ final class FakeAvatarRenderer implements AvatarRenderer {
   }
 
   @override
-  Widget buildSurface({Key? key}) => SizedBox(key: key);
+  Widget buildSurface({Key? key}) =>
+      surfaceBuilder?.call(key) ?? SizedBox(key: key);
 
   @override
   Future<void> sendPcm(Uint8List pcmBytes, {required bool end}) async {

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -298,104 +298,97 @@ void main() {
     expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
   });
 
-  testWidgets(
-    'keeps fallback stable through the 500ms controller replacement',
-    (tester) async {
-      final media = _RealtimeQuestionMediaClient();
-      media.release();
-      final nativePlayer = _RecordingPCMStreamPlayer();
-      final practiceController = PracticeController(
-        client: FakePracticeClient(),
-        mediaClient: media,
-        audioPlayer: _SilentPracticeAudioPlayer(),
-        questionSpeechPlayer: nativePlayer,
-        automaticQuestionSpeechEnabled: false,
-      );
-      addTearDown(practiceController.dispose);
-      await activateTestPractice(
-        controller: practiceController,
-        scene: testScenes[2],
-      );
-      final surfaceEvents = <String>[];
-      final firstRenderer = FakeAvatarRenderer(
-        surfaceBuilder: (key) => _SurfaceLifecycleProbe(
-          key: key,
-          id: 'first',
-          events: surfaceEvents,
+  testWidgets('keeps fallback stable through the first retry replacement', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    media.release();
+    final nativePlayer = _RecordingPCMStreamPlayer();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: nativePlayer,
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final surfaceEvents = <String>[];
+    final firstRenderer = FakeAvatarRenderer(
+      surfaceBuilder: (key) =>
+          _SurfaceLifecycleProbe(key: key, id: 'first', events: surfaceEvents),
+    );
+    final secondRenderer = FakeAvatarRenderer(
+      connectOnPrepare: false,
+      surfaceBuilder: (key) =>
+          _SurfaceLifecycleProbe(key: key, id: 'second', events: surfaceEvents),
+    );
+    final controllers = <AvatarController>[
+      _avatarController(firstRenderer),
+      _avatarController(secondRenderer),
+    ];
+    var factoryCalls = 0;
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => controllers[factoryCalls++],
+          surfaceKey: const Key('test-avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return _avatarStage(avatar);
+          },
         ),
-      );
-      final secondRenderer = FakeAvatarRenderer(
-        connectOnPrepare: false,
-        surfaceBuilder: (key) => _SurfaceLifecycleProbe(
-          key: key,
-          id: 'second',
-          events: surfaceEvents,
-        ),
-      );
-      final controllers = <AvatarController>[
-        _avatarController(firstRenderer),
-        _avatarController(secondRenderer),
-      ];
-      var factoryCalls = 0;
-      PracticeAvatarSessionView? sessionView;
+      ),
+    );
+    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await tester.pump();
+    expect(sessionView?.surfaceVisible, isTrue);
+    expect(find.byKey(const Key('static-fallback')), findsNothing);
+    expect(surfaceEvents, <String>['init:first']);
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PracticeAvatarSession(
-            practiceController: practiceController,
-            avatarControllerFactory: () => controllers[factoryCalls++],
-            surfaceKey: const Key('test-avatar-surface'),
-            builder: (context, avatar) {
-              sessionView = avatar;
-              return _avatarStage(avatar);
-            },
-          ),
-        ),
-      );
-      await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
-      await tester.pump();
-      expect(sessionView?.surfaceVisible, isTrue);
-      expect(find.byKey(const Key('static-fallback')), findsNothing);
-      expect(surfaceEvents, <String>['init:first']);
+    firstRenderer.emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump();
 
-      firstRenderer.emit(
-        const AvatarRendererState(
-          connection: AvatarRendererConnection.failed,
-          failure: AvatarRendererFailure.network,
-        ),
-      );
-      await tester.pump();
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    expect(find.text('正在重新连接情景角色'), findsOneWidget);
+    expect(nativePlayer.events, isEmpty);
 
-      expect(sessionView?.surfaceVisible, isFalse);
-      expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
-      expect(find.byKey(const Key('static-fallback')), findsOneWidget);
-      expect(find.text('正在重新连接情景角色'), findsOneWidget);
-      expect(nativePlayer.events, isEmpty);
+    await tester.pump(const Duration(milliseconds: 999));
+    expect(factoryCalls, 1);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
 
-      await tester.pump(const Duration(milliseconds: 499));
-      expect(factoryCalls, 1);
-      expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 1));
+    await _flushControllerReplacement(tester);
+    await _pumpUntil(tester, () => secondRenderer.preparedGrant != null);
+    await tester.pump();
 
-      await tester.pump(const Duration(milliseconds: 1));
-      await _flushControllerReplacement(tester);
-      await _pumpUntil(tester, () => secondRenderer.preparedGrant != null);
-      await tester.pump();
-
-      expect(factoryCalls, 2);
-      expect(firstRenderer.closeCount, 1);
-      expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
-      expect(find.byKey(const Key('static-fallback')), findsOneWidget);
-      expect(sessionView?.surfaceVisible, isFalse);
-      expect(find.text('正在重新连接情景角色'), findsOneWidget);
-      expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
-      expect(nativePlayer.events, isEmpty);
-      expect(surfaceEvents, hasLength(3));
-      expect(
-        surfaceEvents,
-        containsAll(<String>['init:first', 'dispose:first', 'init:second']),
-      );
-    },
-  );
+    expect(factoryCalls, 2);
+    expect(firstRenderer.closeCount, 1);
+    expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.text('正在重新连接情景角色'), findsOneWidget);
+    expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+    expect(nativePlayer.events, isEmpty);
+    expect(surfaceEvents, hasLength(3));
+    expect(
+      surfaceEvents,
+      containsAll(<String>['init:first', 'dispose:first', 'init:second']),
+    );
+  });
 
   testWidgets('cancels replacement when the renderer reconnects itself', (
     tester,
@@ -617,13 +610,9 @@ void main() {
     expect(nativePlayer.events.length, 4);
   });
 
-  for (final timeoutCase in <({String name, bool stallPrepare})>[
-    (name: 'connect future', stallPrepare: true),
-    (name: 'connected readiness', stallPrepare: false),
-  ]) {
-    testWidgets('retries ${timeoutCase.name} timeout exactly three times', (
-      tester,
-    ) async {
+  testWidgets(
+    'does not replace the controller while avatar assets are still loading',
+    (tester) async {
       final media = _RealtimeQuestionMediaClient();
       media.release();
       final practiceController = PracticeController(
@@ -638,17 +627,11 @@ void main() {
         controller: practiceController,
         scene: testScenes[2],
       );
-      final prepareGates = List<Completer<void>>.generate(
-        3,
-        (_) => Completer<void>(),
-      );
-      final renderers = List<FakeAvatarRenderer>.generate(
-        3,
-        (index) => FakeAvatarRenderer(
-          connectOnPrepare: false,
-          prepareGate: timeoutCase.stallPrepare ? prepareGates[index] : null,
-        ),
-      );
+      final prepareGate = Completer<void>();
+      final renderers = <FakeAvatarRenderer>[
+        FakeAvatarRenderer(connectOnPrepare: false, prepareGate: prepareGate),
+        FakeAvatarRenderer(),
+      ];
       final controllers = renderers.map(_avatarController).toList();
       var factoryCalls = 0;
       PracticeAvatarSessionView? sessionView;
@@ -667,33 +650,99 @@ void main() {
         ),
       );
 
-      for (var attempt = 0; attempt < 3; attempt++) {
-        await _pumpUntil(
-          tester,
-          () => renderers[attempt].preparedGrant != null,
-        );
-        await tester.pump();
-        await tester.pump(const Duration(seconds: 15));
-        await tester.pump();
+      await _pumpUntil(tester, () => renderers.first.preparedGrant != null);
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pump(const Duration(seconds: 2));
 
-        if (attempt < 2) {
-          expect(find.text('正在重新连接情景角色'), findsOneWidget);
-          expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
-          await tester.pump(Duration(milliseconds: 1000 + attempt * 500));
-          await _flushControllerReplacement(tester);
-        }
-      }
-
-      expect(factoryCalls, 3);
+      expect(factoryCalls, 1);
+      expect(renderers.first.closeCount, 0);
+      expect(renderers.last.preparedGrant, isNull);
       expect(sessionView?.surfaceVisible, isFalse);
       expect(find.byKey(const Key('static-fallback')), findsOneWidget);
       expect(find.text('正在重新连接情景角色'), findsNothing);
       expect(find.text('画面暂不可用，语音仍可继续'), findsOneWidget);
 
-      await tester.pump(const Duration(seconds: 2));
-      expect(factoryCalls, 3);
-    });
-  }
+      prepareGate.complete();
+      await _pumpUntil(
+        tester,
+        () =>
+            renderers.first.state.connection ==
+            AvatarRendererConnection.surfaceReady,
+      );
+      renderers.first.emit(
+        const AvatarRendererState(
+          connection: AvatarRendererConnection.connected,
+        ),
+      );
+      await tester.pump();
+
+      expect(factoryCalls, 1);
+      expect(sessionView?.surfaceVisible, isTrue);
+      expect(find.byKey(const Key('static-fallback')), findsNothing);
+    },
+  );
+
+  testWidgets('retries connected readiness timeout exactly three times', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    media.release();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: _RecordingPCMStreamPlayer(),
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final renderers = List<FakeAvatarRenderer>.generate(
+      3,
+      (_) => FakeAvatarRenderer(connectOnPrepare: false),
+    );
+    final controllers = renderers.map(_avatarController).toList();
+    var factoryCalls = 0;
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => controllers[factoryCalls++],
+          surfaceKey: const Key('test-avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return _avatarStage(avatar);
+          },
+        ),
+      ),
+    );
+
+    for (var attempt = 0; attempt < 3; attempt++) {
+      await _pumpUntil(tester, () => renderers[attempt].preparedGrant != null);
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pump();
+
+      if (attempt < 2) {
+        expect(find.text('正在重新连接情景角色'), findsOneWidget);
+        expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+        await tester.pump(Duration(milliseconds: 1000 + attempt * 500));
+        await _flushControllerReplacement(tester);
+      }
+    }
+
+    expect(factoryCalls, 3);
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    expect(find.text('正在重新连接情景角色'), findsNothing);
+    expect(find.text('画面暂不可用，语音仍可继续'), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 2));
+    expect(factoryCalls, 3);
+  });
 
   testWidgets('reveals only the connected replacement after a retry succeeds', (
     tester,
@@ -751,7 +800,7 @@ void main() {
     expect(find.byKey(const Key('static-fallback')), findsOneWidget);
     expect(find.text('正在重新连接情景角色'), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(const Duration(seconds: 1));
     await _flushControllerReplacement(tester);
     await _pumpUntil(tester, () => secondRenderer.preparedGrant != null);
     await tester.pump();

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -617,6 +617,84 @@ void main() {
     expect(nativePlayer.events.length, 4);
   });
 
+  for (final timeoutCase in <({String name, bool stallPrepare})>[
+    (name: 'connect future', stallPrepare: true),
+    (name: 'connected readiness', stallPrepare: false),
+  ]) {
+    testWidgets('retries ${timeoutCase.name} timeout exactly three times', (
+      tester,
+    ) async {
+      final media = _RealtimeQuestionMediaClient();
+      media.release();
+      final practiceController = PracticeController(
+        client: FakePracticeClient(),
+        mediaClient: media,
+        audioPlayer: _SilentPracticeAudioPlayer(),
+        questionSpeechPlayer: _RecordingPCMStreamPlayer(),
+        automaticQuestionSpeechEnabled: false,
+      );
+      addTearDown(practiceController.dispose);
+      await activateTestPractice(
+        controller: practiceController,
+        scene: testScenes[2],
+      );
+      final prepareGates = List<Completer<void>>.generate(
+        3,
+        (_) => Completer<void>(),
+      );
+      final renderers = List<FakeAvatarRenderer>.generate(
+        3,
+        (index) => FakeAvatarRenderer(
+          connectOnPrepare: false,
+          prepareGate: timeoutCase.stallPrepare ? prepareGates[index] : null,
+        ),
+      );
+      final controllers = renderers.map(_avatarController).toList();
+      var factoryCalls = 0;
+      PracticeAvatarSessionView? sessionView;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PracticeAvatarSession(
+            practiceController: practiceController,
+            avatarControllerFactory: () => controllers[factoryCalls++],
+            surfaceKey: const Key('test-avatar-surface'),
+            builder: (context, avatar) {
+              sessionView = avatar;
+              return _avatarStage(avatar);
+            },
+          ),
+        ),
+      );
+
+      for (var attempt = 0; attempt < 3; attempt++) {
+        await _pumpUntil(
+          tester,
+          () => renderers[attempt].preparedGrant != null,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 15));
+        await tester.pump();
+
+        if (attempt < 2) {
+          expect(find.text('正在重新连接情景角色'), findsOneWidget);
+          expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+          await tester.pump(Duration(milliseconds: 1000 + attempt * 500));
+          await _flushControllerReplacement(tester);
+        }
+      }
+
+      expect(factoryCalls, 3);
+      expect(sessionView?.surfaceVisible, isFalse);
+      expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+      expect(find.text('正在重新连接情景角色'), findsNothing);
+      expect(find.text('画面暂不可用，语音仍可继续'), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 2));
+      expect(factoryCalls, 3);
+    });
+  }
+
   testWidgets('reveals only the connected replacement after a retry succeeds', (
     tester,
   ) async {

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -8,6 +8,7 @@ import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/practice/practice_media.dart';
+import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/scenario/scenario_practice_session.dart';
 import 'package:speakup/features/coaching/scene/scene.dart';
 
@@ -240,10 +241,11 @@ void main() {
     },
   );
 
-  testWidgets('keeps a loaded avatar surface visible after a disconnect', (
+  testWidgets('keeps fallback over a mounted surface before first connection', (
     tester,
   ) async {
     final media = _RealtimeQuestionMediaClient();
+    media.release();
     final practiceController = PracticeController(
       client: FakePracticeClient(),
       mediaClient: media,
@@ -256,31 +258,30 @@ void main() {
       controller: practiceController,
       scene: testScenes[2],
     );
-    final renderer = FakeAvatarRenderer();
-    final avatarController = AvatarController(
-      renderer: renderer,
-      tokenClient: FakeAvatarSessionTokenClient(),
-      fallbackPlayback: (_) async {},
-      fallbackStop: () async {},
-      delay: (_) async {},
-    );
+    final renderer = FakeAvatarRenderer(connectOnPrepare: false);
+    final avatarController = _avatarController(renderer);
+    PracticeAvatarSessionView? sessionView;
 
     await tester.pumpWidget(
       MaterialApp(
         home: PracticeAvatarSession(
           practiceController: practiceController,
           avatarControllerFactory: () => avatarController,
-          surfaceKey: const Key('retained-avatar-surface'),
-          builder: (context, avatar) =>
-              avatar.surfaceBuilder?.call(context) ??
-              const SizedBox(key: Key('static-fallback')),
+          surfaceKey: const Key('test-avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return _avatarStage(avatar);
+          },
         ),
       ),
     );
+    await _pumpUntil(tester, () => renderer.preparedGrant != null);
     await tester.pump();
-    media.release();
-    await tester.pumpAndSettle();
-    expect(find.byKey(const Key('retained-avatar-surface')), findsOneWidget);
+
+    expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.text('正在准备情景角色'), findsOneWidget);
 
     renderer.emit(
       const AvatarRendererState(
@@ -290,8 +291,401 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.byKey(const Key('retained-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.text('正在重新连接情景角色'), findsOneWidget);
+    expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+  });
+
+  testWidgets(
+    'keeps fallback stable through the 500ms controller replacement',
+    (tester) async {
+      final media = _RealtimeQuestionMediaClient();
+      media.release();
+      final nativePlayer = _RecordingPCMStreamPlayer();
+      final practiceController = PracticeController(
+        client: FakePracticeClient(),
+        mediaClient: media,
+        audioPlayer: _SilentPracticeAudioPlayer(),
+        questionSpeechPlayer: nativePlayer,
+        automaticQuestionSpeechEnabled: false,
+      );
+      addTearDown(practiceController.dispose);
+      await activateTestPractice(
+        controller: practiceController,
+        scene: testScenes[2],
+      );
+      final surfaceEvents = <String>[];
+      final firstRenderer = FakeAvatarRenderer(
+        surfaceBuilder: (key) => _SurfaceLifecycleProbe(
+          key: key,
+          id: 'first',
+          events: surfaceEvents,
+        ),
+      );
+      final secondRenderer = FakeAvatarRenderer(
+        connectOnPrepare: false,
+        surfaceBuilder: (key) => _SurfaceLifecycleProbe(
+          key: key,
+          id: 'second',
+          events: surfaceEvents,
+        ),
+      );
+      final controllers = <AvatarController>[
+        _avatarController(firstRenderer),
+        _avatarController(secondRenderer),
+      ];
+      var factoryCalls = 0;
+      PracticeAvatarSessionView? sessionView;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PracticeAvatarSession(
+            practiceController: practiceController,
+            avatarControllerFactory: () => controllers[factoryCalls++],
+            surfaceKey: const Key('test-avatar-surface'),
+            builder: (context, avatar) {
+              sessionView = avatar;
+              return _avatarStage(avatar);
+            },
+          ),
+        ),
+      );
+      await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+      await tester.pump();
+      expect(sessionView?.surfaceVisible, isTrue);
+      expect(find.byKey(const Key('static-fallback')), findsNothing);
+      expect(surfaceEvents, <String>['init:first']);
+
+      firstRenderer.emit(
+        const AvatarRendererState(
+          connection: AvatarRendererConnection.failed,
+          failure: AvatarRendererFailure.network,
+        ),
+      );
+      await tester.pump();
+
+      expect(sessionView?.surfaceVisible, isFalse);
+      expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+      expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+      expect(find.text('正在重新连接情景角色'), findsOneWidget);
+      expect(nativePlayer.events, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 499));
+      expect(factoryCalls, 1);
+      expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 1));
+      await _flushControllerReplacement(tester);
+      await _pumpUntil(tester, () => secondRenderer.preparedGrant != null);
+      await tester.pump();
+
+      expect(factoryCalls, 2);
+      expect(firstRenderer.closeCount, 1);
+      expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+      expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+      expect(sessionView?.surfaceVisible, isFalse);
+      expect(find.text('正在重新连接情景角色'), findsOneWidget);
+      expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+      expect(nativePlayer.events, isEmpty);
+      expect(surfaceEvents, hasLength(3));
+      expect(
+        surfaceEvents,
+        containsAll(<String>['init:first', 'dispose:first', 'init:second']),
+      );
+    },
+  );
+
+  testWidgets('cancels replacement when the renderer reconnects itself', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    media.release();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: _RecordingPCMStreamPlayer(),
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final firstRenderer = FakeAvatarRenderer();
+    final secondRenderer = FakeAvatarRenderer();
+    final controllers = <AvatarController>[
+      _avatarController(firstRenderer),
+      _avatarController(secondRenderer),
+    ];
+    var factoryCalls = 0;
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => controllers[factoryCalls++],
+          surfaceKey: const Key('test-avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return _avatarStage(avatar);
+          },
+        ),
+      ),
+    );
+    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await tester.pump();
+
+    firstRenderer.emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump();
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.text('正在重新连接情景角色'), findsOneWidget);
+
+    firstRenderer.emit(
+      const AvatarRendererState(connection: AvatarRendererConnection.connected),
+    );
+    await tester.pump();
+    expect(sessionView?.surfaceVisible, isTrue);
     expect(find.byKey(const Key('static-fallback')), findsNothing);
+    expect(find.text('正在重新连接情景角色'), findsNothing);
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(factoryCalls, 1);
+    expect(firstRenderer.closeCount, 0);
+    expect(secondRenderer.preparedGrant, isNull);
+  });
+
+  testWidgets('rebuilds the controller after an immediate pause and resume', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    media.release();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: _RecordingPCMStreamPlayer(),
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final firstRenderer = FakeAvatarRenderer();
+    final secondRenderer = FakeAvatarRenderer();
+    final controllers = <AvatarController>[
+      _avatarController(firstRenderer),
+      _avatarController(secondRenderer),
+    ];
+    var factoryCalls = 0;
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => controllers[factoryCalls++],
+          surfaceKey: const Key('test-avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return _avatarStage(avatar);
+          },
+        ),
+      ),
+    );
+    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await tester.pump();
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await _flushControllerReplacement(tester);
+    await _pumpUntil(tester, () => secondRenderer.preparedGrant != null);
+    await tester.pump();
+
+    expect(factoryCalls, 2);
+    expect(firstRenderer.closeCount, 1);
+    expect(sessionView?.surfaceVisible, isTrue);
+    expect(find.byKey(const Key('static-fallback')), findsNothing);
+  });
+
+  testWidgets('shows unavailable only after exactly three failed attempts', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    media.release();
+    final nativePlayer = _RecordingPCMStreamPlayer();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: nativePlayer,
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final renderers = List<FakeAvatarRenderer>.generate(
+      3,
+      (_) => FakeAvatarRenderer(connectOnPrepare: false),
+    );
+    final controllers = renderers.map(_avatarController).toList();
+    var factoryCalls = 0;
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => controllers[factoryCalls++],
+          surfaceKey: const Key('test-avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return _avatarStage(avatar);
+          },
+        ),
+      ),
+    );
+    await _pumpUntil(tester, () => renderers[0].preparedGrant != null);
+    await tester.pump();
+
+    renderers[0].emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump();
+    expect(find.text('正在重新连接情景角色'), findsOneWidget);
+    expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+    await tester.pump(const Duration(seconds: 1));
+    await _flushControllerReplacement(tester);
+    await _pumpUntil(tester, () => renderers[1].preparedGrant != null);
+    await tester.pump();
+
+    renderers[1].emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump();
+    expect(find.text('正在重新连接情景角色'), findsOneWidget);
+    expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+    await tester.pump(const Duration(milliseconds: 1500));
+    await _flushControllerReplacement(tester);
+    await _pumpUntil(tester, () => renderers[2].preparedGrant != null);
+    await tester.pump();
+
+    renderers[2].emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await _pumpUntil(tester, () => nativePlayer.events.length == 4);
+
+    expect(factoryCalls, 3);
+    expect(
+      renderers.map((renderer) => renderer.preparedGrant),
+      everyElement(isNotNull),
+    );
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    expect(find.text('正在重新连接情景角色'), findsNothing);
+    expect(find.text('画面暂不可用，语音仍可继续'), findsOneWidget);
+    expect(nativePlayer.events, <String>[
+      'start',
+      'append:4',
+      'append:4',
+      'finish',
+    ]);
+
+    await tester.pump(const Duration(seconds: 2));
+    expect(factoryCalls, 3);
+    expect(nativePlayer.events.length, 4);
+  });
+
+  testWidgets('reveals only the connected replacement after a retry succeeds', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient();
+    media.release();
+    final nativePlayer = _RecordingPCMStreamPlayer();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: nativePlayer,
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final firstRenderer = FakeAvatarRenderer();
+    final secondRenderer = FakeAvatarRenderer();
+    final controllers = <AvatarController>[
+      _avatarController(firstRenderer),
+      _avatarController(secondRenderer),
+    ];
+    var factoryCalls = 0;
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => controllers[factoryCalls++],
+          surfaceKey: const Key('test-avatar-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return _avatarStage(avatar);
+          },
+        ),
+      ),
+    );
+    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await tester.pump();
+    expect(sessionView?.surfaceVisible, isTrue);
+    expect(find.byKey(const Key('static-fallback')), findsNothing);
+
+    firstRenderer.emit(
+      const AvatarRendererState(
+        connection: AvatarRendererConnection.failed,
+        failure: AvatarRendererFailure.network,
+      ),
+    );
+    await tester.pump();
+    expect(sessionView?.surfaceVisible, isFalse);
+    expect(find.byKey(const Key('static-fallback')), findsOneWidget);
+    expect(find.text('正在重新连接情景角色'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    await _flushControllerReplacement(tester);
+    await _pumpUntil(tester, () => secondRenderer.preparedGrant != null);
+    await tester.pump();
+
+    expect(factoryCalls, 2);
+    expect(firstRenderer.closeCount, 1);
+    expect(sessionView?.surfaceVisible, isTrue);
+    expect(find.byKey(const Key('test-avatar-surface')), findsOneWidget);
+    expect(find.byKey(const Key('static-fallback')), findsNothing);
+    expect(find.text('正在重新连接情景角色'), findsNothing);
+    expect(find.text('画面暂不可用，语音仍可继续'), findsNothing);
+    expect(nativePlayer.events, isEmpty);
   });
 
   testWidgets(
@@ -355,6 +749,63 @@ void main() {
   );
 }
 
+AvatarController _avatarController(FakeAvatarRenderer renderer) {
+  return AvatarController(
+    renderer: renderer,
+    tokenClient: FakeAvatarSessionTokenClient(),
+    fallbackPlayback: (_) async {},
+    fallbackStop: () async {},
+    delay: (_) async {},
+  );
+}
+
+Widget _avatarStage(PracticeAvatarSessionView avatar) {
+  return PracticeRoleStage(
+    title: 'Test role',
+    fallback: const ColoredBox(
+      key: Key('static-fallback'),
+      color: Colors.black,
+    ),
+    surfaceBuilder: avatar.surfaceBuilder,
+    surfaceVisible: avatar.surfaceVisible,
+    statusLabel: avatar.statusLabel,
+    onExit: _doNothing,
+  );
+}
+
+void _doNothing() {}
+
+final class _SurfaceLifecycleProbe extends StatefulWidget {
+  const _SurfaceLifecycleProbe({
+    required this.id,
+    required this.events,
+    super.key,
+  });
+
+  final String id;
+  final List<String> events;
+
+  @override
+  State<_SurfaceLifecycleProbe> createState() => _SurfaceLifecycleProbeState();
+}
+
+final class _SurfaceLifecycleProbeState extends State<_SurfaceLifecycleProbe> {
+  @override
+  void initState() {
+    super.initState();
+    widget.events.add('init:${widget.id}');
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.expand();
+
+  @override
+  void dispose() {
+    widget.events.add('dispose:${widget.id}');
+    super.dispose();
+  }
+}
+
 Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
   for (var attempts = 0; attempts < 50; attempts++) {
     if (condition()) {
@@ -363,6 +814,11 @@ Future<void> _pumpUntil(WidgetTester tester, bool Function() condition) async {
     await tester.pump(const Duration(milliseconds: 10));
   }
   fail('Condition was not reached.');
+}
+
+Future<void> _flushControllerReplacement(WidgetTester tester) async {
+  await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+  await tester.pump();
 }
 
 final class _RealtimeQuestionMediaClient


### PR DESCRIPTION
## 功能描述

- 数字人真正连接成功前始终显示稳定静态图，连接和重连过程中不再闪烁 live surface。
- 网络类故障最多尝试 3 次；仅在尝试耗尽后显示“画面暂不可用，语音仍可继续”。
- 重新连接成功后才恢复数字人画面，并正确处理前后台切换和旧 Controller 替换。
- 保持数字人与原生播放器单路 PCM 输出，避免重复播放。
- 记录脱敏后的连接状态、attempt 和失败分类，不记录 Token、URL 或原始错误文本。

## 实现思路

- 保持 AvatarKit surface 挂载以完成连接，但通过显式 `surfaceVisible` 控制静态图覆盖。
- 将重连状态、尝试次数和 Controller 生命周期统一放在 `PracticeAvatarSession` 内管理。
- 使用 AvatarKit 已定义的错误文本映射配置、鉴权、额度、并发及会话类失败，避免不可重试错误被误判成网络故障。
- 已连接后清除旧失败状态，使重连成功能稳定恢复 live surface。

## 可复现测试

```bash
cd mobile
flutter analyze
flutter test test/coaching/practice/avatar test/coaching/practice/scenario_practice_session_test.dart test/coaching/practice/ielts_mock_practice_test.dart
```

本地结果：Flutter analyze 通过；相关 coaching/practice、scenario、IELTS 共 210 项测试通过；其中关键 Session 测试 10/10 通过；`git diff --check` 通过。

## 真机验收

模拟器按仓库约定禁用数字人，因此 AvatarKit 平台视图、供应商网络和实际嘴型会在 PR/CI 完成后使用 Android 真机验收，验收前不推进 v0.1.5 发布。

Closes #939
Related #906 #914 #934
