### PR TITLE
fix(evaluation): 消除完整模考画像等待竞态

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -429,7 +429,6 @@ func run() int {
 				RetryDelay:                time.Second,
 				DependencyDelay:           evaluationDependencyDelay,
 				AcousticDependencyMaxWait: acousticDependencyMaxWait,
-				ProfileDependencyMaxWait:  20 * time.Second,
 				FinalizeTimeout:           5 * time.Second,
 			},
 		},

--- a/server/internal/coaching/evaluation/ielts_profile_completion_test.go
+++ b/server/internal/coaching/evaluation/ielts_profile_completion_test.go
@@ -134,7 +134,7 @@ func TestSessionCommandBuilderKeepsStandaloneIELTSOnV2(t *testing.T) {
 	builder, err := NewSessionCommandBuilder(SessionLineages{
 		Interview:     lineage(InterviewStrategyRef, "interview-report/v2"),
 		IELTSPractice: lineage(IELTSStrategyRef, "ielts-report/v2"),
-		IELTS:         lineage(IELTSStrategyRef, "ielts-report/v3"),
+		IELTS:         lineage(IELTSStrategyRef, "ielts-report/v4"),
 		General:       lineage(GeneralStrategyRef, "general-report/v2"),
 	}, false)
 	if err != nil {
@@ -145,7 +145,7 @@ func TestSessionCommandBuilderKeepsStandaloneIELTSOnV2(t *testing.T) {
 		t.Fatalf("standalone IELTS lineage = %#v, %v", standalone, err)
 	}
 	fullMock, err := builder.lineageFor(IELTSSpeakingFullMockEvaluationPolicyRef)
-	if err != nil || fullMock.PromptVersion != "ielts-report/v3" {
+	if err != nil || fullMock.PromptVersion != "ielts-report/v4" {
 		t.Fatalf("full mock IELTS lineage = %#v, %v", fullMock, err)
 	}
 }

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -30,8 +30,13 @@ const (
 	ieltsPromptVersionV1     = "ielts-report/v1"
 	ieltsPromptVersionV2     = "ielts-report/v2"
 	ieltsPromptVersionV3     = "ielts-report/v3"
+	ieltsPromptVersionV4     = "ielts-report/v4"
 	generalPromptVersionV1   = "general-report/v1"
 	generalPromptVersionV2   = "general-report/v2"
+
+	ieltsInputSchemaVersionV4            = "ielts-report-input/v4"
+	ieltsInputCumulativeParts12PlusPart3 = "CUMULATIVE_PARTS_1_2_PLUS_PART_3"
+	ieltsInputFullRawFallback            = "FULL_RAW_FALLBACK"
 )
 
 func Lineages(
@@ -52,7 +57,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.IELTSStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   ieltsPromptVersionV3,
+			PromptVersion:   ieltsPromptVersionV4,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -189,6 +194,13 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		}
 		err = nil
 	}
+	if lineage.PromptVersion == ieltsPromptVersionV4 {
+		prompt = reportPrompt{
+			system:              ieltsSystemPromptV4,
+			insufficientSummary: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		}
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +214,12 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		dimensions = append(dimensions, "PRONUNCIATION")
 	}
 	var payloadOverride any
-	if snapshot.CumulativeProfile != nil {
+	if lineage.PromptVersion == ieltsPromptVersionV4 {
+		payloadOverride, err = ieltsV4Payload(snapshot, dimensions)
+		if err != nil {
+			return nil, err
+		}
+	} else if snapshot.CumulativeProfile != nil {
 		payloadOverride, err = incrementalIELTSPayload(snapshot, dimensions)
 		if err != nil {
 			return nil, err
@@ -361,6 +378,64 @@ type incrementalIELTSProviderInput struct {
 	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
 	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
 	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+}
+
+type resolvedIELTSProviderInputV4 struct {
+	SchemaVersion     string                               `json:"schema_version"`
+	EvidenceMode      string                               `json:"evidence_mode"`
+	SceneType         evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode      string                               `json:"practice_mode"`
+	DimensionKeys     []string                             `json:"dimension_keys"`
+	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
+	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
+	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+}
+
+type fallbackIELTSProviderInputV4 struct {
+	SchemaVersion string                               `json:"schema_version"`
+	EvidenceMode  string                               `json:"evidence_mode"`
+	SceneType     evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode  string                               `json:"practice_mode"`
+	DimensionKeys []string                             `json:"dimension_keys"`
+	Questions     []evaluation.SessionEvidenceQuestion `json:"questions"`
+	Turns         []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
+}
+
+func ieltsV4Payload(
+	snapshot evaluation.SessionInputSnapshot,
+	dimensionKeys []string,
+) (any, error) {
+	switch snapshot.ProfileResolution {
+	case evaluation.IELTSFinalProfileResolved:
+		incremental, err := incrementalIELTSPayload(snapshot, dimensionKeys)
+		if err != nil {
+			return nil, err
+		}
+		return resolvedIELTSProviderInputV4{
+			SchemaVersion: ieltsInputSchemaVersionV4,
+			EvidenceMode:  ieltsInputCumulativeParts12PlusPart3,
+			SceneType:     incremental.SceneType, PracticeMode: incremental.PracticeMode,
+			DimensionKeys:     incremental.DimensionKeys,
+			CumulativeProfile: incremental.CumulativeProfile,
+			Questions:         incremental.Questions, Turns: incremental.Turns,
+		}, nil
+	case evaluation.IELTSFinalProfileFallback:
+		effectiveTurns := make([]evaluation.SessionEvidenceTurn, 0, len(snapshot.Turns))
+		for _, turn := range snapshot.Turns {
+			if turn.Effective {
+				effectiveTurns = append(effectiveTurns, turn)
+			}
+		}
+		return fallbackIELTSProviderInputV4{
+			SchemaVersion: ieltsInputSchemaVersionV4,
+			EvidenceMode:  ieltsInputFullRawFallback,
+			SceneType:     evaluation.SceneIELTSSpeaking,
+			PracticeMode:  snapshot.PracticeMode, DimensionKeys: dimensionKeys,
+			Questions: snapshot.Questions, Turns: effectiveTurns,
+		}, nil
+	default:
+		return nil, evaluation.ErrInvalidRequest
+	}
 }
 
 func incrementalIELTSPayload(
@@ -846,6 +921,8 @@ const ieltsSystemPromptV1 = `You are an evidence-bound IELTS Speaking practice e
 const ieltsSystemPromptV2 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
 
 const ieltsSystemPromptV3 = `You are an evidence-bound IELTS Speaking practice evaluator. Score the candidate's average performance across the whole test, not separate Part scores. The input may contain a provisional cumulative_profile for Parts 1 and 2 plus raw Part 3 evidence. Treat the profile as provisional evidence: preserve its exact cited quotes, then recalibrate every requested dimension using Part 3. Never mechanically average Parts or copy provisional bands without reconsideration. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote present either in cumulative_profile evidence or Part 3 turns, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Base PRONUNCIATION only on acoustic checkpoints and the provisional pronunciation profile, never on transcript spelling.`
+
+const ieltsSystemPromptV4 = `You are an evidence-bound IELTS Speaking practice evaluator. The input schema_version is ielts-report-input/v4 and evidence_mode is exactly one of CUMULATIVE_PARTS_1_2_PLUS_PART_3 or FULL_RAW_FALLBACK. For CUMULATIVE_PARTS_1_2_PLUS_PART_3, score the candidate's average performance across the whole test using the provisional cumulative_profile for Parts 1 and 2 plus only part_3_questions and part_3_effective_turns as raw evidence. Preserve exact profile quotes, then recalibrate every requested dimension using Part 3; never mechanically average Parts or copy provisional bands without reconsideration. For FULL_RAW_FALLBACK, use only questions and effective_turns as the complete raw evidence for all Parts. Never infer or combine fields from the other evidence mode. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote present in the evidence allowed by evidence_mode, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Base PRONUNCIATION only on acoustic checkpoints and, in CUMULATIVE_PARTS_1_2_PLUS_PART_3 mode, the provisional pronunciation profile; never on transcript spelling.`
 
 const generalSystemPromptV1 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -171,7 +171,7 @@ func (evaluator *InterviewEvaluator) Evaluate(
 			"INTERVIEW_EVIDENCE",
 			"INTERVIEW_PROFESSIONAL",
 			"INTERVIEW_INTERACTION",
-		}, report.ReportScalePercentage100, false, nil)
+		}, report.ReportScalePercentage100, false, nil, nil)
 }
 
 func (evaluator *IELTSEvaluator) Evaluate(
@@ -214,8 +214,9 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		dimensions = append(dimensions, "PRONUNCIATION")
 	}
 	var payloadOverride any
+	var evidencePolicy *providerEvidencePolicy
 	if lineage.PromptVersion == ieltsPromptVersionV4 {
-		payloadOverride, err = ieltsV4Payload(snapshot, dimensions)
+		payloadOverride, evidencePolicy, err = ieltsV4Payload(snapshot, dimensions)
 		if err != nil {
 			return nil, err
 		}
@@ -227,7 +228,7 @@ func (evaluator *IELTSEvaluator) Evaluate(
 	}
 	return evaluate(ctx, evaluator.generator, snapshot, lineage,
 		prompt.system, prompt.insufficientSummary, evaluation.SceneIELTSSpeaking,
-		dimensions, report.ReportScaleIELTSBand, true, payloadOverride)
+		dimensions, report.ReportScaleIELTSBand, true, payloadOverride, evidencePolicy)
 }
 
 func (evaluator *GeneralEvaluator) Evaluate(
@@ -269,7 +270,7 @@ func (evaluator *GeneralEvaluator) Evaluate(
 			"CLARITY_COHERENCE",
 			"LANGUAGE_CONTROL",
 			"INTERACTION",
-		}, report.ReportScalePercentage100, false, nil)
+		}, report.ReportScalePercentage100, false, nil, nil)
 }
 
 func evaluate(
@@ -284,6 +285,7 @@ func evaluate(
 	scale report.ReportScoreScale,
 	allowRepair bool,
 	payloadOverride any,
+	evidencePolicy *providerEvidencePolicy,
 ) (json.RawMessage, error) {
 	if generator == nil || ctx == nil || strings.TrimSpace(systemPrompt) == "" ||
 		strings.TrimSpace(insufficientSummary) == "" ||
@@ -300,6 +302,10 @@ func evaluate(
 		return encodeReport(insufficientReport(
 			snapshot, sceneType, dimensionKeys, scale, insufficientSummary,
 		))
+	}
+	if evidencePolicy == nil {
+		value := fullRawProviderEvidencePolicy(snapshot)
+		evidencePolicy = &value
 	}
 	payloadSource := payloadOverride
 	if payloadSource == nil {
@@ -322,7 +328,7 @@ func evaluate(
 	}
 	formal, normalizeErr := normalizeProviderReport(
 		generated, snapshot, sceneType, dimensionKeys, scale,
-		lineage.Provider, lineage.Model,
+		lineage.Provider, lineage.Model, *evidencePolicy,
 	)
 	if normalizeErr == nil {
 		return encodeReport(formal)
@@ -355,7 +361,7 @@ func evaluate(
 	}
 	formal, err = normalizeProviderReport(
 		repaired, snapshot, sceneType, dimensionKeys, scale,
-		lineage.Provider, lineage.Model,
+		lineage.Provider, lineage.Model, *evidencePolicy,
 	)
 	if err != nil {
 		return nil, err
@@ -404,13 +410,14 @@ type fallbackIELTSProviderInputV4 struct {
 func ieltsV4Payload(
 	snapshot evaluation.SessionInputSnapshot,
 	dimensionKeys []string,
-) (any, error) {
+) (any, *providerEvidencePolicy, error) {
 	switch snapshot.ProfileResolution {
 	case evaluation.IELTSFinalProfileResolved:
 		incremental, err := incrementalIELTSPayload(snapshot, dimensionKeys)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		policy := resolvedIELTSProviderEvidencePolicy(snapshot, incremental)
 		return resolvedIELTSProviderInputV4{
 			SchemaVersion: ieltsInputSchemaVersionV4,
 			EvidenceMode:  ieltsInputCumulativeParts12PlusPart3,
@@ -418,7 +425,7 @@ func ieltsV4Payload(
 			DimensionKeys:     incremental.DimensionKeys,
 			CumulativeProfile: incremental.CumulativeProfile,
 			Questions:         incremental.Questions, Turns: incremental.Turns,
-		}, nil
+		}, &policy, nil
 	case evaluation.IELTSFinalProfileFallback:
 		effectiveTurns := make([]evaluation.SessionEvidenceTurn, 0, len(snapshot.Turns))
 		for _, turn := range snapshot.Turns {
@@ -432,9 +439,9 @@ func ieltsV4Payload(
 			SceneType:     evaluation.SceneIELTSSpeaking,
 			PracticeMode:  snapshot.PracticeMode, DimensionKeys: dimensionKeys,
 			Questions: snapshot.Questions, Turns: effectiveTurns,
-		}, nil
+		}, nil, nil
 	default:
-		return nil, evaluation.ErrInvalidRequest
+		return nil, nil, evaluation.ErrInvalidRequest
 	}
 }
 
@@ -521,6 +528,82 @@ type providerEvidence struct {
 	Occurrence int    `json:"occurrence"`
 }
 
+type providerEvidenceKey struct {
+	TurnID     string
+	Quote      string
+	Occurrence int
+}
+
+type providerEvidencePolicy struct {
+	transcripts map[string]string
+	rawTurns    map[string]struct{}
+	exact       map[providerEvidenceKey]struct{}
+}
+
+func fullRawProviderEvidencePolicy(
+	snapshot evaluation.SessionInputSnapshot,
+) providerEvidencePolicy {
+	policy := providerEvidencePolicy{
+		transcripts: make(map[string]string, len(snapshot.Turns)),
+		rawTurns:    make(map[string]struct{}, len(snapshot.Turns)),
+		exact:       map[providerEvidenceKey]struct{}{},
+	}
+	for _, turn := range snapshot.Turns {
+		if turn.Effective {
+			policy.transcripts[turn.ID] = turn.Transcript
+			policy.rawTurns[turn.ID] = struct{}{}
+		}
+	}
+	return policy
+}
+
+func resolvedIELTSProviderEvidencePolicy(
+	snapshot evaluation.SessionInputSnapshot,
+	payload incrementalIELTSProviderInput,
+) providerEvidencePolicy {
+	policy := providerEvidencePolicy{
+		transcripts: make(map[string]string, len(snapshot.Turns)),
+		rawTurns:    make(map[string]struct{}, len(payload.Turns)),
+		exact:       map[providerEvidenceKey]struct{}{},
+	}
+	for _, turn := range snapshot.Turns {
+		if turn.Effective {
+			policy.transcripts[turn.ID] = turn.Transcript
+		}
+	}
+	for _, turn := range payload.Turns {
+		policy.rawTurns[turn.ID] = struct{}{}
+	}
+	for _, dimension := range payload.CumulativeProfile.Dimensions {
+		for _, observation := range dimension.Observations {
+			for _, evidence := range observation.Evidence {
+				policy.exact[providerEvidenceKey{
+					TurnID: evidence.TurnID, Quote: strings.TrimSpace(evidence.Quote),
+					Occurrence: evidence.Occurrence,
+				}] = struct{}{}
+			}
+		}
+	}
+	return policy
+}
+
+func (policy providerEvidencePolicy) byteOffset(source providerEvidence) (int, bool) {
+	transcript, exists := policy.transcripts[source.TurnID]
+	quote := strings.TrimSpace(source.Quote)
+	if !exists || quote == "" || source.Occurrence < 1 {
+		return -1, false
+	}
+	if _, raw := policy.rawTurns[source.TurnID]; !raw {
+		if _, exact := policy.exact[providerEvidenceKey{
+			TurnID: source.TurnID, Quote: quote, Occurrence: source.Occurrence,
+		}]; !exact {
+			return -1, false
+		}
+	}
+	start := byteOccurrence(transcript, quote, source.Occurrence)
+	return start, start >= 0
+}
+
 type providerPriorityAction struct {
 	DimensionKey     string `json:"dimension_key"`
 	ImprovementIndex int    `json:"improvement_index"`
@@ -534,6 +617,7 @@ func normalizeProviderReport(
 	scale report.ReportScoreScale,
 	expectedProvider string,
 	expectedModel string,
+	evidencePolicy providerEvidencePolicy,
 ) (report.FormalReport, error) {
 	if generated.Provider != expectedProvider || generated.Model != expectedModel ||
 		generated.RequestID == "" || len(generated.Content) == 0 ||
@@ -560,12 +644,6 @@ func normalizeProviderReport(
 		return report.FormalReport{}, providerResponseError(
 			normalizeReasonDimensionCountInvalid,
 		)
-	}
-	turns := make(map[string]string, len(snapshot.Turns))
-	for _, turn := range snapshot.Turns {
-		if turn.Effective {
-			turns[turn.ID] = turn.Transcript
-		}
 	}
 	formal := report.FormalReport{
 		SchemaVersion:      report.FormalReportSchemaVersion,
@@ -606,19 +684,19 @@ func normalizeProviderReport(
 		}
 		var err error
 		dimension.Strengths, err = normalizeFindings(
-			expectedKey, "strength", providedDimension.Strengths, turns,
+			expectedKey, "strength", providedDimension.Strengths, evidencePolicy,
 		)
 		if err != nil {
 			return report.FormalReport{}, err
 		}
 		dimension.Improvements, err = normalizeFindings(
-			expectedKey, "improvement", providedDimension.Improvements, turns,
+			expectedKey, "improvement", providedDimension.Improvements, evidencePolicy,
 		)
 		if err != nil {
 			return report.FormalReport{}, err
 		}
 		dimension.Examples, err = normalizeFindings(
-			expectedKey, "example", providedDimension.Examples, turns,
+			expectedKey, "example", providedDimension.Examples, evidencePolicy,
 		)
 		if err != nil {
 			return report.FormalReport{}, err
@@ -784,7 +862,7 @@ func normalizeFindings(
 	dimensionKey string,
 	kind string,
 	provided []providerFinding,
-	turns map[string]string,
+	evidencePolicy providerEvidencePolicy,
 ) ([]report.ReportFinding, error) {
 	if provided == nil || len(provided) > 5 {
 		return nil, providerResponseError(normalizeReasonFindingCountInvalid)
@@ -801,10 +879,9 @@ func normalizeFindings(
 			return nil, providerResponseError(normalizeReasonEvidenceCountInvalid)
 		}
 		for evidenceIndex, source := range item.Evidence {
-			transcript, exists := turns[source.TurnID]
 			quote := strings.TrimSpace(source.Quote)
-			start := byteOccurrence(transcript, quote, source.Occurrence)
-			if !exists || source.Occurrence < 1 || start < 0 {
+			start, allowed := evidencePolicy.byteOffset(source)
+			if !allowed {
 				return nil, providerResponseError(normalizeReasonEvidenceInvalid)
 			}
 			finding.Evidence[evidenceIndex] = report.ReportEvidence{

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -294,11 +294,98 @@ func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T
 	); err != nil {
 		t.Fatalf("EvaluateIELTS() error = %v", err)
 	}
-	if strings.Contains(generator.last.UserPrompt, "PART_ONE_RAW_TRANSCRIPT") ||
-		strings.Contains(generator.last.UserPrompt, "PART_TWO_RAW_TRANSCRIPT") ||
-		!strings.Contains(generator.last.UserPrompt, "PART_THREE_RAW_TRANSCRIPT") ||
-		!strings.Contains(generator.last.UserPrompt, `"cumulative_profile"`) {
-		t.Fatalf("final incremental payload = %s", generator.last.UserPrompt)
+	var payload resolvedIELTSProviderInputV4
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode resolved v4 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if lineages.IELTS.PromptVersion != ieltsPromptVersionV4 ||
+		payload.SchemaVersion != ieltsInputSchemaVersionV4 ||
+		payload.EvidenceMode != ieltsInputCumulativeParts12PlusPart3 ||
+		len(payload.CumulativeProfile.CompletedParts) != 2 ||
+		len(payload.Questions) != 1 || len(payload.Turns) != 1 ||
+		payload.Turns[0].Transcript != "PART_THREE_RAW_TRANSCRIPT" ||
+		strings.Contains(generator.last.UserPrompt, "PART_ONE_RAW_TRANSCRIPT") ||
+		strings.Contains(generator.last.UserPrompt, "PART_TWO_RAW_TRANSCRIPT") {
+		t.Fatalf("resolved v4 payload = %#v: %s", payload, generator.last.UserPrompt)
+	}
+}
+
+func TestIELTSEvaluatorUsesTaggedFullRawFallbackPayload(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := sessionSnapshotFixture()
+	snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
+		ID: "40000000-0000-4000-8000-000000000002", Position: 2,
+		Text: "Unused question", SpeakerParticipantID: "assistant-1",
+		AddresseeParticipantIDs: []string{"user-1"},
+	})
+	snapshot.Turns = append(snapshot.Turns, evaluation.SessionEvidenceTurn{
+		ID: "30000000-0000-4000-8000-000000000002", Position: 2,
+		QuestionID:              "40000000-0000-4000-8000-000000000002",
+		RespondentParticipantID: "user-1", Transcript: "INEFFECTIVE_RAW_TRANSCRIPT",
+		Effective: false, ConfirmedAt: snapshot.CompletedAt,
+	})
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	var payload fallbackIELTSProviderInputV4
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode fallback v4 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if payload.SchemaVersion != ieltsInputSchemaVersionV4 ||
+		payload.EvidenceMode != ieltsInputFullRawFallback ||
+		len(payload.Questions) != 2 || len(payload.Turns) != 1 ||
+		payload.Turns[0].Transcript != snapshot.Turns[0].Transcript ||
+		strings.Contains(generator.last.UserPrompt, "INEFFECTIVE_RAW_TRANSCRIPT") ||
+		strings.Contains(generator.last.UserPrompt, `"cumulative_profile"`) ||
+		strings.Contains(generator.last.UserPrompt, `"part_3_effective_turns"`) {
+		t.Fatalf("fallback v4 payload = %#v: %s", payload, generator.last.UserPrompt)
+	}
+}
+
+func TestIELTSEvaluatorPreservesHistoricalV3FallbackContract(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage := lineages.IELTS
+	lineage.PromptVersion = ieltsPromptVersionV3
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, sessionSnapshotFixture(), lineage,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	var payload providerInput
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode historical v3 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if generator.last.SystemPrompt != ieltsSystemPromptV3 ||
+		strings.Contains(generator.last.UserPrompt, `"schema_version"`) ||
+		strings.Contains(generator.last.UserPrompt, `"evidence_mode"`) ||
+		len(payload.Questions) != 1 || len(payload.Turns) != 1 {
+		t.Fatalf("historical v3 contract changed: %#v: %s", payload, generator.last.UserPrompt)
 	}
 }
 
@@ -473,7 +560,7 @@ func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *te
 		version string
 	}{
 		{name: "interview", prompt: interviewSystemPromptV2, version: interviewPromptVersionV2},
-		{name: "IELTS", prompt: ieltsSystemPromptV3, version: ieltsPromptVersionV3},
+		{name: "IELTS", prompt: ieltsSystemPromptV4, version: ieltsPromptVersionV4},
 		{name: "general", prompt: generalSystemPromptV2, version: generalPromptVersionV2},
 	}
 	lineages, err := Lineages("qianwen", "qwen-plus")
@@ -759,6 +846,7 @@ func sessionSnapshotFixture() evaluation.SessionInputSnapshot {
 		PracticeExperience:  "IELTS_SPEAKING",
 		SceneCategory:       "IELTS_SPEAKING",
 		PracticeMode:        "FULL_MOCK",
+		ProfileResolution:   evaluation.IELTSFinalProfileFallback,
 		CompletedAt:         now,
 		AcousticCapability:  evaluation.AcousticCapabilityNotConfigured,
 		PlanSnapshot:        json.RawMessage(`{}`),

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -31,6 +31,7 @@ func TestInvalidProviderReportRemainsRetryableAtTheJobBoundary(t *testing.T) {
 
 func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) {
 	score := 7.0
+	snapshot := sessionSnapshotFixture()
 	generated := mustProviderResult(t, providerReport{
 		ScoreabilityStatus: report.ReportScoreabilityInsufficient,
 		Summary:            "The available evidence is insufficient.",
@@ -43,9 +44,9 @@ func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) 
 	})
 
 	formal, err := normalizeProviderReport(
-		generated, sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		generated, snapshot, evaluation.SceneIELTSSpeaking,
 		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
-		"qianwen", "qwen-plus",
+		"qianwen", "qwen-plus", fullRawProviderEvidencePolicy(snapshot),
 	)
 	if err != nil {
 		t.Fatalf("normalizeProviderReport() error = %v", err)
@@ -62,11 +63,12 @@ func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) 
 
 func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T) {
 	score := 7.0
+	snapshot := sessionSnapshotFixture()
 	dimension := providerDimensionFixture("FLUENCY_COHERENCE", &score)
 	dimension.Strengths = []providerFinding{{
 		Message: "Unsupported strength",
 		Evidence: []providerEvidence{{
-			TurnID: sessionSnapshotFixture().Turns[0].ID,
+			TurnID: snapshot.Turns[0].ID,
 			Quote:  "provider-invented quote", Occurrence: 1,
 		}},
 	}}
@@ -76,9 +78,9 @@ func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T)
 			Summary:            "The available evidence is insufficient.", Dimensions: []providerDimension{dimension},
 			PriorityActions: []providerPriorityAction{},
 		}),
-		sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		snapshot, evaluation.SceneIELTSSpeaking,
 		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
-		"qianwen", "qwen-plus",
+		"qianwen", "qwen-plus", fullRawProviderEvidencePolicy(snapshot),
 	)
 	if !errors.Is(err, ErrProviderResponse) ||
 		normalizeReasonFromError(err) != normalizeReasonEvidenceInvalid {
@@ -127,11 +129,12 @@ func TestProvisionalProviderReportRemainsFailClosed(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			snapshot := sessionSnapshotFixture()
 			_, err := normalizeProviderReport(
 				mustProviderResult(t, test.report),
-				sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+				snapshot, evaluation.SceneIELTSSpeaking,
 				[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
-				"qianwen", "qwen-plus",
+				"qianwen", "qwen-plus", fullRawProviderEvidencePolicy(snapshot),
 			)
 			if !errors.Is(err, ErrProviderResponse) ||
 				normalizeReasonFromError(err) != test.wantReason {
@@ -263,31 +266,7 @@ func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	snapshot := sessionSnapshotFixture()
-	now := snapshot.CompletedAt
-	snapshot.PlanSnapshot = json.RawMessage(`{"ielts_assignment":{"parts":[{"turn_blueprints":["p1"]},{"turn_blueprints":["p2"]},{"turn_blueprints":["p3"]}]}}`)
-	snapshot.Questions[0].Text = "Part 1 question"
-	snapshot.Turns[0].Transcript = "PART_ONE_RAW_TRANSCRIPT"
-	for index, transcript := range []string{"PART_TWO_RAW_TRANSCRIPT", "PART_THREE_RAW_TRANSCRIPT"} {
-		position := index + 2
-		questionID := fmt.Sprintf("40000000-0000-4000-8000-%012d", position)
-		turnID := fmt.Sprintf("30000000-0000-4000-8000-%012d", position)
-		snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
-			ID: questionID, Position: position, Text: fmt.Sprintf("Part %d question", position),
-			SpeakerParticipantID: "assistant-1", AddresseeParticipantIDs: []string{"user-1"},
-		})
-		snapshot.Turns = append(snapshot.Turns, evaluation.SessionEvidenceTurn{
-			ID: turnID, Position: position, QuestionID: questionID,
-			RespondentParticipantID: "user-1", Transcript: transcript,
-			Effective: true, ConfirmedAt: now,
-		})
-	}
-	snapshot.CumulativeProfile = &evaluation.IELTSCumulativeProfile{
-		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
-		SessionID:     snapshot.SessionID, CompletedParts: []int{1, 2},
-		Dimensions: cumulativeProfileDimensions(), Provider: "qianwen", Model: "qwen-plus",
-	}
-	snapshot.ProfileResolution = evaluation.IELTSFinalProfileResolved
+	snapshot := resolvedFullMockSnapshot()
 
 	if _, err := evaluators.EvaluateIELTS(
 		context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
@@ -306,9 +285,133 @@ func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T
 		len(payload.CumulativeProfile.CompletedParts) != 2 ||
 		len(payload.Questions) != 1 || len(payload.Turns) != 1 ||
 		payload.Turns[0].Transcript != "PART_THREE_RAW_TRANSCRIPT" ||
-		strings.Contains(generator.last.UserPrompt, "PART_ONE_RAW_TRANSCRIPT") ||
+		strings.Contains(generator.last.UserPrompt, "PART_ONE_HIDDEN_RAW") ||
 		strings.Contains(generator.last.UserPrompt, "PART_TWO_RAW_TRANSCRIPT") {
 		t.Fatalf("resolved v4 payload = %#v: %s", payload, generator.last.UserPrompt)
+	}
+}
+
+func TestIELTSEvaluatorV4ResolvedRejectsPart12RawEvidenceOutsideProfile(t *testing.T) {
+	snapshot := resolvedFullMockSnapshot()
+	for _, test := range []struct {
+		name     string
+		evidence providerEvidence
+	}{
+		{
+			name: "Part 1 raw outside profile",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[0].ID, Quote: "PART_ONE_HIDDEN_RAW", Occurrence: 1,
+			},
+		},
+		{
+			name: "Part 2 raw outside profile",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[1].ID, Quote: "PART_TWO_RAW_TRANSCRIPT", Occurrence: 1,
+			},
+		},
+		{
+			name: "profile quote with different occurrence",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[0].ID, Quote: "PROFILE_ALLOWED_QUOTE", Occurrence: 2,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			generator := &reportGeneratorFake{evidence: &test.evidence}
+			evaluators, err := New(generator)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lineages, err := Lineages("qianwen", "qwen-plus")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = evaluators.EvaluateIELTS(
+				context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+			)
+			if !errors.Is(err, ErrProviderResponse) || generator.calls != 2 {
+				t.Fatalf(
+					"EvaluateIELTS() error = %v, generator calls = %d",
+					err, generator.calls,
+				)
+			}
+		})
+	}
+}
+
+func TestIELTSEvaluatorV4ResolvedAcceptsOnlyProfileOrPart3Evidence(t *testing.T) {
+	snapshot := resolvedFullMockSnapshot()
+	tests := []struct {
+		name      string
+		evidence  providerEvidence
+		turnIndex int
+	}{
+		{
+			name: "cumulative profile evidence",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[0].ID, Quote: "PROFILE_ALLOWED_QUOTE", Occurrence: 1,
+			}, turnIndex: 0,
+		},
+		{
+			name: "Part 3 raw evidence",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[2].ID, Quote: "THREE_RAW", Occurrence: 1,
+			}, turnIndex: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generator := &reportGeneratorFake{evidence: &test.evidence}
+			evaluators, err := New(generator)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lineages, err := Lineages("qianwen", "qwen-plus")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			encoded, err := evaluators.EvaluateIELTS(
+				context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+			)
+			if err != nil {
+				t.Fatalf("EvaluateIELTS() error = %v", err)
+			}
+			var formal report.FormalReport
+			if err := evaluation.DecodeStrict(encoded, &formal); err != nil {
+				t.Fatal(err)
+			}
+			got := formal.Dimensions[0].Strengths[0].Evidence[0]
+			wantStart := strings.Index(
+				snapshot.Turns[test.turnIndex].Transcript, test.evidence.Quote,
+			)
+			if got.TurnID != test.evidence.TurnID ||
+				got.OriginalExcerpt != test.evidence.Quote || got.StartUTF8Byte != wantStart {
+				t.Fatalf("normalized evidence = %#v, want start %d", got, wantStart)
+			}
+		})
+	}
+}
+
+func TestIELTSEvaluatorV4FallbackKeepsFullRawEvidence(t *testing.T) {
+	snapshot := sessionSnapshotFixture()
+	generator := &reportGeneratorFake{evidence: &providerEvidence{
+		TurnID: snapshot.Turns[0].ID, Quote: "small engineering", Occurrence: 1,
+	}}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
 	}
 }
 
@@ -386,6 +489,40 @@ func TestIELTSEvaluatorPreservesHistoricalV3FallbackContract(t *testing.T) {
 		strings.Contains(generator.last.UserPrompt, `"evidence_mode"`) ||
 		len(payload.Questions) != 1 || len(payload.Turns) != 1 {
 		t.Fatalf("historical v3 contract changed: %#v: %s", payload, generator.last.UserPrompt)
+	}
+}
+
+func TestIELTSEvaluatorPreservesHistoricalV3ResolvedContract(t *testing.T) {
+	snapshot := resolvedFullMockSnapshot()
+	generator := &reportGeneratorFake{evidence: &providerEvidence{
+		TurnID: snapshot.Turns[0].ID, Quote: "PART_ONE_HIDDEN_RAW", Occurrence: 1,
+	}}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage := lineages.IELTS
+	lineage.PromptVersion = ieltsPromptVersionV3
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, snapshot, lineage,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	var payload incrementalIELTSProviderInput
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode historical resolved v3 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if generator.last.SystemPrompt != ieltsSystemPromptV3 ||
+		len(payload.CumulativeProfile.CompletedParts) != 2 ||
+		len(payload.Questions) != 1 || len(payload.Turns) != 1 {
+		t.Fatalf("historical resolved v3 contract changed: %#v", payload)
 	}
 }
 
@@ -722,7 +859,9 @@ func TestInsufficientReportFollowsRecordedVersionAndPreservesOriginalText(t *tes
 }
 
 type reportGeneratorFake struct {
-	last textgeneration.Request
+	last     textgeneration.Request
+	evidence *providerEvidence
+	calls    int
 }
 
 type repairReportGeneratorFake struct {
@@ -804,6 +943,7 @@ func (generator *reportGeneratorFake) Generate(
 	_ context.Context,
 	request textgeneration.Request,
 ) (textgeneration.Result, error) {
+	generator.calls++
 	generator.last = request
 	var input struct {
 		DimensionKeys []string `json:"dimension_keys"`
@@ -813,9 +953,16 @@ func (generator *reportGeneratorFake) Generate(
 	}
 	dimensions := make([]map[string]any, len(input.DimensionKeys))
 	for index, key := range input.DimensionKeys {
+		strengths := []any{}
+		if index == 0 && generator.evidence != nil {
+			strengths = []any{map[string]any{
+				"message": "有明确证据。", "suggestion": "继续保持。",
+				"evidence": []providerEvidence{*generator.evidence},
+			}}
+		}
 		dimensions[index] = map[string]any{
 			"key": key, "score": 7.0, "coverage": 1.0, "confidence": 0.8,
-			"reason_codes": []string{}, "strengths": []any{},
+			"reason_codes": []string{}, "strengths": strengths,
 			"improvements": []any{}, "recommended_examples": []any{},
 		}
 	}
@@ -834,6 +981,43 @@ func (generator *reportGeneratorFake) Generate(
 		Provider:  "qianwen",
 		Model:     "qwen-plus",
 	}, nil
+}
+
+func resolvedFullMockSnapshot() evaluation.SessionInputSnapshot {
+	snapshot := sessionSnapshotFixture()
+	now := snapshot.CompletedAt
+	snapshot.PlanSnapshot = json.RawMessage(`{"ielts_assignment":{"parts":[{"turn_blueprints":["p1"]},{"turn_blueprints":["p2"]},{"turn_blueprints":["p3"]}]}}`)
+	snapshot.Questions[0].Text = "Part 1 question"
+	snapshot.Turns[0].Transcript = "PROFILE_ALLOWED_QUOTE PART_ONE_HIDDEN_RAW"
+	for index, transcript := range []string{"PART_TWO_RAW_TRANSCRIPT", "PART_THREE_RAW_TRANSCRIPT"} {
+		position := index + 2
+		questionID := fmt.Sprintf("40000000-0000-4000-8000-%012d", position)
+		turnID := fmt.Sprintf("30000000-0000-4000-8000-%012d", position)
+		snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
+			ID: questionID, Position: position, Text: fmt.Sprintf("Part %d question", position),
+			SpeakerParticipantID: "assistant-1", AddresseeParticipantIDs: []string{"user-1"},
+		})
+		snapshot.Turns = append(snapshot.Turns, evaluation.SessionEvidenceTurn{
+			ID: turnID, Position: position, QuestionID: questionID,
+			RespondentParticipantID: "user-1", Transcript: transcript,
+			Effective: true, ConfirmedAt: now,
+		})
+	}
+	dimensions := cumulativeProfileDimensions()
+	dimensions[0].Observations = []evaluation.IELTSProfileObservation{{
+		Kind: "STRENGTH", ReasonCode: "PROFILE_EVIDENCE",
+		Evidence: []evaluation.IELTSProfileEvidence{{
+			TurnID: snapshot.Turns[0].ID, Quote: "PROFILE_ALLOWED_QUOTE",
+			Occurrence: 1, Part: 1,
+		}},
+	}}
+	snapshot.CumulativeProfile = &evaluation.IELTSCumulativeProfile{
+		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
+		SessionID:     snapshot.SessionID, CompletedParts: []int{1, 2},
+		Dimensions: dimensions, Provider: "qianwen", Model: "qwen-plus",
+	}
+	snapshot.ProfileResolution = evaluation.IELTSFinalProfileResolved
+	return snapshot
 }
 
 func sessionSnapshotFixture() evaluation.SessionInputSnapshot {

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -9,6 +9,11 @@ import (
 
 const MinimumIELTSTwoRoundDeadline = 2*45*time.Second + 10*time.Second
 
+const (
+	previousProfileLifecycleStages = 1
+	finalProfileLifecycleStages    = 2
+)
+
 const acousticDependencyTimeoutReason = "ACOUSTIC_DEPENDENCY_TIMEOUT"
 
 var ErrAcousticDependencyFailed error = acousticDependencyFailure{}
@@ -103,7 +108,6 @@ type WorkerConfiguration struct {
 	RetryDelay                time.Duration
 	DependencyDelay           time.Duration
 	AcousticDependencyMaxWait time.Duration
-	ProfileDependencyMaxWait  time.Duration
 	FinalizeTimeout           time.Duration
 }
 
@@ -134,10 +138,16 @@ func (configuration WorkerConfiguration) Valid() bool {
 		configuration.DependencyDelay <= time.Minute &&
 		configuration.AcousticDependencyMaxWait >= configuration.DependencyDelay &&
 		configuration.AcousticDependencyMaxWait <= 5*time.Minute &&
-		configuration.ProfileDependencyMaxWait >= configuration.DependencyDelay &&
-		configuration.ProfileDependencyMaxWait <= 5*time.Minute &&
+		configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages) <= 5*time.Minute &&
 		configuration.FinalizeTimeout >= time.Second &&
 		configuration.FinalizeTimeout <= 30*time.Second
+}
+
+func (configuration WorkerConfiguration) profileLifecycleWaitBudget(stages int) time.Duration {
+	attempts := time.Duration(configuration.ProfileLane.MaxAttempts)
+	perStage := attempts*configuration.ProfileDeadline +
+		(attempts-1)*configuration.RetryDelay + configuration.DependencyDelay
+	return time.Duration(stages) * perStage
 }
 
 type Worker struct {
@@ -246,7 +256,9 @@ func (worker *Worker) resolvePreviousProfile(
 		ctx, claim.UserID, KindIELTSPart1Profile, snapshot.SessionID,
 	)
 	if err == nil && (record.Status == JobQueued || record.Status == JobRunning) &&
-		time.Since(claim.CreatedAt) < worker.configuration.ProfileDependencyMaxWait {
+		time.Now().UTC().Before(record.CreatedAt.Add(
+			worker.configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages),
+		)) {
 		finalizeContext, cancel := worker.finalizeContext(ctx)
 		defer cancel()
 		return true, worker.store.DeferClaim(finalizeContext, Deferral{
@@ -455,7 +467,9 @@ func (worker *Worker) resolveFinalProfile(
 		ctx, claim.UserID, KindIELTSPart2Profile, snapshot.SessionID,
 	)
 	if err == nil && (record.Status == JobQueued || record.Status == JobRunning) &&
-		time.Since(claim.CreatedAt) < worker.configuration.ProfileDependencyMaxWait {
+		time.Now().UTC().Before(record.CreatedAt.Add(
+			worker.configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages),
+		)) {
 		finalizeContext, cancel := worker.finalizeContext(ctx)
 		defer cancel()
 		return true, worker.store.DeferClaim(finalizeContext, Deferral{

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -12,6 +12,7 @@ const MinimumIELTSTwoRoundDeadline = 2*45*time.Second + 10*time.Second
 const (
 	previousProfileLifecycleStages = 1
 	finalProfileLifecycleStages    = 2
+	maximumProfileLifecycleWait    = 30 * time.Minute
 )
 
 const acousticDependencyTimeoutReason = "ACOUSTIC_DEPENDENCY_TIMEOUT"
@@ -138,15 +139,21 @@ func (configuration WorkerConfiguration) Valid() bool {
 		configuration.DependencyDelay <= time.Minute &&
 		configuration.AcousticDependencyMaxWait >= configuration.DependencyDelay &&
 		configuration.AcousticDependencyMaxWait <= 5*time.Minute &&
-		configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages) <= 5*time.Minute &&
+		configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages) <=
+			maximumProfileLifecycleWait &&
 		configuration.FinalizeTimeout >= time.Second &&
 		configuration.FinalizeTimeout <= 30*time.Second
 }
 
 func (configuration WorkerConfiguration) profileLifecycleWaitBudget(stages int) time.Duration {
 	attempts := time.Duration(configuration.ProfileLane.MaxAttempts)
-	perStage := attempts*configuration.ProfileDeadline +
+	processing := attempts*configuration.ProfileDeadline +
 		(attempts-1)*configuration.RetryDelay + configuration.DependencyDelay
+	// A crashed worker can retain each attempt until its lease expires. The
+	// lease margin extends, rather than duplicates, the provider deadline.
+	leaseRecoveryMargin := attempts *
+		(configuration.ProfileLane.LeaseDuration - configuration.ProfileDeadline)
+	perStage := configuration.AcousticDependencyMaxWait + processing + leaseRecoveryMargin
 	return time.Duration(stages) * perStage
 }
 

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -40,6 +40,18 @@ func TestWorkerConfigurationRejectsIELTSDeadlineThatCutsRepairRound(t *testing.T
 	}
 }
 
+func TestWorkerConfigurationDerivesProfileWaitFromLaneLifecycle(t *testing.T) {
+	configuration := workerConfigurationFixture()
+	perStage := 2*configuration.ProfileDeadline + configuration.RetryDelay +
+		configuration.DependencyDelay
+	if got := configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages); got != perStage {
+		t.Fatalf("single-stage profile wait = %s, want %s", got, perStage)
+	}
+	if got := configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages); got != 2*perStage {
+		t.Fatalf("two-stage profile wait = %s, want %s", got, 2*perStage)
+	}
+}
+
 func TestWorkerPart2ProfileReusesReadyPart1Profile(t *testing.T) {
 	now := time.Now().UTC()
 	claim := profileClaimFixture(t, now, IELTSProfileStagePart2)
@@ -81,7 +93,7 @@ func TestWorkerPart2ProfileDefersWhilePart1IsRunning(t *testing.T) {
 	store := &workerStoreFake{
 		claims: []Claim{claim},
 		records: map[Kind]Record{
-			KindIELTSPart1Profile: {Status: JobRunning},
+			KindIELTSPart1Profile: {Status: JobRunning, CreatedAt: now},
 		},
 	}
 	profiles := &profileEvaluatorsFake{}
@@ -127,7 +139,7 @@ func TestWorkerPart2ProfileFallsBackWhenPart1IsMissing(t *testing.T) {
 	}
 }
 
-func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
+func TestWorkerFinalReportResolvesPart2ProfileReadyAfter45Seconds(t *testing.T) {
 	now := time.Now().UTC()
 	claim := sessionClaimFixture(t, now, IELTSStrategyRef)
 	part2 := cumulativeProfileFixture(claim.SourceID, []int{1, 2})
@@ -138,7 +150,10 @@ func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
 	store := &workerStoreFake{
 		claims: []Claim{claim},
 		records: map[Kind]Record{
-			KindIELTSPart2Profile: {Status: JobReady, Result: part2Result},
+			KindIELTSPart2Profile: {
+				Status: JobReady, Result: part2Result,
+				CreatedAt: now.Add(-45 * time.Second),
+			},
 		},
 	}
 	sessions := &sessionEvaluatorsFake{}
@@ -157,6 +172,52 @@ func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
 	}
 }
 
+func TestWorkerFinalReportDefersThroughNormalPart2ProfileRuntime(t *testing.T) {
+	configuration := workerConfigurationFixture()
+	for _, test := range []struct {
+		name     string
+		age      time.Duration
+		attempts int
+	}{
+		{name: "ready-window-28s", age: 28 * time.Second, attempts: 1},
+		{name: "ready-window-45s", age: 45 * time.Second, attempts: 1},
+		{
+			name:     "second-attempt-after-upstream-stage",
+			age:      configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages) + time.Second,
+			attempts: 2,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			claim := sessionClaimFixture(t, now, IELTSStrategyRef)
+			store := &workerStoreFake{
+				claims: []Claim{claim},
+				records: map[Kind]Record{
+					KindIELTSPart2Profile: {
+						Status: JobRunning, AttemptCount: test.attempts,
+						CreatedAt: now.Add(-test.age),
+					},
+				},
+			}
+			sessions := &sessionEvaluatorsFake{}
+			worker := workerFixture(
+				t, store, sessions, &speechEvaluatorsFake{}, &acousticEvaluatorFake{},
+			)
+
+			processed, err := worker.ProcessSession(context.Background())
+			if err != nil || !processed || sessions.ieltsCalls != 0 ||
+				len(store.deferrals) != 1 || len(store.checkpoints) != 0 ||
+				len(store.completions) != 0 || len(store.failures) != 0 {
+				t.Fatalf(
+					"ProcessSession=(%t,%v), calls=%d deferrals=%d checkpoints=%d completions=%d failures=%d",
+					processed, err, sessions.ieltsCalls, len(store.deferrals),
+					len(store.checkpoints), len(store.completions), len(store.failures),
+				)
+			}
+		})
+	}
+}
+
 func TestWorkerFinalReportFallsBackWhenPart2ProfileIsUnavailable(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -165,7 +226,7 @@ func TestWorkerFinalReportFallsBackWhenPart2ProfileIsUnavailable(t *testing.T) {
 	}{
 		{
 			name:     "dependency timeout",
-			record:   Record{Status: JobRunning},
+			record:   Record{Status: JobRunning, AttemptCount: 2},
 			timedOut: true,
 		},
 		{
@@ -185,10 +246,9 @@ func TestWorkerFinalReportFallsBackWhenPart2ProfileIsUnavailable(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			now := time.Now().UTC()
 			claim := sessionClaimFixture(t, now, IELTSStrategyRef)
-			claim.CreatedAt = now
 			if test.timedOut {
-				claim.CreatedAt = now.Add(
-					-workerConfigurationFixture().ProfileDependencyMaxWait - time.Second,
+				test.record.CreatedAt = now.Add(
+					-workerConfigurationFixture().profileLifecycleWaitBudget(finalProfileLifecycleStages) - time.Second,
 				)
 			}
 			store := &workerStoreFake{
@@ -974,7 +1034,6 @@ func workerConfigurationFixture() WorkerConfiguration {
 		RetryDelay:                time.Second,
 		DependencyDelay:           5 * time.Second,
 		AcousticDependencyMaxWait: 150 * time.Second,
-		ProfileDependencyMaxWait:  20 * time.Second,
 		FinalizeTimeout:           5 * time.Second,
 	}
 }

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -42,13 +42,79 @@ func TestWorkerConfigurationRejectsIELTSDeadlineThatCutsRepairRound(t *testing.T
 
 func TestWorkerConfigurationDerivesProfileWaitFromLaneLifecycle(t *testing.T) {
 	configuration := workerConfigurationFixture()
-	perStage := 2*configuration.ProfileDeadline + configuration.RetryDelay +
-		configuration.DependencyDelay
+	attempts := time.Duration(configuration.ProfileLane.MaxAttempts)
+	perStage := configuration.AcousticDependencyMaxWait +
+		attempts*configuration.ProfileLane.LeaseDuration +
+		(attempts-1)*configuration.RetryDelay + configuration.DependencyDelay
 	if got := configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages); got != perStage {
 		t.Fatalf("single-stage profile wait = %s, want %s", got, perStage)
 	}
 	if got := configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages); got != 2*perStage {
 		t.Fatalf("two-stage profile wait = %s, want %s", got, 2*perStage)
+	}
+	if !configuration.Valid() {
+		t.Fatal("production-sized profile lifecycle should remain valid")
+	}
+	configuration.ProfileLane.MaxAttempts = 10
+	if configuration.Valid() {
+		t.Fatal("profile lifecycle beyond the bounded maximum should be invalid")
+	}
+}
+
+func TestWorkerPart2ProfileWaitsForFullLifecycleBudget(t *testing.T) {
+	configuration := workerConfigurationFixture()
+	fullBudget := configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages)
+	for _, test := range []struct {
+		name     string
+		age      time.Duration
+		fallback bool
+	}{
+		{name: "past legacy 96 second budget", age: 97 * time.Second},
+		{name: "immediately before full budget", age: fullBudget - time.Second},
+		{name: "after full budget", age: fullBudget + time.Second, fallback: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			claim := profileClaimFixture(t, now, IELTSProfileStagePart2)
+			store := &workerStoreFake{
+				claims: []Claim{claim},
+				records: map[Kind]Record{
+					KindIELTSPart1Profile: {
+						Status: JobRunning, AttemptCount: configuration.ProfileLane.MaxAttempts,
+						CreatedAt: now.Add(-test.age),
+					},
+				},
+			}
+			profiles := &profileEvaluatorsFake{}
+			worker, err := NewWorker(
+				store, &sessionEvaluatorsFake{}, profiles, &speechEvaluatorsFake{},
+				&acousticEvaluatorFake{}, store, configuration,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			processed, err := worker.ProcessProfile(context.Background())
+			wantDeferred := 1
+			wantCompleted := 0
+			wantProfileCalls := 0
+			if test.fallback {
+				wantDeferred = 0
+				wantCompleted = 1
+				wantProfileCalls = 1
+			}
+			if err != nil || !processed || profiles.calls != wantProfileCalls ||
+				len(store.deferrals) != wantDeferred || len(store.checkpoints) != wantCompleted ||
+				len(store.completions) != wantCompleted || len(store.failures) != 0 ||
+				(test.fallback && profiles.last.DependencyResolution != IELTSProfileDependencyFallback) {
+				t.Fatalf(
+					"ProcessProfile=(%t,%v), calls=%d resolution=%s deferrals=%d checkpoints=%d completions=%d failures=%d",
+					processed, err, profiles.calls, profiles.last.DependencyResolution,
+					len(store.deferrals), len(store.checkpoints), len(store.completions),
+					len(store.failures),
+				)
+			}
+		})
 	}
 }
 
@@ -182,9 +248,20 @@ func TestWorkerFinalReportDefersThroughNormalPart2ProfileRuntime(t *testing.T) {
 		{name: "ready-window-28s", age: 28 * time.Second, attempts: 1},
 		{name: "ready-window-45s", age: 45 * time.Second, attempts: 1},
 		{
+			name:     "past-legacy-two-stage-budget",
+			age:      193 * time.Second,
+			attempts: configuration.ProfileLane.MaxAttempts,
+		},
+		{
 			name:     "second-attempt-after-upstream-stage",
 			age:      configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages) + time.Second,
 			attempts: 2,
+		},
+		{
+			name: "immediately-before-full-two-stage-budget",
+			age: configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages) -
+				time.Second,
+			attempts: configuration.ProfileLane.MaxAttempts,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
+++ b/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
@@ -373,7 +373,6 @@ func customLifecycleWorkerConfiguration() evaluation.WorkerConfiguration {
 		RetryDelay:                time.Second,
 		DependencyDelay:           time.Second,
 		AcousticDependencyMaxWait: 150 * time.Second,
-		ProfileDependencyMaxWait:  20 * time.Second,
 		FinalizeTimeout:           5 * time.Second,
 	}
 }

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -982,7 +982,6 @@ func migrationEvaluationWorkerConfiguration() evaluation.WorkerConfiguration {
 		RetryDelay:                time.Second,
 		DependencyDelay:           time.Second,
 		AcousticDependencyMaxWait: 150 * time.Second,
-		ProfileDependencyMaxWait:  20 * time.Second,
 		FinalizeTimeout:           5 * time.Second,
 	}
 }


### PR DESCRIPTION
## 功能描述

- FULL_MOCK 报告不再用固定 20 秒提前放弃仍在 QUEUED/RUNNING 的画像链路。
- 新增 `ielts-report/v4` 与带 `schema_version`、`evidence_mode` 的输入契约，明确区分画像增量证据和全量原始回退证据。
- 保留 `ielts-report/v3` 的 prompt、payload 和历史全量证据语义，可继续处理既有 lineage。

## 实现思路

- 单阶段等待预算为：`AcousticDependencyMaxWait + MaxAttempts*LeaseDuration + (MaxAttempts-1)*RetryDelay + DependencyDelay`。
- 代码按 `MaxAttempts*ProfileDeadline + MaxAttempts*(LeaseDuration-ProfileDeadline)` 展开 lease 项；因 `ProfileDeadline < LeaseDuration`，两式等价，既覆盖正常处理，也覆盖每次尝试崩溃后等 lease 回收的可证明上界。
- Part 2 等 Part 1 使用一个阶段；最终 Session Report 等 Part 2 使用两个阶段，覆盖 Part 2 先等 Part 1 再执行自身尝试的链路。
- 当前生产尺寸为单阶段约 336 秒、两阶段约 672 秒；配置校验保留 30 分钟有界上限。该上界覆盖已配置的生命周期与 lease，不声称覆盖无界队列饥饿。
- READY 且合法的 Part 2 画像写入 `RESOLVED`，使用 `CUMULATIVE_PARTS_1_2_PLUS_PART_3`；FAILED、缺失、非法或完整预算耗尽才写入 `FALLBACK`，使用 `FULL_RAW_FALLBACK`。
- v4 `RESOLVED` 仅允许报告引用累计画像中已存在的精确 `(turn_id, trim(quote), occurrence)`，或 Part 3 原始 turn；Part 1/2 其他原始内容会在首轮和 repair 轮统一拒绝。v4 fallback 继续允许全部 effective raw turns。
- Deferral 复用现有 `DeferClaim`，不消耗 Session Report attempt。

## 可复现测试

```bash
cd server
go test ./internal/coaching/evaluation ./internal/coaching/evaluation/sessionevaluation
go test -race ./internal/coaching/evaluation ./internal/coaching/evaluation/sessionevaluation
go test ./...
cd ..
make check-go-coverage
```

本地结果：聚焦测试、竞态测试、全量 Go、Go vet 与覆盖率生成均通过；总覆盖率 `47.8%`。边界测试覆盖 28–45 秒 READY、超过旧 96/192 秒仍 defer、完整一/两阶段预算前仍 defer、预算耗尽后 fallback，以及 v4 resolved 越权/合法证据与 v3 回归。

## 范围说明

- 不包含 #947 的 `INSUFFICIENT` 归一化。
- 不涉及模型/供应商替换、移动端、Staging、Production 或迁移文件。

Closes #948
Related #934
Related #940
