### PR TITLE
fix(evaluation): 规范化证据不足报告

### DIFF
--- a/server/cmd/server/evaluation_worker.go
+++ b/server/cmd/server/evaluation_worker.go
@@ -104,6 +104,10 @@ type evaluationFailureMetadata interface {
 	EvaluationJobError() evaluation.JobError
 }
 
+type evaluationNormalizeFailure interface {
+	EvaluationNormalizeReason() string
+}
+
 func evaluationErrorAttributes(lane string, err error) []slog.Attr {
 	attributes := []slog.Attr{
 		slog.String("lane", lane),
@@ -118,6 +122,12 @@ func evaluationErrorAttributes(lane string, err error) []slog.Attr {
 			slog.Int("attempt_count", metadata.EvaluationAttemptCount()),
 			slog.String("failure_code", failure.Code),
 			slog.Bool("retryable", failure.Retryable),
+		)
+	}
+	var normalization evaluationNormalizeFailure
+	if errors.As(err, &normalization) && normalization.EvaluationNormalizeReason() != "" {
+		attributes = append(attributes,
+			slog.String("normalize_reason", normalization.EvaluationNormalizeReason()),
 		)
 	}
 	return attributes

--- a/server/cmd/server/evaluation_worker_test.go
+++ b/server/cmd/server/evaluation_worker_test.go
@@ -39,12 +39,13 @@ func TestEvaluationFailureAttributesExposeSafeDiagnosticMetadata(t *testing.T) {
 		values[attribute.Key] = attribute.Value.String()
 	}
 	for key, want := range map[string]string{
-		"lane":            "session",
-		"evaluation_id":   "70000000-0000-4000-8000-000000000001",
-		"evaluation_kind": "SESSION_REPORT",
-		"attempt_count":   "2",
-		"failure_code":    "PROVIDER_RESPONSE_INVALID",
-		"retryable":       "true",
+		"lane":             "session",
+		"evaluation_id":    "70000000-0000-4000-8000-000000000001",
+		"evaluation_kind":  "SESSION_REPORT",
+		"attempt_count":    "2",
+		"failure_code":     "PROVIDER_RESPONSE_INVALID",
+		"normalize_reason": "priority_action_invalid",
+		"retryable":        "true",
 	} {
 		if values[key] != want {
 			t.Fatalf("%s = %q, want %q; attributes=%#v", key, values[key], want, values)
@@ -79,6 +80,9 @@ func (evaluationFailureStub) EvaluationKind() evaluation.Kind {
 	return evaluation.KindSessionReport
 }
 func (evaluationFailureStub) EvaluationAttemptCount() int { return 2 }
+func (evaluationFailureStub) EvaluationNormalizeReason() string {
+	return "priority_action_invalid"
+}
 func (evaluationFailureStub) EvaluationJobError() evaluation.JobError {
 	return evaluation.JobError{
 		Code: "PROVIDER_RESPONSE_INVALID", Retryable: true,

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -17,7 +17,7 @@ import (
 )
 
 var ErrProviderResponse error = providerResponseFailure{
-	message: "evaluation: report provider response invalid",
+	reason: normalizeReasonNormalizedReportInvalid,
 }
 
 const pipelineVersion = "session-evaluation/v1"
@@ -316,11 +316,15 @@ func evaluate(
 	repairPayload, err := json.Marshal(struct {
 		Input          json.RawMessage `json:"input"`
 		RejectedOutput string          `json:"rejected_output"`
+		Violation      normalizeReason `json:"violation"`
 		Instruction    string          `json:"instruction"`
 	}{
 		Input:          payload,
 		RejectedOutput: generated.Content,
-		Instruction:    "Return a complete corrected JSON object that obeys the contract exactly.",
+		Violation:      normalizeReasonFromError(normalizeErr),
+		Instruction: "Return a complete corrected JSON object that obeys the contract exactly. " +
+			"For INSUFFICIENT, every score must be null and priority_actions must be empty. " +
+			"For PROVISIONAL, each priority action must reference an existing improvement in the same dimension.",
 	})
 	if err != nil {
 		return nil, evaluation.ErrInvalidRequest
@@ -337,7 +341,7 @@ func evaluate(
 		lineage.Provider, lineage.Model,
 	)
 	if err != nil {
-		return nil, errors.Join(ErrProviderResponse, err)
+		return nil, err
 	}
 	return encodeReport(formal)
 }
@@ -459,20 +463,28 @@ func normalizeProviderReport(
 	if generated.Provider != expectedProvider || generated.Model != expectedModel ||
 		generated.RequestID == "" || len(generated.Content) == 0 ||
 		len(generated.Content) > 256*1024 {
-		return report.FormalReport{}, ErrProviderResponse
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonResponseMetadataInvalid,
+		)
 	}
 	decoder := json.NewDecoder(bytes.NewBufferString(generated.Content))
 	decoder.DisallowUnknownFields()
 	var provided providerReport
 	if err := decoder.Decode(&provided); err != nil {
-		return report.FormalReport{}, fmt.Errorf("%w: decode: %v", ErrProviderResponse, err)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonResponseJSONInvalid,
+		)
 	}
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
-		return report.FormalReport{}, fmt.Errorf("%w: trailing JSON", ErrProviderResponse)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonResponseJSONInvalid,
+		)
 	}
 	if len(provided.Dimensions) != len(dimensionKeys) {
-		return report.FormalReport{}, fmt.Errorf("%w: dimension count", ErrProviderResponse)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonDimensionCountInvalid,
+		)
 	}
 	turns := make(map[string]string, len(snapshot.Turns))
 	for _, turn := range snapshot.Turns {
@@ -496,11 +508,18 @@ func normalizeProviderReport(
 	for index, expectedKey := range dimensionKeys {
 		providedDimension := provided.Dimensions[index]
 		if providedDimension.Key != expectedKey {
-			return report.FormalReport{}, fmt.Errorf("%w: dimension order", ErrProviderResponse)
+			return report.FormalReport{}, providerResponseError(
+				normalizeReasonDimensionOrderInvalid,
+			)
+		}
+		score := providedDimension.Score
+		if provided.ScoreabilityStatus == report.ReportScoreabilityInsufficient &&
+			score != nil {
+			score = nil
 		}
 		dimension := report.ReportDimension{
 			Key:          expectedKey,
-			Score:        providedDimension.Score,
+			Score:        score,
 			Scale:        scale,
 			Coverage:     providedDimension.Coverage,
 			Confidence:   providedDimension.Confidence,
@@ -548,22 +567,28 @@ func normalizeProviderReport(
 		}
 		formal.Dimensions[index] = dimension
 	}
-	for _, action := range provided.PriorityActions {
-		ids, exists := improvementIDs[action.DimensionKey]
-		if !exists || action.ImprovementIndex < 1 || action.ImprovementIndex > len(ids) {
-			return report.FormalReport{}, fmt.Errorf("%w: priority action", ErrProviderResponse)
+	// Evidence-insufficient reports must not expose provider-generated
+	// priorities, even when those references happen to resolve.
+	if provided.ScoreabilityStatus != report.ReportScoreabilityInsufficient {
+		for _, action := range provided.PriorityActions {
+			ids, exists := improvementIDs[action.DimensionKey]
+			if !exists || action.ImprovementIndex < 1 || action.ImprovementIndex > len(ids) {
+				return report.FormalReport{}, providerResponseError(
+					normalizeReasonPriorityActionInvalid,
+				)
+			}
+			formal.PriorityActions = append(formal.PriorityActions, report.ReportPriorityAction{
+				DimensionKey: action.DimensionKey,
+				FindingID:    ids[action.ImprovementIndex-1],
+			})
 		}
-		formal.PriorityActions = append(formal.PriorityActions, report.ReportPriorityAction{
-			DimensionKey: action.DimensionKey,
-			FindingID:    ids[action.ImprovementIndex-1],
-		})
 	}
 	if sceneType == evaluation.SceneIELTSSpeaking &&
 		slices.Contains(dimensionKeys, "PRONUNCIATION") {
 		available, coverage, _ := pronunciationAvailability(snapshot)
 		if !available {
-			return report.FormalReport{}, fmt.Errorf(
-				"%w: pronunciation coverage changed", ErrProviderResponse,
+			return report.FormalReport{}, providerResponseError(
+				normalizeReasonPronunciationCoverageChanged,
 			)
 		}
 		for index := range formal.Dimensions {
@@ -604,7 +629,9 @@ func normalizeProviderReport(
 		})
 	}
 	if !formal.Valid() {
-		return report.FormalReport{}, fmt.Errorf("%w: normalized report", ErrProviderResponse)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonNormalizedReportInvalid,
+		)
 	}
 	return formal, nil
 }
@@ -685,7 +712,7 @@ func normalizeFindings(
 	turns map[string]string,
 ) ([]report.ReportFinding, error) {
 	if provided == nil || len(provided) > 5 {
-		return nil, fmt.Errorf("%w: finding count", ErrProviderResponse)
+		return nil, providerResponseError(normalizeReasonFindingCountInvalid)
 	}
 	result := make([]report.ReportFinding, len(provided))
 	for index, item := range provided {
@@ -696,14 +723,14 @@ func normalizeFindings(
 			Evidence:   make([]report.ReportEvidence, len(item.Evidence)),
 		}
 		if len(item.Evidence) > 8 {
-			return nil, fmt.Errorf("%w: evidence count", ErrProviderResponse)
+			return nil, providerResponseError(normalizeReasonEvidenceCountInvalid)
 		}
 		for evidenceIndex, source := range item.Evidence {
 			transcript, exists := turns[source.TurnID]
 			quote := strings.TrimSpace(source.Quote)
 			start := byteOccurrence(transcript, quote, source.Occurrence)
 			if !exists || source.Occurrence < 1 || start < 0 {
-				return nil, fmt.Errorf("%w: evidence quote", ErrProviderResponse)
+				return nil, providerResponseError(normalizeReasonEvidenceInvalid)
 			}
 			finding.Evidence[evidenceIndex] = report.ReportEvidence{
 				EvidenceRefID:   source.TurnID,
@@ -824,10 +851,67 @@ const generalSystemPromptV1 = `You are an evidence-bound everyday or workplace E
 
 const generalSystemPromptV2 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
 
-func (failure providerResponseFailure) Error() string          { return failure.message }
-func (failure providerResponseFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }
-func (failure providerResponseFailure) Retryable() bool        { return true }
+type normalizeReason string
 
-type providerResponseFailure struct{ message string }
+const (
+	normalizeReasonResponseMetadataInvalid      normalizeReason = "response_metadata_invalid"
+	normalizeReasonResponseJSONInvalid          normalizeReason = "response_json_invalid"
+	normalizeReasonDimensionCountInvalid        normalizeReason = "dimension_count_invalid"
+	normalizeReasonDimensionOrderInvalid        normalizeReason = "dimension_order_invalid"
+	normalizeReasonFindingCountInvalid          normalizeReason = "finding_count_invalid"
+	normalizeReasonEvidenceCountInvalid         normalizeReason = "evidence_count_invalid"
+	normalizeReasonEvidenceInvalid              normalizeReason = "evidence_invalid"
+	normalizeReasonPriorityActionInvalid        normalizeReason = "priority_action_invalid"
+	normalizeReasonPronunciationCoverageChanged normalizeReason = "pronunciation_coverage_changed"
+	normalizeReasonNormalizedReportInvalid      normalizeReason = "normalized_report_invalid"
+)
+
+func (reason normalizeReason) valid() bool {
+	switch reason {
+	case normalizeReasonResponseMetadataInvalid,
+		normalizeReasonResponseJSONInvalid,
+		normalizeReasonDimensionCountInvalid,
+		normalizeReasonDimensionOrderInvalid,
+		normalizeReasonFindingCountInvalid,
+		normalizeReasonEvidenceCountInvalid,
+		normalizeReasonEvidenceInvalid,
+		normalizeReasonPriorityActionInvalid,
+		normalizeReasonPronunciationCoverageChanged,
+		normalizeReasonNormalizedReportInvalid:
+		return true
+	default:
+		return false
+	}
+}
+
+func providerResponseError(reason normalizeReason) error {
+	if !reason.valid() {
+		reason = normalizeReasonNormalizedReportInvalid
+	}
+	return providerResponseFailure{reason: reason}
+}
+
+func normalizeReasonFromError(err error) normalizeReason {
+	var failure providerResponseFailure
+	if errors.As(err, &failure) && failure.reason.valid() {
+		return failure.reason
+	}
+	return normalizeReasonNormalizedReportInvalid
+}
+
+type providerResponseFailure struct{ reason normalizeReason }
+
+func (providerResponseFailure) Error() string {
+	return "evaluation: report provider response invalid"
+}
+func (providerResponseFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }
+func (providerResponseFailure) Retryable() bool        { return true }
+func (failure providerResponseFailure) EvaluationNormalizeReason() string {
+	return string(failure.reason)
+}
+func (providerResponseFailure) Is(target error) bool {
+	_, ok := target.(providerResponseFailure)
+	return ok
+}
 
 var _ evaluation.SessionEvaluators = (*Evaluators)(nil)

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -19,11 +19,158 @@ func TestInvalidProviderReportRemainsRetryableAtTheJobBoundary(t *testing.T) {
 	var failure interface {
 		StableCategory() string
 		Retryable() bool
+		EvaluationNormalizeReason() string
 	}
 	if !errors.As(ErrProviderResponse, &failure) ||
 		failure.StableCategory() != "PROVIDER_RESPONSE_INVALID" ||
+		failure.EvaluationNormalizeReason() != "normalized_report_invalid" ||
 		!failure.Retryable() {
 		t.Fatalf("provider response failure = %#v", failure)
+	}
+}
+
+func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) {
+	score := 7.0
+	generated := mustProviderResult(t, providerReport{
+		ScoreabilityStatus: report.ReportScoreabilityInsufficient,
+		Summary:            "The available evidence is insufficient.",
+		Dimensions: []providerDimension{
+			providerDimensionFixture("FLUENCY_COHERENCE", &score),
+		},
+		PriorityActions: []providerPriorityAction{{
+			DimensionKey: "UNKNOWN", ImprovementIndex: 99,
+		}},
+	})
+
+	formal, err := normalizeProviderReport(
+		generated, sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
+		"qianwen", "qwen-plus",
+	)
+	if err != nil {
+		t.Fatalf("normalizeProviderReport() error = %v", err)
+	}
+	for _, dimension := range formal.Dimensions {
+		if dimension.Score != nil {
+			t.Fatalf("INSUFFICIENT dimension retained score: %#v", dimension)
+		}
+	}
+	if len(formal.PriorityActions) != 0 {
+		t.Fatalf("INSUFFICIENT priority actions = %#v", formal.PriorityActions)
+	}
+}
+
+func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T) {
+	score := 7.0
+	dimension := providerDimensionFixture("FLUENCY_COHERENCE", &score)
+	dimension.Strengths = []providerFinding{{
+		Message: "Unsupported strength",
+		Evidence: []providerEvidence{{
+			TurnID: sessionSnapshotFixture().Turns[0].ID,
+			Quote:  "provider-invented quote", Occurrence: 1,
+		}},
+	}}
+	_, err := normalizeProviderReport(
+		mustProviderResult(t, providerReport{
+			ScoreabilityStatus: report.ReportScoreabilityInsufficient,
+			Summary:            "The available evidence is insufficient.", Dimensions: []providerDimension{dimension},
+			PriorityActions: []providerPriorityAction{},
+		}),
+		sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
+		"qianwen", "qwen-plus",
+	)
+	if !errors.Is(err, ErrProviderResponse) ||
+		normalizeReasonFromError(err) != normalizeReasonEvidenceInvalid {
+		t.Fatalf("invalid INSUFFICIENT evidence error = %v", err)
+	}
+}
+
+func TestProvisionalProviderReportRemainsFailClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		report     providerReport
+		wantReason normalizeReason
+	}{
+		{
+			name: "invalid score",
+			report: func() providerReport {
+				score := 9.5
+				return providerReport{
+					ScoreabilityStatus: report.ReportScoreabilityProvisional,
+					Summary:            "Provisional report.",
+					Dimensions: []providerDimension{
+						providerDimensionFixture("FLUENCY_COHERENCE", &score),
+					},
+					PriorityActions: []providerPriorityAction{},
+				}
+			}(),
+			wantReason: normalizeReasonNormalizedReportInvalid,
+		},
+		{
+			name: "invalid priority action",
+			report: func() providerReport {
+				score := 7.0
+				return providerReport{
+					ScoreabilityStatus: report.ReportScoreabilityProvisional,
+					Summary:            "Provisional report.",
+					Dimensions: []providerDimension{
+						providerDimensionFixture("FLUENCY_COHERENCE", &score),
+					},
+					PriorityActions: []providerPriorityAction{{
+						DimensionKey: "FLUENCY_COHERENCE", ImprovementIndex: 1,
+					}},
+				}
+			}(),
+			wantReason: normalizeReasonPriorityActionInvalid,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := normalizeProviderReport(
+				mustProviderResult(t, test.report),
+				sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+				[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
+				"qianwen", "qwen-plus",
+			)
+			if !errors.Is(err, ErrProviderResponse) ||
+				normalizeReasonFromError(err) != test.wantReason {
+				t.Fatalf("normalizeProviderReport() error = %v, reason = %q", err, normalizeReasonFromError(err))
+			}
+		})
+	}
+}
+
+func TestIELTSRepairReceivesBoundedNormalizeReason(t *testing.T) {
+	generator := &repairReportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, sessionSnapshotFixture(), lineages.IELTS,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	if len(generator.requests) != 2 {
+		t.Fatalf("generation requests = %d", len(generator.requests))
+	}
+	var repair struct {
+		Violation   normalizeReason `json:"violation"`
+		Instruction string          `json:"instruction"`
+	}
+	if err := json.Unmarshal([]byte(generator.requests[1].UserPrompt), &repair); err != nil {
+		t.Fatal(err)
+	}
+	if repair.Violation != normalizeReasonPriorityActionInvalid ||
+		!repair.Violation.valid() ||
+		!strings.Contains(repair.Instruction, "For INSUFFICIENT, every score must be null") ||
+		!strings.Contains(repair.Instruction, "existing improvement in the same dimension") {
+		t.Fatalf("repair contract = %#v", repair)
 	}
 }
 
@@ -491,6 +638,81 @@ type reportGeneratorFake struct {
 	last textgeneration.Request
 }
 
+type repairReportGeneratorFake struct {
+	requests []textgeneration.Request
+}
+
+func (generator *repairReportGeneratorFake) Generate(
+	_ context.Context,
+	request textgeneration.Request,
+) (textgeneration.Result, error) {
+	generator.requests = append(generator.requests, request)
+	var dimensionKeys []string
+	if len(generator.requests) == 1 {
+		var input struct {
+			DimensionKeys []string `json:"dimension_keys"`
+		}
+		if err := json.Unmarshal([]byte(request.UserPrompt), &input); err != nil {
+			return textgeneration.Result{}, err
+		}
+		dimensionKeys = input.DimensionKeys
+	} else {
+		var repair struct {
+			Input struct {
+				DimensionKeys []string `json:"dimension_keys"`
+			} `json:"input"`
+		}
+		if err := json.Unmarshal([]byte(request.UserPrompt), &repair); err != nil {
+			return textgeneration.Result{}, err
+		}
+		dimensionKeys = repair.Input.DimensionKeys
+	}
+	score := 7.0
+	dimensions := make([]providerDimension, len(dimensionKeys))
+	for index, key := range dimensionKeys {
+		dimensions[index] = providerDimensionFixture(key, &score)
+	}
+	actions := []providerPriorityAction{}
+	if len(generator.requests) == 1 {
+		actions = append(actions, providerPriorityAction{
+			DimensionKey: dimensionKeys[0], ImprovementIndex: 1,
+		})
+	}
+	content, err := json.Marshal(providerReport{
+		ScoreabilityStatus: report.ReportScoreabilityProvisional,
+		Summary:            "Provisional report.",
+		Dimensions:         dimensions,
+		PriorityActions:    actions,
+	})
+	if err != nil {
+		return textgeneration.Result{}, err
+	}
+	return textgeneration.Result{
+		RequestID: fmt.Sprintf("request-%d", len(generator.requests)),
+		Content:   string(content), Provider: "qianwen", Model: "qwen-plus",
+	}, nil
+}
+
+func providerDimensionFixture(key string, score *float64) providerDimension {
+	return providerDimension{
+		Key: key, Score: score, Coverage: 1, Confidence: 0.8,
+		ReasonCodes: []string{}, Strengths: []providerFinding{},
+		Improvements: []providerFinding{}, Examples: []providerFinding{},
+	}
+}
+
+func mustProviderResult(t *testing.T, value providerReport) textgeneration.Result {
+	t.Helper()
+	content, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return textgeneration.Result{
+		RequestID: "request-1", Content: string(content),
+		Provider: "qianwen", Model: "qwen-plus",
+	}
+}
+
 func (generator *reportGeneratorFake) Generate(
 	_ context.Context,
 	request textgeneration.Request,
@@ -557,3 +779,4 @@ func sessionSnapshotFixture() evaluation.SessionInputSnapshot {
 }
 
 var _ textgeneration.Generator = (*reportGeneratorFake)(nil)
+var _ textgeneration.Generator = (*repairReportGeneratorFake)(nil)


### PR DESCRIPTION
## 功能描述

- 将 provider 返回的 `INSUFFICIENT` 报告确定性规范化为所有维度 `score=null`。
- 清空 `INSUFFICIENT` 的全部 priority actions，不生成替代建议、分数或证据。
- 保持 `PROVISIONAL` 的分数、证据和 priority action 校验严格失败关闭。
- 为 repair 与现有 worker 日志提供有限、无内容的 `normalize_reason` 枚举。

## 实现思路

- 在 session report provider 可信边界完成规范化，避免把跨字段约束交给 JSON Schema。
- repair 请求仅携带稳定 violation 枚举，并明确 `INSUFFICIENT` 与 `PROVISIONAL` 的修复规则。
- provider response error 不包含 transcript、provider 原文、提示词或密钥；worker 继续只记录安全诊断字段。
- 保留现有 Interview/General/IELTS Prompt lineage，不与 #948 的 FULL_MOCK payload/prompt 版本化交叉。

## 可复现测试

- `go test ./internal/coaching/evaluation/sessionevaluation ./cmd/server`
- `go test -race ./internal/coaching/evaluation/sessionevaluation ./cmd/server`
- `go test -count=20 -run 'Test(InsufficientProviderReport|ProvisionalProviderReport|IELTSRepairReceivesBoundedNormalizeReason|EvaluationFailureAttributesExposeSafeDiagnosticMetadata)' ./internal/coaching/evaluation/sessionevaluation ./cmd/server`
- `make check-go-coverage`（total: 47.6%）
- `make check-api check-production-deploy check-staging-deploy`

Closes #947
Related #934
Related #940
