### PR TITLE
fix(evaluation): 自动重试语音反馈语义规范化失败

### DIFF
--- a/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
@@ -1,0 +1,292 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	speechRetryUserID    = "91000000-0000-4000-8000-000000000001"
+	speechRetryTurnID    = "92000000-0000-4000-8000-000000000001"
+	speechRetrySessionID = "93000000-0000-4000-8000-000000000001"
+	speechRetryQuestion  = "94000000-0000-4000-8000-000000000001"
+)
+
+func TestSpeechFeedbackPart1InvalidThenValidReusesAcoustics(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, speechRetryUserID, "speech-retry-part1@example.com")
+	generator := &speechRetryGenerator{contents: []string{
+		`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"missing excerpt","source_occurrence":1,"suggested_text":"read"}]}`,
+		`{"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"这是更自然的表达。","source_text":"read","source_occurrence":1,"suggested_text":"do some reading"}]}`,
+	}}
+	acoustics := &speechRetryAcoustics{}
+	store, worker := speechRetryWorker(t, pool, generator, acoustics)
+	queueSpeechRetry(t, store, "I usually read before work.")
+
+	processed, err := worker.ProcessSpeech(context.Background())
+	if !processed || err == nil {
+		t.Fatalf("first ProcessSpeech = (%t, %v)", processed, err)
+	}
+	queued, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || queued.Status != evaluation.JobQueued ||
+		queued.AttemptCount != 1 || queued.Error != nil {
+		t.Fatalf("queued retry = %#v, %v", queued, err)
+	}
+	var checkpointed evaluation.SpeechInputSnapshot
+	if evaluation.DecodeStrict(queued.InputSnapshot, &checkpointed) != nil ||
+		checkpointed.Acoustic == nil ||
+		checkpointed.Acoustic.Status != evaluation.AcousticAssessed {
+		t.Fatalf("checkpointed input = %#v", checkpointed)
+	}
+
+	processed, err = worker.ProcessSpeech(context.Background())
+	if err != nil || !processed {
+		t.Fatalf("second ProcessSpeech = (%t, %v)", processed, err)
+	}
+	ready, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || ready.Status != evaluation.JobReady ||
+		ready.AttemptCount != 2 || ready.Error != nil ||
+		acoustics.calls != 1 || generator.calls != 2 {
+		t.Fatalf(
+			"ready=%#v err=%v acoustic=%d text=%d",
+			ready, err, acoustics.calls, generator.calls,
+		)
+	}
+	items, err := store.ListFeedbackItems(
+		context.Background(), speechRetryUserID, ready.ID,
+	)
+	if err != nil || len(items) != 1 ||
+		items[0].Category != "RECOMMENDED_EXPRESSION" ||
+		items[0].Evidence.OriginalExcerpt != "read" {
+		t.Fatalf("feedback items = %#v, %v", items, err)
+	}
+}
+
+func TestSpeechFeedbackPart3ThreeInvalidResponsesFailPubliclyNonRetryable(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, speechRetryUserID, "speech-retry-part3@example.com")
+	const invalid = `{"items":[{"kind":"STRENGTH","explanation":"无需修改。","source_text":"technology","source_occurrence":1,"suggested_text":null}]}`
+	generator := &speechRetryGenerator{contents: []string{invalid, invalid, invalid}}
+	acoustics := &speechRetryAcoustics{}
+	store, worker := speechRetryWorker(t, pool, generator, acoustics)
+	const transcript = "I think technology can improve education when teachers guide its use."
+	queueSpeechRetry(t, store, transcript)
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		processed, err := worker.ProcessSpeech(context.Background())
+		if !processed || err == nil {
+			t.Fatalf("ProcessSpeech attempt %d = (%t, %v)", attempt, processed, err)
+		}
+		record, getErr := store.GetRecordBySource(
+			context.Background(), speechRetryUserID,
+			evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+		)
+		if getErr != nil || record.AttemptCount != attempt {
+			t.Fatalf("record attempt %d = %#v, %v", attempt, record, getErr)
+		}
+		if attempt < 3 && (record.Status != evaluation.JobQueued || record.Error != nil) {
+			t.Fatalf("intermediate record %d = %#v", attempt, record)
+		}
+	}
+	failed, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || failed.Status != evaluation.JobFailed ||
+		failed.Error == nil || failed.Error.Code != "PROVIDER_RESPONSE_INVALID" ||
+		failed.Error.Retryable || acoustics.calls != 1 || generator.calls != 3 {
+		t.Fatalf(
+			"failed=%#v err=%v acoustic=%d text=%d",
+			failed, err, acoustics.calls, generator.calls,
+		)
+	}
+	var storedError string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT error::text FROM evaluations WHERE id=$1`, failed.ID,
+	).Scan(&storedError); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(storedError, transcript) || strings.Contains(storedError, invalid) {
+		t.Fatalf("terminal error leaked speech or provider output: %s", storedError)
+	}
+}
+
+func speechRetryWorker(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	generator speechfeedback.TextGenerator,
+	acoustics evaluation.AcousticEvaluator,
+) (*Store, *evaluation.Worker) {
+	t.Helper()
+	store := mustStore(t, pool)
+	speech, err := speechfeedback.NewCompactEvaluator(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker, err := evaluation.NewWorker(
+		store,
+		speechRetrySessions{},
+		speechRetryProfiles{},
+		speech,
+		acoustics,
+		speechRetrySessionAudio{},
+		evaluation.WorkerConfiguration{
+			SessionLane: evaluation.ClaimLane{
+				Kinds:         []evaluation.Kind{evaluation.KindSessionReport},
+				LeaseDuration: 3 * time.Minute, MaxAttempts: 3,
+			},
+			ProfileLane: evaluation.ClaimLane{
+				Kinds: []evaluation.Kind{
+					evaluation.KindIELTSPart1Profile,
+					evaluation.KindIELTSPart2Profile,
+				},
+				LeaseDuration: time.Minute, MaxAttempts: 2,
+			},
+			SpeechLane: evaluation.ClaimLane{
+				Kinds: []evaluation.Kind{
+					evaluation.KindPracticeTurnFeedback,
+					evaluation.KindAgentMessageFeedback,
+				},
+				LeaseDuration: time.Minute, MaxAttempts: 3,
+			},
+			AcousticsEnabled:          true,
+			InterviewDeadline:         30 * time.Second,
+			IELTSDeadline:             110 * time.Second,
+			GeneralDeadline:           30 * time.Second,
+			SpeechDeadline:            30 * time.Second,
+			ProfileDeadline:           30 * time.Second,
+			RetryDelay:                0,
+			DependencyDelay:           time.Second,
+			AcousticDependencyMaxWait: time.Minute,
+			FinalizeTimeout:           5 * time.Second,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, worker
+}
+
+func queueSpeechRetry(t *testing.T, store *Store, transcript string) {
+	t.Helper()
+	input, inputHash, err := evaluation.EncodeStrict(evaluation.SpeechInputSnapshot{
+		SchemaVersion: evaluation.SpeechInputSchemaVersion,
+		Transcript:    transcript,
+		EvidenceRefID: speechRetryTurnID,
+		QuestionID:    speechRetryQuestion,
+		AudioAssetID:  "speech-retry-audio",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage, err := speechfeedback.Lineage("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, configHash, err := evaluation.EncodeStrict(lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.Queue(context.Background(), evaluation.QueueCommand{
+		UserID: speechRetryUserID, Kind: evaluation.KindPracticeTurnFeedback,
+		SourceID: speechRetryTurnID, ContextID: speechRetrySessionID,
+		InputSnapshot: input, InputHash: inputHash,
+		ConfigLineage: config, ConfigHash: configHash,
+		AvailableAt: time.Now().UTC().Add(-time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type speechRetryGenerator struct {
+	contents []string
+	calls    int
+}
+
+func (generator *speechRetryGenerator) Generate(
+	context.Context,
+	speechfeedback.TextGenerationRequest,
+) (speechfeedback.TextGenerationResult, error) {
+	generator.calls++
+	if generator.calls > len(generator.contents) {
+		return speechfeedback.TextGenerationResult{}, errors.New("unexpected generation")
+	}
+	return speechfeedback.TextGenerationResult{
+		RequestID: fmt.Sprintf("speech-retry-request-%d", generator.calls),
+		Content:   generator.contents[generator.calls-1],
+		Provider:  "qianwen",
+		Model:     "qwen-plus",
+	}, nil
+}
+
+type speechRetryAcoustics struct{ calls int }
+
+func (acoustics *speechRetryAcoustics) EvaluateAcoustic(
+	context.Context,
+	evaluation.Record,
+	evaluation.SpeechInputSnapshot,
+) (evaluation.AcousticCheckpoint, error) {
+	acoustics.calls++
+	pronunciation := 86.0
+	return evaluation.AcousticCheckpoint{
+		Status:          evaluation.AcousticAssessed,
+		Pronunciation:   &pronunciation,
+		Provider:        "iflytek",
+		ProviderSession: "speech-retry-ise-1",
+	}, nil
+}
+
+type speechRetrySessions struct{}
+
+func (speechRetrySessions) EvaluateInterview(
+	context.Context, evaluation.Record, evaluation.SessionInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected Interview evaluation")
+}
+
+func (speechRetrySessions) EvaluateIELTS(
+	context.Context, evaluation.Record, evaluation.SessionInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected IELTS evaluation")
+}
+
+func (speechRetrySessions) EvaluateGeneral(
+	context.Context, evaluation.Record, evaluation.SessionInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected General evaluation")
+}
+
+type speechRetryProfiles struct{}
+
+func (speechRetryProfiles) EvaluateProfile(
+	context.Context, evaluation.Record, evaluation.IELTSProfileInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected IELTS profile evaluation")
+}
+
+type speechRetrySessionAudio struct{}
+
+func (speechRetrySessionAudio) ReadSessionAcoustics(
+	context.Context, string, string, []string,
+) (evaluation.SessionAcousticRead, error) {
+	return evaluation.SessionAcousticRead{}, errors.New("unexpected Session acoustic read")
+}

--- a/server/internal/coaching/evaluation/postgres/store.go
+++ b/server/internal/coaching/evaluation/postgres/store.go
@@ -544,7 +544,7 @@ func (store *Store) FailClaim(
 		WHERE id = $1 AND user_id = $7 AND status = 'RUNNING'
 		  AND lease_token = $2 AND lease_expires_at > transaction_timestamp()`,
 		failure.ID, failure.LeaseToken, failure.RetryAt.UTC(),
-		failure.MaxAttempts, failure.Error.Retryable, failureJSON, failure.UserID)
+		failure.MaxAttempts, failure.AutomaticRetryable, failureJSON, failure.UserID)
 	if err != nil {
 		return fmt.Errorf("fail Evaluation claim: %w", err)
 	}

--- a/server/internal/coaching/evaluation/postgres/store_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/store_integration_test.go
@@ -228,7 +228,8 @@ func TestStoreRetryableFinalAndExpiredClaimsConverge(t *testing.T) {
 		Error: evaluation.JobError{
 			Code: "PROVIDER_UNAVAILABLE", Retryable: true, Message: "retry",
 		},
-		RetryAt: time.Now().UTC().Add(-time.Second), MaxAttempts: 3,
+		AutomaticRetryable: true,
+		RetryAt:            time.Now().UTC().Add(-time.Second), MaxAttempts: 3,
 	}); err != nil {
 		t.Fatalf("FailClaim(retryable): %v", err)
 	}

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
@@ -382,9 +382,10 @@ func encodeCompactSpeechResult(
 
 type compactProviderFailure struct{ message string }
 
-func (failure compactProviderFailure) Error() string          { return failure.message }
-func (failure compactProviderFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }
-func (failure compactProviderFailure) Retryable() bool        { return false }
+func (failure compactProviderFailure) Error() string            { return failure.message }
+func (failure compactProviderFailure) StableCategory() string   { return "PROVIDER_RESPONSE_INVALID" }
+func (failure compactProviderFailure) Retryable() bool          { return false }
+func (failure compactProviderFailure) AutomaticRetryable() bool { return true }
 
 func compactProviderError(message string) error {
 	return compactProviderFailure{message: message}

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
@@ -3,10 +3,37 @@ package speechfeedback
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 )
+
+func TestCompactProviderSemanticFailureIsAutomaticOnly(t *testing.T) {
+	snapshot := evaluation.SpeechInputSnapshot{
+		Transcript:    "I usually read before work.",
+		EvidenceRefID: "30000000-0000-4000-8000-000000000001",
+	}
+	_, err := compactFeedbackItems(
+		compactResult(`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"missing excerpt","source_occurrence":1,"suggested_text":"read"}]}`),
+		snapshot,
+		snapshot.Transcript,
+		"SAME_QUESTION",
+	)
+	if err == nil {
+		t.Fatal("semantic-invalid provider response was accepted")
+	}
+	var publicFailure GenerationFailure
+	if !errors.As(err, &publicFailure) ||
+		publicFailure.StableCategory() != "PROVIDER_RESPONSE_INVALID" ||
+		publicFailure.Retryable() {
+		t.Fatalf("public failure = %#v", publicFailure)
+	}
+	var automatic interface{ AutomaticRetryable() bool }
+	if !errors.As(err, &automatic) || !automatic.AutomaticRetryable() {
+		t.Fatalf("automatic retry contract missing from %T", err)
+	}
+}
 
 func TestCompactEvaluatorUsesOralReferenceWithoutChangingEvidence(t *testing.T) {
 	generator := &recordingCompactGenerator{

--- a/server/internal/coaching/evaluation/state.go
+++ b/server/internal/coaching/evaluation/state.go
@@ -112,12 +112,15 @@ func (completion Completion) Valid() bool {
 }
 
 type Failure struct {
-	UserID      string
-	ID          string
-	LeaseToken  string
-	Error       JobError
-	RetryAt     time.Time
-	MaxAttempts int
+	UserID     string
+	ID         string
+	LeaseToken string
+	Error      JobError
+	// AutomaticRetryable controls worker requeueing independently from the
+	// public/manual retry contract carried by Error.Retryable.
+	AutomaticRetryable bool
+	RetryAt            time.Time
+	MaxAttempts        int
 }
 
 func (failure Failure) Valid() bool {

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -716,12 +716,13 @@ func (worker *Worker) fail(ctx context.Context, claim Claim, cause error) error 
 	finalizeContext, cancel := worker.finalizeContext(ctx)
 	defer cancel()
 	err := worker.store.FailClaim(finalizeContext, Failure{
-		UserID:      claim.UserID,
-		ID:          claim.ID,
-		LeaseToken:  claim.LeaseToken,
-		Error:       failure,
-		RetryAt:     time.Now().UTC().Add(worker.configuration.RetryDelay),
-		MaxAttempts: maxAttemptsFor(claim.Kind, worker.configuration),
+		UserID:             claim.UserID,
+		ID:                 claim.ID,
+		LeaseToken:         claim.LeaseToken,
+		Error:              failure,
+		AutomaticRetryable: automaticRetryable(cause, failure),
+		RetryAt:            time.Now().UTC().Add(worker.configuration.RetryDelay),
+		MaxAttempts:        maxAttemptsFor(claim.Kind, worker.configuration),
 	})
 	if err != nil {
 		return errors.Join(processing, err)
@@ -740,6 +741,18 @@ type stableFailure interface {
 	error
 	StableCategory() string
 	Retryable() bool
+}
+
+type automaticRetryableFailure interface {
+	AutomaticRetryable() bool
+}
+
+func automaticRetryable(err error, publicFailure JobError) bool {
+	var automatic automaticRetryableFailure
+	if errors.As(err, &automatic) {
+		return automatic.AutomaticRetryable()
+	}
+	return publicFailure.Retryable
 }
 
 func stableJobError(err error) JobError {

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -411,7 +411,8 @@ func TestWorkerRetriesTransientAcousticFailureWhileAttemptsRemain(t *testing.T) 
 	processed, err := worker.ProcessSpeech(context.Background())
 	if !processed || err == nil || acoustics.calls != 1 || speech.practiceCalls != 0 ||
 		len(store.checkpoints) != 0 || len(store.completions) != 0 ||
-		len(store.failures) != 1 || !store.failures[0].Error.Retryable {
+		len(store.failures) != 1 || !store.failures[0].Error.Retryable ||
+		!store.failures[0].AutomaticRetryable {
 		t.Fatalf(
 			"ProcessSpeech=(%v,%v) acoustic=%d text=%d checkpoints=%d completions=%d failures=%#v",
 			processed, err, acoustics.calls, speech.practiceCalls,


### PR DESCRIPTION
## 功能描述

- 将 speech-feedback 语义规范化失败拆分为“后台可自动重试、公开不可手动重试”两种语义。
- 复用 Speech Lane 既有最多 3 次尝试；中间失败重新排队，最终失败保持 `PROVIDER_RESPONSE_INVALID` 与 `retryable=false`。
- 保留已写入快照的讯飞声学结果，自动重试时只重新调用千问文本反馈。
- 不放宽 strict schema、excerpt/occurrence 或跨字段校验，不生成虚假 STRENGTH。

## 实现思路

- `Failure.AutomaticRetryable` 仅控制内部重新排队；`JobError.Retryable` 继续作为 API/人工重试契约。
- compact normalizer 的稳定错误实现自动重试能力，但公开重试能力保持 false。
- PostgreSQL 只依据内部标记重新排队，达到最大尝试数后持久化公开终态错误。

## 可复现测试

- `go test -count=1 -run "^TestCompactProviderSemanticFailureIsAutomaticOnly$" ./internal/coaching/evaluation/speechfeedback`
- `TEST_DATABASE_URL=<local-postgres-url> go test -count=1 -v -run "^TestSpeechFeedback(Part1InvalidThenValidReusesAcoustics|Part3ThreeInvalidResponsesFailPubliclyNonRetryable)$" ./internal/coaching/evaluation/postgres`
- `TEST_DATABASE_URL=<local-postgres-url> DATABASE_URL=<local-postgres-url> MIGRATION_ENV=test make check-go-test`

本地结果：以上全部通过。Part 1 fixture 为讯飞 1 次、千问 2 次后 READY；Part 3 fixture 为讯飞 1 次、千问 3 次后 FAILED，公开 `retryable=false`，错误 JSON 不含 transcript/provider output。

Fixes #949
Related #934
Related #940