### PR TITLE
chore(release): bump version to 0.1.6

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.5+6
+version: 0.1.6+7
 
 environment:
   sdk: ^3.12.2


### PR DESCRIPTION
## 功能说明

- 将 Android/Flutter 权威版本源从 `0.1.5+6` 更新为 `0.1.6+7`。
- 保持 application ID、签名配置、历史发布文档和远端更新元数据夹具不变。
- 本 PR 仅准备候选版本元数据，不创建 Tag、不构建制品、不部署任何环境。

## 实现思路

发布流水线从 `mobile/pubspec.yaml` 读取 `versionName` 与 `versionCode`，并在正式 Tag 触发时校验 Tag、main 提交、历史版本递增和制品 manifest 一致性。因此这里只修改唯一权威版本源；测试中的 v0.1.5 下载元数据是客户端输入夹具，不代表当前 App 版本，不随版本号机械更新。

## 依赖与合入限制

- Depends on #947
- Depends on #948
- Depends on #949
- 合入前必须等待以上修复全部进入 `dev`，再 rebase 到最新 `upstream/dev` 并重跑组合质量检查。
- 本 PR 合入不代表授权创建 `v0.1.6` Tag 或部署 Staging/Production；Tag、制品构建与部署必须按 #953 的后续门禁单独执行。

## 可复现测试

```bash
make check-release-candidate
make check-android-release-guard
cd mobile
flutter pub get --enforce-lockfile
flutter test --no-pub \
  test/update/app_update_test.dart \
  test/update/app_update_ui_test.dart \
  test/config/app_environment_test.dart
cd ..
git diff --check upstream/dev...HEAD
```

本地结果：发布元数据测试 31/31 通过；Android keystore、显式签名、APK 验证与 release guard 夹具通过；相关 Flutter 测试 38/38 通过。

Relates to #953