### PR TITLE
test(release): 固化 Staging 真实业务 UAT 执行器

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,7 @@ check-production-nginx:
 	./deploy/production/test-nginx.sh
 
 check-staging-deploy:
+	node --test deploy/staging/uat.test.mjs
 	./deploy/staging/test.sh
 
 check-staging-nginx:

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -230,6 +230,38 @@ services, image digests and OCI labels, networks, ports, and volumes; it then
 runs the migration image with `--pull never` to confirm the live schema before
 checking the three loopback endpoints.
 
+## Release business UAT
+
+Preview the immutable five-session matrix without making any network request:
+
+```sh
+node deploy/staging/uat.mjs
+```
+
+After the candidate is deployed, create a private receipt directory and opt in
+to the real Staging-only run explicitly:
+
+```sh
+receipt_directory="$(mktemp -d)"
+receipt_directory="$(cd "$receipt_directory" && pwd -P)"
+UAT_ENV=staging node deploy/staging/uat.mjs \
+  --execute \
+  --base-url https://staging-api.speak-up.top \
+  --receipt "$receipt_directory/receipt.json"
+```
+
+The executor creates a one-time account, dynamically freezes the current IELTS
+question assignments, and exercises PART 1 text/voice, PART 2 voice, PART 3
+voice, and FULL MOCK text through the terminal session report. Voice cases use
+the repository's fixed WAV fixture only as transport/ASR evidence. The `0600`
+receipt contains hashed resource references and status/timing metadata; it
+does not persist credentials, account identifiers, questions, answers,
+transcripts, audio, or provider payloads. Redirects, non-Staging origins,
+disabled TLS verification, failed evaluations, invalid evidence, and bounded
+polling timeouts fail closed.
+The receipt directory must already exist, be owned by the invoking user, have
+mode `0700`, and resolve without symbolic-link ancestors.
+
 ## 6. Stop or clean up Staging
 
 ```sh

--- a/deploy/staging/uat.mjs
+++ b/deploy/staging/uat.mjs
@@ -1,0 +1,1221 @@
+#!/usr/bin/env node
+
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import {
+  constants,
+  closeSync,
+  fchmodSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+export const STAGING_BASE_URL = "https://staging-api.speak-up.top";
+
+export const UAT_MATRIX = Object.freeze([
+  Object.freeze({ case_id: "part-1-text", mode: "PART_1", input: "text", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "part-1-voice", mode: "PART_1", input: "voice", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "part-2-voice", mode: "PART_2", input: "voice", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "part-3-voice", mode: "PART_3", input: "voice", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "full-mock-text", mode: "FULL_MOCK", input: "text", timeout_seconds: 720 }),
+]);
+
+const voiceFixturePath = fileURLToPath(
+  new URL("../../server/internal/providers/qianwen/testdata/asr-live-fixture.wav", import.meta.url),
+);
+const jsonBodyLimit = 2 * 1024 * 1024;
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const identifierPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const optionByMode = Object.freeze({
+  FULL_MOCK: "option_ielts_speaking_full_mock",
+  PART_1: "option_ielts_speaking_part_1",
+  PART_2: "option_ielts_speaking_part_2",
+  PART_3: "option_ielts_speaking_part_3",
+});
+
+const usage = `Usage:
+  node deploy/staging/uat.mjs [--base-url ${STAGING_BASE_URL}]
+  UAT_ENV=staging node deploy/staging/uat.mjs --execute \\
+    --base-url ${STAGING_BASE_URL} --receipt <private-json-path>`;
+
+export class UatError extends Error {
+  constructor(category, message = category) {
+    super(message);
+    this.name = "UatError";
+    this.category = category;
+  }
+}
+
+class UatSessionError extends UatError {
+  constructor(error, sessionReceipt) {
+    super(error instanceof UatError ? error.category : "unexpected_error");
+    this.sessionReceipt = sessionReceipt;
+  }
+}
+
+class UatRunError extends UatError {
+  constructor(error, receipt) {
+    super(error instanceof UatError ? error.category : "unexpected_error");
+    this.receipt = receipt;
+  }
+}
+
+export function parseCli(arguments_) {
+  const result = {
+    baseUrl: STAGING_BASE_URL,
+    execute: false,
+    help: false,
+    receiptPath: null,
+  };
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--execute") {
+      if (result.execute) throw new UatError("invalid_arguments", usage);
+      result.execute = true;
+      continue;
+    }
+    if (argument === "--help") {
+      result.help = true;
+      continue;
+    }
+    if (argument !== "--base-url" && argument !== "--receipt") {
+      throw new UatError("invalid_arguments", usage);
+    }
+    const value = arguments_[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new UatError("invalid_arguments", usage);
+    }
+    index += 1;
+    if (argument === "--base-url") result.baseUrl = value;
+    if (argument === "--receipt") result.receiptPath = value;
+  }
+  return result;
+}
+
+export function validateExecutionBoundary(options, environment = process.env) {
+  if (!options.execute) {
+    throw new UatError("execute_opt_in_required");
+  }
+  if (environment.UAT_ENV !== "staging") {
+    throw new UatError("staging_environment_required");
+  }
+  if (options.baseUrl !== STAGING_BASE_URL) {
+    throw new UatError("untrusted_base_url");
+  }
+  if (environment.NODE_TLS_REJECT_UNAUTHORIZED === "0") {
+    throw new UatError("tls_verification_disabled");
+  }
+  if (!options.receiptPath) {
+    throw new UatError("receipt_path_required");
+  }
+  return new URL(`${STAGING_BASE_URL}/`);
+}
+
+export function executionPlan(baseUrl = STAGING_BASE_URL) {
+  if (baseUrl !== STAGING_BASE_URL) throw new UatError("untrusted_base_url");
+  return {
+    plan_version: 1,
+    dry_run: true,
+    environment: "staging",
+    base_url: baseUrl,
+    network_requests: 0,
+    writes: 0,
+    sessions: UAT_MATRIX,
+  };
+}
+
+export function createHttpClient({
+  baseUrl,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 30_000,
+}) {
+  const base = new URL(baseUrl);
+  if (typeof fetchImpl !== "function" || !Number.isSafeInteger(timeoutMs) || timeoutMs < 1) {
+    throw new UatError("invalid_http_client_configuration");
+  }
+  return async function request(resourcePath, options = {}) {
+    if (typeof resourcePath !== "string" || !resourcePath.startsWith("/") || resourcePath.startsWith("//")) {
+      throw new UatError("invalid_request_path");
+    }
+    const url = new URL(resourcePath, base);
+    if (url.origin !== base.origin) throw new UatError("untrusted_request_origin");
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        redirect: "manual",
+        signal: options.signal ?? AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      if (error?.name === "TimeoutError" || error?.name === "AbortError") {
+        throw new UatError("request_timeout");
+      }
+      throw new UatError("network_error");
+    }
+    if (response.status >= 300 && response.status < 400) {
+      throw new UatError("redirect_rejected");
+    }
+    return response;
+  };
+}
+
+function requireObject(value, category) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireArray(value, category, { minimum = 0, maximum = 128 } = {}) {
+  if (!Array.isArray(value) || value.length < minimum || value.length > maximum) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireString(value, category, maximumBytes = 65_536) {
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    value.includes("\0") ||
+    Buffer.byteLength(value) > maximumBytes
+  ) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireUuid(value, category) {
+  if (typeof value !== "string" || !uuidPattern.test(value)) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireIdentifier(value, category) {
+  if (typeof value !== "string" || !identifierPattern.test(value)) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireInteger(value, category, minimum = 0) {
+  if (!Number.isSafeInteger(value) || value < minimum) throw new UatError(category);
+  return value;
+}
+
+async function readJsonResponse(response, category) {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > jsonBodyLimit) {
+    throw new UatError(category);
+  }
+  let bytes;
+  try {
+    bytes = Buffer.from(await response.arrayBuffer());
+  } catch {
+    throw new UatError("network_error");
+  }
+  if (bytes.length > jsonBodyLimit) throw new UatError(category);
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new UatError(category);
+  }
+}
+
+async function requestJson(request, resourcePath, {
+  method = "GET",
+  token,
+  body,
+  bytes,
+  idempotencyKey,
+  expectedStatuses = [200],
+  retryUncertain = false,
+  timeoutMs,
+  requireNoStore = false,
+  deadlineAt,
+  now = Date.now,
+} = {}) {
+  if (body !== undefined && bytes !== undefined) throw new UatError("invalid_request_body");
+  const headers = { accept: "application/json", "cache-control": "no-store" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  if (idempotencyKey) headers["idempotency-key"] = idempotencyKey;
+  if (body !== undefined) headers["content-type"] = "application/json";
+  if (bytes !== undefined) headers["content-type"] = "audio/wav";
+  const attempts = retryUncertain ? 2 : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      let attemptTimeout = timeoutMs;
+      if (deadlineAt !== undefined) {
+        const remaining = deadlineAt - now();
+        if (!Number.isFinite(remaining) || remaining <= 0) {
+          throw new UatError("session_timeout");
+        }
+        attemptTimeout = Math.min(attemptTimeout ?? remaining, remaining);
+      }
+      const response = await request(resourcePath, {
+        method,
+        headers,
+        body: body === undefined ? bytes : JSON.stringify(body),
+        signal: attemptTimeout === undefined ? undefined : AbortSignal.timeout(attemptTimeout),
+      });
+      if (!expectedStatuses.includes(response.status)) {
+        throw new UatError(`unexpected_http_status_${response.status}`);
+      }
+      if (
+        requireNoStore &&
+        (!response.headers.get("cache-control")?.toLowerCase().split(",").map((value) => value.trim()).includes("no-store") ||
+          response.headers.get("pragma")?.toLowerCase().trim() !== "no-cache")
+      ) {
+        throw new UatError("invalid_auth_cache_control");
+      }
+      if (response.status === 204) return null;
+      return await readJsonResponse(response, "invalid_json_response");
+    } catch (error) {
+      if (
+        attempt === attempts ||
+        !(error instanceof UatError) ||
+        !["network_error", "request_timeout"].includes(error.category)
+      ) {
+        throw error;
+      }
+    }
+  }
+  throw new UatError("network_error");
+}
+
+function idempotencyKey(runId, caseId, operation, position = 0) {
+  return `uat-${runId}-${caseId}-${operation}-${position}`;
+}
+
+function selectQuestions(bank, mode) {
+  const root = requireObject(bank, "invalid_question_bank");
+  requireString(root.bank_id, "invalid_question_bank", 128);
+  const firstPart1 = requireObject(
+    requireArray(root.part1_topics, "invalid_question_bank", { minimum: 1 })[0],
+    "invalid_question_bank",
+  );
+  const firstGroup = requireObject(
+    requireArray(root.topic_groups, "invalid_question_bank", { minimum: 1 })[0],
+    "invalid_question_bank",
+  );
+  const part1Id = requireString(firstPart1.id, "invalid_question_bank", 128);
+  const groupId = requireString(firstGroup.id, "invalid_question_bank", 128);
+  if (mode === "PART_1") return { part_1_set_id: part1Id };
+  if (mode === "PART_2" || mode === "PART_3") return { topic_group_id: groupId };
+  if (mode === "FULL_MOCK") return null;
+  throw new UatError("unsupported_uat_mode");
+}
+
+function parseAssignment(value, expectedMode, expectedBankId) {
+  const assignment = requireObject(value, "invalid_plan_response");
+  if (assignment.mode !== expectedMode || assignment.bank_id !== expectedBankId) {
+    throw new UatError("plan_mode_mismatch");
+  }
+  const normalized = {
+    bank_id: requireString(assignment.bank_id, "invalid_plan_response", 128),
+    season: requireString(assignment.season, "invalid_plan_response", 128),
+    mode: assignment.mode,
+    parts: [],
+  };
+  const parts = requireArray(assignment.parts, "invalid_plan_response", { minimum: 1 });
+  const expectedParts = expectedMode === "FULL_MOCK"
+    ? ["PART_1", "PART_2", "PART_3"]
+    : [expectedMode];
+  if (
+    parts.length !== expectedParts.length ||
+    parts.some((rawPart, index) => rawPart?.part !== expectedParts[index])
+  ) {
+    throw new UatError("plan_mode_mismatch");
+  }
+  const expectedQuestionCount = parts.reduce((total, rawPart) => {
+    const part = requireObject(rawPart, "invalid_plan_response");
+    const normalizedPart = {
+      part: part.part,
+      source_id: requireString(part.source_id, "invalid_plan_response", 128),
+      turn_blueprints: requireArray(
+        part.turn_blueprints,
+        "invalid_plan_response",
+        { minimum: 1, maximum: 64 },
+      ).map((blueprint) => requireString(blueprint, "invalid_plan_response", 16_384)),
+    };
+    for (const optional of ["topic_title", "cue_card"]) {
+      if (Object.hasOwn(part, optional)) {
+        normalizedPart[optional] = requireString(part[optional], "invalid_plan_response", 16_384);
+      }
+    }
+    if (Object.hasOwn(part, "prepared_answers")) {
+      normalizedPart.prepared_answers = requireArray(
+        part.prepared_answers,
+        "invalid_plan_response",
+        { maximum: 64 },
+      ).map((rawAnswer) => {
+        const answer = requireObject(rawAnswer, "invalid_plan_response");
+        if (typeof answer.personalized !== "boolean") throw new UatError("invalid_plan_response");
+        return {
+          question_position: requireInteger(answer.question_position, "invalid_plan_response", 1),
+          answer: requireString(answer.answer, "invalid_plan_response", 16_384),
+          personalized: answer.personalized,
+        };
+      });
+    }
+    normalized.parts.push(normalizedPart);
+    return total + normalizedPart.turn_blueprints.length;
+  }, 0);
+  if (expectedQuestionCount < 1 || expectedQuestionCount > 64) {
+    throw new UatError("invalid_plan_response");
+  }
+  return { assignment: normalized, expectedQuestionCount };
+}
+
+function parsePlan(value, expectedMode, expectedBankId) {
+  const plan = requireObject(value, "invalid_plan_response");
+  const planId = requireUuid(plan.practice_plan_id, "invalid_plan_response");
+  const version = requireInteger(plan.version, "invalid_plan_response", 1);
+  if (plan.practice_plan_status !== "ready") throw new UatError("plan_not_ready");
+  return {
+    planId,
+    version,
+    ...parseAssignment(plan.ielts_assignment, expectedMode, expectedBankId),
+  };
+}
+
+function parseSessionBootstrap(value, plan, expectedMode) {
+  const root = requireObject(value, "invalid_session_response");
+  const session = requireObject(root.practice_session, "invalid_session_response");
+  const sessionId = requireUuid(session.practice_session_id, "invalid_session_response");
+  if (
+    session.practice_plan_id !== plan.planId ||
+    session.plan_version !== plan.version ||
+    session.practice_mode !== expectedMode ||
+    session.practice_session_status !== "starting"
+  ) {
+    throw new UatError("session_binding_mismatch");
+  }
+  const snapshot = requireObject(root.snapshot, "invalid_session_response");
+  const snapshotAssignment = parseAssignment(
+    snapshot.ielts_assignment,
+    expectedMode,
+    plan.assignment.bank_id,
+  ).assignment;
+  if (
+    snapshot.practice_session_id !== sessionId ||
+    snapshot.plan_version !== plan.version ||
+    snapshot.practice_mode !== expectedMode ||
+    !isDeepStrictEqual(snapshotAssignment, plan.assignment)
+  ) {
+    throw new UatError("session_binding_mismatch");
+  }
+  return {
+    sessionId,
+    sessionVersion: requireInteger(session.session_version, "invalid_session_response", 1),
+  };
+}
+
+function parseInteractionState(value, sessionId, mode, plan) {
+  const state = requireObject(value, "invalid_interaction_state");
+  const stateAssignment = parseAssignment(
+    state.ielts_assignment,
+    mode,
+    plan.assignment.bank_id,
+  ).assignment;
+  if (
+    state.practice_session_id !== sessionId ||
+    state.practice_plan_id !== plan.planId ||
+    state.practice_mode !== mode ||
+    !isDeepStrictEqual(stateAssignment, plan.assignment)
+  ) {
+    throw new UatError("interaction_state_mismatch");
+  }
+  requireInteger(state.effective_turns, "invalid_interaction_state");
+  requireInteger(state.turn_limit, "invalid_interaction_state");
+  requireInteger(state.session_version, "invalid_interaction_state", 1);
+  if (typeof state.session_completed !== "boolean") {
+    throw new UatError("invalid_interaction_state");
+  }
+  const terminal = ["completed", "ended_early"].includes(state.practice_session_status);
+  if (
+    !["in_progress", "completed", "ended_early"].includes(state.practice_session_status) ||
+    state.session_completed !== terminal ||
+    state.effective_turns > state.turn_limit ||
+    (terminal && Object.hasOwn(state, "current_question")) ||
+    (state.effective_turns === 0 && Object.hasOwn(state, "current_turn")) ||
+    (state.effective_turns > 0 && !Object.hasOwn(state, "current_turn"))
+  ) {
+    throw new UatError("invalid_interaction_lifecycle");
+  }
+  if (!state.session_completed) {
+    const question = requireObject(state.current_question, "invalid_interaction_state");
+    requireUuid(question.question_id, "invalid_interaction_state");
+    if (question.practice_session_id !== sessionId) {
+      throw new UatError("interaction_state_mismatch");
+    }
+    requireString(question.content, "invalid_interaction_state", 16_384);
+  }
+  return state;
+}
+
+function parseTranscriptionCandidate(value, sessionId, questionId) {
+  const candidate = requireObject(value, "invalid_transcription_candidate");
+  const candidateId = requireUuid(candidate.candidate_id, "invalid_transcription_candidate");
+  const respondentParticipantId = requireUuid(
+    candidate.respondent_participant_id,
+    "invalid_transcription_candidate",
+  );
+  const transcriptId = requireIdentifier(
+    candidate.transcript_id,
+    "invalid_transcription_candidate",
+  );
+  const evidenceVersion = requireInteger(
+    candidate.evidence_version,
+    "invalid_transcription_candidate",
+    1,
+  );
+  if (candidate.practice_session_id !== sessionId || candidate.question_id !== questionId) {
+    throw new UatError("transcription_candidate_mismatch");
+  }
+  return {
+    candidateId,
+    respondentParticipantId,
+    transcriptId,
+    evidenceVersion,
+    transcript: requireString(candidate.transcript, "invalid_transcription_candidate", 16_384),
+  };
+}
+
+function parseConfirmedTurn(state, {
+  expectedQuestionId,
+  expectedTranscript,
+  inputKind,
+  candidate,
+}) {
+  const turn = requireObject(state.current_turn, "invalid_turn_confirmation");
+  const turnId = requireUuid(turn.turn_id, "invalid_turn_confirmation");
+  const candidateId = requireUuid(turn.candidate_id, "invalid_turn_confirmation");
+  const respondentParticipantId = requireUuid(
+    turn.respondent_participant_id,
+    "invalid_turn_confirmation",
+  );
+  const evidenceVersion = requireInteger(
+    turn.evidence_version,
+    "invalid_turn_confirmation",
+    1,
+  );
+  if (
+    turn.practice_session_id !== state.practice_session_id ||
+    turn.question_id !== expectedQuestionId ||
+    turn.answer_text !== expectedTranscript ||
+    turn.effective_turns !== state.effective_turns ||
+    turn.session_completed !== state.session_completed ||
+    turn.counts_toward_effective_turn_limit !== true
+  ) {
+    throw new UatError("turn_confirmation_mismatch");
+  }
+  if (inputKind === "voice") {
+    if (
+      candidateId !== candidate.candidateId ||
+      respondentParticipantId !== candidate.respondentParticipantId ||
+      evidenceVersion !== candidate.evidenceVersion ||
+      !requireUuid(turn.audio_asset_id, "invalid_turn_confirmation")
+    ) {
+      throw new UatError("turn_confirmation_mismatch");
+    }
+  } else if (Object.hasOwn(turn, "audio_asset_id")) {
+    throw new UatError("turn_confirmation_mismatch");
+  }
+  return turnId;
+}
+
+function sessionRequest(request, deadlineAt, now) {
+  return (resourcePath, options = {}) => {
+    const remaining = deadlineAt - now();
+    if (!Number.isFinite(remaining) || remaining <= 0) {
+      throw new UatError("session_timeout");
+    }
+    const requestedTimeout = options.timeoutMs ?? remaining;
+    return requestJson(request, resourcePath, {
+      ...options,
+      timeoutMs: Math.min(requestedTimeout, remaining),
+      deadlineAt,
+      now,
+    });
+  };
+}
+
+function validateEvidence(evidence, transcripts, dimensionRefs) {
+  const item = requireObject(evidence, "invalid_report_evidence");
+  const evidenceRef = requireUuid(item.evidence_ref_id, "invalid_report_evidence");
+  const turnId = requireUuid(item.turn_id, "invalid_report_evidence");
+  if (evidenceRef !== turnId || !transcripts.has(turnId)) {
+    throw new UatError("invalid_report_evidence");
+  }
+  const start = requireInteger(item.start_utf8_byte, "invalid_report_evidence");
+  const end = requireInteger(item.end_utf8_byte, "invalid_report_evidence", 1);
+  const excerpt = requireString(item.original_excerpt, "invalid_report_evidence", 16_384);
+  const transcript = Buffer.from(transcripts.get(turnId), "utf8");
+  if (
+    end <= start ||
+    end > transcript.length ||
+    transcript.subarray(start, end).toString("utf8") !== excerpt
+  ) {
+    throw new UatError("invalid_report_evidence");
+  }
+  dimensionRefs.add(evidenceRef);
+}
+
+function validateReport(result, expectedMode, answeredQuestions) {
+  const report = requireObject(result, "invalid_report");
+  if (
+    report.schema_version !== "evaluation-report/v2" ||
+    report.scene_type !== "IELTS_SPEAKING" ||
+    report.practice_experience !== "IELTS_SPEAKING" ||
+    report.scene_category !== "IELTS_SPEAKING" ||
+    report.practice_mode !== expectedMode
+  ) {
+    throw new UatError("report_contract_mismatch");
+  }
+  if (!["PROVISIONAL", "INSUFFICIENT"].includes(report.scoreability_status)) {
+    throw new UatError("invalid_report");
+  }
+  const questions = requireArray(report.questions, "invalid_report", {
+    minimum: 1,
+    maximum: 128,
+  });
+  if (questions.length !== answeredQuestions.length) {
+    throw new UatError("report_question_count_mismatch");
+  }
+  const transcripts = new Map();
+  for (let index = 0; index < questions.length; index += 1) {
+    const actual = requireObject(questions[index], "invalid_report");
+    const expected = answeredQuestions[index];
+    const answer = requireObject(actual.answer, "invalid_report");
+    if (
+      actual.position !== index + 1 ||
+      actual.question_id !== expected.questionId ||
+      actual.text !== expected.questionText ||
+      answer.turn_id !== expected.turnId ||
+      answer.transcript !== expected.transcript
+    ) {
+      throw new UatError("report_turn_mismatch");
+    }
+    transcripts.set(expected.turnId, expected.transcript);
+  }
+  const dimensions = requireArray(report.dimensions, "invalid_report", {
+    minimum: 1,
+    maximum: 8,
+  });
+  const findingIds = new Set();
+  const improvementIds = new Map();
+  const dimensionKeys = new Set();
+  for (const rawDimension of dimensions) {
+    const dimension = requireObject(rawDimension, "invalid_report");
+    const key = requireIdentifier(dimension.key, "invalid_report");
+    if (!dimensionKeys.add(key) || dimension.scale !== "IELTS_BAND_9") {
+      throw new UatError("invalid_report_dimension");
+    }
+    const score = dimension.score;
+    if (
+      score !== null &&
+      (typeof score !== "number" ||
+        !Number.isFinite(score) ||
+        score < 0 ||
+        score > 9 ||
+        !Number.isInteger(score * 2))
+    ) {
+      throw new UatError("invalid_report_dimension");
+    }
+    for (const ratio of [dimension.coverage, dimension.confidence]) {
+      if (typeof ratio !== "number" || !Number.isFinite(ratio) || ratio < 0 || ratio > 1) {
+        throw new UatError("invalid_report_dimension");
+      }
+    }
+    if (
+      report.scoreability_status === "INSUFFICIENT" &&
+      score !== null
+    ) {
+      throw new UatError("insufficient_report_has_score");
+    }
+    const reasonCodes = requireArray(dimension.reason_codes, "invalid_report", { maximum: 8 });
+    const uniqueReasons = new Set(
+      reasonCodes.map((value) => requireIdentifier(value, "invalid_report")),
+    );
+    if (uniqueReasons.size !== reasonCodes.length) throw new UatError("invalid_report_dimension");
+    const evidenceRefs = requireArray(dimension.evidence_ref_ids, "invalid_report", {
+      maximum: 128,
+    }).map((value) => requireUuid(value, "invalid_report"));
+    const declaredRefs = new Set(
+      evidenceRefs,
+    );
+    if (declaredRefs.size !== evidenceRefs.length) throw new UatError("invalid_report_evidence_refs");
+    const actualRefs = new Set();
+    const improvements = new Set();
+    for (const collectionName of ["strengths", "improvements", "recommended_examples"]) {
+      const findings = requireArray(dimension[collectionName], "invalid_report", { maximum: 5 });
+      for (const rawFinding of findings) {
+        const finding = requireObject(rawFinding, "invalid_report");
+        const findingId = requireIdentifier(finding.finding_id, "invalid_report");
+        if (findingIds.has(findingId)) throw new UatError("invalid_report");
+        findingIds.add(findingId);
+        if (collectionName === "improvements") improvements.add(findingId);
+        for (const evidence of requireArray(finding.evidence, "invalid_report", { maximum: 8 })) {
+          validateEvidence(evidence, transcripts, actualRefs);
+        }
+      }
+    }
+    if (
+      declaredRefs.size !== actualRefs.size ||
+      [...declaredRefs].some((reference) => !actualRefs.has(reference))
+    ) {
+      throw new UatError("invalid_report_evidence_refs");
+    }
+    improvementIds.set(key, improvements);
+  }
+  const actions = requireArray(report.priority_actions, "invalid_report", { maximum: 5 });
+  if (report.scoreability_status === "INSUFFICIENT" && actions.length !== 0) {
+    throw new UatError("insufficient_report_has_priority_actions");
+  }
+  for (const rawAction of actions) {
+    const action = requireObject(rawAction, "invalid_report");
+    if (!improvementIds.get(action.dimension_key)?.has(action.finding_id)) {
+      throw new UatError("invalid_report_priority_action");
+    }
+  }
+  return {
+    schemaVersion: report.schema_version,
+    scoreabilityStatus: report.scoreability_status,
+  };
+}
+
+function parseEvaluation(value, sessionId) {
+  const evaluation = requireObject(value, "invalid_evaluation_response");
+  const evaluationId = requireUuid(evaluation.evaluation_id, "invalid_evaluation_response");
+  if (
+    evaluation.kind !== "SESSION_REPORT" ||
+    evaluation.source_id !== sessionId ||
+    evaluation.context_id !== sessionId ||
+    !["QUEUED", "RUNNING", "READY", "FAILED"].includes(evaluation.status)
+  ) {
+    throw new UatError("evaluation_binding_mismatch");
+  }
+  if (
+    requireArray(evaluation.feedback_items, "invalid_evaluation_response", { maximum: 32 }).length !== 0
+  ) {
+    throw new UatError("invalid_evaluation_response");
+  }
+  const hasResult = Object.hasOwn(evaluation, "result");
+  const hasError = Object.hasOwn(evaluation, "error");
+  if (
+    (["QUEUED", "RUNNING"].includes(evaluation.status) && (hasResult || hasError)) ||
+    (evaluation.status === "READY" && (!hasResult || hasError)) ||
+    (evaluation.status === "FAILED" && (!hasError || hasResult))
+  ) {
+    throw new UatError("invalid_evaluation_state");
+  }
+  if (evaluation.status === "FAILED") {
+    const failure = requireObject(evaluation.error, "invalid_evaluation_state");
+    requireIdentifier(failure.code, "invalid_evaluation_state");
+    requireString(failure.message, "invalid_evaluation_state", 2048);
+    if (typeof failure.retryable !== "boolean") {
+      throw new UatError("invalid_evaluation_state");
+    }
+  }
+  return { evaluation, evaluationId };
+}
+
+async function pollEvaluation({
+  request,
+  token,
+  sessionId,
+  mode,
+  answeredQuestions,
+  deadlineAt,
+  pollIntervalMs,
+  now,
+  sleep,
+  onEvaluationState,
+}) {
+  let stableEvaluationId = null;
+  while (now() < deadlineAt) {
+    const value = await request(
+      `/v1/practice-sessions/${encodeURIComponent(sessionId)}/evaluation`,
+      { token },
+    );
+    const { evaluation, evaluationId } = parseEvaluation(value, sessionId);
+    onEvaluationState(evaluationId, evaluation.status);
+    if (stableEvaluationId !== null && stableEvaluationId !== evaluationId) {
+      throw new UatError("evaluation_identity_changed");
+    }
+    stableEvaluationId = evaluationId;
+    if (evaluation.status === "FAILED") throw new UatError("evaluation_failed");
+    if (evaluation.status === "READY") {
+      return {
+        evaluationId,
+        ...validateReport(evaluation.result, mode, answeredQuestions),
+      };
+    }
+    const remaining = deadlineAt - now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(pollIntervalMs, remaining));
+  }
+  throw new UatError("session_timeout");
+}
+
+async function runSessionInternal({
+  request,
+  token,
+  bank,
+  entry,
+  runId,
+  voiceBytes,
+  now,
+  sleep,
+  pollIntervalMs,
+  startedAt,
+  progress,
+}) {
+  const deadlineAt = startedAt + entry.timeout_seconds * 1000;
+  const requestWithinSession = sessionRequest(request, deadlineAt, now);
+  const selection = selectQuestions(bank, entry.mode);
+  const planValue = await requestWithinSession("/v1/practice-plans", {
+    method: "POST",
+    token,
+    idempotencyKey: idempotencyKey(runId, entry.case_id, "plan"),
+    retryUncertain: true,
+    expectedStatuses: [201],
+    body: {
+      background_summary: "Staging release UAT.",
+      scene_id: "scn_ielts_speaking",
+      scene_version: 1,
+      selected_role_ids: ["role_ielts_speaking_examiner"],
+      practice_option_id: optionByMode[entry.mode],
+      ...(selection === null ? {} : { ielts_selection: selection }),
+    },
+  });
+  const plan = parsePlan(planValue, entry.mode, bank.bank_id);
+  progress.resource_refs.plan = redactResource(plan.planId);
+  const bootstrap = await requestWithinSession(
+    `/v1/practice-plans/${encodeURIComponent(plan.planId)}/practice-sessions`,
+    {
+      method: "POST",
+      token,
+      idempotencyKey: idempotencyKey(runId, entry.case_id, "session"),
+      retryUncertain: true,
+      expectedStatuses: [201],
+      body: { expected_plan_version: plan.version },
+    },
+  );
+  const session = parseSessionBootstrap(bootstrap, plan, entry.mode);
+  const { sessionId } = session;
+  progress.resource_refs.session = redactResource(sessionId);
+  let state = parseInteractionState(
+    await requestWithinSession(
+      `/v1/practice-sessions/${encodeURIComponent(sessionId)}/activation`,
+      {
+        method: "POST",
+        token,
+        idempotencyKey: idempotencyKey(runId, entry.case_id, "activate"),
+        retryUncertain: true,
+      },
+    ),
+    sessionId,
+    entry.mode,
+    plan,
+  );
+  if (
+    state.practice_session_status !== "in_progress" ||
+    state.session_version <= session.sessionVersion ||
+    state.effective_turns !== 0 ||
+    state.session_completed ||
+    Object.hasOwn(state, "current_turn")
+  ) {
+    throw new UatError("invalid_interaction_lifecycle");
+  }
+  const turnLimit = state.turn_limit;
+  if (state.turn_limit !== plan.expectedQuestionCount) {
+    throw new UatError("session_question_count_mismatch");
+  }
+  const answeredQuestions = [];
+  const seenQuestions = new Set();
+  while (!state.session_completed) {
+    if (answeredQuestions.length >= 64) throw new UatError("session_turn_limit_exceeded");
+    const question = state.current_question;
+    const previousSessionVersion = state.session_version;
+    const questionId = question.question_id;
+    if (!seenQuestions.add(questionId)) throw new UatError("repeated_current_question");
+    let transcript;
+    if (entry.input === "voice") {
+      const candidate = requireObject(
+        await requestWithinSession(
+          `/v1/practice-sessions/${encodeURIComponent(sessionId)}/questions/${encodeURIComponent(questionId)}/transcription-candidates`,
+          {
+            method: "POST",
+            token,
+            bytes: voiceBytes,
+            idempotencyKey: idempotencyKey(
+              runId,
+              entry.case_id,
+              "transcribe",
+              answeredQuestions.length + 1,
+            ),
+            retryUncertain: true,
+            expectedStatuses: [201],
+            timeoutMs: 540_000,
+          },
+        ),
+        "invalid_transcription_candidate",
+      );
+      const candidateBinding = parseTranscriptionCandidate(candidate, sessionId, questionId);
+      transcript = candidateBinding.transcript;
+      state = parseInteractionState(
+        await requestWithinSession(
+          `/v1/transcription-candidates/${encodeURIComponent(candidateBinding.candidateId)}/confirmations`,
+          {
+            method: "POST",
+            token,
+            idempotencyKey: idempotencyKey(
+              runId,
+              entry.case_id,
+              "confirm",
+              answeredQuestions.length + 1,
+            ),
+            retryUncertain: true,
+          },
+        ),
+        sessionId,
+        entry.mode,
+        plan,
+      );
+      const turnId = parseConfirmedTurn(state, {
+        expectedQuestionId: questionId,
+        expectedTranscript: transcript,
+        inputKind: entry.input,
+        candidate: candidateBinding,
+      });
+      answeredQuestions.push({ questionId, questionText: question.content, turnId, transcript });
+    } else {
+      transcript = "I can explain this clearly with a concrete example from my experience.";
+      state = parseInteractionState(
+        await requestWithinSession(
+          `/v1/practice-sessions/${encodeURIComponent(sessionId)}/questions/${encodeURIComponent(questionId)}/text-answers`,
+          {
+            method: "POST",
+            token,
+            body: { answer_text: transcript },
+            idempotencyKey: idempotencyKey(
+              runId,
+              entry.case_id,
+              "text",
+              answeredQuestions.length + 1,
+            ),
+            retryUncertain: true,
+          },
+        ),
+        sessionId,
+        entry.mode,
+        plan,
+      );
+      const turnId = parseConfirmedTurn(state, {
+        expectedQuestionId: questionId,
+        expectedTranscript: transcript,
+        inputKind: entry.input,
+      });
+      answeredQuestions.push({ questionId, questionText: question.content, turnId, transcript });
+    }
+    const expectedEffectiveTurns = answeredQuestions.length;
+    const expectedCompleted = expectedEffectiveTurns === turnLimit;
+    if (
+      state.session_version <= previousSessionVersion ||
+      state.turn_limit !== turnLimit ||
+      state.effective_turns !== expectedEffectiveTurns ||
+      state.session_completed !== expectedCompleted ||
+      state.practice_session_status !== (expectedCompleted ? "completed" : "in_progress")
+    ) {
+      throw new UatError("invalid_interaction_lifecycle");
+    }
+  }
+  if (answeredQuestions.length !== plan.expectedQuestionCount) {
+    throw new UatError("session_question_count_mismatch");
+  }
+  const evaluation = await pollEvaluation({
+    request: requestWithinSession,
+    token,
+    sessionId,
+    mode: entry.mode,
+    answeredQuestions,
+    deadlineAt,
+    pollIntervalMs,
+    now,
+    sleep,
+    onEvaluationState: (evaluationId, status) => {
+      progress.resource_refs.evaluation = redactResource(evaluationId);
+      progress.evaluation_status = status;
+    },
+  });
+  return {
+    case_id: entry.case_id,
+    mode: entry.mode,
+    input_kind: entry.input,
+    duration_ms: now() - startedAt,
+    evaluation_status: "READY",
+    schema_version: evaluation.schemaVersion,
+    scoreability_status: evaluation.scoreabilityStatus,
+    error_category: null,
+    resource_refs: {
+      ...progress.resource_refs,
+    },
+  };
+}
+
+async function runSession(arguments_) {
+  const startedAt = arguments_.now();
+  const progress = {
+    case_id: arguments_.entry.case_id,
+    mode: arguments_.entry.mode,
+    input_kind: arguments_.entry.input,
+    resource_refs: {},
+  };
+  try {
+    return await runSessionInternal({ ...arguments_, startedAt, progress });
+  } catch (error) {
+    throw new UatSessionError(error, {
+      ...progress,
+      duration_ms: arguments_.now() - startedAt,
+      evaluation_status: progress.evaluation_status ?? "NOT_REACHED",
+      schema_version: null,
+      scoreability_status: null,
+      error_category: error instanceof UatError ? error.category : "unexpected_error",
+    });
+  }
+}
+
+function redactResource(value) {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export async function runStagingUat({
+  baseUrl = STAGING_BASE_URL,
+  fetchImpl = globalThis.fetch,
+  now = Date.now,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  pollIntervalMs = 5_000,
+  matrix = UAT_MATRIX,
+  voiceBytes = readFileSync(voiceFixturePath),
+} = {}) {
+  const startedAt = new Date(now()).toISOString();
+  const runId = randomUUID();
+  const request = createHttpClient({ baseUrl, fetchImpl });
+  const sessions = [];
+  try {
+    const health = requireObject(
+      await requestJson(request, "/health"),
+      "invalid_health_response",
+    );
+    if (health.status !== "ok") throw new UatError("staging_not_ready");
+    const readiness = requireObject(
+      await requestJson(request, "/readyz"),
+      "invalid_readiness_response",
+    );
+    if (
+      readiness.status !== "ready" ||
+      requireObject(readiness.checks, "invalid_readiness_response").database !== "ready"
+    ) {
+      throw new UatError("staging_not_ready");
+    }
+    const emailNonce = randomBytes(18).toString("hex");
+    const email = `speakup-uat-${emailNonce}@example.invalid`;
+    const password = `Uat-${randomBytes(24).toString("base64url")}`;
+    await requestJson(request, "/v1/auth/register", {
+      method: "POST",
+      expectedStatuses: [201],
+      body: { email, password },
+    });
+    const login = requireObject(
+      await requestJson(request, "/v1/auth/login", {
+        method: "POST",
+        body: { email, password },
+        requireNoStore: true,
+      }),
+      "invalid_login_response",
+    );
+    const token = requireString(login.session_token, "invalid_login_response", 2048);
+    if (!token.startsWith("sess_") || login.token_type !== "Bearer") {
+      throw new UatError("invalid_login_response");
+    }
+    const bank = await requestJson(request, "/v1/ielts-speaking/question-bank", { token });
+    if (requireObject(bank, "invalid_question_bank").schema_version !== 4) {
+      throw new UatError("invalid_question_bank");
+    }
+    for (const entry of matrix) {
+      sessions.push(
+        await runSession({
+          request,
+          token,
+          bank,
+          entry,
+          runId,
+          voiceBytes,
+          now,
+          sleep,
+          pollIntervalMs,
+        }),
+      );
+    }
+    await requestJson(request, "/v1/auth/logout", {
+      method: "POST",
+      token,
+      expectedStatuses: [204],
+    });
+    return {
+      receipt_version: 1,
+      run_id: runId,
+      environment: "staging",
+      base_host: new URL(baseUrl).hostname,
+      started_at: startedAt,
+      completed_at: new Date(now()).toISOString(),
+      outcome: "passed",
+      sessions,
+      error_category: null,
+    };
+  } catch (error) {
+    if (error instanceof UatSessionError) sessions.push(error.sessionReceipt);
+    throw new UatRunError(error, {
+      receipt_version: 1,
+      run_id: runId,
+      environment: "staging",
+      base_host: new URL(baseUrl).hostname,
+      started_at: startedAt,
+      completed_at: new Date(now()).toISOString(),
+      outcome: "failed",
+      sessions,
+      error_category: error instanceof UatError ? error.category : "unexpected_error",
+    });
+  }
+}
+
+const sensitiveKeyPattern = /(?:password|token|email|question|answer|transcript|audio|provider|payload|secret|access.?key)/i;
+const credentialValuePattern = /(?:sess_[A-Za-z0-9._~+/=-]+|[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/;
+
+export function assertReceiptIsRedacted(value, trail = "receipt") {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertReceiptIsRedacted(entry, `${trail}[${index}]`));
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      if (sensitiveKeyPattern.test(key)) {
+        throw new UatError("receipt_contains_sensitive_field", `${trail}.${key}`);
+      }
+      assertReceiptIsRedacted(entry, `${trail}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === "string" && credentialValuePattern.test(value)) {
+    throw new UatError("receipt_contains_sensitive_value", trail);
+  }
+}
+
+function prepareReceiptTarget(receiptPath) {
+  const resolved = path.resolve(receiptPath);
+  try {
+    lstatSync(resolved);
+    throw new UatError("receipt_already_exists");
+  } catch (error) {
+    if (error instanceof UatError) throw error;
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const parent = path.dirname(resolved);
+  let status;
+  try {
+    status = lstatSync(parent);
+  } catch (error) {
+    if (error?.code === "ENOENT") throw new UatError("receipt_directory_required");
+    throw error;
+  }
+  const wrongOwner = typeof process.getuid === "function" && status.uid !== process.getuid();
+  if (
+    status.isSymbolicLink() ||
+    !status.isDirectory() ||
+    (status.mode & 0o777) !== 0o700 ||
+    wrongOwner ||
+    realpathSync(parent) !== parent
+  ) {
+    throw new UatError("receipt_directory_not_private");
+  }
+  return resolved;
+}
+
+export function writeReceipt(receiptPath, receipt) {
+  assertReceiptIsRedacted(receipt);
+  const resolved = prepareReceiptTarget(receiptPath);
+  let descriptor;
+  try {
+    descriptor = openSync(
+      resolved,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+      0o600,
+    );
+    fchmodSync(descriptor, 0o600);
+    writeFileSync(descriptor, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+export async function runCli({
+  arguments_: argumentsValue,
+  environment = process.env,
+  output = process.stdout,
+  executeUat,
+}) {
+  const options = parseCli(argumentsValue);
+  if (options.help) {
+    output.write(`${usage}\n`);
+    return { kind: "help" };
+  }
+  if (!options.execute) {
+    const plan = executionPlan(options.baseUrl);
+    output.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return { kind: "dry-run", plan };
+  }
+  validateExecutionBoundary(options, environment);
+  prepareReceiptTarget(options.receiptPath);
+  if (typeof executeUat !== "function") {
+    throw new UatError("uat_executor_required");
+  }
+  let receipt;
+  try {
+    receipt = await executeUat(options);
+  } catch (error) {
+    writeReceipt(options.receiptPath, error instanceof UatRunError ? error.receipt : {
+      receipt_version: 1,
+      run_id: randomUUID(),
+      environment: "staging",
+      base_host: new URL(options.baseUrl).hostname,
+      completed_at: new Date().toISOString(),
+      outcome: "failed",
+      sessions: [],
+      error_category: error instanceof UatError ? error.category : "unexpected_error",
+    });
+    throw error;
+  }
+  writeReceipt(options.receiptPath, receipt);
+  output.write(`${JSON.stringify({ outcome: receipt.outcome, receipt: path.resolve(options.receiptPath) })}\n`);
+  return { kind: "executed", receipt };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli({
+    arguments_: process.argv.slice(2),
+    executeUat: (options) => runStagingUat({ baseUrl: options.baseUrl }),
+  }).catch((error) => {
+    const category = error instanceof UatError ? error.category : "unexpected_error";
+    process.stderr.write(`Staging UAT failed: ${category}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/deploy/staging/uat.test.mjs
+++ b/deploy/staging/uat.test.mjs
@@ -1,0 +1,729 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+} from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  STAGING_BASE_URL,
+  UAT_MATRIX,
+  UatError,
+  createHttpClient,
+  runCli,
+  runStagingUat,
+  validateExecutionBoundary,
+  writeReceipt,
+} from "./uat.mjs";
+
+function outputBuffer() {
+  let value = "";
+  return {
+    output: { write: (chunk) => { value += chunk; } },
+    read: () => value,
+  };
+}
+
+function uuid(value) {
+  return `00000000-0000-4000-8000-${value.toString(16).padStart(12, "0")}`;
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function json(response, status, value, headers = {}) {
+  const body = Buffer.from(JSON.stringify(value));
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": body.length,
+    ...headers,
+  });
+  response.end(body);
+}
+
+async function createUatServer(behavior = "ready") {
+  let sequence = 1;
+  const plans = new Map();
+  const sessions = new Map();
+  const candidates = new Map();
+  const counts = { plans: 0, requests: 0 };
+  const nextId = () => uuid(sequence++);
+  const modeByOption = {
+    option_ielts_speaking_part_1: "PART_1",
+    option_ielts_speaking_part_2: "PART_2",
+    option_ielts_speaking_part_3: "PART_3",
+    option_ielts_speaking_full_mock: "FULL_MOCK",
+  };
+  const totalByMode = { PART_1: 2, PART_2: 1, PART_3: 2, FULL_MOCK: 3 };
+
+  function interaction(session) {
+    const completed = session.answers.length === session.questions.length;
+    return {
+      practice_session_id: session.id,
+      practice_plan_id: behavior === "bad-state-plan" ? nextId() : session.planId,
+      practice_mode: session.mode,
+      ielts_assignment: behavior === "bad-state-assignment"
+        ? {
+            ...session.assignment,
+            parts: session.assignment.parts.map((part, index) => index === 0
+              ? { ...part, source_id: "mutated-state-source" }
+              : part),
+          }
+        : session.assignment,
+      practice_session_status: behavior === "bad-lifecycle" && completed
+        ? "in_progress"
+        : completed ? "completed" : "in_progress",
+      session_version: session.answers.length + 2,
+      effective_turns: session.answers.length,
+      turn_limit: session.questions.length,
+      session_completed: completed,
+      ...(completed
+        ? {}
+        : { current_question: session.questions[session.answers.length] }),
+      ...(session.answers.length === 0
+        ? {}
+        : { current_turn: session.answers.at(-1) }),
+    };
+  }
+
+  function advance(session, questionId, transcript, binding = {}) {
+    assert.equal(session.questions[session.answers.length].question_id, questionId);
+    const nextEffectiveTurns = session.answers.length + 1;
+    session.answers.push({
+      turn_id: nextId(),
+      practice_session_id: session.id,
+      question_id: questionId,
+      respondent_participant_id: binding.respondentParticipantId ?? nextId(),
+      candidate_id: binding.candidateId ?? nextId(),
+      answer_text: transcript,
+      evidence_version: binding.evidenceVersion ?? 1,
+      effective_turns: nextEffectiveTurns,
+      counts_toward_effective_turn_limit: true,
+      session_completed: nextEffectiveTurns === session.questions.length,
+      ...(binding.audioAssetId === undefined ? {} : { audio_asset_id: binding.audioAssetId }),
+    });
+    return interaction(session);
+  }
+
+  function report(session) {
+    const first = session.answers[0];
+    const transcript = first.answer_text;
+    const excerpt = transcript.slice(0, 5);
+    const invalidEnd = behavior === "invalid-evidence" ? 6 : Buffer.byteLength(excerpt);
+    const insufficient = behavior === "insufficient-score";
+    const finding = {
+      finding_id: "finding-1",
+      message: "Use a more specific supporting example.",
+      suggestion: "Add one measurable result.",
+      evidence: [{
+        evidence_ref_id: first.turn_id,
+        turn_id: first.turn_id,
+        start_utf8_byte: 0,
+        end_utf8_byte: invalidEnd,
+        original_excerpt: excerpt,
+      }],
+    };
+    return {
+      schema_version: "evaluation-report/v2",
+      scene_type: "IELTS_SPEAKING",
+      practice_experience: "IELTS_SPEAKING",
+      scene_category: "IELTS_SPEAKING",
+      practice_mode: session.mode,
+      scoreability_status: insufficient ? "INSUFFICIENT" : "PROVISIONAL",
+      summary: "Staging UAT report.",
+      questions: session.questions.map((question, index) => ({
+        question_id: question.question_id,
+        position: index + 1,
+        text: question.content,
+        answer: {
+          turn_id: session.answers[index].turn_id,
+          transcript: session.answers[index].answer_text,
+        },
+      })),
+      dimensions: [{
+        key: "FLUENCY_COHERENCE",
+        score: insufficient ? 6.5 : behavior === "invalid-dimension" ? 6.3 : 6,
+        scale: "IELTS_BAND_9",
+        coverage: 1,
+        confidence: 0.8,
+        reason_codes: [],
+        evidence_ref_ids: [first.turn_id],
+        strengths: [],
+        improvements: [finding],
+        recommended_examples: [],
+      }],
+      priority_actions: insufficient
+        ? []
+        : [{ dimension_key: "FLUENCY_COHERENCE", finding_id: "finding-1" }],
+    };
+  }
+
+  const server = http.createServer(async (request, response) => {
+    counts.requests += 1;
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/health") {
+      json(response, 200, {
+        status: behavior === "bad-health" ? "degraded" : "ok",
+        modules: ["practice"],
+      });
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/readyz") {
+      json(response, 200, {
+        status: behavior === "bad-readiness" ? "unavailable" : "ready",
+        checks: {
+          database: behavior === "bad-readiness" ? "unavailable" : "ready",
+        },
+      });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/auth/register") {
+      await requestBody(request);
+      json(response, 201, { user_id: nextId(), email: "redacted@example.invalid" });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/auth/login") {
+      await requestBody(request);
+      json(
+        response,
+        200,
+        { session_token: "sess_test-only-token", token_type: "Bearer" },
+        behavior === "bad-login-cache"
+          ? { "cache-control": "public, max-age=60" }
+          : { "cache-control": "no-store", pragma: "no-cache" },
+      );
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/auth/logout") {
+      response.writeHead(204).end();
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/v1/ielts-speaking/question-bank") {
+      json(response, 200, {
+        schema_version: behavior === "bad-bank-version" ? 3 : 4,
+        bank_id: "bank-current",
+        part1_topics: [{ id: "part-1-current" }],
+        topic_groups: [{ id: "topic-current" }],
+      });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/practice-plans") {
+      const body = JSON.parse((await requestBody(request)).toString("utf8"));
+      const mode = modeByOption[body.practice_option_id];
+      assert.ok(mode);
+      assert.equal(body.scene_id, "scn_ielts_speaking");
+      if (mode === "FULL_MOCK") {
+        assert.equal(Object.hasOwn(body, "ielts_selection"), false);
+      } else {
+        assert.equal(body.ielts_selection.part_1_set_id, mode === "PART_1" ? "part-1-current" : undefined);
+        assert.equal(body.ielts_selection.topic_group_id, mode === "PART_1" ? undefined : "topic-current");
+      }
+      const planId = nextId();
+      const total = totalByMode[mode];
+      const partModes = mode === "FULL_MOCK" ? ["PART_1", "PART_2", "PART_3"] : [mode];
+      const assignment = {
+        bank_id: behavior === "bad-assignment-bank" ? "stale-bank" : "bank-current",
+        season: "2026-08",
+        mode,
+        parts: (behavior === "bad-assignment-parts" ? ["PART_3"] : partModes).map((part) => ({
+          part,
+          source_id: `${part.toLowerCase()}-source-current`,
+          turn_blueprints: Array.from(
+            { length: mode === "FULL_MOCK" ? 1 : total },
+            (_, index) => `${part}-question-${index + 1}`,
+          ),
+        })),
+      };
+      plans.set(planId, { mode, total, assignment });
+      counts.plans += 1;
+      json(response, 201, {
+        practice_plan_id: planId,
+        version: 1,
+        practice_plan_status: "ready",
+        ielts_assignment: assignment,
+      });
+      return;
+    }
+    const sessionCreate = url.pathname.match(/^\/v1\/practice-plans\/([^/]+)\/practice-sessions$/);
+    if (request.method === "POST" && sessionCreate) {
+      await requestBody(request);
+      const planId = sessionCreate[1];
+      const plan = plans.get(planId);
+      assert.ok(plan);
+      const sessionId = nextId();
+      const questions = Array.from({ length: plan.total }, (_, index) => ({
+        question_id: nextId(),
+        practice_session_id: sessionId,
+        content: `Question ${index + 1} for ${plan.mode}`,
+      }));
+      sessions.set(sessionId, {
+        id: sessionId,
+        planId,
+        mode: plan.mode,
+        questions,
+        answers: [],
+        ordinal: sessions.size + 1,
+        assignment: plan.assignment,
+      });
+      json(response, 201, {
+        practice_session: {
+          practice_session_id: sessionId,
+          practice_plan_id: planId,
+          plan_version: 1,
+          practice_mode: plan.mode,
+          practice_session_status: "starting",
+          session_version: 1,
+        },
+        snapshot: {
+          practice_session_id: sessionId,
+          plan_version: 1,
+          practice_mode: plan.mode,
+          ielts_assignment: behavior === "bad-snapshot-freeze"
+            ? {
+                ...plan.assignment,
+                parts: plan.assignment.parts.map((part, index) => index === 0
+                  ? { ...part, source_id: "mutated-source" }
+                  : part),
+              }
+            : plan.assignment,
+        },
+      });
+      return;
+    }
+    const activation = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/activation$/);
+    if (request.method === "POST" && activation) {
+      json(response, 200, interaction(sessions.get(activation[1])));
+      return;
+    }
+    const textAnswer = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/questions\/([^/]+)\/text-answers$/);
+    if (request.method === "POST" && textAnswer) {
+      const body = JSON.parse((await requestBody(request)).toString("utf8"));
+      json(response, 200, advance(sessions.get(textAnswer[1]), textAnswer[2], body.answer_text));
+      return;
+    }
+    const transcription = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/questions\/([^/]+)\/transcription-candidates$/);
+    if (request.method === "POST" && transcription) {
+      assert.ok((await requestBody(request)).length > 0);
+      const candidateId = nextId();
+      const respondentParticipantId = nextId();
+      const transcriptId = `fun-asr-safe-${sequence++}`;
+      candidates.set(candidateId, {
+        sessionId: transcription[1],
+        questionId: transcription[2],
+        transcript: "Voice fixture answer.",
+        respondentParticipantId,
+        transcriptId,
+        evidenceVersion: 1,
+      });
+      json(response, 201, {
+        candidate_id: candidateId,
+        practice_session_id: behavior === "bad-candidate-binding" ? nextId() : transcription[1],
+        question_id: transcription[2],
+        respondent_participant_id: respondentParticipantId,
+        transcript_id: transcriptId,
+        evidence_version: 1,
+        transcript: "Voice fixture answer.",
+      });
+      return;
+    }
+    const confirmation = url.pathname.match(/^\/v1\/transcription-candidates\/([^/]+)\/confirmations$/);
+    if (request.method === "POST" && confirmation) {
+      const candidate = candidates.get(confirmation[1]);
+      json(response, 200, advance(
+        sessions.get(candidate.sessionId),
+        candidate.questionId,
+        candidate.transcript,
+        {
+          candidateId: behavior === "bad-turn-binding" ? nextId() : confirmation[1],
+          respondentParticipantId: candidate.respondentParticipantId,
+          evidenceVersion: candidate.evidenceVersion,
+          audioAssetId: nextId(),
+        },
+      ));
+      return;
+    }
+    const evaluation = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/evaluation$/);
+    if (request.method === "GET" && evaluation) {
+      const session = sessions.get(evaluation[1]);
+      session.evaluationId ??= nextId();
+      const base = {
+        evaluation_id: session.evaluationId,
+        kind: "SESSION_REPORT",
+        source_id: session.id,
+        context_id: session.id,
+        feedback_items: [],
+      };
+      if (behavior === "failed" || (behavior === "fail-second" && session.ordinal === 2)) {
+        json(response, 200, { ...base, status: "FAILED", error: { code: "provider_response", retryable: false, message: "failed" } });
+      } else if (behavior === "queued-with-result") {
+        json(response, 200, { ...base, status: "RUNNING", result: report(session) });
+      } else if (behavior === "timeout") {
+        json(response, 200, { ...base, status: "RUNNING" });
+      } else {
+        json(response, 200, { ...base, status: "READY", result: report(session) });
+      }
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+    counts,
+  };
+}
+
+test("default dry-run prints the five-session plan without invoking the network executor", async () => {
+  const buffer = outputBuffer();
+  let calls = 0;
+  const result = await runCli({
+    arguments_: [],
+    environment: {},
+    output: buffer.output,
+    executeUat: async () => { calls += 1; },
+  });
+  assert.equal(result.kind, "dry-run");
+  assert.equal(calls, 0);
+  const plan = JSON.parse(buffer.read());
+  assert.equal(plan.network_requests, 0);
+  assert.equal(plan.writes, 0);
+  assert.deepEqual(
+    plan.sessions.map(({ mode, input }) => `${mode}:${input}`),
+    ["PART_1:text", "PART_1:voice", "PART_2:voice", "PART_3:voice", "FULL_MOCK:text"],
+  );
+  await assert.rejects(
+    runCli({
+      arguments_: ["--base-url", "https://api.speak-up.top"],
+      environment: {},
+      output: buffer.output,
+      executeUat: async () => { calls += 1; },
+    }),
+    (error) => error instanceof UatError && error.category === "untrusted_base_url",
+  );
+  assert.equal(calls, 0);
+});
+
+test("execution boundary fails closed unless every Staging opt-in is exact", () => {
+  const valid = {
+    execute: true,
+    baseUrl: STAGING_BASE_URL,
+    receiptPath: "/private/tmp/staging-uat-receipt.json",
+  };
+  assert.throws(
+    () => validateExecutionBoundary({ ...valid, execute: false }, { UAT_ENV: "staging" }),
+    (error) => error instanceof UatError && error.category === "execute_opt_in_required",
+  );
+  for (const baseUrl of [
+    "https://api.speak-up.top",
+    "http://staging-api.speak-up.top",
+    "https://149.71.241.71",
+    "http://localhost:8080",
+    `${STAGING_BASE_URL}/`,
+  ]) {
+    assert.throws(
+      () => validateExecutionBoundary({ ...valid, baseUrl }, { UAT_ENV: "staging" }),
+      (error) => error instanceof UatError && error.category === "untrusted_base_url",
+    );
+  }
+  assert.throws(
+    () => validateExecutionBoundary(valid, { UAT_ENV: "production" }),
+    (error) => error instanceof UatError && error.category === "staging_environment_required",
+  );
+  assert.throws(
+    () => validateExecutionBoundary(valid, { UAT_ENV: "staging", NODE_TLS_REJECT_UNAUTHORIZED: "0" }),
+    (error) => error instanceof UatError && error.category === "tls_verification_disabled",
+  );
+  assert.equal(validateExecutionBoundary(valid, { UAT_ENV: "staging" }).origin, STAGING_BASE_URL);
+});
+
+test("HTTP client never follows redirects", async (context) => {
+  let destinationRequests = 0;
+  const server = http.createServer((request, response) => {
+    if (request.url === "/redirect") {
+      response.writeHead(302, { location: "/destination" }).end();
+      return;
+    }
+    destinationRequests += 1;
+    response.writeHead(200).end("unexpected");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  context.after(() => new Promise((resolve) => server.close(resolve)));
+  const { port } = server.address();
+  const request = createHttpClient({ baseUrl: `http://127.0.0.1:${port}` });
+  await assert.rejects(
+    request("/redirect"),
+    (error) => error instanceof UatError && error.category === "redirect_rejected",
+  );
+  assert.equal(destinationRequests, 0);
+});
+
+test("receipt writer creates a redacted private file and refuses sensitive fields", () => {
+  const directory = realpathSync(mkdtempSync(path.join(os.tmpdir(), "speakup-staging-uat-")));
+  try {
+    const privateDirectory = path.join(directory, "private");
+    mkdirSync(privateDirectory, { mode: 0o700 });
+    const receiptPath = path.join(privateDirectory, "receipt.json");
+    const receipt = {
+      receipt_version: 1,
+      outcome: "passed",
+      environment: "staging",
+      resource_refs: ["sha256:" + "a".repeat(64)],
+      sessions: [{ case_id: "part-1-text", error_category: null }],
+    };
+    writeReceipt(receiptPath, receipt);
+    assert.deepEqual(JSON.parse(readFileSync(receiptPath, "utf8")), receipt);
+    assert.equal(statSync(receiptPath).mode & 0o777, 0o600);
+    assert.throws(
+      () => writeReceipt(path.join(directory, "leak.json"), { session_token: "sess_secret" }),
+      (error) => error instanceof UatError && error.category === "receipt_contains_sensitive_field",
+    );
+    assert.throws(
+      () => writeReceipt(path.join(directory, "email.json"), { owner: "person@example.com" }),
+      (error) => error instanceof UatError && error.category === "receipt_contains_sensitive_value",
+    );
+    const publicDirectory = path.join(directory, "public");
+    mkdirSync(publicDirectory, { mode: 0o755 });
+    chmodSync(publicDirectory, 0o755);
+    assert.throws(
+      () => writeReceipt(path.join(publicDirectory, "receipt.json"), receipt),
+      (error) => error instanceof UatError && error.category === "receipt_directory_not_private",
+    );
+    const canonicalDirectory = path.join(directory, "canonical");
+    mkdirSync(canonicalDirectory, { mode: 0o700 });
+    const linkedDirectory = path.join(directory, "linked");
+    symlinkSync(canonicalDirectory, linkedDirectory, "dir");
+    assert.throws(
+      () => writeReceipt(path.join(linkedDirectory, "receipt.json"), receipt),
+      (error) => error instanceof UatError && error.category === "receipt_directory_not_private",
+    );
+    assert.throws(
+      () => writeReceipt(path.join(directory, "missing", "receipt.json"), receipt),
+      (error) => error instanceof UatError && error.category === "receipt_directory_required",
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("an opted-in failed execution still writes only a redacted 0600 receipt", async () => {
+  const directory = realpathSync(mkdtempSync(path.join(os.tmpdir(), "speakup-staging-uat-failed-")));
+  try {
+    const receiptPath = path.join(directory, "receipt.json");
+    await assert.rejects(
+      runCli({
+        arguments_: ["--execute", "--receipt", receiptPath],
+        environment: { UAT_ENV: "staging" },
+        output: outputBuffer().output,
+        executeUat: async () => { throw new UatError("evaluation_failed", "provider payload must not persist"); },
+      }),
+      (error) => error instanceof UatError && error.category === "evaluation_failed",
+    );
+    const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+    assert.equal(receipt.outcome, "failed");
+    assert.equal(receipt.error_category, "evaluation_failed");
+    assert.equal(statSync(receiptPath).mode & 0o777, 0o600);
+    assert.doesNotMatch(JSON.stringify(receipt), /provider payload/);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("five-session driver uses dynamic bank, plan, session, question, turn, and evaluation identities", async (context) => {
+  const fake = await createUatServer();
+  context.after(fake.close);
+  const receipt = await runStagingUat({
+    baseUrl: fake.baseUrl,
+    voiceBytes: Buffer.from("RIFF fixed test WAV"),
+    pollIntervalMs: 1,
+  });
+  assert.equal(receipt.outcome, "passed");
+  assert.equal(fake.counts.plans, 5);
+  assert.deepEqual(
+    receipt.sessions.map(({ mode, input_kind }) => `${mode}:${input_kind}`),
+    ["PART_1:text", "PART_1:voice", "PART_2:voice", "PART_3:voice", "FULL_MOCK:text"],
+  );
+  for (const session of receipt.sessions) {
+    assert.equal(session.evaluation_status, "READY");
+    assert.equal(session.schema_version, "evaluation-report/v2");
+    assert.equal(session.scoreability_status, "PROVISIONAL");
+    assert.match(session.resource_refs.plan, /^sha256:[0-9a-f]{64}$/);
+    assert.match(session.resource_refs.session, /^sha256:[0-9a-f]{64}$/);
+    assert.match(session.resource_refs.evaluation, /^sha256:[0-9a-f]{64}$/);
+  }
+  const serialized = JSON.stringify(receipt);
+  assert.doesNotMatch(serialized, /sess_|example\.invalid|Voice fixture answer|Question 1/);
+});
+
+test("FAILED evaluation is a release-blocking terminal failure", async (context) => {
+  const fake = await createUatServer("failed");
+  context.after(fake.close);
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[0]],
+      voiceBytes: Buffer.from("unused"),
+    }),
+    (error) => error instanceof UatError && error.category === "evaluation_failed",
+  );
+});
+
+test("failed run receipt preserves its run identity and completed case progress", async (context) => {
+  const fake = await createUatServer("fail-second");
+  context.after(fake.close);
+  const directory = realpathSync(mkdtempSync(path.join(os.tmpdir(), "speakup-staging-uat-progress-")));
+  const receiptPath = path.join(directory, "receipt.json");
+  try {
+    let failure;
+    await assert.rejects(
+      runCli({
+        arguments_: ["--execute", "--receipt", receiptPath],
+        environment: { UAT_ENV: "staging" },
+        output: outputBuffer().output,
+        executeUat: () => runStagingUat({
+          baseUrl: fake.baseUrl,
+          matrix: [UAT_MATRIX[0], UAT_MATRIX[1]],
+          voiceBytes: Buffer.from("RIFF fixed test WAV"),
+          pollIntervalMs: 1,
+        }),
+      }),
+      (error) => {
+        failure = error;
+        return error instanceof UatError && error.category === "evaluation_failed";
+      },
+    );
+    const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+    assert.equal(receipt.run_id, failure.receipt.run_id);
+    assert.equal(receipt.sessions.length, 2);
+    assert.equal(receipt.sessions[0].evaluation_status, "READY");
+    assert.equal(receipt.sessions[1].evaluation_status, "FAILED");
+    assert.equal(receipt.sessions[1].error_category, "evaluation_failed");
+    assert.match(receipt.sessions[1].resource_refs.plan, /^sha256:[0-9a-f]{64}$/);
+    assert.match(receipt.sessions[1].resource_refs.session, /^sha256:[0-9a-f]{64}$/);
+    assert.match(receipt.sessions[1].resource_refs.evaluation, /^sha256:[0-9a-f]{64}$/);
+    assert.doesNotMatch(JSON.stringify(receipt), /sess_|example\.invalid|Voice fixture answer|Question 1/);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("evaluation polling stops at the per-session deadline", async (context) => {
+  const fake = await createUatServer("timeout");
+  context.after(fake.close);
+  let clock = 0;
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [{ ...UAT_MATRIX[0], timeout_seconds: 1 }],
+      voiceBytes: Buffer.from("unused"),
+      now: () => clock,
+      pollIntervalMs: 600,
+      sleep: async (milliseconds) => { clock += milliseconds; },
+    }),
+    (error) => error instanceof UatError && error.category === "session_timeout",
+  );
+});
+
+for (const [name, behavior, category] of [
+  ["voice candidate identity", "bad-candidate-binding", "transcription_candidate_mismatch"],
+  ["confirmed voice turn identity", "bad-turn-binding", "turn_confirmation_mismatch"],
+]) {
+  test(`${name} is bound end to end`, async (context) => {
+    const fake = await createUatServer(behavior);
+    context.after(fake.close);
+    await assert.rejects(
+      runStagingUat({
+        baseUrl: fake.baseUrl,
+        matrix: [UAT_MATRIX[1]],
+        voiceBytes: Buffer.from("RIFF fixed test WAV"),
+      }),
+      (error) => error instanceof UatError && error.category === category,
+    );
+  });
+}
+
+test("failure before evaluation is reported as not reached", async (context) => {
+  const fake = await createUatServer("bad-candidate-binding");
+  context.after(fake.close);
+  let failure;
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[1]],
+      voiceBytes: Buffer.from("RIFF fixed test WAV"),
+    }),
+    (error) => {
+      failure = error;
+      return error instanceof UatError && error.category === "transcription_candidate_mismatch";
+    },
+  );
+  assert.equal(failure.receipt.sessions[0].evaluation_status, "NOT_REACHED");
+  assert.equal(Object.hasOwn(failure.receipt.sessions[0].resource_refs, "evaluation"), false);
+});
+
+test("report evidence must resolve the exact UTF-8 byte range", async (context) => {
+  const fake = await createUatServer("invalid-evidence");
+  context.after(fake.close);
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[0]],
+      voiceBytes: Buffer.from("unused"),
+    }),
+    (error) => error instanceof UatError && error.category === "invalid_report_evidence",
+  );
+});
+
+test("INSUFFICIENT report cannot expose a score", async (context) => {
+  const fake = await createUatServer("insufficient-score");
+  context.after(fake.close);
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[0]],
+      voiceBytes: Buffer.from("unused"),
+    }),
+    (error) => error instanceof UatError && error.category === "insufficient_report_has_score",
+  );
+});
+
+for (const [name, behavior, category] of [
+  ["health JSON status", "bad-health", "staging_not_ready"],
+  ["readiness database check", "bad-readiness", "staging_not_ready"],
+  ["login no-store response", "bad-login-cache", "invalid_auth_cache_control"],
+  ["question bank schema version", "bad-bank-version", "invalid_question_bank"],
+  ["plan assignment bank binding", "bad-assignment-bank", "plan_mode_mismatch"],
+  ["plan assignment part order", "bad-assignment-parts", "plan_mode_mismatch"],
+  ["session frozen assignment", "bad-snapshot-freeze", "session_binding_mismatch"],
+  ["interaction plan identity", "bad-state-plan", "interaction_state_mismatch"],
+  ["interaction frozen assignment", "bad-state-assignment", "interaction_state_mismatch"],
+  ["interaction lifecycle", "bad-lifecycle", "invalid_interaction_lifecycle"],
+  ["nonterminal evaluation payload exclusion", "queued-with-result", "invalid_evaluation_state"],
+  ["IELTS dimension score step", "invalid-dimension", "invalid_report_dimension"],
+]) {
+  test(`${name} is validated fail closed`, async (context) => {
+    const fake = await createUatServer(behavior);
+    context.after(fake.close);
+    await assert.rejects(
+      runStagingUat({
+        baseUrl: fake.baseUrl,
+        matrix: [UAT_MATRIX[0]],
+        voiceBytes: Buffer.from("unused"),
+      }),
+      (error) => error instanceof UatError && error.category === category,
+    );
+  });
+}


### PR DESCRIPTION
## 功能描述

新增只面向 `staging-api.speak-up.top` 的真实业务 UAT 执行器，固定验证 PART 1 文本、PART 1 语音、PART 2 语音、PART 3 语音和完整模考文本五类会话，并生成脱敏、权限为 `0600` 的审计回执。

## 实现思路

- 默认 dry-run，明确输出 0 网络请求、0 写入和五会话计划。
- 真实执行同时要求 `--execute`、`UAT_ENV=staging` 和精确 Staging HTTPS origin；拒绝生产、IP、localhost、重定向和 TLS 绕过。
- 动态读取题库、创建 Plan/Session、激活并完成文本或固定 WAV 答题，再在统一 8/12 分钟会话期限内等待 Session Evaluation。
- 严格核对 Plan、Session snapshot、每次 Interaction、candidate→confirmed turn、evaluation 状态、`evaluation-report/v2`、UTF-8 evidence 和 `INSUFFICIENT` 无分数/无优先行动约束。
- 成功或失败回执沿用同一 run ID，只保存脱敏状态、耗时和资源哈希；不保存账号、Token、题目、答案、转写、音频或 provider payload。
- 本地测试仅使用假 HTTP 服务和仓库固定 WAV，不调用 Staging 或真实供应商。

## 可复现测试

```sh
node --test deploy/staging/uat.test.mjs
make check-staging-deploy
git diff --check upstream/dev...HEAD
node deploy/staging/uat.mjs
```

本地结果：Node 26/26 通过；完整 Staging 部署契约通过；dry-run 为 0 network / 0 writes / 5 sessions。

Closes #955
Related #953
Related #940
Related #947
Related #948
Related #949
