### PR TITLE
test(release): 固化生产 schema 7→9 隔离升级演练

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -462,6 +462,9 @@ jobs:
       - name: Exercise Production PostgreSQL backup and isolated restore
         run: make check-production-backup
 
+      - name: Exercise isolated Production schema upgrade rehearsal
+        run: make check-production-rehearsal
+
       - name: Validate offline release contract
         run: make check-offline-release
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SHELL := /bin/bash
 	check-api-contracts \
 	check-release-candidate \
 	check-production-backup \
+	check-production-rehearsal \
 	check-offline-release \
 	check-android-download \
 	check-tls-lifecycle \
@@ -56,6 +57,7 @@ help:
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
 		'  make check-production-backup  Exercise PostgreSQL backup and isolated restore' \
+		'  make check-production-rehearsal  Validate the isolated schema 7 to 9 rehearsal' \
 		'  make check-offline-release  Validate offline image build/load contracts' \
 		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-tls-lifecycle  Validate TLS issuance and renewal contracts' \
@@ -307,6 +309,9 @@ check-release-candidate:
 
 check-production-backup:
 	./deploy/production/test-backup.sh
+
+check-production-rehearsal:
+	./deploy/production/test-rehearsal.sh
 
 check-offline-release:
 	./tools/release-candidate/build-offline-images.test.sh

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -293,6 +293,53 @@ loopback bindings, the exact runtime identities and image digests, and the clean
 database schema from the selected manifest. Public HTTPS and business-route
 smoke tests remain part of the higher-level release Workflow.
 
+## Rehearse a schema upgrade without touching Production
+
+Before promoting a Release Candidate that advances schema 7 to schema 9, run
+the isolated rehearsal with the finalized Production backup, the reviewed
+manifest, and both immutable Server image identities. The command is a dry-run
+unless `--execute` is present. When a distinct forward-hotfix image exists, add
+its immutable official digest with `--forward-server-image`; it must differ from
+both the candidate and previous images:
+
+```sh
+./deploy/production/rehearse-schema-upgrade.sh \
+  --backup /var/lib/speakup/postgres-backups/20260825T010203Z-predeploy \
+  --manifest /opt/speakup/releases/v0.1.6/release-manifest.json \
+  --previous-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:DIGEST \
+  --forward-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:FORWARD_DIGEST \
+  --server-env-file /etc/speakup/production-server.env \
+  --receipt /opt/speakup/releases/v0.1.6/schema-rehearsal-receipt.json \
+  --lock-timeout-seconds 5
+```
+
+The dry-run validates the backup metadata, manifest, private Server environment
+file, image references and no-clobber receipt path. It does not read the dump,
+inspect images, create Docker resources or write a receipt. After reviewing the
+output, repeat the exact command with `--execute`.
+
+Execution restores the dump into a uniquely named, labeled volume on an
+internal Docker network with no host ports or Production network attachment. It
+runs the manifest-pinned migration image with a finite PostgreSQL lock timeout,
+then verifies clean schema 9, the five product-health views, the IELTS
+evaluation constraint, candidate readiness, the old image's readiness-only
+boundary, rollback fail-closed behavior and a same-schema redeploy of the same
+candidate image. If a distinct forward image is supplied, that final step uses
+the forward image instead and records its OCI version and revision only after
+its migration preserves clean schema 9 and its Server passes readiness.
+The old image is **not** claimed to process schema-9 profiles correctly. Success
+or failure produces a mode `0600`, redacted receipt after owned-resource cleanup;
+failure or interruption never removes unlabeled or differently labeled Docker
+resources.
+
+This repository test uses a synthetic schema-7 backup and local fixture images.
+It does not replace the required runtime evidence from the selected finalized
+Production backup and the actual immutable Release Candidate and previous image.
+Without `--forward-server-image`, the receipt explicitly records that no forward
+image was provided. If an incident later requires a distinct hotfix image, rerun
+the rehearsal with that immutable image before promoting it; the earlier
+same-candidate redeploy is not forward-hotfix evidence.
+
 ## Capture the initial Production baseline
 
 Create the first receipt once, before the first automated promotion. The live
@@ -539,6 +586,7 @@ database.
 
 ```sh
 make check-production-backup
+make check-production-rehearsal
 make check-android-download
 make check-production-deploy
 make check-production-nginx

--- a/deploy/production/manage.sh
+++ b/deploy/production/manage.sh
@@ -25,6 +25,8 @@ readonly server_readiness_url="http://127.0.0.1:18083/readyz"
 usage() {
   cat >&2 <<'EOF'
 Usage:
+  manage.sh validate-manifest --manifest FILE
+  manage.sh validate-rollback-schema --current-schema N --target-schema N
   manage.sh validate --manifest FILE --env-file FILE
   manage.sh baseline --manifest FILE --env-file FILE --receipt FILE
   manage.sh deploy --manifest FILE --env-file FILE --bundle DIRECTORY --current-receipt FILE --receipt FILE
@@ -819,6 +821,18 @@ validate_receipt_target() {
   require_owned_directory "Production receipt directory" "$directory"
   [[ -w "$directory" ]] ||
     fail "Production receipt directory is not writable: $directory"
+}
+
+require_matching_rollback_schema() {
+  local current_schema=$1
+  local target_schema=$2
+
+  [[ "$current_schema" =~ ^[1-9][0-9]*$ ]] ||
+    fail "current rollback schema must be a positive integer"
+  [[ "$target_schema" =~ ^[1-9][0-9]*$ ]] ||
+    fail "target rollback schema must be a positive integer"
+  [[ "$current_schema" == "$target_schema" ]] ||
+    fail "rollback requires the current database schema to match the target release"
 }
 
 require_safe_lock_file() {
@@ -1660,8 +1674,8 @@ rollback_production() {
     fail "a Production receipt changed while waiting for the deployment lock"
   validate_receipt_matches_release TARGET
   validate_current_receipt_state "$current_receipt" CURRENT
-  [[ "$CURRENT_SCHEMA_VERSION" == "$SELECTED_SCHEMA_VERSION" ]] ||
-    fail "rollback requires the current database schema to match the target release"
+  require_matching_rollback_schema \
+    "$CURRENT_SCHEMA_VERSION" "$SELECTED_SCHEMA_VERSION"
   acquire_backup_locks
 
   use_release_state SELECTED
@@ -1708,6 +1722,8 @@ main() {
   local receipt=""
   local current_receipt=""
   local target_receipt=""
+  local current_schema=""
+  local target_schema=""
 
   [[ -n "$command" ]] || {
     usage
@@ -1751,11 +1767,46 @@ main() {
         target_receipt=$2
         shift 2
         ;;
+      --current-schema)
+        (($# >= 2)) || fail "--current-schema requires a value"
+        current_schema=$2
+        shift 2
+        ;;
+      --target-schema)
+        (($# >= 2)) || fail "--target-schema requires a value"
+        target_schema=$2
+        shift 2
+        ;;
       *)
         fail "unknown argument: $1"
         ;;
     esac
   done
+
+  if [[ "$command" == "validate-manifest" ]]; then
+    [[ -n "$manifest" ]] || fail "validate-manifest requires --manifest"
+    [[ -z "$environment_file$output$bundle$receipt$current_receipt$target_receipt$current_schema$target_schema" ]] ||
+      fail "validate-manifest accepts only --manifest"
+    validate_manifest "$manifest"
+    printf 'version=%s git_sha=%s schema=%s manifest_sha256=%s validated=true\n' \
+      "$RELEASE_VERSION" "$RELEASE_GIT_SHA" "$RELEASE_SCHEMA_VERSION" \
+      "$RELEASE_MANIFEST_SHA256"
+    return
+  fi
+
+  if [[ "$command" == "validate-rollback-schema" ]]; then
+    [[ -n "$current_schema" && -n "$target_schema" ]] ||
+      fail "validate-rollback-schema requires both schema values"
+    [[ -z "$manifest$environment_file$output$bundle$receipt$current_receipt$target_receipt" ]] ||
+      fail "validate-rollback-schema accepts only schema values"
+    require_matching_rollback_schema "$current_schema" "$target_schema"
+    printf 'current_schema=%s target_schema=%s rollback_allowed=true\n' \
+      "$current_schema" "$target_schema"
+    return
+  fi
+
+  [[ -z "$current_schema$target_schema" ]] ||
+    fail "$command does not accept rollback schema values"
 
   [[ -n "$environment_file" ]] || fail "--env-file is required"
   load_configuration "$environment_file"

--- a/deploy/production/rehearse-schema-upgrade.sh
+++ b/deploy/production/rehearse-schema-upgrade.sh
@@ -1,0 +1,1096 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly production_manager="$production_directory/manage.sh"
+readonly postgres_image='postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+readonly server_repository='ghcr.io/1024xengineer/xe3-esl-server'
+readonly resource_label='com.xengineer.speakup.production-rehearsal'
+readonly run_label='com.xengineer.speakup.production-rehearsal-run-id'
+readonly source_project='xe3-speakup-production'
+readonly source_service='postgres'
+readonly source_volume='xe3-speakup-postgres-data'
+readonly source_schema=7
+readonly target_schema=9
+readonly container_cpus='1.0'
+readonly container_memory='512m'
+readonly container_memory_bytes=536870912
+readonly container_pids_limit=256
+readonly container_log_max_size='10m'
+readonly container_log_max_file='3'
+
+execute=false
+backup_directory=''
+manifest=''
+manifest_snapshot_directory=''
+manifest_snapshot=''
+previous_server_image=''
+forward_server_image=''
+validated_forward_server_image=''
+server_environment=''
+receipt=''
+lock_timeout_seconds=''
+run_id=''
+network_name=''
+volume_name=''
+declare -a container_names=()
+declare -a container_ids=()
+postgres_container_id=''
+last_created_container_id=''
+receipt_ready=false
+docker_touched=false
+cleanup_verified=false
+phase='preflight'
+started_at_seconds=0
+restore_duration_seconds=0
+migration_duration_seconds=0
+total_duration_seconds=0
+release_version=''
+release_git_sha=''
+release_manifest_sha256=''
+candidate_server_image=''
+selected_backup_id=''
+selected_backup_sha256=''
+selected_database=''
+selected_database_user=''
+backup_deployment_version=''
+backup_git_sha=''
+forward_server_image_version=''
+forward_server_image_revision=''
+forward_hotfix_status='not_provided'
+schema_verified=false
+views_verified=false
+constraint_verified=false
+candidate_readiness_verified=false
+previous_readiness_verified=false
+rollback_guard_verified=false
+same_schema_candidate_redeploy_verified=false
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  rehearse-schema-upgrade.sh [--execute] \
+    --backup DIRECTORY \
+    --manifest FILE \
+    --previous-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:DIGEST \
+    [--forward-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:DIGEST] \
+    --server-env-file FILE \
+    --receipt FILE \
+    --lock-timeout-seconds N
+
+Without --execute this performs a read-only dry-run. It validates metadata but
+does not read database.dump, inspect images, or create Docker resources.
+EOF
+}
+
+fail() {
+  printf 'Production schema rehearsal error: %s\n' "$*" >&2
+  exit 1
+}
+
+now_seconds() {
+  date -u +%s
+}
+
+write_receipt() {
+  local status=$1 temporary recorded_at parent
+
+  parent=${receipt%/*}
+  temporary=$(mktemp "$parent/.production-rehearsal-receipt.XXXXXX") || return 1
+  recorded_at=$(date -u +%Y-%m-%dT%H:%M:%SZ) || {
+    rm -f -- "$temporary"
+    return 1
+  }
+  if ! jq --null-input --sort-keys \
+    --arg status "$status" \
+    --arg failed_step "$phase" \
+    --arg run_id "$run_id" \
+    --arg backup_id "$selected_backup_id" \
+    --arg backup_sha256 "$selected_backup_sha256" \
+    --arg manifest_sha256 "$release_manifest_sha256" \
+    --arg version "$release_version" \
+    --arg git_sha "$release_git_sha" \
+    --arg candidate_server_image "$candidate_server_image" \
+    --arg previous_server_image "$previous_server_image" \
+    --arg forward_server_image "$validated_forward_server_image" \
+    --arg forward_server_image_version "$forward_server_image_version" \
+    --arg forward_server_image_revision "$forward_server_image_revision" \
+    --arg forward_hotfix_status "$forward_hotfix_status" \
+    --arg recorded_at "$recorded_at" \
+    --argjson source_schema "$source_schema" \
+    --argjson target_schema "$target_schema" \
+    --argjson lock_timeout_seconds "$lock_timeout_seconds" \
+    --argjson restore_duration_seconds "$restore_duration_seconds" \
+    --argjson migration_duration_seconds "$migration_duration_seconds" \
+    --argjson total_duration_seconds "$total_duration_seconds" \
+    --argjson schema_verified "$schema_verified" \
+    --argjson views_verified "$views_verified" \
+    --argjson constraint_verified "$constraint_verified" \
+    --argjson candidate_readiness_verified "$candidate_readiness_verified" \
+    --argjson previous_readiness_verified "$previous_readiness_verified" \
+    --argjson rollback_guard_verified "$rollback_guard_verified" \
+    --argjson same_schema_candidate_redeploy_verified \
+      "$same_schema_candidate_redeploy_verified" \
+    --argjson cleanup_verified "$cleanup_verified" '
+      {
+        receipt_version: 1,
+        operation: "production_schema_upgrade_rehearsal",
+        environment: "isolated",
+        status: $status,
+        failed_step: (if $status == "failed" then $failed_step else null end),
+        run_id: $run_id,
+        backup_id: (if $backup_id == "" then null else $backup_id end),
+        backup_sha256:
+          (if $backup_sha256 == "" then null else $backup_sha256 end),
+        manifest_sha256:
+          (if $manifest_sha256 == "" then null else $manifest_sha256 end),
+        version: (if $version == "" then null else $version end),
+        git_sha: (if $git_sha == "" then null else $git_sha end),
+        candidate_server_image:
+          (if $candidate_server_image == "" then null else $candidate_server_image end),
+        previous_server_image:
+          (if $previous_server_image == "" then null else $previous_server_image end),
+        forward_server_image:
+          (if $forward_server_image == "" then null else $forward_server_image end),
+        forward_server_image_version:
+          (if $forward_server_image_version == "" then null
+           else $forward_server_image_version end),
+        forward_server_image_revision:
+          (if $forward_server_image_revision == "" then null
+           else $forward_server_image_revision end),
+        source_schema: $source_schema,
+        target_schema: $target_schema,
+        lock_timeout_seconds: $lock_timeout_seconds,
+        restore_duration_seconds: $restore_duration_seconds,
+        migration_duration_seconds: $migration_duration_seconds,
+        total_duration_seconds: $total_duration_seconds,
+        checks: {
+          clean_target_schema: $schema_verified,
+          product_health_views: $views_verified,
+          ielts_evaluation_constraint: $constraint_verified,
+          candidate_readiness: $candidate_readiness_verified,
+          previous_image_readiness_only: $previous_readiness_verified,
+          previous_image_profile_processing: "not_verified",
+          schema7_rollback_guard: $rollback_guard_verified,
+          same_schema_candidate_redeploy: $same_schema_candidate_redeploy_verified,
+          forward_hotfix_image: $forward_hotfix_status,
+          owned_resource_cleanup: $cleanup_verified
+        },
+        recorded_at_utc: $recorded_at
+      }
+    ' >"$temporary"; then
+    rm -f -- "$temporary"
+    return 1
+  fi
+  chmod 0600 "$temporary" || {
+    rm -f -- "$temporary"
+    return 1
+  }
+  if ! ln "$temporary" "$receipt"; then
+    rm -f -- "$temporary"
+    return 1
+  fi
+  rm -f -- "$temporary"
+  [[ "$(path_mode "$receipt")" == 600 ]]
+}
+
+cleanup_on_exit() {
+  local status=$?
+
+  trap - EXIT INT HUP TERM
+  set +e
+  if [[ "$docker_touched" == true ]]; then
+    if cleanup_owned_resources; then
+      cleanup_verified=true
+    else
+      cleanup_verified=false
+      status=1
+      phase='cleanup'
+    fi
+  elif [[ "$execute" == true ]]; then
+    cleanup_verified=true
+  fi
+  if ! cleanup_manifest_snapshot; then
+    status=1
+    phase='cleanup'
+  fi
+  if ((started_at_seconds > 0)); then
+    total_duration_seconds=$(( $(now_seconds) - started_at_seconds ))
+  fi
+  if [[ "$execute" == true && "$receipt_ready" == true ]]; then
+    if ((status == 0)); then
+      if write_receipt succeeded; then
+        printf 'backup_id=%s version=%s source_schema=%s target_schema=%s receipt=%s rehearsal=verified\n' \
+          "$selected_backup_id" "$release_version" "$source_schema" \
+          "$target_schema" "$receipt"
+      else
+        status=1
+      fi
+    else
+      write_receipt failed || status=1
+    fi
+  fi
+  exit "$status"
+}
+
+cleanup_manifest_snapshot() {
+  local name
+
+  [[ -n "$manifest_snapshot_directory" ]] || return 0
+  name=${manifest_snapshot_directory##*/}
+  [[ "$name" == xe3-production-rehearsal-manifest.* &&
+    -d "$manifest_snapshot_directory" && ! -L "$manifest_snapshot_directory" &&
+    "$(path_owner "$manifest_snapshot_directory")" == "$EUID" ]] || return 1
+  if [[ -e "$manifest_snapshot" || -L "$manifest_snapshot" ]]; then
+    [[ "$manifest_snapshot" == "$manifest_snapshot_directory/release-manifest.json" &&
+      -f "$manifest_snapshot" && ! -L "$manifest_snapshot" &&
+      "$(path_owner "$manifest_snapshot")" == "$EUID" ]] || return 1
+    rm -- "$manifest_snapshot" || return 1
+  fi
+  rmdir -- "$manifest_snapshot_directory" || return 1
+  manifest_snapshot_directory=''
+  manifest_snapshot=''
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+path_mode() {
+  if stat -c '%a' -- "$1" >/dev/null 2>&1; then
+    stat -c '%a' -- "$1"
+  else
+    stat -f '%Lp' "$1"
+  fi
+}
+
+path_owner() {
+  if stat -c '%u' -- "$1" >/dev/null 2>&1; then
+    stat -c '%u' -- "$1"
+  else
+    stat -f '%u' "$1"
+  fi
+}
+
+file_size() {
+  if stat -c '%s' -- "$1" >/dev/null 2>&1; then
+    stat -c '%s' -- "$1"
+  else
+    stat -f '%z' "$1"
+  fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  else
+    fail 'sha256sum or shasum is required'
+  fi
+}
+
+valid_absolute_path() {
+  local value=$1
+
+  [[ "$value" =~ ^/[A-Za-z0-9._/-]+$ ]] &&
+    [[ "$value" != / && "$value" != *//* ]] &&
+    [[ "$value" != */../* && "$value" != */.. ]] &&
+    [[ "$value" != */./* && "$value" != */. ]]
+}
+
+require_regular_file() {
+  local description=$1
+  local file=$2
+
+  [[ -f "$file" && ! -L "$file" && -r "$file" && -s "$file" ]] ||
+    fail "$description must be a readable non-empty regular file"
+}
+
+require_private_file() {
+  local description=$1
+  local file=$2
+  local mode
+
+  require_regular_file "$description" "$file"
+  [[ "$(path_owner "$file")" == "$EUID" ]] ||
+    fail "$description must be owned by the current user"
+  mode=$(path_mode "$file") || fail "cannot inspect $description permissions"
+  [[ "$mode" == 400 || "$mode" == 600 ]] ||
+    fail "$description must have mode 0400 or 0600"
+}
+
+require_receipt_target() {
+  local parent mode
+
+  valid_absolute_path "$receipt" || fail '--receipt must be a safe absolute path'
+  [[ ! -e "$receipt" && ! -L "$receipt" ]] ||
+    fail 'rehearsal receipt already exists'
+  parent=${receipt%/*}
+  [[ -d "$parent" && ! -L "$parent" && -w "$parent" ]] ||
+    fail 'rehearsal receipt parent must be a writable real directory'
+  [[ "$(path_owner "$parent")" == "$EUID" ]] ||
+    fail 'rehearsal receipt parent must be owned by the current user'
+  mode=$(path_mode "$parent") || fail 'cannot inspect receipt parent permissions'
+  (( (8#$mode & 0022) == 0 )) ||
+    fail 'rehearsal receipt parent cannot be group or world writable'
+}
+
+validate_manifest() {
+  local output mode canonical temporary_base
+
+  require_regular_file 'release manifest' "$manifest"
+  valid_absolute_path "$manifest" || fail '--manifest must be a safe absolute path'
+  canonical=$(realpath "$manifest") || fail 'cannot resolve release manifest'
+  [[ "$canonical" == "$manifest" ]] || fail '--manifest must be a canonical path'
+  [[ "$(path_owner "$manifest")" == "$EUID" ]] ||
+    fail 'release manifest must be owned by the current user'
+  mode=$(path_mode "$manifest") || fail 'cannot inspect release manifest permissions'
+  (( (8#$mode & 0022) == 0 )) ||
+    fail 'release manifest cannot be group or world writable'
+
+  temporary_base=${TMPDIR:-/tmp}
+  temporary_base=${temporary_base%/}
+  manifest_snapshot_directory=$(mktemp -d \
+    "$temporary_base/xe3-production-rehearsal-manifest.XXXXXX") ||
+    fail 'cannot create private manifest snapshot directory'
+  chmod 0700 "$manifest_snapshot_directory" ||
+    fail 'cannot protect manifest snapshot directory'
+  manifest_snapshot="$manifest_snapshot_directory/release-manifest.json"
+  cp "$manifest" "$manifest_snapshot" || fail 'cannot freeze release manifest snapshot'
+  chmod 0600 "$manifest_snapshot" || fail 'cannot protect release manifest snapshot'
+
+  output=$("$production_manager" validate-manifest --manifest "$manifest_snapshot") ||
+    fail 'release manifest validation failed'
+  [[ "$output" =~ ^version=([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]git_sha=([a-f0-9]{40})[[:space:]]schema=([1-9][0-9]*)[[:space:]]manifest_sha256=([a-f0-9]{64})[[:space:]]validated=true$ ]] ||
+    fail 'release manifest validator returned an invalid contract'
+  [[ "${BASH_REMATCH[3]}" == "$target_schema" ]] ||
+    fail "release manifest must target schema $target_schema"
+  release_version=${BASH_REMATCH[1]}
+  release_git_sha=${BASH_REMATCH[2]}
+  release_manifest_sha256=${BASH_REMATCH[4]}
+  candidate_server_image="$server_repository@$(jq --raw-output \
+    '.server_image_digest' "$manifest_snapshot")"
+}
+
+validate_previous_server_image() {
+  [[ "$previous_server_image" =~ ^${server_repository}@sha256:[a-f0-9]{64}$ ]] ||
+    fail '--previous-server-image must be an immutable official Server digest'
+  [[ "$previous_server_image" != "$candidate_server_image" ]] ||
+    fail 'previous and candidate Server images must differ'
+}
+
+validate_forward_server_image() {
+  [[ -n "$forward_server_image" ]] || return 0
+  [[ "$forward_server_image" =~ ^${server_repository}@sha256:[a-f0-9]{64}$ ]] ||
+    fail '--forward-server-image must be an immutable official Server digest'
+  [[ "$forward_server_image" != "$candidate_server_image" &&
+    "$forward_server_image" != "$previous_server_image" ]] ||
+    fail 'forward Server image must differ from candidate and previous images'
+  validated_forward_server_image=$forward_server_image
+}
+
+validate_backup_metadata() {
+  local backup_id checksum_line expected_checksum expected_size actual_size mode canonical
+  local entry name
+  local -a entries
+
+  [[ -d "$backup_directory" && ! -L "$backup_directory" ]] ||
+    fail '--backup must be a real directory'
+  valid_absolute_path "$backup_directory" || fail '--backup must be a safe absolute path'
+  canonical=$(realpath "$backup_directory") || fail 'cannot resolve backup directory'
+  [[ "$canonical" == "$backup_directory" ]] || fail '--backup must be a canonical path'
+  [[ "$(path_owner "$backup_directory")" == "$EUID" ]] ||
+    fail 'backup directory must be owned by the current user'
+  mode=$(path_mode "$backup_directory") || fail 'cannot inspect backup directory permissions'
+  [[ "$mode" == 700 ]] || fail 'backup directory must have mode 0700'
+  backup_id=${backup_directory##*/}
+  [[ "$backup_id" =~ ^[0-9]{8}T[0-9]{6}Z-(daily|predeploy)$ ]] ||
+    fail 'backup directory name is not a finalized backup ID'
+
+  shopt -s nullglob dotglob
+  entries=("$backup_directory"/*)
+  shopt -u nullglob dotglob
+  [[ ${#entries[@]} == 3 ]] ||
+    fail 'backup directory must contain exactly three contract files'
+  for entry in "${entries[@]}"; do
+    name=${entry##*/}
+    case "$name" in
+      database.dump | database.dump.sha256 | metadata.json) ;;
+      *) fail 'backup directory contains an unexpected entry' ;;
+    esac
+    require_private_file "backup $name" "$entry"
+    [[ "$(path_mode "$entry")" == 600 ]] ||
+      fail "backup $name must have mode 0600"
+  done
+
+  jq --exit-status \
+    --arg backup_id "$backup_id" \
+    --arg postgres_image "$postgres_image" \
+    --arg source_project "$source_project" \
+    --arg source_service "$source_service" \
+    --arg source_volume "$source_volume" \
+    --argjson source_schema "$source_schema" '
+      type == "object" and
+      keys == [
+        "backup_id", "backup_type", "created_at", "database_name",
+        "database_user", "deployment_version", "format_version", "git_sha",
+        "postgres_image", "postgres_version", "schema_dirty", "schema_version",
+        "sha256", "size_bytes", "source_compose_project",
+        "source_compose_service", "source_volume"
+      ] and
+      .format_version == 1 and
+      .backup_id == $backup_id and
+      (.backup_type == "daily" or .backup_type == "predeploy") and
+      ((.created_at | gsub("[-:]"; "")) + "-" + .backup_type == .backup_id) and
+      (.created_at | type == "string" and fromdateiso8601 > 0) and
+      (.deployment_version | type == "string" and
+        test("^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$")) and
+      (.git_sha | type == "string" and test("^[a-f0-9]{40}$")) and
+      .source_compose_project == $source_project and
+      .source_compose_service == $source_service and
+      .source_volume == $source_volume and
+      .postgres_image == $postgres_image and
+      (.postgres_version | type == "string" and test("^18\\.")) and
+      (.database_name | type == "string" and test("^[a-z_][a-z0-9_]{0,62}$")) and
+      (.database_user | type == "string" and test("^[a-z_][a-z0-9_]{0,62}$")) and
+      .schema_version == $source_schema and .schema_dirty == false and
+      (.size_bytes | type == "number" and floor == . and . > 0) and
+      (.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+    ' "$backup_directory/metadata.json" >/dev/null ||
+    fail 'backup metadata is invalid or is not a clean Production schema 7 backup'
+
+  expected_checksum=$(jq --raw-output '.sha256' "$backup_directory/metadata.json")
+  expected_size=$(jq --raw-output '.size_bytes' "$backup_directory/metadata.json")
+  checksum_line=$(<"$backup_directory/database.dump.sha256")
+  [[ "$checksum_line" == "$expected_checksum  database.dump" ]] ||
+    fail 'backup checksum descriptor does not match metadata'
+  actual_size=$(file_size "$backup_directory/database.dump") ||
+    fail 'cannot inspect backup dump size'
+  [[ "$actual_size" == "$expected_size" ]] ||
+    fail 'backup dump size does not match metadata'
+
+  selected_backup_id=$backup_id
+  selected_backup_sha256=$expected_checksum
+  selected_database=$(jq --raw-output '.database_name' "$backup_directory/metadata.json")
+  selected_database_user=$(jq --raw-output '.database_user' "$backup_directory/metadata.json")
+  backup_deployment_version=$(jq --raw-output \
+    '.deployment_version' "$backup_directory/metadata.json")
+  backup_git_sha=$(jq --raw-output '.git_sha' "$backup_directory/metadata.json")
+}
+
+validate_backup_content() {
+  local actual_checksum
+
+  actual_checksum=$(sha256_file "$backup_directory/database.dump") ||
+    fail 'cannot calculate backup dump SHA-256'
+  [[ "$actual_checksum" == "$selected_backup_sha256" ]] ||
+    fail 'backup dump SHA-256 does not match metadata'
+  [[ "$(dd if="$backup_directory/database.dump" bs=5 count=1 2>/dev/null)" == PGDMP ]] ||
+    fail 'backup dump is not PostgreSQL custom format'
+}
+
+image_id_for_reference() {
+  local reference=$1 expected_version=$2 expected_revision=$3
+  local inspection image_id repo_digest=$1
+
+  if [[ "$reference" == postgres:*@sha256:* ]]; then
+    repo_digest="postgres@${reference##*@}"
+  fi
+
+  inspection=$(docker image inspect "$reference") ||
+    fail 'required immutable image is not available locally'
+  jq --exit-status \
+    --arg reference "$repo_digest" \
+    --arg expected_version "$expected_version" \
+    --arg expected_revision "$expected_revision" '
+    length == 1 and
+    (.[0].Id | type == "string" and test("^sha256:[a-f0-9]{64}$")) and
+    ((.[0].RepoDigests // []) | index($reference) != null) and
+    ($expected_version == "" or
+      .[0].Config.Labels["org.opencontainers.image.version"] == $expected_version) and
+    ($expected_revision == "" or
+      .[0].Config.Labels["org.opencontainers.image.revision"] == $expected_revision)
+  ' <<<"$inspection" >/dev/null ||
+    fail 'local image identity does not match the immutable reference'
+  image_id=$(jq --raw-output '.[0].Id' <<<"$inspection")
+  printf '%s\n' "$image_id"
+}
+
+forward_image_identity_for_reference() {
+  local reference=$1 inspection image_id version revision
+
+  inspection=$(docker image inspect "$reference") ||
+    fail 'required immutable forward image is not available locally'
+  jq --exit-status --arg reference "$reference" '
+    length == 1 and
+    (.[0].Id | type == "string" and test("^sha256:[a-f0-9]{64}$")) and
+    ((.[0].RepoDigests // []) | index($reference) != null) and
+    (.[0].Config.Labels["org.opencontainers.image.version"] |
+      type == "string" and
+      test("^[0-9]+\\.[0-9]+\\.[0-9]+([-.+][A-Za-z0-9.-]+)?$")) and
+    (.[0].Config.Labels["org.opencontainers.image.revision"] |
+      type == "string" and test("^[a-f0-9]{40}$"))
+  ' <<<"$inspection" >/dev/null ||
+    fail 'forward image identity or OCI labels are invalid'
+  image_id=$(jq --raw-output '.[0].Id' <<<"$inspection")
+  version=$(jq --raw-output \
+    '.[0].Config.Labels["org.opencontainers.image.version"]' <<<"$inspection")
+  revision=$(jq --raw-output \
+    '.[0].Config.Labels["org.opencontainers.image.revision"]' <<<"$inspection")
+  printf '%s\t%s\t%s\n' "$image_id" "$version" "$revision"
+}
+
+create_isolated_resources() {
+  local suffix network_id created_volume
+
+  suffix=$run_id
+  network_name="xe3-speakup-prod-rehearsal-$suffix"
+  volume_name="xe3-speakup-prod-rehearsal-$suffix"
+  [[ "$network_name" != *production* && "$volume_name" != "$source_volume" ]] ||
+    fail 'rehearsal resource identity is unsafe'
+
+  docker_touched=true
+  network_id=$(docker network create \
+    --internal \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    "$network_name") || fail 'cannot create isolated rehearsal network'
+  [[ "$network_id" =~ ^[a-f0-9]{64}$ ]] ||
+    fail 'isolated rehearsal network returned an invalid ID'
+  owned_network || fail 'isolated rehearsal network identity is invalid'
+
+  created_volume=$(docker volume create \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    "$volume_name") || fail 'cannot create isolated rehearsal volume'
+  [[ "$created_volume" == "$volume_name" ]] ||
+    fail 'isolated rehearsal volume returned an invalid identity'
+  owned_volume || fail 'isolated rehearsal volume identity is invalid'
+}
+
+verify_container_isolation() {
+  local name=$1 container_id=$2 inspection
+
+  inspection=$(docker container inspect "$container_id") ||
+    fail 'cannot inspect rehearsal container isolation'
+  jq --exit-status \
+    --arg name "$name" \
+    --arg id "$container_id" \
+    --arg network "$network_name" \
+    --argjson memory "$container_memory_bytes" \
+    --argjson pids "$container_pids_limit" \
+    --arg max_size "$container_log_max_size" \
+    --arg max_file "$container_log_max_file" '
+    length == 1 and
+    .[0].Id == $id and .[0].Name == ("/" + $name) and
+    ((.[0].HostConfig.PortBindings // {}) == {}) and
+    .[0].HostConfig.NetworkMode == $network and
+    (.[0].NetworkSettings.Networks | keys) == [$network] and
+    .[0].HostConfig.NanoCpus == 1000000000 and
+    .[0].HostConfig.Memory == $memory and
+    .[0].HostConfig.PidsLimit == $pids and
+    .[0].HostConfig.LogConfig.Type == "local" and
+    .[0].HostConfig.LogConfig.Config["max-size"] == $max_size and
+    .[0].HostConfig.LogConfig.Config["max-file"] == $max_file
+  ' <<<"$inspection" >/dev/null ||
+    fail 'rehearsal container violates isolation or resource limits'
+}
+
+record_created_container() {
+  local name=$1 container_id=$2
+
+  [[ "$container_id" =~ ^[a-f0-9]{64}$ ]] ||
+    fail 'Docker returned an invalid rehearsal container ID'
+  container_names+=("$name")
+  container_ids+=("$container_id")
+  last_created_container_id=$container_id
+  owned_container "$name" "$container_id" ||
+    fail 'created rehearsal container identity is invalid'
+  verify_container_isolation "$name" "$container_id"
+}
+
+start_postgres() {
+  local created_id
+
+  postgres_container="xe3-speakup-prod-rehearsal-db-$run_id"
+  created_id=$(docker container create \
+    --pull never \
+    --name "$postgres_container" \
+    --network "$network_name" \
+    --cpus "$container_cpus" \
+    --memory "$container_memory" \
+    --pids-limit "$container_pids_limit" \
+    --log-driver local \
+    --log-opt "max-size=$container_log_max_size" \
+    --log-opt "max-file=$container_log_max_file" \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    --mount "type=volume,src=$volume_name,dst=/var/lib/postgresql,volume-nocopy" \
+    --env "POSTGRES_DB=$selected_database" \
+    --env "POSTGRES_USER=$selected_database_user" \
+    --env POSTGRES_HOST_AUTH_METHOD=trust \
+    "$postgres_image_id") ||
+    fail 'cannot start isolated rehearsal PostgreSQL'
+  record_created_container "$postgres_container" "$created_id"
+  postgres_container_id=$created_id
+  docker container start "$postgres_container_id" >/dev/null ||
+    fail 'cannot start isolated rehearsal PostgreSQL'
+}
+
+wait_for_postgres() {
+  local attempt state process
+
+  for ((attempt = 1; attempt <= 60; attempt += 1)); do
+    process=$(docker container exec "$postgres_container_id" cat /proc/1/comm 2>/dev/null || true)
+    if [[ "$process" == postgres ]] && \
+      docker container exec --user postgres "$postgres_container_id" \
+      pg_isready \
+        --username "$selected_database_user" \
+        --dbname "$selected_database" >/dev/null 2>&1; then
+      return
+    fi
+    state=$(docker container inspect --format '{{.State.Status}}' \
+      "$postgres_container_id" 2>/dev/null || true)
+    [[ "$state" != exited && "$state" != dead ]] ||
+      fail 'isolated rehearsal PostgreSQL stopped before readiness'
+    sleep 1
+  done
+  fail 'isolated rehearsal PostgreSQL did not become ready'
+}
+
+database_query() {
+  local sql=$1
+
+  docker container exec --user postgres "$postgres_container_id" \
+    psql \
+      --no-psqlrc \
+      --set ON_ERROR_STOP=1 \
+      --tuples-only \
+      --no-align \
+      --quiet \
+      --username "$selected_database_user" \
+      --dbname "$selected_database" \
+      --command "$sql"
+}
+
+schema_state() {
+  local state
+
+  state=$(database_query \
+    "SELECT version::text || '|' || dirty::text FROM public.schema_migrations;") ||
+    fail 'cannot read isolated migration state'
+  [[ "$state" =~ ^([1-9][0-9]*)\|false$ ]] ||
+    fail 'isolated migration state is not one clean positive version'
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+restore_backup() {
+  local started
+
+  phase='restore'
+  started=$(now_seconds)
+  docker container exec --interactive --user postgres "$postgres_container_id" \
+    pg_restore \
+      --single-transaction \
+      --exit-on-error \
+      --no-owner \
+      --no-privileges \
+      --username "$selected_database_user" \
+      --dbname "$selected_database" <"$backup_directory/database.dump" ||
+    fail 'isolated PostgreSQL restore failed'
+  [[ "$(schema_state)" == "$source_schema" ]] ||
+    fail "restored backup is not clean schema $source_schema"
+  database_query \
+    "ALTER DATABASE $selected_database SET lock_timeout = '${lock_timeout_seconds}s';" \
+    >/dev/null || fail 'cannot set finite migration lock timeout'
+  restore_duration_seconds=$(( $(now_seconds) - started ))
+}
+
+run_migration() {
+  local name=$1 image_id=$2 created_id
+
+  created_id=$(docker container create \
+    --name "$name" \
+    --pull never \
+    --network "$network_name" \
+    --cpus "$container_cpus" \
+    --memory "$container_memory" \
+    --pids-limit "$container_pids_limit" \
+    --log-driver local \
+    --log-opt "max-size=$container_log_max_size" \
+    --log-opt "max-file=$container_log_max_file" \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    --env "DATABASE_URL=postgres://$selected_database_user@$postgres_container:5432/$selected_database?sslmode=disable" \
+    --entrypoint /usr/local/bin/speakup-migrate \
+    "$image_id" up) ||
+    fail 'cannot create isolated candidate migration container'
+  record_created_container "$name" "$created_id"
+  docker container start --attach "$created_id" >/dev/null ||
+    fail 'candidate migration failed within the finite lock timeout'
+}
+
+verify_target_database() {
+  local views barrier_count constraint_count expected_views actual_views
+
+  [[ "$(schema_state)" == "$target_schema" ]] ||
+    fail "candidate migration did not produce clean schema $target_schema"
+  schema_verified=true
+  expected_views=$'product_health_daily_artifact_coverage\nproduct_health_daily_evaluation_health\nproduct_health_daily_practice_activity\nproduct_health_daily_scoreability\nproduct_health_daily_session_outcomes'
+  actual_views=$(database_query \
+    "SELECT c.relname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'product_health_daily_%' ORDER BY c.relname;") ||
+    fail 'cannot inspect product health views'
+  [[ "$actual_views" == "$expected_views" ]] ||
+    fail 'schema 9 does not contain exactly the five product health views'
+  barrier_count=$(database_query \
+    "SELECT count(*) FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'product_health_daily_%' AND c.reloptions @> ARRAY['security_barrier=true'];") ||
+    fail 'cannot inspect product health view security barriers'
+  [[ "$barrier_count" == 5 ]] ||
+    fail 'product health views are missing security barriers'
+  views_verified=true
+
+  constraint_count=$(database_query \
+    "SELECT count(*) FROM pg_catalog.pg_constraint c WHERE c.conrelid = 'public.evaluations'::regclass AND c.conname = 'evaluations_kind_check' AND c.contype = 'c' AND c.convalidated = true AND pg_get_expr(c.conbin, c.conrelid) ~ '^\\(kind = ANY \\(ARRAY\\[' AND (SELECT array_agg((match)[1] ORDER BY (match)[1]) FROM regexp_matches(pg_get_constraintdef(c.oid), '''([^'']+)''', 'g') AS match) = ARRAY['AGENT_MESSAGE_FEEDBACK', 'IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE', 'PRACTICE_TURN_FEEDBACK', 'SESSION_REPORT']::text[];") ||
+    fail 'cannot inspect IELTS evaluation constraint'
+  [[ "$constraint_count" == 1 ]] ||
+    fail 'schema 9 IELTS evaluation kind constraint is invalid'
+  constraint_verified=true
+}
+
+start_server_and_wait() {
+  local name=$1 image_id=$2 attempt state created_id
+
+  created_id=$(docker container create \
+    --pull never \
+    --name "$name" \
+    --network "$network_name" \
+    --cpus "$container_cpus" \
+    --memory "$container_memory" \
+    --pids-limit "$container_pids_limit" \
+    --log-driver local \
+    --log-opt "max-size=$container_log_max_size" \
+    --log-opt "max-file=$container_log_max_file" \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    --env-file "$server_environment" \
+    --env "DATABASE_URL=postgres://$selected_database_user@$postgres_container:5432/$selected_database?sslmode=disable" \
+    --env SERVER_HOST=0.0.0.0 \
+    --env SERVER_PORT=8080 \
+    --env METRICS_HOST=127.0.0.1 \
+    "$image_id") || fail 'cannot create isolated Server image'
+  record_created_container "$name" "$created_id"
+  docker container start "$created_id" >/dev/null ||
+    fail 'cannot start isolated Server image'
+  for ((attempt = 1; attempt <= 60; attempt += 1)); do
+    if docker container exec "$created_id" \
+      wget -q -T 2 --spider http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
+      return
+    fi
+    state=$(docker container inspect --format '{{.State.Status}}' \
+      "$created_id" 2>/dev/null || true)
+    [[ "$state" != exited && "$state" != dead ]] ||
+      fail 'isolated Server image stopped before readiness'
+    sleep 1
+  done
+  fail 'isolated Server image did not pass readiness'
+}
+
+stop_server() {
+  docker container stop --time 5 "$1" >/dev/null ||
+    fail 'cannot stop isolated Server image after readiness'
+}
+
+verify_rollback_guard() {
+  local output
+
+  if output=$("$production_manager" validate-rollback-schema \
+    --current-schema "$target_schema" --target-schema "$source_schema" 2>&1); then
+    fail 'Production rollback guard allowed schema 9 to schema 7'
+  fi
+  [[ "$output" == *'rollback requires the current database schema to match the target release'* ]] ||
+    fail 'Production rollback guard failed for an unexpected reason'
+  rollback_guard_verified=true
+}
+
+run_isolated_rehearsal() {
+  local migration_started candidate_server previous_server
+  local redeploy_migration redeploy_server forward_migration forward_server
+  local forward_identity forward_server_image_id
+
+  phase='image_identity'
+  postgres_image_id=$(image_id_for_reference "$postgres_image" '' '')
+  candidate_server_image_id=$(image_id_for_reference \
+    "$candidate_server_image" "$release_version" "$release_git_sha")
+  previous_server_image_id=$(image_id_for_reference \
+    "$previous_server_image" "$backup_deployment_version" "$backup_git_sha")
+  if [[ -n "$validated_forward_server_image" ]]; then
+    forward_identity=$(forward_image_identity_for_reference \
+      "$validated_forward_server_image")
+    IFS=$'\t' read -r forward_server_image_id \
+      forward_server_image_version forward_server_image_revision \
+      <<<"$forward_identity"
+    [[ "$forward_server_image_id" =~ ^sha256:[a-f0-9]{64}$ &&
+      -n "$forward_server_image_version" &&
+      "$forward_server_image_revision" =~ ^[a-f0-9]{40}$ ]] ||
+      fail 'forward image identity fields are invalid'
+  fi
+  phase='resource_creation'
+  create_isolated_resources
+  start_postgres
+  wait_for_postgres
+  restore_backup
+
+  phase='migration'
+  migration_started=$(now_seconds)
+  run_migration "xe3-speakup-prod-rehearsal-migrate-$run_id" \
+    "$candidate_server_image_id"
+  migration_duration_seconds=$(( $(now_seconds) - migration_started ))
+  phase='schema_verification'
+  verify_target_database
+
+  phase='candidate_readiness'
+  candidate_server="xe3-speakup-prod-rehearsal-candidate-$run_id"
+  start_server_and_wait "$candidate_server" "$candidate_server_image_id"
+  candidate_readiness_verified=true
+  stop_server "$last_created_container_id"
+
+  phase='previous_image_boundary'
+  previous_server="xe3-speakup-prod-rehearsal-previous-$run_id"
+  start_server_and_wait "$previous_server" "$previous_server_image_id"
+  previous_readiness_verified=true
+  stop_server "$last_created_container_id"
+
+  phase='rollback_guard'
+  verify_rollback_guard
+
+  if [[ -n "$validated_forward_server_image" ]]; then
+    phase='forward_hotfix'
+    forward_migration="xe3-speakup-prod-rehearsal-forward-migrate-$run_id"
+    run_migration "$forward_migration" "$forward_server_image_id"
+    verify_target_database
+    forward_server="xe3-speakup-prod-rehearsal-forward-$run_id"
+    start_server_and_wait "$forward_server" "$forward_server_image_id"
+    stop_server "$last_created_container_id"
+    forward_hotfix_status='verified'
+  else
+    phase='same_schema_candidate_redeploy'
+    redeploy_migration="xe3-speakup-prod-rehearsal-redeploy-migrate-$run_id"
+    run_migration "$redeploy_migration" "$candidate_server_image_id"
+    [[ "$(schema_state)" == "$target_schema" ]] ||
+      fail 'same-schema candidate redeploy changed the clean target schema'
+    redeploy_server="xe3-speakup-prod-rehearsal-redeploy-$run_id"
+    start_server_and_wait "$redeploy_server" "$candidate_server_image_id"
+    stop_server "$last_created_container_id"
+    same_schema_candidate_redeploy_verified=true
+  fi
+  phase='complete'
+}
+
+owned_container() {
+  local name=$1 container_id=$2 inspection
+
+  inspection=$(docker container inspect "$container_id" 2>/dev/null) || return 1
+  jq --exit-status \
+    --arg name "$name" --arg container_id "$container_id" \
+    --arg resource_label "$resource_label" \
+    --arg run_label "$run_label" --arg run_id "$run_id" '
+      length == 1 and .[0].Id == $container_id and
+      .[0].Name == ("/" + $name) and
+      .[0].Config.Labels[$resource_label] == "true" and
+      .[0].Config.Labels[$run_label] == $run_id
+    ' <<<"$inspection" >/dev/null
+}
+
+owned_volume() {
+  local inspection
+
+  inspection=$(docker volume inspect "$volume_name" 2>/dev/null) || return 1
+  jq --exit-status \
+    --arg name "$volume_name" --arg resource_label "$resource_label" \
+    --arg run_label "$run_label" --arg run_id "$run_id" '
+      length == 1 and .[0].Name == $name and
+      .[0].Labels[$resource_label] == "true" and
+      .[0].Labels[$run_label] == $run_id
+    ' <<<"$inspection" >/dev/null
+}
+
+owned_network() {
+  local inspection
+
+  inspection=$(docker network inspect "$network_name" 2>/dev/null) || return 1
+  jq --exit-status \
+    --arg name "$network_name" --arg resource_label "$resource_label" \
+    --arg run_label "$run_label" --arg run_id "$run_id" '
+      length == 1 and .[0].Name == $name and .[0].Internal == true and
+      .[0].Labels[$resource_label] == "true" and
+      .[0].Labels[$run_label] == $run_id
+    ' <<<"$inspection" >/dev/null
+}
+
+container_absence_proven() {
+  local expected_name=$1 expected_id=$2 listing listed_id listed_name
+
+  listing=$(docker container ls --all --no-trunc \
+    --format '{{.ID}}\t{{.Names}}') || return 1
+  while IFS=$'\t' read -r listed_id listed_name; do
+    [[ -n "$listed_id" ]] || continue
+    if [[ "$listed_id" == "$expected_id" || "$listed_name" == "$expected_name" ]]; then
+      return 1
+    fi
+  done <<<"$listing"
+  return 0
+}
+
+network_absence_proven() {
+  local expected_name=$1 listing listed_id listed_name
+
+  listing=$(docker network ls --no-trunc --format '{{.ID}}\t{{.Name}}') || return 1
+  while IFS=$'\t' read -r listed_id listed_name; do
+    [[ -n "$listed_id" ]] || continue
+    [[ "$listed_name" != "$expected_name" ]] || return 1
+  done <<<"$listing"
+  return 0
+}
+
+volume_absence_proven() {
+  local expected_name=$1 listing listed_name
+
+  listing=$(docker volume ls --format '{{.Name}}') || return 1
+  while IFS= read -r listed_name; do
+    [[ -n "$listed_name" ]] || continue
+    [[ "$listed_name" != "$expected_name" ]] || return 1
+  done <<<"$listing"
+  return 0
+}
+
+cleanup_owned_resources() {
+  local failed=0 name container_id index
+
+  for ((index = ${#container_names[@]} - 1; index >= 0; index -= 1)); do
+    name=${container_names[index]}
+    container_id=${container_ids[index]}
+    if docker container inspect "$container_id" >/dev/null 2>&1; then
+      if owned_container "$name" "$container_id"; then
+        docker container rm --force "$container_id" >/dev/null 2>&1 || failed=1
+      else
+        failed=1
+      fi
+    elif ! container_absence_proven "$name" "$container_id"; then
+      # Inspect errors and same-name replacements fail closed. Never delete them.
+      failed=1
+    fi
+  done
+  if [[ -n "$network_name" ]]; then
+    if docker network inspect "$network_name" >/dev/null 2>&1; then
+      if owned_network; then
+        docker network rm "$network_name" >/dev/null 2>&1 || failed=1
+      else
+        failed=1
+      fi
+    elif ! network_absence_proven "$network_name"; then
+      failed=1
+    fi
+  fi
+  if [[ -n "$volume_name" ]]; then
+    if docker volume inspect "$volume_name" >/dev/null 2>&1; then
+      if [[ "$volume_name" != "$source_volume" ]] && owned_volume; then
+        docker volume rm "$volume_name" >/dev/null 2>&1 || failed=1
+      else
+        failed=1
+      fi
+    elif ! volume_absence_proven "$volume_name"; then
+      failed=1
+    fi
+  fi
+  ((failed == 0))
+}
+
+parse_arguments() {
+  while (($# > 0)); do
+    case "$1" in
+      --execute)
+        execute=true
+        shift
+        ;;
+      --backup | --manifest | --previous-server-image | --forward-server-image | --server-env-file | --receipt | --lock-timeout-seconds)
+        (($# >= 2)) || fail "$1 requires a value"
+        case "$1" in
+          --backup) backup_directory=$2 ;;
+          --manifest) manifest=$2 ;;
+          --previous-server-image) previous_server_image=$2 ;;
+          --forward-server-image) forward_server_image=$2 ;;
+          --server-env-file) server_environment=$2 ;;
+          --receipt) receipt=$2 ;;
+          --lock-timeout-seconds) lock_timeout_seconds=$2 ;;
+        esac
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *) fail "unknown argument: $1" ;;
+    esac
+  done
+}
+
+validate_inputs() {
+  local name
+
+  for name in backup_directory manifest previous_server_image server_environment receipt lock_timeout_seconds; do
+    [[ -n "${!name}" ]] || fail "required argument is missing: $name"
+  done
+  [[ "$lock_timeout_seconds" =~ ^[1-9][0-9]*$ ]] &&
+    ((lock_timeout_seconds <= 60)) ||
+    fail '--lock-timeout-seconds must be an integer from 1 to 60'
+  require_command jq
+  require_command stat
+  require_command awk
+  require_receipt_target
+  if [[ "$execute" == true ]]; then
+    receipt_ready=true
+  fi
+  if [[ -n "$forward_server_image" ]]; then
+    forward_hotfix_status='not_verified'
+  fi
+  require_command realpath
+  require_command mktemp
+  require_command cp
+  require_regular_file 'Production manager' "$production_manager"
+  phase='environment_validation'
+  require_private_file 'server environment file' "$server_environment"
+  phase='manifest_validation'
+  validate_manifest
+  validate_previous_server_image
+  validate_forward_server_image
+  phase='backup_metadata_validation'
+  validate_backup_metadata
+}
+
+main() {
+  parse_arguments "$@"
+  run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$-$RANDOM"
+  started_at_seconds=$(now_seconds)
+  trap cleanup_on_exit EXIT
+  trap 'exit 130' INT HUP TERM
+  validate_inputs
+  if [[ "$execute" == false ]]; then
+    printf 'backup_id=%s version=%s source_schema=%s target_schema=%s forward_hotfix=%s dry_run=true docker_touched=false\n' \
+      "$selected_backup_id" "$release_version" "$source_schema" "$target_schema" \
+      "$forward_hotfix_status"
+    return
+  fi
+
+  phase='backup_content_validation'
+  validate_backup_content
+  require_command docker
+  require_command date
+  require_command sleep
+  require_command dd
+  run_isolated_rehearsal
+}
+
+main "$@"

--- a/deploy/production/test-rehearsal.sh
+++ b/deploy/production/test-rehearsal.sh
@@ -1,0 +1,1190 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly rehearsal="$production_directory/rehearse-schema-upgrade.sh"
+readonly postgres_image='postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+readonly candidate_digest="sha256:$(printf 'b%.0s' {1..64})"
+readonly previous_image="ghcr.io/1024xengineer/xe3-esl-server@sha256:$(printf 'a%.0s' {1..64})"
+readonly forward_image="ghcr.io/1024xengineer/xe3-esl-server@sha256:$(printf 'e%.0s' {1..64})"
+readonly secret_value='rehearsal-test-secret-must-not-leak'
+
+fail() {
+  printf 'Production schema rehearsal test: %s\n' "$*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  else
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  fi
+}
+
+file_mode() {
+  if stat -c '%a' -- "$1" >/dev/null 2>&1; then
+    stat -c '%a' -- "$1"
+  else
+    stat -f '%Lp' "$1"
+  fi
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  if "$@" >"$temporary_directory/failure.out" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+  ! grep -Fq "$secret_value" "$temporary_directory/failure.out" ||
+    fail "$name exposed the server environment secret"
+}
+
+verify_failed_receipt() {
+  local selected_receipt=$1 expected_step=$2
+
+  [[ -f "$selected_receipt" && ! -L "$selected_receipt" ]] ||
+    fail "$expected_step did not write a failure receipt"
+  [[ "$(file_mode "$selected_receipt")" == 600 ]] ||
+    fail "$expected_step receipt is not mode 0600"
+  jq --exit-status --arg expected_step "$expected_step" '
+    .receipt_version == 1 and
+    .operation == "production_schema_upgrade_rehearsal" and
+    .environment == "isolated" and .status == "failed" and
+    .failed_step == $expected_step and
+    .checks.owned_resource_cleanup == true
+  ' "$selected_receipt" >/dev/null ||
+    fail "$expected_step receipt is incomplete"
+  ! grep -Fq "$secret_value" "$selected_receipt" ||
+    fail "$expected_step receipt exposed a server secret"
+}
+
+assert_no_rehearsal_resources() {
+  local selected_run=$1
+
+  [[ -z "$(docker container ls --all --quiet \
+    --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$selected_run")" ]] ||
+    fail "$selected_run leaked a container"
+  ! docker network inspect "xe3-speakup-prod-rehearsal-$selected_run" \
+    >/dev/null 2>&1 || fail "$selected_run leaked its network"
+  ! docker volume inspect "xe3-speakup-prod-rehearsal-$selected_run" \
+    >/dev/null 2>&1 || fail "$selected_run leaked its volume"
+}
+
+selected_background_container=''
+selected_background_run_id=''
+
+run_id_belongs_to_pid() {
+  local selected_run=$1 selected_pid=$2
+
+  [[ "$selected_pid" =~ ^[1-9][0-9]*$ &&
+    "$selected_run" =~ ^[0-9]{8}T[0-9]{6}Z-${selected_pid}-[0-9]+$ ]]
+}
+
+verify_pid_rehearsal_container() {
+  local selected_pid=$1 role=$2 selected_name=$3 selected_run=$4
+  local inspection expected_name
+
+  run_id_belongs_to_pid "$selected_run" "$selected_pid" || return 1
+  expected_name="xe3-speakup-prod-rehearsal-$role-$selected_run"
+  [[ "$selected_name" == "$expected_name" ]] || return 1
+  inspection=$(docker container inspect "$selected_name") || return 1
+  jq --exit-status \
+    --arg name "$selected_name" \
+    --arg run "$selected_run" '
+      length == 1 and .[0].Name == ("/" + $name) and
+      .[0].Config.Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+      .[0].Config.Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+    ' <<<"$inspection" >/dev/null
+}
+
+wait_for_pid_rehearsal_container() {
+  local selected_pid=$1 role=$2 attempt name selected_run matches
+
+  selected_background_container=''
+  selected_background_run_id=''
+  for ((attempt = 1; attempt <= 300; attempt += 1)); do
+    matches=0
+    while IFS=$'\t' read -r name selected_run; do
+      [[ -n "$name" && -n "$selected_run" ]] || continue
+      if run_id_belongs_to_pid "$selected_run" "$selected_pid" &&
+        [[ "$name" == "xe3-speakup-prod-rehearsal-$role-$selected_run" ]]; then
+        selected_background_container=$name
+        selected_background_run_id=$selected_run
+        matches=$((matches + 1))
+      fi
+    done < <(docker container ls --all \
+      --filter 'label=com.xengineer.speakup.production-rehearsal=true' \
+      --format '{{.Names}}\t{{.Label "com.xengineer.speakup.production-rehearsal-run-id"}}')
+    ((matches <= 1)) || return 1
+    if ((matches == 1)); then
+      verify_pid_rehearsal_container "$selected_pid" "$role" \
+        "$selected_background_container" "$selected_background_run_id"
+      return
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+wait_for_postgres() {
+  local container=$1 attempt process
+
+  for ((attempt = 1; attempt <= 60; attempt += 1)); do
+    process=$(docker container exec "$container" cat /proc/1/comm 2>/dev/null || true)
+    if [[ "$process" == postgres ]] && docker container exec "$container" pg_isready \
+      --username speakup --dbname speakup >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  fail "$container did not become ready"
+}
+
+remove_test_container() {
+  local container=$1
+
+  if docker container inspect "$container" >/dev/null 2>&1; then
+    docker container inspect "$container" | jq --exit-status \
+      --arg container "$container" --arg test_id "$test_id" '
+        length == 1 and .[0].Name == ("/" + $container) and
+        .[0].Config.Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker container rm --force "$container" >/dev/null
+  fi
+}
+
+remove_test_volume() {
+  local volume=$1
+
+  if docker volume inspect "$volume" >/dev/null 2>&1; then
+    docker volume inspect "$volume" | jq --exit-status \
+      --arg volume "$volume" --arg test_id "$test_id" '
+        length == 1 and .[0].Name == $volume and
+        .[0].Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker volume rm "$volume" >/dev/null
+  fi
+}
+
+remove_test_image() {
+  local image_id
+
+  for image_id in \
+    "${forward_fixture_image_id:-}" \
+    "${negative_constraint_fixture_image_id:-}" \
+    "${interrupt_fixture_image_id:-}" \
+    "${invalid_constraint_fixture_image_id:-}" \
+    "${missing_constraint_fixture_image_id:-}" \
+    "${missing_view_fixture_image_id:-}" \
+    "${previous_fixture_image_id:-}" \
+    "${fixture_image_id:-}"; do
+    [[ -n "$image_id" ]] || continue
+    docker image inspect "$image_id" >/dev/null 2>&1 || continue
+    docker image inspect "$image_id" | jq --exit-status \
+      --arg test_id "$test_id" '
+        length == 1 and
+        .[0].Config.Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker image rm --force "$image_id" >/dev/null
+  done
+}
+
+remove_rehearsal_run() {
+  local selected_run=$1 resource name
+
+  [[ -n "$selected_run" ]] || return 0
+  while IFS= read -r resource; do
+    [[ -n "$resource" ]] || continue
+    docker container inspect "$resource" | jq --exit-status \
+      --arg run "$selected_run" '
+        length == 1 and
+        .[0].Config.Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+        .[0].Config.Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+      ' >/dev/null || return 1
+    docker container rm --force "$resource" >/dev/null
+  done < <(docker container ls --all --quiet \
+    --filter 'label=com.xengineer.speakup.production-rehearsal=true' \
+    --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$selected_run")
+  name="xe3-speakup-prod-rehearsal-$selected_run"
+  if docker network inspect "$name" >/dev/null 2>&1; then
+    docker network inspect "$name" | jq --exit-status --arg run "$selected_run" '
+      length == 1 and .[0].Internal == true and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+    ' >/dev/null || return 1
+    docker network rm "$name" >/dev/null
+  fi
+  if docker volume inspect "$name" >/dev/null 2>&1; then
+    docker volume inspect "$name" | jq --exit-status --arg run "$selected_run" '
+      length == 1 and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+    ' >/dev/null || return 1
+    docker volume rm "$name" >/dev/null
+  fi
+}
+
+write_manifest() {
+  cat >"$manifest" <<EOF
+{
+  "manifest_version": 1,
+  "version": "0.1.6",
+  "version_code": 7,
+  "git_sha": "cccccccccccccccccccccccccccccccccccccccc",
+  "portal_image": "ghcr.io/1024xengineer/xe3-esl-portal",
+  "portal_image_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "server_image": "ghcr.io/1024xengineer/xe3-esl-server",
+  "server_image_digest": "$candidate_digest",
+  "staging_apk_file": "speakup-v0.1.6-staging-arm64.apk",
+  "staging_apk_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "production_apk_file": "speakup-v0.1.6-production-arm64.apk",
+  "production_apk_size_bytes": 123,
+  "production_apk_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "application_id": "com.xengineer.speakup",
+  "minimum_android_api": 24,
+  "abis": ["arm64-v8a"],
+  "apk_certificate_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "database_schema_version": 9,
+  "quality_run_url": "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456"
+}
+EOF
+}
+
+temporary_base=${TMPDIR:-/tmp}
+temporary_base=${temporary_base%/}
+temporary_directory="$(realpath \
+  "$(mktemp -d "$temporary_base/xe3-production-rehearsal-test.XXXXXX")")"
+readonly temporary_directory
+readonly backup_directory="$temporary_directory/20260825T010203Z-predeploy"
+readonly manifest="$temporary_directory/release-manifest.json"
+readonly server_environment="$temporary_directory/server.env"
+readonly receipt="$temporary_directory/receipt.json"
+readonly dump="$backup_directory/database.dump"
+readonly docker_marker="$temporary_directory/docker-called"
+readonly dump_hash_marker="$temporary_directory/dump-hashed"
+readonly wrapper_directory="$temporary_directory/bin"
+readonly test_id="$(basename "$temporary_directory")"
+readonly decoy_run_id="20260825T000000Z-1-$$"
+readonly decoy_candidate="xe3-speakup-prod-rehearsal-candidate-$decoy_run_id"
+readonly decoy_database="xe3-speakup-prod-rehearsal-db-$decoy_run_id"
+readonly source_container="$test_id-source"
+readonly source_volume="$test_id-source-data"
+readonly fixture_builder="$test_id-image-builder"
+readonly fixture_smoke="$test_id-image-smoke"
+readonly previous_fixture_builder="$test_id-previous-image-builder"
+readonly forward_fixture_builder="$test_id-forward-image-builder"
+readonly missing_view_fixture_builder="$test_id-missing-view-image-builder"
+readonly missing_constraint_fixture_builder="$test_id-missing-constraint-image-builder"
+readonly invalid_constraint_fixture_builder="$test_id-invalid-constraint-image-builder"
+readonly negative_constraint_fixture_builder="$test_id-negative-constraint-image-builder"
+readonly interrupt_fixture_builder="$test_id-interrupt-image-builder"
+readonly fixture_image="xe3-speakup-prod-rehearsal-fixture:$test_id"
+readonly previous_fixture_image="xe3-speakup-prod-rehearsal-previous-fixture:$test_id"
+readonly forward_fixture_image="xe3-speakup-prod-rehearsal-forward-fixture:$test_id"
+readonly missing_view_fixture_image="xe3-speakup-prod-rehearsal-missing-view:$test_id"
+readonly missing_constraint_fixture_image="xe3-speakup-prod-rehearsal-missing-constraint:$test_id"
+readonly invalid_constraint_fixture_image="xe3-speakup-prod-rehearsal-invalid-constraint:$test_id"
+readonly negative_constraint_fixture_image="xe3-speakup-prod-rehearsal-negative-constraint:$test_id"
+readonly interrupt_fixture_image="xe3-speakup-prod-rehearsal-interrupt:$test_id"
+fixture_image_id=''
+previous_fixture_image_id=''
+forward_fixture_image_id=''
+missing_view_fixture_image_id=''
+missing_constraint_fixture_image_id=''
+invalid_constraint_fixture_image_id=''
+negative_constraint_fixture_image_id=''
+interrupt_fixture_image_id=''
+declare -a observed_rehearsal_runs=()
+
+cleanup() {
+  local status=$?
+  local observed_run
+  trap - EXIT INT TERM
+  set +e
+  set +u
+  for observed_run in "${observed_rehearsal_runs[@]}"; do
+    remove_rehearsal_run "$observed_run" >/dev/null 2>&1 || status=1
+  done
+  remove_test_container "$source_container" >/dev/null 2>&1 || status=1
+  remove_test_container "$fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$fixture_smoke" >/dev/null 2>&1 || status=1
+  remove_test_container "$previous_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$forward_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$missing_view_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$missing_constraint_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$invalid_constraint_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$negative_constraint_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$interrupt_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$decoy_candidate" >/dev/null 2>&1 || status=1
+  remove_test_container "$decoy_database" >/dev/null 2>&1 || status=1
+  remove_test_volume "$source_volume" >/dev/null 2>&1 || status=1
+  remove_test_image >/dev/null 2>&1 || status=1
+  if [[ "$temporary_directory" == */xe3-production-rehearsal-test.* ]]; then
+    rm -rf -- "$temporary_directory"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -m 0700 "$backup_directory" "$wrapper_directory"
+write_manifest
+printf 'DASHSCOPE_API_KEY=%s\n' "$secret_value" >"$server_environment"
+printf 'PGDMP synthetic dry-run fixture\n' >"$dump"
+dump_sha256=$(sha256_file "$dump")
+dump_size=$(wc -c <"$dump" | tr -d '[:space:]')
+printf '%s  database.dump\n' "$dump_sha256" >"$backup_directory/database.dump.sha256"
+jq --null-input \
+  --arg sha256 "$dump_sha256" \
+  --arg postgres_image "$postgres_image" \
+  --argjson size_bytes "$dump_size" '
+    {
+      format_version: 1,
+      backup_id: "20260825T010203Z-predeploy",
+      created_at: "2026-08-25T01:02:03Z",
+      backup_type: "predeploy",
+      deployment_version: "0.1.4",
+      git_sha: "2222222222222222222222222222222222222222",
+      source_compose_project: "xe3-speakup-production",
+      source_compose_service: "postgres",
+      source_volume: "xe3-speakup-postgres-data",
+      postgres_image: $postgres_image,
+      postgres_version: "18.0",
+      database_name: "speakup",
+      database_user: "speakup",
+      schema_version: 7,
+      schema_dirty: false,
+      size_bytes: $size_bytes,
+      sha256: $sha256
+    }
+  ' >"$backup_directory/metadata.json"
+chmod 0600 \
+  "$manifest" "$server_environment" "$dump" \
+  "$backup_directory/database.dump.sha256" \
+  "$backup_directory/metadata.json"
+
+real_sha256sum=$(command -v sha256sum || true)
+real_shasum=$(command -v shasum || true)
+cat >"$wrapper_directory/docker" <<'EOF'
+#!/usr/bin/env bash
+: >"$TEST_DOCKER_MARKER"
+exit 97
+EOF
+cat >"$wrapper_directory/sha256sum" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  if [[ "$argument" == */database.dump ]]; then
+    : >"$TEST_DUMP_HASH_MARKER"
+    exit 96
+  fi
+done
+exec "$TEST_REAL_SHA256SUM" "$@"
+EOF
+cat >"$wrapper_directory/shasum" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  if [[ "$argument" == */database.dump ]]; then
+    : >"$TEST_DUMP_HASH_MARKER"
+    exit 96
+  fi
+done
+exec "$TEST_REAL_SHASUM" "$@"
+EOF
+chmod 0700 "$wrapper_directory/docker" "$wrapper_directory/sha256sum" "$wrapper_directory/shasum"
+
+if [[ -n "$real_sha256sum" ]]; then
+  export TEST_REAL_SHA256SUM=$real_sha256sum
+else
+  rm "$wrapper_directory/sha256sum"
+fi
+if [[ -n "$real_shasum" ]]; then
+  export TEST_REAL_SHASUM=$real_shasum
+else
+  rm "$wrapper_directory/shasum"
+fi
+export TEST_DOCKER_MARKER=$docker_marker
+export TEST_DUMP_HASH_MARKER=$dump_hash_marker
+
+invalid_environment="$temporary_directory/invalid-server.env"
+invalid_environment_receipt="$temporary_directory/invalid-env-receipt.json"
+printf 'DASHSCOPE_API_KEY=invalid-mode\n' >"$invalid_environment"
+chmod 0644 "$invalid_environment"
+expect_failure 'invalid environment execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$invalid_environment" \
+    --receipt "$invalid_environment_receipt" \
+    --lock-timeout-seconds 3
+verify_failed_receipt "$invalid_environment_receipt" environment_validation
+[[ ! -e "$docker_marker" ]] || fail 'invalid environment called Docker'
+
+dry_run_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" \
+  --backup "$backup_directory" \
+  --manifest "$manifest" \
+  --previous-server-image "$previous_image" \
+  --server-env-file "$server_environment" \
+  --receipt "$receipt" \
+  --lock-timeout-seconds 3)"
+[[ "$dry_run_output" == \
+  'backup_id=20260825T010203Z-predeploy version=0.1.6 source_schema=7 target_schema=9 forward_hotfix=not_provided dry_run=true docker_touched=false' ]] ||
+  fail 'dry-run returned an unexpected contract'
+[[ ! -e "$docker_marker" ]] || fail 'dry-run called Docker'
+[[ ! -e "$dump_hash_marker" ]] || fail 'dry-run read database.dump'
+[[ ! -e "$receipt" ]] || fail 'dry-run wrote a receipt'
+! grep -Fq "$secret_value" <<<"$dry_run_output" ||
+  fail 'dry-run exposed the server environment secret'
+
+jq '.database_schema_version = 8' "$manifest" >"$temporary_directory/schema8.json"
+chmod 0600 "$temporary_directory/schema8.json"
+expect_failure 'wrong target schema' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" \
+    --backup "$backup_directory" \
+    --manifest "$temporary_directory/schema8.json" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$receipt" \
+    --lock-timeout-seconds 3
+[[ ! -e "$docker_marker" ]] || fail 'invalid manifest called Docker'
+
+invalid_manifest_receipt="$temporary_directory/invalid-manifest-receipt.json"
+expect_failure 'wrong target schema execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$temporary_directory/schema8.json" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$invalid_manifest_receipt" \
+    --lock-timeout-seconds 3
+verify_failed_receipt "$invalid_manifest_receipt" manifest_validation
+
+invalid_backup_directory="$temporary_directory/20260825T010204Z-predeploy"
+invalid_metadata_receipt="$temporary_directory/invalid-metadata-receipt.json"
+mkdir -m 0700 "$invalid_backup_directory"
+cp "$dump" "$backup_directory/database.dump.sha256" \
+  "$invalid_backup_directory/"
+jq '
+  .backup_id = "20260825T010204Z-predeploy" |
+  .created_at = "2026-08-25T01:02:04Z" |
+  .schema_version = 8
+' "$backup_directory/metadata.json" >"$invalid_backup_directory/metadata.json"
+chmod 0600 "$invalid_backup_directory"/*
+expect_failure 'invalid backup metadata execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$invalid_backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$invalid_metadata_receipt" \
+    --lock-timeout-seconds 3
+verify_failed_receipt "$invalid_metadata_receipt" backup_metadata_validation
+[[ ! -e "$docker_marker" ]] || fail 'invalid backup metadata called Docker'
+
+printf 'X' | dd of="$dump" bs=1 seek=6 conv=notrunc 2>/dev/null
+expect_failure 'corrupt dump execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$receipt" \
+    --lock-timeout-seconds 3
+[[ -e "$dump_hash_marker" ]] || fail 'execute did not verify database.dump'
+[[ ! -e "$docker_marker" ]] || fail 'invalid backup called Docker'
+[[ -f "$receipt" && ! -L "$receipt" ]] ||
+  fail 'failed execute did not write an audit receipt'
+[[ "$(file_mode "$receipt")" == 600 ]] ||
+  fail 'failed execute receipt is not mode 0600'
+jq --exit-status '
+  .receipt_version == 1 and
+  .operation == "production_schema_upgrade_rehearsal" and
+  .environment == "isolated" and
+  .status == "failed" and
+  .failed_step == "backup_content_validation" and
+  .source_schema == 7 and .target_schema == 9 and
+  .checks.owned_resource_cleanup == true
+' "$receipt" >/dev/null || fail 'failed execute receipt is incomplete'
+! grep -Fq "$secret_value" "$receipt" || fail 'receipt exposed a server secret'
+! grep -Fq "$backup_directory" "$receipt" || fail 'receipt exposed the backup path'
+
+[[ "$("$production_directory/manage.sh" validate-rollback-schema \
+  --current-schema 9 --target-schema 9)" == \
+  'current_schema=9 target_schema=9 rollback_allowed=true' ]] ||
+  fail 'Production rollback schema guard rejected an equal schema'
+expect_failure 'Production rollback schema guard mismatch' \
+  "$production_directory/manage.sh" validate-rollback-schema \
+    --current-schema 9 --target-schema 7
+rm -f "$wrapper_directory/sha256sum" "$wrapper_directory/shasum"
+
+# The runtime fixture uses only the already-required PostgreSQL 18 image. Its
+# migration entrypoint applies the repository's real schema 8 and 9 SQL, while
+# its HTTP process exposes only a local readiness endpoint.
+fixture_directory="$temporary_directory/fixture-image"
+mkdir -m 0700 "$fixture_directory"
+cp "$production_directory/../../server/migrations/000008_product_health_views.up.sql" \
+  "$fixture_directory/000008.up.sql"
+cp "$production_directory/../../server/migrations/000009_ielts_incremental_profile.up.sql" \
+  "$fixture_directory/000009.up.sql"
+cat >"$fixture_directory/speakup-migrate" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == up ]] || exit 2
+sleep 2
+version="$(psql "$DATABASE_URL" --no-psqlrc --tuples-only --no-align --quiet \
+  --set ON_ERROR_STOP=1 --command 'SELECT version FROM public.schema_migrations;')"
+case "$version" in
+  7)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --file /fixture/000008.up.sql >/dev/null
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'UPDATE public.schema_migrations SET version = 8;' >/dev/null
+    ;&
+  8)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --file /fixture/000009.up.sql >/dev/null
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'UPDATE public.schema_migrations SET version = 9;' >/dev/null
+    ;;
+  9)
+    ;;
+  *)
+    exit 3
+    ;;
+esac
+case "${REHEARSAL_FIXTURE_FAULT:-}" in
+  '' | server-unready) ;;
+  missing-view)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'DROP VIEW public.product_health_daily_scoreability;' >/dev/null
+    ;;
+  missing-constraint)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER TABLE public.evaluations DROP CONSTRAINT evaluations_kind_check;' \
+      >/dev/null
+    ;;
+  invalid-constraint)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER TABLE public.evaluations DROP CONSTRAINT evaluations_kind_check;' \
+      --command "ALTER TABLE public.evaluations ADD CONSTRAINT evaluations_kind_check CHECK (kind IN ('SESSION_REPORT', 'PRACTICE_TURN_FEEDBACK', 'AGENT_MESSAGE_FEEDBACK', 'IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE', 'UNREVIEWED_EXTRA'));" \
+      >/dev/null
+    ;;
+  negative-constraint)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER TABLE public.evaluations DROP CONSTRAINT evaluations_kind_check;' \
+      --command "ALTER TABLE public.evaluations ADD CONSTRAINT evaluations_kind_check CHECK (kind NOT IN ('SESSION_REPORT', 'PRACTICE_TURN_FEEDBACK', 'AGENT_MESSAGE_FEEDBACK', 'IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE'));" \
+      >/dev/null
+    ;;
+  *) exit 4 ;;
+esac
+EOF
+cat >"$fixture_directory/speakup-server" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${REHEARSAL_FIXTURE_FAULT:-}" == server-unready ]]; then
+  sleep 300
+  exit 5
+fi
+exec perl -MIO::Socket::INET -e '
+  my $server = IO::Socket::INET->new(
+    LocalAddr => "127.0.0.1", LocalPort => 8080, Listen => 5,
+    ReuseAddr => 1, Proto => "tcp"
+  ) or die "listen failed";
+  while (my $client = $server->accept()) {
+    scalar <$client>;
+    print $client "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+    close $client;
+  }
+'
+EOF
+cat >"$fixture_directory/wget" <<'EOF'
+#!/usr/bin/env bash
+exec perl -MIO::Socket::INET -e '
+  my $client = IO::Socket::INET->new(
+    PeerAddr => "127.0.0.1", PeerPort => 8080, Proto => "tcp", Timeout => 2
+  );
+  exit($client ? 0 : 1);
+'
+EOF
+chmod 0755 \
+  "$fixture_directory/speakup-migrate" \
+  "$fixture_directory/speakup-server" \
+  "$fixture_directory/wget"
+docker container create \
+  --name "$fixture_builder" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$postgres_image" >/dev/null
+docker container cp "$fixture_directory" "$fixture_builder:/fixture"
+docker container cp \
+  "$fixture_directory/speakup-migrate" \
+  "$fixture_builder:/usr/local/bin/speakup-migrate"
+docker container cp \
+  "$fixture_directory/speakup-server" \
+  "$fixture_builder:/usr/local/bin/speakup-server"
+docker container cp \
+  "$fixture_directory/wget" \
+  "$fixture_builder:/usr/local/bin/wget"
+docker container commit \
+  --change 'ENTRYPOINT ["/usr/local/bin/speakup-server"]' \
+  --change 'CMD []' \
+  --change 'LABEL org.opencontainers.image.version=0.1.6' \
+  --change 'LABEL org.opencontainers.image.revision=cccccccccccccccccccccccccccccccccccccccc' \
+  --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+  "$fixture_builder" "$fixture_image" >/dev/null
+remove_test_container "$fixture_builder" || fail 'cannot remove fixture image builder'
+fixture_image_id=$(docker image inspect --format '{{.Id}}' "$fixture_image")
+[[ "$fixture_image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+  fail 'fixture image ID is invalid'
+docker container run --detach --pull never \
+  --name "$fixture_smoke" --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$fixture_image_id" >/dev/null
+sleep 1
+if ! docker container exec "$fixture_smoke" \
+  wget -q -T 2 --spider http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
+  docker container inspect "$fixture_smoke" --format \
+    'fixture state={{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}' >&2 || true
+  docker container logs "$fixture_smoke" >&2 || true
+  fail 'fixture Server image is not runnable'
+fi
+remove_test_container "$fixture_smoke" || fail 'cannot remove fixture smoke container'
+
+docker container create \
+  --name "$previous_fixture_builder" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$fixture_image_id" >/dev/null
+docker container commit \
+  --change 'ENTRYPOINT ["/usr/local/bin/speakup-server"]' \
+  --change 'CMD []' \
+  --change 'LABEL org.opencontainers.image.version=0.1.4' \
+  --change 'LABEL org.opencontainers.image.revision=2222222222222222222222222222222222222222' \
+  --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+  "$previous_fixture_builder" "$previous_fixture_image" >/dev/null
+previous_fixture_image_id=$(docker image inspect --format '{{.Id}}' \
+  "$previous_fixture_image")
+[[ "$previous_fixture_image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+  fail 'previous fixture image ID is invalid'
+remove_test_container "$previous_fixture_builder" ||
+  fail 'cannot remove previous fixture image builder'
+
+docker container create \
+  --name "$forward_fixture_builder" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$fixture_image_id" >/dev/null
+docker container commit \
+  --change 'ENTRYPOINT ["/usr/local/bin/speakup-server"]' \
+  --change 'CMD []' \
+  --change 'LABEL org.opencontainers.image.version=0.1.7' \
+  --change 'LABEL org.opencontainers.image.revision=ffffffffffffffffffffffffffffffffffffffff' \
+  --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+  "$forward_fixture_builder" "$forward_fixture_image" >/dev/null
+forward_fixture_image_id=$(docker image inspect --format '{{.Id}}' \
+  "$forward_fixture_image")
+[[ "$forward_fixture_image_id" =~ ^sha256:[a-f0-9]{64}$ &&
+  "$forward_fixture_image_id" != "$fixture_image_id" &&
+  "$forward_fixture_image_id" != "$previous_fixture_image_id" ]] ||
+  fail 'forward fixture must have a distinct immutable image ID'
+remove_test_container "$forward_fixture_builder" ||
+  fail 'cannot remove forward fixture image builder'
+
+create_fixture_variant() {
+  local fault=$1 builder=$2 image=$3 image_id
+
+  docker container create \
+    --name "$builder" \
+    --label "com.xengineer.speakup.test-run=$test_id" \
+    --entrypoint /bin/true \
+    "$fixture_image_id" >/dev/null
+  docker container commit \
+    --change "ENV REHEARSAL_FIXTURE_FAULT=$fault" \
+    --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+    "$builder" "$image" >/dev/null
+  image_id=$(docker image inspect --format '{{.Id}}' "$image")
+  [[ "$image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+    fail "$fault fixture image ID is invalid"
+  remove_test_container "$builder" || fail "cannot remove $fault fixture builder"
+  printf '%s\n' "$image_id"
+}
+
+missing_view_fixture_image_id=$(create_fixture_variant \
+  missing-view "$missing_view_fixture_builder" "$missing_view_fixture_image")
+missing_constraint_fixture_image_id=$(create_fixture_variant \
+  missing-constraint "$missing_constraint_fixture_builder" \
+  "$missing_constraint_fixture_image")
+invalid_constraint_fixture_image_id=$(create_fixture_variant \
+  invalid-constraint "$invalid_constraint_fixture_builder" \
+  "$invalid_constraint_fixture_image")
+negative_constraint_fixture_image_id=$(create_fixture_variant \
+  negative-constraint "$negative_constraint_fixture_builder" \
+  "$negative_constraint_fixture_image")
+interrupt_fixture_image_id=$(create_fixture_variant \
+  server-unready "$interrupt_fixture_builder" "$interrupt_fixture_image")
+
+docker volume create \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$source_volume" >/dev/null
+docker container run \
+  --detach \
+  --pull never \
+  --name "$source_container" \
+  --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --mount "type=volume,src=$source_volume,dst=/var/lib/postgresql,volume-nocopy" \
+  --env POSTGRES_DB=speakup \
+  --env POSTGRES_USER=speakup \
+  --env POSTGRES_HOST_AUTH_METHOD=trust \
+  "$postgres_image" >/dev/null
+wait_for_postgres "$source_container"
+for migration in \
+  "$production_directory"/../../server/migrations/00000[1-7]*.up.sql; do
+  docker container exec --interactive "$source_container" \
+    psql --no-psqlrc --set ON_ERROR_STOP=1 \
+      --username speakup --dbname speakup <"$migration" >/dev/null
+done
+docker container exec "$source_container" \
+  psql --no-psqlrc --set ON_ERROR_STOP=1 \
+    --username speakup --dbname speakup \
+    --command 'CREATE TABLE public.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL);' \
+    --command 'INSERT INTO public.schema_migrations (version, dirty) VALUES (7, false);' \
+    >/dev/null
+docker container exec "$source_container" \
+  pg_dump --format custom --no-owner --no-privileges \
+    --username speakup --dbname speakup >"$dump"
+dump_sha256=$(sha256_file "$dump")
+dump_size=$(wc -c <"$dump" | tr -d '[:space:]')
+printf '%s  database.dump\n' "$dump_sha256" >"$backup_directory/database.dump.sha256"
+jq \
+  --arg sha256 "$dump_sha256" \
+  --argjson size_bytes "$dump_size" \
+  '.sha256 = $sha256 | .size_bytes = $size_bytes' \
+  "$backup_directory/metadata.json" >"$temporary_directory/metadata.updated.json"
+mv "$temporary_directory/metadata.updated.json" "$backup_directory/metadata.json"
+chmod 0600 "$dump" "$backup_directory/database.dump.sha256" \
+  "$backup_directory/metadata.json"
+remove_test_container "$source_container" || fail 'cannot remove source fixture container'
+remove_test_volume "$source_volume" || fail 'cannot remove source fixture volume'
+
+command_log="$temporary_directory/docker-runtime.log"
+cat >"$wrapper_directory/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+arguments=("$@")
+if [[ "$#" == 3 && "$1" == container && "$2" == inspect &&
+  -s "$TEST_INSPECT_ERROR_TARGET_FILE" &&
+  "$3" == "$(<"$TEST_INSPECT_ERROR_TARGET_FILE")" ]]; then
+  if [[ ! -e "$TEST_INSPECT_ERROR_INJECTED_FILE" ]]; then
+    (umask 077 && printf '%s\n' "$3" >"$TEST_INSPECT_ERROR_INJECTED_FILE")
+  fi
+  exit 74
+fi
+if [[ "$#" == 3 && "$1" == image && "$2" == inspect &&
+  ("$3" == "$TEST_CANDIDATE_IMAGE" || "$3" == "$TEST_PREVIOUS_IMAGE" ||
+   "$3" == "$TEST_FORWARD_IMAGE") ]]; then
+  selected_image=$TEST_FIXTURE_IMAGE_ID
+  if [[ "$3" == "$TEST_CANDIDATE_IMAGE" ]]; then
+    selected_image=$TEST_CANDIDATE_FIXTURE_IMAGE_ID
+  fi
+  if [[ "$3" == "$TEST_PREVIOUS_IMAGE" ]]; then
+    selected_image=$TEST_PREVIOUS_FIXTURE_IMAGE_ID
+  fi
+  if [[ "$3" == "$TEST_FORWARD_IMAGE" ]]; then
+    selected_image=$TEST_FORWARD_FIXTURE_IMAGE_ID
+  fi
+  "$TEST_REAL_DOCKER" image inspect "$selected_image" |
+    jq --arg reference "$3" '.[0].RepoDigests = [$reference]'
+  exit 0
+fi
+{
+  printf '%q' "$1"
+  shift
+  printf ' %q' "$@"
+  printf '\n'
+} >>"$TEST_DOCKER_COMMAND_LOG"
+exec "$TEST_REAL_DOCKER" "${arguments[@]}"
+EOF
+chmod 0700 "$wrapper_directory/docker"
+export TEST_REAL_DOCKER="$(command -v docker)"
+export TEST_CANDIDATE_IMAGE="ghcr.io/1024xengineer/xe3-esl-server@$candidate_digest"
+export TEST_PREVIOUS_IMAGE="$previous_image"
+export TEST_FORWARD_IMAGE="$forward_image"
+export TEST_FIXTURE_IMAGE_ID="$fixture_image_id"
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID="$fixture_image_id"
+export TEST_PREVIOUS_FIXTURE_IMAGE_ID="$previous_fixture_image_id"
+export TEST_FORWARD_FIXTURE_IMAGE_ID="$forward_fixture_image_id"
+export TEST_DOCKER_COMMAND_LOG="$command_log"
+export TEST_INSPECT_ERROR_TARGET_FILE="$temporary_directory/inspect-error-target"
+export TEST_INSPECT_ERROR_INJECTED_FILE="$temporary_directory/inspect-error-injected"
+
+success_receipt="$temporary_directory/success-receipt.json"
+success_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" --execute \
+  --backup "$backup_directory" \
+  --manifest "$manifest" \
+  --previous-server-image "$previous_image" \
+  --forward-server-image "$forward_image" \
+  --server-env-file "$server_environment" \
+  --receipt "$success_receipt" \
+  --lock-timeout-seconds 2)"
+success_run_id=$(jq --raw-output '.run_id' "$success_receipt")
+observed_rehearsal_runs+=("$success_run_id")
+[[ "$success_output" == *'rehearsal=verified' ]] ||
+  fail 'successful rehearsal returned an invalid contract'
+jq --exit-status '
+  .status == "succeeded" and .failed_step == null and
+  .source_schema == 7 and .target_schema == 9 and
+  .checks.clean_target_schema == true and
+  .checks.product_health_views == true and
+  .checks.ielts_evaluation_constraint == true and
+  .checks.candidate_readiness == true and
+  .checks.previous_image_readiness_only == true and
+  .checks.previous_image_profile_processing == "not_verified" and
+  .checks.schema7_rollback_guard == true and
+  .checks.same_schema_candidate_redeploy == false and
+  .checks.forward_hotfix_image == "verified" and
+  .forward_server_image == "ghcr.io/1024xengineer/xe3-esl-server@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" and
+  .forward_server_image_version == "0.1.7" and
+  .forward_server_image_revision == "ffffffffffffffffffffffffffffffffffffffff" and
+  .checks.owned_resource_cleanup == true
+' "$success_receipt" >/dev/null || fail 'successful rehearsal receipt is incomplete'
+[[ "$(file_mode "$success_receipt")" == 600 ]] ||
+  fail 'successful rehearsal receipt is not mode 0600'
+! grep -Fq "$secret_value" "$success_receipt" ||
+  fail 'successful receipt exposed the server secret'
+! grep -Fq "$backup_directory" "$success_receipt" ||
+  fail 'successful receipt exposed the backup path'
+[[ -z "$(docker container ls --all --quiet \
+  --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$success_run_id")" ]] ||
+  fail 'successful rehearsal leaked a container'
+! docker network inspect "xe3-speakup-prod-rehearsal-$success_run_id" >/dev/null 2>&1 ||
+  fail 'successful rehearsal leaked its network'
+! docker volume inspect "xe3-speakup-prod-rehearsal-$success_run_id" >/dev/null 2>&1 ||
+  fail 'successful rehearsal leaked its volume'
+grep -Eq '^network create --internal ' "$command_log" ||
+  fail 'rehearsal did not create an internal network'
+if grep -Eq -- '--publish|(^|[[:space:]])-p([[:space:]]|$)|xe3-speakup-production_database' \
+  "$command_log"; then
+  fail 'rehearsal used a host port or Production network'
+fi
+container_create_count=$(grep -Ec '^container create ' "$command_log")
+((container_create_count >= 6)) || fail 'rehearsal did not create all isolated containers'
+while IFS= read -r create_command; do
+  [[ "$create_command" == *'--cpus 1.0'* &&
+    "$create_command" == *'--memory 512m'* &&
+    "$create_command" == *'--pids-limit 256'* &&
+    "$create_command" == *'--log-driver local'* &&
+    "$create_command" == *'--log-opt max-size=10m'* &&
+    "$create_command" == *'--log-opt max-file=3'* ]] ||
+    fail 'an isolated container is missing shared-server resource limits'
+done < <(grep -E '^container create ' "$command_log")
+
+run_schema_fault_test() {
+  local fault=$1 fixture_id=$2 expected_views=$3
+  local fault_receipt="$temporary_directory/$fault-receipt.json"
+  local fault_run_id
+
+  export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_id
+  expect_failure "$fault schema verification" env PATH="$wrapper_directory:$PATH" \
+    "$rehearsal" --execute \
+      --backup "$backup_directory" \
+      --manifest "$manifest" \
+      --previous-server-image "$previous_image" \
+      --server-env-file "$server_environment" \
+      --receipt "$fault_receipt" \
+      --lock-timeout-seconds 2
+  verify_failed_receipt "$fault_receipt" schema_verification
+  jq --exit-status --argjson expected_views "$expected_views" '
+    .checks.clean_target_schema == true and
+    .checks.product_health_views == $expected_views and
+    .checks.ielts_evaluation_constraint == false
+  ' "$fault_receipt" >/dev/null || fail "$fault failure receipt has wrong checks"
+  fault_run_id=$(jq --raw-output '.run_id' "$fault_receipt")
+  observed_rehearsal_runs+=("$fault_run_id")
+  assert_no_rehearsal_resources "$fault_run_id"
+}
+
+run_schema_fault_test missing-view "$missing_view_fixture_image_id" false
+run_schema_fault_test missing-constraint "$missing_constraint_fixture_image_id" true
+run_schema_fault_test invalid-constraint "$invalid_constraint_fixture_image_id" true
+run_schema_fault_test negative-constraint "$negative_constraint_fixture_image_id" true
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_image_id
+
+decoy_candidate_id=$(docker container run --detach --pull never \
+  --name "$decoy_candidate" --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --label 'com.xengineer.speakup.production-rehearsal=true' \
+  --label "com.xengineer.speakup.production-rehearsal-run-id=$decoy_run_id" \
+  "$fixture_image_id")
+decoy_database_id=$(docker container run --detach --pull never \
+  --name "$decoy_database" --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --label 'com.xengineer.speakup.production-rehearsal=true' \
+  --label "com.xengineer.speakup.production-rehearsal-run-id=$decoy_run_id" \
+  "$fixture_image_id")
+
+lock_receipt="$temporary_directory/lock-timeout-receipt.json"
+lock_output="$temporary_directory/lock-timeout.out"
+PATH="$wrapper_directory:$PATH" "$rehearsal" --execute \
+  --backup "$backup_directory" \
+  --manifest "$manifest" \
+  --previous-server-image "$previous_image" \
+  --server-env-file "$server_environment" \
+  --receipt "$lock_receipt" \
+  --lock-timeout-seconds 1 >"$lock_output" 2>&1 &
+rehearsal_pid=$!
+if ! wait_for_pid_rehearsal_container "$rehearsal_pid" db; then
+  wait "$rehearsal_pid" || true
+  fail 'lock-timeout rehearsal did not create one PID-owned database'
+fi
+lock_database=$selected_background_container
+lock_run_id=$selected_background_run_id
+observed_rehearsal_runs+=("$lock_run_id")
+
+schema7_ready=false
+for ((attempt = 1; attempt <= 150; attempt += 1)); do
+  if [[ "$(docker container exec --user postgres "$lock_database" \
+    psql --no-psqlrc --tuples-only --no-align --quiet \
+      --username speakup --dbname speakup \
+      --command "SELECT count(*) FROM public.schema_migrations WHERE version = 7 AND dirty = false AND to_regclass('public.evaluations') IS NOT NULL;" \
+      2>/dev/null || true)" == 1 ]]; then
+    schema7_ready=true
+    break
+  fi
+  sleep 0.1
+done
+[[ "$schema7_ready" == true ]] || {
+  wait "$rehearsal_pid" || true
+  fail 'lock-timeout rehearsal did not restore clean schema 7'
+}
+
+verify_pid_rehearsal_container "$rehearsal_pid" db \
+  "$lock_database" "$lock_run_id" ||
+  fail 'lock-timeout database ownership changed before acquiring the test lock'
+
+docker container exec --user postgres "$lock_database" \
+  psql --no-psqlrc --set ON_ERROR_STOP=1 \
+    --username speakup --dbname speakup \
+    --command 'BEGIN; LOCK TABLE public.evaluations IN ACCESS EXCLUSIVE MODE; SELECT pg_sleep(20);' \
+    >"$temporary_directory/lock-holder.out" 2>&1 &
+lock_holder_pid=$!
+lock_granted=false
+for ((attempt = 1; attempt <= 50; attempt += 1)); do
+  if [[ "$(docker container exec --user postgres "$lock_database" \
+    psql --no-psqlrc --tuples-only --no-align --quiet \
+      --username speakup --dbname speakup \
+      --command "SELECT count(*) FROM pg_catalog.pg_locks l JOIN pg_catalog.pg_class c ON c.oid = l.relation WHERE c.relname = 'evaluations' AND l.mode = 'AccessExclusiveLock' AND l.granted;" \
+      2>/dev/null || true)" == 1 ]]; then
+    lock_granted=true
+    break
+  fi
+  sleep 0.1
+done
+[[ "$lock_granted" == true ]] || {
+  kill "$lock_holder_pid" >/dev/null 2>&1 || true
+  wait "$rehearsal_pid" || true
+  fail 'test could not acquire the migration-blocking lock'
+}
+if wait "$rehearsal_pid"; then
+  kill "$lock_holder_pid" >/dev/null 2>&1 || true
+  wait "$lock_holder_pid" >/dev/null 2>&1 || true
+  fail 'lock-timeout rehearsal unexpectedly succeeded'
+fi
+wait "$lock_holder_pid" >/dev/null 2>&1 || true
+[[ -f "$lock_receipt" && "$(file_mode "$lock_receipt")" == 600 ]] ||
+  fail 'lock-timeout failure did not write a mode 0600 receipt'
+jq --exit-status '
+  .status == "failed" and .failed_step == "migration" and
+  .lock_timeout_seconds == 1 and
+  .checks.clean_target_schema == false and
+  .checks.owned_resource_cleanup == true
+' "$lock_receipt" >/dev/null || fail 'lock-timeout receipt is incomplete'
+[[ -z "$(docker container ls --all --quiet \
+  --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$lock_run_id")" ]] ||
+  fail 'lock-timeout rehearsal leaked a container'
+! docker network inspect "xe3-speakup-prod-rehearsal-$lock_run_id" >/dev/null 2>&1 ||
+  fail 'lock-timeout rehearsal leaked its network'
+! docker volume inspect "xe3-speakup-prod-rehearsal-$lock_run_id" >/dev/null 2>&1 ||
+  fail 'lock-timeout rehearsal leaked its volume'
+
+command -v perl >/dev/null 2>&1 || fail 'perl is required for signal tests'
+interruption_pid=''
+interruption_candidate=''
+interruption_run_id=''
+
+start_interruptible_rehearsal() {
+  local selected_receipt=$1 selected_output=$2
+
+  PATH="$wrapper_directory:$PATH" perl -e '
+    $SIG{INT} = "DEFAULT";
+    $SIG{TERM} = "DEFAULT";
+    exec @ARGV or die "exec failed";
+  ' "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$selected_receipt" \
+    --lock-timeout-seconds 2 >"$selected_output" 2>&1 &
+  interruption_pid=$!
+}
+
+wait_for_candidate_container() {
+  wait_for_pid_rehearsal_container "$interruption_pid" candidate || return 1
+  interruption_candidate=$selected_background_container
+  interruption_run_id=$selected_background_run_id
+}
+
+run_signal_cleanup_test() {
+  local signal=$1 suffix=$2
+  local signal_receipt="$temporary_directory/$suffix-receipt.json"
+  local signal_output="$temporary_directory/$suffix.out"
+  local signal_run_id
+
+  start_interruptible_rehearsal "$signal_receipt" "$signal_output"
+  wait_for_candidate_container || {
+    wait "$interruption_pid" >/dev/null 2>&1 || true
+    fail "$signal test did not reach one PID-owned candidate"
+  }
+  signal_run_id=$interruption_run_id
+  observed_rehearsal_runs+=("$signal_run_id")
+  verify_pid_rehearsal_container "$interruption_pid" candidate \
+    "$interruption_candidate" "$signal_run_id" ||
+    fail "$signal candidate ownership changed before $signal"
+  kill -"$signal" "$interruption_pid"
+  if wait "$interruption_pid"; then
+    fail "$signal interruption unexpectedly succeeded"
+  fi
+  verify_failed_receipt "$signal_receipt" candidate_readiness
+  assert_no_rehearsal_resources "$signal_run_id"
+}
+
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$interrupt_fixture_image_id
+run_signal_cleanup_test TERM sigterm
+run_signal_cleanup_test INT sigint
+
+replacement_receipt="$temporary_directory/replacement-receipt.json"
+replacement_output="$temporary_directory/replacement.out"
+start_interruptible_rehearsal "$replacement_receipt" "$replacement_output"
+wait_for_candidate_container || {
+  wait "$interruption_pid" >/dev/null 2>&1 || true
+  fail 'replacement test did not reach one PID-owned candidate'
+}
+replacement_run_id=$interruption_run_id
+observed_rehearsal_runs+=("$replacement_run_id")
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$replacement_run_id" ||
+  fail 'replacement candidate ownership changed before stopping the rehearsal'
+kill -STOP "$interruption_pid"
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$replacement_run_id" ||
+  fail 'replacement candidate ownership changed before queuing termination'
+kill -TERM "$interruption_pid"
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$replacement_run_id" ||
+  fail 'replacement candidate ownership changed before removal'
+original_candidate_id=$(docker container inspect --format '{{.Id}}' \
+  "$interruption_candidate")
+docker container rm --force "$original_candidate_id" >/dev/null
+replacement_id=$(docker container create \
+  --name "$interruption_candidate" \
+  --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$fixture_image_id")
+kill -CONT "$interruption_pid"
+if wait "$interruption_pid"; then
+  fail 'replacement interruption unexpectedly succeeded'
+fi
+[[ -f "$replacement_receipt" && "$(file_mode "$replacement_receipt")" == 600 ]] ||
+  fail 'replacement failure did not write a mode 0600 receipt'
+jq --exit-status '
+  .status == "failed" and .failed_step == "cleanup" and
+  .checks.owned_resource_cleanup == false
+' "$replacement_receipt" >/dev/null ||
+  fail 'replacement failure receipt did not fail closed'
+[[ "$(docker container inspect --format '{{.Id}}' "$replacement_id")" == \
+  "$replacement_id" ]] || fail 'cleanup deleted the replacement container'
+remove_test_container "$interruption_candidate" ||
+  fail 'test could not remove its preserved replacement container'
+assert_no_rehearsal_resources "$replacement_run_id"
+
+inspect_error_receipt="$temporary_directory/inspect-error-receipt.json"
+inspect_error_output="$temporary_directory/inspect-error.out"
+start_interruptible_rehearsal "$inspect_error_receipt" "$inspect_error_output"
+wait_for_candidate_container || {
+  wait "$interruption_pid" >/dev/null 2>&1 || true
+  fail 'inspect-error test did not reach one PID-owned candidate'
+}
+inspect_error_run_id=$interruption_run_id
+observed_rehearsal_runs+=("$inspect_error_run_id")
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$inspect_error_run_id" ||
+  fail 'inspect-error candidate ownership changed before fault injection'
+inspect_error_candidate_inspection=$(docker container inspect \
+  "$interruption_candidate")
+inspect_error_candidate_id=$(jq --exit-status --raw-output \
+  'if length == 1 then .[0].Id else empty end' \
+  <<<"$inspect_error_candidate_inspection") ||
+  fail 'inspect-error candidate has no immutable ID'
+jq --exit-status \
+  --arg id "$inspect_error_candidate_id" \
+  --arg name "$interruption_candidate" \
+  --arg run "$inspect_error_run_id" '
+    length == 1 and .[0].Id == $id and .[0].Name == ("/" + $name) and
+    .[0].Config.Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+    .[0].Config.Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+  ' <<<"$inspect_error_candidate_inspection" >/dev/null ||
+  fail 'inspect-error target is not the current PID-owned candidate'
+printf '%s\n' "$inspect_error_candidate_id" >"$TEST_INSPECT_ERROR_TARGET_FILE"
+chmod 0600 "$TEST_INSPECT_ERROR_TARGET_FILE"
+docker container stop --time 2 "$inspect_error_candidate_id" >/dev/null ||
+  fail 'inspect-error test could not stop its verified candidate'
+if wait "$interruption_pid"; then
+  fail 'inspect-error rehearsal unexpectedly succeeded'
+else
+  inspect_error_status=$?
+fi
+[[ "$inspect_error_status" == 1 ]] ||
+  fail "inspect-error rehearsal returned unexpected status $inspect_error_status"
+[[ -f "$TEST_INSPECT_ERROR_INJECTED_FILE" &&
+  ! -L "$TEST_INSPECT_ERROR_INJECTED_FILE" &&
+  "$(file_mode "$TEST_INSPECT_ERROR_INJECTED_FILE")" == 600 &&
+  "$(<"$TEST_INSPECT_ERROR_INJECTED_FILE")" == "$inspect_error_candidate_id" ]] ||
+  fail 'inspect-error wrapper did not inject against the verified candidate ID'
+grep -Fxq \
+  'Production schema rehearsal error: isolated Server image stopped before readiness' \
+  "$inspect_error_output" ||
+  fail 'inspect-error rehearsal did not report the expected natural readiness failure'
+[[ -e "$inspect_error_receipt" || -L "$inspect_error_receipt" ]] ||
+  fail 'inspect-error failure receipt is missing after confirmed injection'
+[[ -f "$inspect_error_receipt" && ! -L "$inspect_error_receipt" ]] ||
+  fail 'inspect-error failure receipt is not a regular file'
+inspect_error_receipt_mode=$(file_mode "$inspect_error_receipt") ||
+  fail 'inspect-error failure receipt mode cannot be inspected'
+[[ "$inspect_error_receipt_mode" == 600 ]] ||
+  fail "inspect-error failure receipt mode is $inspect_error_receipt_mode, expected 600"
+jq --exit-status '
+  .status == "failed" and .failed_step == "cleanup" and
+  .checks.owned_resource_cleanup == false
+' "$inspect_error_receipt" >/dev/null ||
+  fail 'inspect-error cleanup did not fail closed'
+[[ "$(docker container inspect --format '{{.Id}}' \
+  "$inspect_error_candidate_id")" == "$inspect_error_candidate_id" ]] ||
+  fail 'inspect error caused cleanup to delete an unverified container'
+rm "$TEST_INSPECT_ERROR_TARGET_FILE"
+rm "$TEST_INSPECT_ERROR_INJECTED_FILE"
+remove_rehearsal_run "$inspect_error_run_id" ||
+  fail 'test could not remove inspect-error resources after verification'
+assert_no_rehearsal_resources "$inspect_error_run_id"
+[[ "$(docker container inspect --format '{{.Id}}' "$decoy_candidate")" == \
+  "$decoy_candidate_id" ]] || fail 'candidate selection modified the concurrent decoy'
+[[ "$(docker container inspect --format '{{.Id}}' "$decoy_database")" == \
+  "$decoy_database_id" ]] || fail 'database selection modified the concurrent decoy'
+remove_test_container "$decoy_candidate" || fail 'cannot remove candidate decoy'
+remove_test_container "$decoy_database" || fail 'cannot remove database decoy'
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_image_id
+
+printf '%s\n' 'Production schema rehearsal tests passed'


### PR DESCRIPTION
## 功能描述

为 v0.1.6 Production schema 7→9 上线增加可追溯、fail-closed 的隔离演练工具。演练只使用显式指定的 finalized 备份、release manifest 与不可变 Server 镜像，在独立 Docker network/container/volume 中执行，不连接 Production network、不暴露宿主机端口，也不自动部署或切换正式数据库。

## 实现思路

- 新增 `rehearse-schema-upgrade.sh`，默认只做 dry-run；仅显式 `--execute` 后读取 dump、检查镜像并创建临时资源。
- 冻结并校验 manifest 快照，严格校验备份目录/文件权限、SHA-256、schema 7 元数据，以及 candidate/previous OCI version 与 revision。
- 恢复 PostgreSQL 18 副本，设置有限 lock timeout，迁移到 clean schema 9，并精确核验 5 个统计 View、security barrier 与 IELTS evaluation kind 正向约束。
- 验证 candidate readiness、v0.1.4 readiness-only 兼容边界、schema 9→7 rollback fail-closed；可选使用不同 digest 的 forward image 验证同 schema 前向修复。
- 临时容器统一限制为 1 CPU / 512 MiB / 256 PID，使用 local 日志轮转；按 immutable container ID、名称与双标签清理，无法证明安全时保守失败。
- 成功、失败与信号中断均生成 `0600` 脱敏 JSON 回执，不记录密钥、连接串、业务内容或 dump 路径。
- 将演练合同接入 Deployment CI。

## 可复现测试

```sh
make check-production-rehearsal
make check-production-deploy
make check-production-backup
bash -n deploy/production/manage.sh \
  deploy/production/rehearse-schema-upgrade.sh \
  deploy/production/test-rehearsal.sh
git diff --check upstream/dev...HEAD
```

覆盖：schema 7→9 成功、锁超时、无效 env/manifest/metadata、缺失 View/constraint、反向 `NOT IN` constraint、不同 digest forward migration/readiness、SIGTERM/SIGINT 清理、同名 replacement、Docker inspect error，以及两份完整演练并发互不误锁/误删。两份并发演练均返回 0，测试后无相关 container/network/volume 残留。

本 PR 未访问生产服务器、真实生产备份或任何云服务密钥，也未执行 Staging/Production 部署。

Closes #956
Related #953
