### PR TITLE
release: promote v0.1.6 to main

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -462,6 +462,9 @@ jobs:
       - name: Exercise Production PostgreSQL backup and isolated restore
         run: make check-production-backup
 
+      - name: Exercise isolated Production schema upgrade rehearsal
+        run: make check-production-rehearsal
+
       - name: Validate offline release contract
         run: make check-offline-release
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SHELL := /bin/bash
 	check-api-contracts \
 	check-release-candidate \
 	check-production-backup \
+	check-production-rehearsal \
 	check-offline-release \
 	check-android-download \
 	check-tls-lifecycle \
@@ -56,6 +57,7 @@ help:
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
 		'  make check-production-backup  Exercise PostgreSQL backup and isolated restore' \
+		'  make check-production-rehearsal  Validate the isolated schema 7 to 9 rehearsal' \
 		'  make check-offline-release  Validate offline image build/load contracts' \
 		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-tls-lifecycle  Validate TLS issuance and renewal contracts' \
@@ -307,6 +309,9 @@ check-release-candidate:
 
 check-production-backup:
 	./deploy/production/test-backup.sh
+
+check-production-rehearsal:
+	./deploy/production/test-rehearsal.sh
 
 check-offline-release:
 	./tools/release-candidate/build-offline-images.test.sh

--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,7 @@ check-production-nginx:
 	./deploy/production/test-nginx.sh
 
 check-staging-deploy:
+	node --test deploy/staging/uat.test.mjs
 	./deploy/staging/test.sh
 
 check-staging-nginx:

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -293,6 +293,53 @@ loopback bindings, the exact runtime identities and image digests, and the clean
 database schema from the selected manifest. Public HTTPS and business-route
 smoke tests remain part of the higher-level release Workflow.
 
+## Rehearse a schema upgrade without touching Production
+
+Before promoting a Release Candidate that advances schema 7 to schema 9, run
+the isolated rehearsal with the finalized Production backup, the reviewed
+manifest, and both immutable Server image identities. The command is a dry-run
+unless `--execute` is present. When a distinct forward-hotfix image exists, add
+its immutable official digest with `--forward-server-image`; it must differ from
+both the candidate and previous images:
+
+```sh
+./deploy/production/rehearse-schema-upgrade.sh \
+  --backup /var/lib/speakup/postgres-backups/20260825T010203Z-predeploy \
+  --manifest /opt/speakup/releases/v0.1.6/release-manifest.json \
+  --previous-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:DIGEST \
+  --forward-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:FORWARD_DIGEST \
+  --server-env-file /etc/speakup/production-server.env \
+  --receipt /opt/speakup/releases/v0.1.6/schema-rehearsal-receipt.json \
+  --lock-timeout-seconds 5
+```
+
+The dry-run validates the backup metadata, manifest, private Server environment
+file, image references and no-clobber receipt path. It does not read the dump,
+inspect images, create Docker resources or write a receipt. After reviewing the
+output, repeat the exact command with `--execute`.
+
+Execution restores the dump into a uniquely named, labeled volume on an
+internal Docker network with no host ports or Production network attachment. It
+runs the manifest-pinned migration image with a finite PostgreSQL lock timeout,
+then verifies clean schema 9, the five product-health views, the IELTS
+evaluation constraint, candidate readiness, the old image's readiness-only
+boundary, rollback fail-closed behavior and a same-schema redeploy of the same
+candidate image. If a distinct forward image is supplied, that final step uses
+the forward image instead and records its OCI version and revision only after
+its migration preserves clean schema 9 and its Server passes readiness.
+The old image is **not** claimed to process schema-9 profiles correctly. Success
+or failure produces a mode `0600`, redacted receipt after owned-resource cleanup;
+failure or interruption never removes unlabeled or differently labeled Docker
+resources.
+
+This repository test uses a synthetic schema-7 backup and local fixture images.
+It does not replace the required runtime evidence from the selected finalized
+Production backup and the actual immutable Release Candidate and previous image.
+Without `--forward-server-image`, the receipt explicitly records that no forward
+image was provided. If an incident later requires a distinct hotfix image, rerun
+the rehearsal with that immutable image before promoting it; the earlier
+same-candidate redeploy is not forward-hotfix evidence.
+
 ## Capture the initial Production baseline
 
 Create the first receipt once, before the first automated promotion. The live
@@ -539,6 +586,7 @@ database.
 
 ```sh
 make check-production-backup
+make check-production-rehearsal
 make check-android-download
 make check-production-deploy
 make check-production-nginx

--- a/deploy/production/manage.sh
+++ b/deploy/production/manage.sh
@@ -25,6 +25,8 @@ readonly server_readiness_url="http://127.0.0.1:18083/readyz"
 usage() {
   cat >&2 <<'EOF'
 Usage:
+  manage.sh validate-manifest --manifest FILE
+  manage.sh validate-rollback-schema --current-schema N --target-schema N
   manage.sh validate --manifest FILE --env-file FILE
   manage.sh baseline --manifest FILE --env-file FILE --receipt FILE
   manage.sh deploy --manifest FILE --env-file FILE --bundle DIRECTORY --current-receipt FILE --receipt FILE
@@ -819,6 +821,18 @@ validate_receipt_target() {
   require_owned_directory "Production receipt directory" "$directory"
   [[ -w "$directory" ]] ||
     fail "Production receipt directory is not writable: $directory"
+}
+
+require_matching_rollback_schema() {
+  local current_schema=$1
+  local target_schema=$2
+
+  [[ "$current_schema" =~ ^[1-9][0-9]*$ ]] ||
+    fail "current rollback schema must be a positive integer"
+  [[ "$target_schema" =~ ^[1-9][0-9]*$ ]] ||
+    fail "target rollback schema must be a positive integer"
+  [[ "$current_schema" == "$target_schema" ]] ||
+    fail "rollback requires the current database schema to match the target release"
 }
 
 require_safe_lock_file() {
@@ -1660,8 +1674,8 @@ rollback_production() {
     fail "a Production receipt changed while waiting for the deployment lock"
   validate_receipt_matches_release TARGET
   validate_current_receipt_state "$current_receipt" CURRENT
-  [[ "$CURRENT_SCHEMA_VERSION" == "$SELECTED_SCHEMA_VERSION" ]] ||
-    fail "rollback requires the current database schema to match the target release"
+  require_matching_rollback_schema \
+    "$CURRENT_SCHEMA_VERSION" "$SELECTED_SCHEMA_VERSION"
   acquire_backup_locks
 
   use_release_state SELECTED
@@ -1708,6 +1722,8 @@ main() {
   local receipt=""
   local current_receipt=""
   local target_receipt=""
+  local current_schema=""
+  local target_schema=""
 
   [[ -n "$command" ]] || {
     usage
@@ -1751,11 +1767,46 @@ main() {
         target_receipt=$2
         shift 2
         ;;
+      --current-schema)
+        (($# >= 2)) || fail "--current-schema requires a value"
+        current_schema=$2
+        shift 2
+        ;;
+      --target-schema)
+        (($# >= 2)) || fail "--target-schema requires a value"
+        target_schema=$2
+        shift 2
+        ;;
       *)
         fail "unknown argument: $1"
         ;;
     esac
   done
+
+  if [[ "$command" == "validate-manifest" ]]; then
+    [[ -n "$manifest" ]] || fail "validate-manifest requires --manifest"
+    [[ -z "$environment_file$output$bundle$receipt$current_receipt$target_receipt$current_schema$target_schema" ]] ||
+      fail "validate-manifest accepts only --manifest"
+    validate_manifest "$manifest"
+    printf 'version=%s git_sha=%s schema=%s manifest_sha256=%s validated=true\n' \
+      "$RELEASE_VERSION" "$RELEASE_GIT_SHA" "$RELEASE_SCHEMA_VERSION" \
+      "$RELEASE_MANIFEST_SHA256"
+    return
+  fi
+
+  if [[ "$command" == "validate-rollback-schema" ]]; then
+    [[ -n "$current_schema" && -n "$target_schema" ]] ||
+      fail "validate-rollback-schema requires both schema values"
+    [[ -z "$manifest$environment_file$output$bundle$receipt$current_receipt$target_receipt" ]] ||
+      fail "validate-rollback-schema accepts only schema values"
+    require_matching_rollback_schema "$current_schema" "$target_schema"
+    printf 'current_schema=%s target_schema=%s rollback_allowed=true\n' \
+      "$current_schema" "$target_schema"
+    return
+  fi
+
+  [[ -z "$current_schema$target_schema" ]] ||
+    fail "$command does not accept rollback schema values"
 
   [[ -n "$environment_file" ]] || fail "--env-file is required"
   load_configuration "$environment_file"

--- a/deploy/production/rehearse-schema-upgrade.sh
+++ b/deploy/production/rehearse-schema-upgrade.sh
@@ -1,0 +1,1096 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly production_manager="$production_directory/manage.sh"
+readonly postgres_image='postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+readonly server_repository='ghcr.io/1024xengineer/xe3-esl-server'
+readonly resource_label='com.xengineer.speakup.production-rehearsal'
+readonly run_label='com.xengineer.speakup.production-rehearsal-run-id'
+readonly source_project='xe3-speakup-production'
+readonly source_service='postgres'
+readonly source_volume='xe3-speakup-postgres-data'
+readonly source_schema=7
+readonly target_schema=9
+readonly container_cpus='1.0'
+readonly container_memory='512m'
+readonly container_memory_bytes=536870912
+readonly container_pids_limit=256
+readonly container_log_max_size='10m'
+readonly container_log_max_file='3'
+
+execute=false
+backup_directory=''
+manifest=''
+manifest_snapshot_directory=''
+manifest_snapshot=''
+previous_server_image=''
+forward_server_image=''
+validated_forward_server_image=''
+server_environment=''
+receipt=''
+lock_timeout_seconds=''
+run_id=''
+network_name=''
+volume_name=''
+declare -a container_names=()
+declare -a container_ids=()
+postgres_container_id=''
+last_created_container_id=''
+receipt_ready=false
+docker_touched=false
+cleanup_verified=false
+phase='preflight'
+started_at_seconds=0
+restore_duration_seconds=0
+migration_duration_seconds=0
+total_duration_seconds=0
+release_version=''
+release_git_sha=''
+release_manifest_sha256=''
+candidate_server_image=''
+selected_backup_id=''
+selected_backup_sha256=''
+selected_database=''
+selected_database_user=''
+backup_deployment_version=''
+backup_git_sha=''
+forward_server_image_version=''
+forward_server_image_revision=''
+forward_hotfix_status='not_provided'
+schema_verified=false
+views_verified=false
+constraint_verified=false
+candidate_readiness_verified=false
+previous_readiness_verified=false
+rollback_guard_verified=false
+same_schema_candidate_redeploy_verified=false
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  rehearse-schema-upgrade.sh [--execute] \
+    --backup DIRECTORY \
+    --manifest FILE \
+    --previous-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:DIGEST \
+    [--forward-server-image ghcr.io/1024xengineer/xe3-esl-server@sha256:DIGEST] \
+    --server-env-file FILE \
+    --receipt FILE \
+    --lock-timeout-seconds N
+
+Without --execute this performs a read-only dry-run. It validates metadata but
+does not read database.dump, inspect images, or create Docker resources.
+EOF
+}
+
+fail() {
+  printf 'Production schema rehearsal error: %s\n' "$*" >&2
+  exit 1
+}
+
+now_seconds() {
+  date -u +%s
+}
+
+write_receipt() {
+  local status=$1 temporary recorded_at parent
+
+  parent=${receipt%/*}
+  temporary=$(mktemp "$parent/.production-rehearsal-receipt.XXXXXX") || return 1
+  recorded_at=$(date -u +%Y-%m-%dT%H:%M:%SZ) || {
+    rm -f -- "$temporary"
+    return 1
+  }
+  if ! jq --null-input --sort-keys \
+    --arg status "$status" \
+    --arg failed_step "$phase" \
+    --arg run_id "$run_id" \
+    --arg backup_id "$selected_backup_id" \
+    --arg backup_sha256 "$selected_backup_sha256" \
+    --arg manifest_sha256 "$release_manifest_sha256" \
+    --arg version "$release_version" \
+    --arg git_sha "$release_git_sha" \
+    --arg candidate_server_image "$candidate_server_image" \
+    --arg previous_server_image "$previous_server_image" \
+    --arg forward_server_image "$validated_forward_server_image" \
+    --arg forward_server_image_version "$forward_server_image_version" \
+    --arg forward_server_image_revision "$forward_server_image_revision" \
+    --arg forward_hotfix_status "$forward_hotfix_status" \
+    --arg recorded_at "$recorded_at" \
+    --argjson source_schema "$source_schema" \
+    --argjson target_schema "$target_schema" \
+    --argjson lock_timeout_seconds "$lock_timeout_seconds" \
+    --argjson restore_duration_seconds "$restore_duration_seconds" \
+    --argjson migration_duration_seconds "$migration_duration_seconds" \
+    --argjson total_duration_seconds "$total_duration_seconds" \
+    --argjson schema_verified "$schema_verified" \
+    --argjson views_verified "$views_verified" \
+    --argjson constraint_verified "$constraint_verified" \
+    --argjson candidate_readiness_verified "$candidate_readiness_verified" \
+    --argjson previous_readiness_verified "$previous_readiness_verified" \
+    --argjson rollback_guard_verified "$rollback_guard_verified" \
+    --argjson same_schema_candidate_redeploy_verified \
+      "$same_schema_candidate_redeploy_verified" \
+    --argjson cleanup_verified "$cleanup_verified" '
+      {
+        receipt_version: 1,
+        operation: "production_schema_upgrade_rehearsal",
+        environment: "isolated",
+        status: $status,
+        failed_step: (if $status == "failed" then $failed_step else null end),
+        run_id: $run_id,
+        backup_id: (if $backup_id == "" then null else $backup_id end),
+        backup_sha256:
+          (if $backup_sha256 == "" then null else $backup_sha256 end),
+        manifest_sha256:
+          (if $manifest_sha256 == "" then null else $manifest_sha256 end),
+        version: (if $version == "" then null else $version end),
+        git_sha: (if $git_sha == "" then null else $git_sha end),
+        candidate_server_image:
+          (if $candidate_server_image == "" then null else $candidate_server_image end),
+        previous_server_image:
+          (if $previous_server_image == "" then null else $previous_server_image end),
+        forward_server_image:
+          (if $forward_server_image == "" then null else $forward_server_image end),
+        forward_server_image_version:
+          (if $forward_server_image_version == "" then null
+           else $forward_server_image_version end),
+        forward_server_image_revision:
+          (if $forward_server_image_revision == "" then null
+           else $forward_server_image_revision end),
+        source_schema: $source_schema,
+        target_schema: $target_schema,
+        lock_timeout_seconds: $lock_timeout_seconds,
+        restore_duration_seconds: $restore_duration_seconds,
+        migration_duration_seconds: $migration_duration_seconds,
+        total_duration_seconds: $total_duration_seconds,
+        checks: {
+          clean_target_schema: $schema_verified,
+          product_health_views: $views_verified,
+          ielts_evaluation_constraint: $constraint_verified,
+          candidate_readiness: $candidate_readiness_verified,
+          previous_image_readiness_only: $previous_readiness_verified,
+          previous_image_profile_processing: "not_verified",
+          schema7_rollback_guard: $rollback_guard_verified,
+          same_schema_candidate_redeploy: $same_schema_candidate_redeploy_verified,
+          forward_hotfix_image: $forward_hotfix_status,
+          owned_resource_cleanup: $cleanup_verified
+        },
+        recorded_at_utc: $recorded_at
+      }
+    ' >"$temporary"; then
+    rm -f -- "$temporary"
+    return 1
+  fi
+  chmod 0600 "$temporary" || {
+    rm -f -- "$temporary"
+    return 1
+  }
+  if ! ln "$temporary" "$receipt"; then
+    rm -f -- "$temporary"
+    return 1
+  fi
+  rm -f -- "$temporary"
+  [[ "$(path_mode "$receipt")" == 600 ]]
+}
+
+cleanup_on_exit() {
+  local status=$?
+
+  trap - EXIT INT HUP TERM
+  set +e
+  if [[ "$docker_touched" == true ]]; then
+    if cleanup_owned_resources; then
+      cleanup_verified=true
+    else
+      cleanup_verified=false
+      status=1
+      phase='cleanup'
+    fi
+  elif [[ "$execute" == true ]]; then
+    cleanup_verified=true
+  fi
+  if ! cleanup_manifest_snapshot; then
+    status=1
+    phase='cleanup'
+  fi
+  if ((started_at_seconds > 0)); then
+    total_duration_seconds=$(( $(now_seconds) - started_at_seconds ))
+  fi
+  if [[ "$execute" == true && "$receipt_ready" == true ]]; then
+    if ((status == 0)); then
+      if write_receipt succeeded; then
+        printf 'backup_id=%s version=%s source_schema=%s target_schema=%s receipt=%s rehearsal=verified\n' \
+          "$selected_backup_id" "$release_version" "$source_schema" \
+          "$target_schema" "$receipt"
+      else
+        status=1
+      fi
+    else
+      write_receipt failed || status=1
+    fi
+  fi
+  exit "$status"
+}
+
+cleanup_manifest_snapshot() {
+  local name
+
+  [[ -n "$manifest_snapshot_directory" ]] || return 0
+  name=${manifest_snapshot_directory##*/}
+  [[ "$name" == xe3-production-rehearsal-manifest.* &&
+    -d "$manifest_snapshot_directory" && ! -L "$manifest_snapshot_directory" &&
+    "$(path_owner "$manifest_snapshot_directory")" == "$EUID" ]] || return 1
+  if [[ -e "$manifest_snapshot" || -L "$manifest_snapshot" ]]; then
+    [[ "$manifest_snapshot" == "$manifest_snapshot_directory/release-manifest.json" &&
+      -f "$manifest_snapshot" && ! -L "$manifest_snapshot" &&
+      "$(path_owner "$manifest_snapshot")" == "$EUID" ]] || return 1
+    rm -- "$manifest_snapshot" || return 1
+  fi
+  rmdir -- "$manifest_snapshot_directory" || return 1
+  manifest_snapshot_directory=''
+  manifest_snapshot=''
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+path_mode() {
+  if stat -c '%a' -- "$1" >/dev/null 2>&1; then
+    stat -c '%a' -- "$1"
+  else
+    stat -f '%Lp' "$1"
+  fi
+}
+
+path_owner() {
+  if stat -c '%u' -- "$1" >/dev/null 2>&1; then
+    stat -c '%u' -- "$1"
+  else
+    stat -f '%u' "$1"
+  fi
+}
+
+file_size() {
+  if stat -c '%s' -- "$1" >/dev/null 2>&1; then
+    stat -c '%s' -- "$1"
+  else
+    stat -f '%z' "$1"
+  fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  else
+    fail 'sha256sum or shasum is required'
+  fi
+}
+
+valid_absolute_path() {
+  local value=$1
+
+  [[ "$value" =~ ^/[A-Za-z0-9._/-]+$ ]] &&
+    [[ "$value" != / && "$value" != *//* ]] &&
+    [[ "$value" != */../* && "$value" != */.. ]] &&
+    [[ "$value" != */./* && "$value" != */. ]]
+}
+
+require_regular_file() {
+  local description=$1
+  local file=$2
+
+  [[ -f "$file" && ! -L "$file" && -r "$file" && -s "$file" ]] ||
+    fail "$description must be a readable non-empty regular file"
+}
+
+require_private_file() {
+  local description=$1
+  local file=$2
+  local mode
+
+  require_regular_file "$description" "$file"
+  [[ "$(path_owner "$file")" == "$EUID" ]] ||
+    fail "$description must be owned by the current user"
+  mode=$(path_mode "$file") || fail "cannot inspect $description permissions"
+  [[ "$mode" == 400 || "$mode" == 600 ]] ||
+    fail "$description must have mode 0400 or 0600"
+}
+
+require_receipt_target() {
+  local parent mode
+
+  valid_absolute_path "$receipt" || fail '--receipt must be a safe absolute path'
+  [[ ! -e "$receipt" && ! -L "$receipt" ]] ||
+    fail 'rehearsal receipt already exists'
+  parent=${receipt%/*}
+  [[ -d "$parent" && ! -L "$parent" && -w "$parent" ]] ||
+    fail 'rehearsal receipt parent must be a writable real directory'
+  [[ "$(path_owner "$parent")" == "$EUID" ]] ||
+    fail 'rehearsal receipt parent must be owned by the current user'
+  mode=$(path_mode "$parent") || fail 'cannot inspect receipt parent permissions'
+  (( (8#$mode & 0022) == 0 )) ||
+    fail 'rehearsal receipt parent cannot be group or world writable'
+}
+
+validate_manifest() {
+  local output mode canonical temporary_base
+
+  require_regular_file 'release manifest' "$manifest"
+  valid_absolute_path "$manifest" || fail '--manifest must be a safe absolute path'
+  canonical=$(realpath "$manifest") || fail 'cannot resolve release manifest'
+  [[ "$canonical" == "$manifest" ]] || fail '--manifest must be a canonical path'
+  [[ "$(path_owner "$manifest")" == "$EUID" ]] ||
+    fail 'release manifest must be owned by the current user'
+  mode=$(path_mode "$manifest") || fail 'cannot inspect release manifest permissions'
+  (( (8#$mode & 0022) == 0 )) ||
+    fail 'release manifest cannot be group or world writable'
+
+  temporary_base=${TMPDIR:-/tmp}
+  temporary_base=${temporary_base%/}
+  manifest_snapshot_directory=$(mktemp -d \
+    "$temporary_base/xe3-production-rehearsal-manifest.XXXXXX") ||
+    fail 'cannot create private manifest snapshot directory'
+  chmod 0700 "$manifest_snapshot_directory" ||
+    fail 'cannot protect manifest snapshot directory'
+  manifest_snapshot="$manifest_snapshot_directory/release-manifest.json"
+  cp "$manifest" "$manifest_snapshot" || fail 'cannot freeze release manifest snapshot'
+  chmod 0600 "$manifest_snapshot" || fail 'cannot protect release manifest snapshot'
+
+  output=$("$production_manager" validate-manifest --manifest "$manifest_snapshot") ||
+    fail 'release manifest validation failed'
+  [[ "$output" =~ ^version=([0-9]+\.[0-9]+\.[0-9]+)[[:space:]]git_sha=([a-f0-9]{40})[[:space:]]schema=([1-9][0-9]*)[[:space:]]manifest_sha256=([a-f0-9]{64})[[:space:]]validated=true$ ]] ||
+    fail 'release manifest validator returned an invalid contract'
+  [[ "${BASH_REMATCH[3]}" == "$target_schema" ]] ||
+    fail "release manifest must target schema $target_schema"
+  release_version=${BASH_REMATCH[1]}
+  release_git_sha=${BASH_REMATCH[2]}
+  release_manifest_sha256=${BASH_REMATCH[4]}
+  candidate_server_image="$server_repository@$(jq --raw-output \
+    '.server_image_digest' "$manifest_snapshot")"
+}
+
+validate_previous_server_image() {
+  [[ "$previous_server_image" =~ ^${server_repository}@sha256:[a-f0-9]{64}$ ]] ||
+    fail '--previous-server-image must be an immutable official Server digest'
+  [[ "$previous_server_image" != "$candidate_server_image" ]] ||
+    fail 'previous and candidate Server images must differ'
+}
+
+validate_forward_server_image() {
+  [[ -n "$forward_server_image" ]] || return 0
+  [[ "$forward_server_image" =~ ^${server_repository}@sha256:[a-f0-9]{64}$ ]] ||
+    fail '--forward-server-image must be an immutable official Server digest'
+  [[ "$forward_server_image" != "$candidate_server_image" &&
+    "$forward_server_image" != "$previous_server_image" ]] ||
+    fail 'forward Server image must differ from candidate and previous images'
+  validated_forward_server_image=$forward_server_image
+}
+
+validate_backup_metadata() {
+  local backup_id checksum_line expected_checksum expected_size actual_size mode canonical
+  local entry name
+  local -a entries
+
+  [[ -d "$backup_directory" && ! -L "$backup_directory" ]] ||
+    fail '--backup must be a real directory'
+  valid_absolute_path "$backup_directory" || fail '--backup must be a safe absolute path'
+  canonical=$(realpath "$backup_directory") || fail 'cannot resolve backup directory'
+  [[ "$canonical" == "$backup_directory" ]] || fail '--backup must be a canonical path'
+  [[ "$(path_owner "$backup_directory")" == "$EUID" ]] ||
+    fail 'backup directory must be owned by the current user'
+  mode=$(path_mode "$backup_directory") || fail 'cannot inspect backup directory permissions'
+  [[ "$mode" == 700 ]] || fail 'backup directory must have mode 0700'
+  backup_id=${backup_directory##*/}
+  [[ "$backup_id" =~ ^[0-9]{8}T[0-9]{6}Z-(daily|predeploy)$ ]] ||
+    fail 'backup directory name is not a finalized backup ID'
+
+  shopt -s nullglob dotglob
+  entries=("$backup_directory"/*)
+  shopt -u nullglob dotglob
+  [[ ${#entries[@]} == 3 ]] ||
+    fail 'backup directory must contain exactly three contract files'
+  for entry in "${entries[@]}"; do
+    name=${entry##*/}
+    case "$name" in
+      database.dump | database.dump.sha256 | metadata.json) ;;
+      *) fail 'backup directory contains an unexpected entry' ;;
+    esac
+    require_private_file "backup $name" "$entry"
+    [[ "$(path_mode "$entry")" == 600 ]] ||
+      fail "backup $name must have mode 0600"
+  done
+
+  jq --exit-status \
+    --arg backup_id "$backup_id" \
+    --arg postgres_image "$postgres_image" \
+    --arg source_project "$source_project" \
+    --arg source_service "$source_service" \
+    --arg source_volume "$source_volume" \
+    --argjson source_schema "$source_schema" '
+      type == "object" and
+      keys == [
+        "backup_id", "backup_type", "created_at", "database_name",
+        "database_user", "deployment_version", "format_version", "git_sha",
+        "postgres_image", "postgres_version", "schema_dirty", "schema_version",
+        "sha256", "size_bytes", "source_compose_project",
+        "source_compose_service", "source_volume"
+      ] and
+      .format_version == 1 and
+      .backup_id == $backup_id and
+      (.backup_type == "daily" or .backup_type == "predeploy") and
+      ((.created_at | gsub("[-:]"; "")) + "-" + .backup_type == .backup_id) and
+      (.created_at | type == "string" and fromdateiso8601 > 0) and
+      (.deployment_version | type == "string" and
+        test("^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$")) and
+      (.git_sha | type == "string" and test("^[a-f0-9]{40}$")) and
+      .source_compose_project == $source_project and
+      .source_compose_service == $source_service and
+      .source_volume == $source_volume and
+      .postgres_image == $postgres_image and
+      (.postgres_version | type == "string" and test("^18\\.")) and
+      (.database_name | type == "string" and test("^[a-z_][a-z0-9_]{0,62}$")) and
+      (.database_user | type == "string" and test("^[a-z_][a-z0-9_]{0,62}$")) and
+      .schema_version == $source_schema and .schema_dirty == false and
+      (.size_bytes | type == "number" and floor == . and . > 0) and
+      (.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+    ' "$backup_directory/metadata.json" >/dev/null ||
+    fail 'backup metadata is invalid or is not a clean Production schema 7 backup'
+
+  expected_checksum=$(jq --raw-output '.sha256' "$backup_directory/metadata.json")
+  expected_size=$(jq --raw-output '.size_bytes' "$backup_directory/metadata.json")
+  checksum_line=$(<"$backup_directory/database.dump.sha256")
+  [[ "$checksum_line" == "$expected_checksum  database.dump" ]] ||
+    fail 'backup checksum descriptor does not match metadata'
+  actual_size=$(file_size "$backup_directory/database.dump") ||
+    fail 'cannot inspect backup dump size'
+  [[ "$actual_size" == "$expected_size" ]] ||
+    fail 'backup dump size does not match metadata'
+
+  selected_backup_id=$backup_id
+  selected_backup_sha256=$expected_checksum
+  selected_database=$(jq --raw-output '.database_name' "$backup_directory/metadata.json")
+  selected_database_user=$(jq --raw-output '.database_user' "$backup_directory/metadata.json")
+  backup_deployment_version=$(jq --raw-output \
+    '.deployment_version' "$backup_directory/metadata.json")
+  backup_git_sha=$(jq --raw-output '.git_sha' "$backup_directory/metadata.json")
+}
+
+validate_backup_content() {
+  local actual_checksum
+
+  actual_checksum=$(sha256_file "$backup_directory/database.dump") ||
+    fail 'cannot calculate backup dump SHA-256'
+  [[ "$actual_checksum" == "$selected_backup_sha256" ]] ||
+    fail 'backup dump SHA-256 does not match metadata'
+  [[ "$(dd if="$backup_directory/database.dump" bs=5 count=1 2>/dev/null)" == PGDMP ]] ||
+    fail 'backup dump is not PostgreSQL custom format'
+}
+
+image_id_for_reference() {
+  local reference=$1 expected_version=$2 expected_revision=$3
+  local inspection image_id repo_digest=$1
+
+  if [[ "$reference" == postgres:*@sha256:* ]]; then
+    repo_digest="postgres@${reference##*@}"
+  fi
+
+  inspection=$(docker image inspect "$reference") ||
+    fail 'required immutable image is not available locally'
+  jq --exit-status \
+    --arg reference "$repo_digest" \
+    --arg expected_version "$expected_version" \
+    --arg expected_revision "$expected_revision" '
+    length == 1 and
+    (.[0].Id | type == "string" and test("^sha256:[a-f0-9]{64}$")) and
+    ((.[0].RepoDigests // []) | index($reference) != null) and
+    ($expected_version == "" or
+      .[0].Config.Labels["org.opencontainers.image.version"] == $expected_version) and
+    ($expected_revision == "" or
+      .[0].Config.Labels["org.opencontainers.image.revision"] == $expected_revision)
+  ' <<<"$inspection" >/dev/null ||
+    fail 'local image identity does not match the immutable reference'
+  image_id=$(jq --raw-output '.[0].Id' <<<"$inspection")
+  printf '%s\n' "$image_id"
+}
+
+forward_image_identity_for_reference() {
+  local reference=$1 inspection image_id version revision
+
+  inspection=$(docker image inspect "$reference") ||
+    fail 'required immutable forward image is not available locally'
+  jq --exit-status --arg reference "$reference" '
+    length == 1 and
+    (.[0].Id | type == "string" and test("^sha256:[a-f0-9]{64}$")) and
+    ((.[0].RepoDigests // []) | index($reference) != null) and
+    (.[0].Config.Labels["org.opencontainers.image.version"] |
+      type == "string" and
+      test("^[0-9]+\\.[0-9]+\\.[0-9]+([-.+][A-Za-z0-9.-]+)?$")) and
+    (.[0].Config.Labels["org.opencontainers.image.revision"] |
+      type == "string" and test("^[a-f0-9]{40}$"))
+  ' <<<"$inspection" >/dev/null ||
+    fail 'forward image identity or OCI labels are invalid'
+  image_id=$(jq --raw-output '.[0].Id' <<<"$inspection")
+  version=$(jq --raw-output \
+    '.[0].Config.Labels["org.opencontainers.image.version"]' <<<"$inspection")
+  revision=$(jq --raw-output \
+    '.[0].Config.Labels["org.opencontainers.image.revision"]' <<<"$inspection")
+  printf '%s\t%s\t%s\n' "$image_id" "$version" "$revision"
+}
+
+create_isolated_resources() {
+  local suffix network_id created_volume
+
+  suffix=$run_id
+  network_name="xe3-speakup-prod-rehearsal-$suffix"
+  volume_name="xe3-speakup-prod-rehearsal-$suffix"
+  [[ "$network_name" != *production* && "$volume_name" != "$source_volume" ]] ||
+    fail 'rehearsal resource identity is unsafe'
+
+  docker_touched=true
+  network_id=$(docker network create \
+    --internal \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    "$network_name") || fail 'cannot create isolated rehearsal network'
+  [[ "$network_id" =~ ^[a-f0-9]{64}$ ]] ||
+    fail 'isolated rehearsal network returned an invalid ID'
+  owned_network || fail 'isolated rehearsal network identity is invalid'
+
+  created_volume=$(docker volume create \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    "$volume_name") || fail 'cannot create isolated rehearsal volume'
+  [[ "$created_volume" == "$volume_name" ]] ||
+    fail 'isolated rehearsal volume returned an invalid identity'
+  owned_volume || fail 'isolated rehearsal volume identity is invalid'
+}
+
+verify_container_isolation() {
+  local name=$1 container_id=$2 inspection
+
+  inspection=$(docker container inspect "$container_id") ||
+    fail 'cannot inspect rehearsal container isolation'
+  jq --exit-status \
+    --arg name "$name" \
+    --arg id "$container_id" \
+    --arg network "$network_name" \
+    --argjson memory "$container_memory_bytes" \
+    --argjson pids "$container_pids_limit" \
+    --arg max_size "$container_log_max_size" \
+    --arg max_file "$container_log_max_file" '
+    length == 1 and
+    .[0].Id == $id and .[0].Name == ("/" + $name) and
+    ((.[0].HostConfig.PortBindings // {}) == {}) and
+    .[0].HostConfig.NetworkMode == $network and
+    (.[0].NetworkSettings.Networks | keys) == [$network] and
+    .[0].HostConfig.NanoCpus == 1000000000 and
+    .[0].HostConfig.Memory == $memory and
+    .[0].HostConfig.PidsLimit == $pids and
+    .[0].HostConfig.LogConfig.Type == "local" and
+    .[0].HostConfig.LogConfig.Config["max-size"] == $max_size and
+    .[0].HostConfig.LogConfig.Config["max-file"] == $max_file
+  ' <<<"$inspection" >/dev/null ||
+    fail 'rehearsal container violates isolation or resource limits'
+}
+
+record_created_container() {
+  local name=$1 container_id=$2
+
+  [[ "$container_id" =~ ^[a-f0-9]{64}$ ]] ||
+    fail 'Docker returned an invalid rehearsal container ID'
+  container_names+=("$name")
+  container_ids+=("$container_id")
+  last_created_container_id=$container_id
+  owned_container "$name" "$container_id" ||
+    fail 'created rehearsal container identity is invalid'
+  verify_container_isolation "$name" "$container_id"
+}
+
+start_postgres() {
+  local created_id
+
+  postgres_container="xe3-speakup-prod-rehearsal-db-$run_id"
+  created_id=$(docker container create \
+    --pull never \
+    --name "$postgres_container" \
+    --network "$network_name" \
+    --cpus "$container_cpus" \
+    --memory "$container_memory" \
+    --pids-limit "$container_pids_limit" \
+    --log-driver local \
+    --log-opt "max-size=$container_log_max_size" \
+    --log-opt "max-file=$container_log_max_file" \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    --mount "type=volume,src=$volume_name,dst=/var/lib/postgresql,volume-nocopy" \
+    --env "POSTGRES_DB=$selected_database" \
+    --env "POSTGRES_USER=$selected_database_user" \
+    --env POSTGRES_HOST_AUTH_METHOD=trust \
+    "$postgres_image_id") ||
+    fail 'cannot start isolated rehearsal PostgreSQL'
+  record_created_container "$postgres_container" "$created_id"
+  postgres_container_id=$created_id
+  docker container start "$postgres_container_id" >/dev/null ||
+    fail 'cannot start isolated rehearsal PostgreSQL'
+}
+
+wait_for_postgres() {
+  local attempt state process
+
+  for ((attempt = 1; attempt <= 60; attempt += 1)); do
+    process=$(docker container exec "$postgres_container_id" cat /proc/1/comm 2>/dev/null || true)
+    if [[ "$process" == postgres ]] && \
+      docker container exec --user postgres "$postgres_container_id" \
+      pg_isready \
+        --username "$selected_database_user" \
+        --dbname "$selected_database" >/dev/null 2>&1; then
+      return
+    fi
+    state=$(docker container inspect --format '{{.State.Status}}' \
+      "$postgres_container_id" 2>/dev/null || true)
+    [[ "$state" != exited && "$state" != dead ]] ||
+      fail 'isolated rehearsal PostgreSQL stopped before readiness'
+    sleep 1
+  done
+  fail 'isolated rehearsal PostgreSQL did not become ready'
+}
+
+database_query() {
+  local sql=$1
+
+  docker container exec --user postgres "$postgres_container_id" \
+    psql \
+      --no-psqlrc \
+      --set ON_ERROR_STOP=1 \
+      --tuples-only \
+      --no-align \
+      --quiet \
+      --username "$selected_database_user" \
+      --dbname "$selected_database" \
+      --command "$sql"
+}
+
+schema_state() {
+  local state
+
+  state=$(database_query \
+    "SELECT version::text || '|' || dirty::text FROM public.schema_migrations;") ||
+    fail 'cannot read isolated migration state'
+  [[ "$state" =~ ^([1-9][0-9]*)\|false$ ]] ||
+    fail 'isolated migration state is not one clean positive version'
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+restore_backup() {
+  local started
+
+  phase='restore'
+  started=$(now_seconds)
+  docker container exec --interactive --user postgres "$postgres_container_id" \
+    pg_restore \
+      --single-transaction \
+      --exit-on-error \
+      --no-owner \
+      --no-privileges \
+      --username "$selected_database_user" \
+      --dbname "$selected_database" <"$backup_directory/database.dump" ||
+    fail 'isolated PostgreSQL restore failed'
+  [[ "$(schema_state)" == "$source_schema" ]] ||
+    fail "restored backup is not clean schema $source_schema"
+  database_query \
+    "ALTER DATABASE $selected_database SET lock_timeout = '${lock_timeout_seconds}s';" \
+    >/dev/null || fail 'cannot set finite migration lock timeout'
+  restore_duration_seconds=$(( $(now_seconds) - started ))
+}
+
+run_migration() {
+  local name=$1 image_id=$2 created_id
+
+  created_id=$(docker container create \
+    --name "$name" \
+    --pull never \
+    --network "$network_name" \
+    --cpus "$container_cpus" \
+    --memory "$container_memory" \
+    --pids-limit "$container_pids_limit" \
+    --log-driver local \
+    --log-opt "max-size=$container_log_max_size" \
+    --log-opt "max-file=$container_log_max_file" \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    --env "DATABASE_URL=postgres://$selected_database_user@$postgres_container:5432/$selected_database?sslmode=disable" \
+    --entrypoint /usr/local/bin/speakup-migrate \
+    "$image_id" up) ||
+    fail 'cannot create isolated candidate migration container'
+  record_created_container "$name" "$created_id"
+  docker container start --attach "$created_id" >/dev/null ||
+    fail 'candidate migration failed within the finite lock timeout'
+}
+
+verify_target_database() {
+  local views barrier_count constraint_count expected_views actual_views
+
+  [[ "$(schema_state)" == "$target_schema" ]] ||
+    fail "candidate migration did not produce clean schema $target_schema"
+  schema_verified=true
+  expected_views=$'product_health_daily_artifact_coverage\nproduct_health_daily_evaluation_health\nproduct_health_daily_practice_activity\nproduct_health_daily_scoreability\nproduct_health_daily_session_outcomes'
+  actual_views=$(database_query \
+    "SELECT c.relname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'product_health_daily_%' ORDER BY c.relname;") ||
+    fail 'cannot inspect product health views'
+  [[ "$actual_views" == "$expected_views" ]] ||
+    fail 'schema 9 does not contain exactly the five product health views'
+  barrier_count=$(database_query \
+    "SELECT count(*) FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'product_health_daily_%' AND c.reloptions @> ARRAY['security_barrier=true'];") ||
+    fail 'cannot inspect product health view security barriers'
+  [[ "$barrier_count" == 5 ]] ||
+    fail 'product health views are missing security barriers'
+  views_verified=true
+
+  constraint_count=$(database_query \
+    "SELECT count(*) FROM pg_catalog.pg_constraint c WHERE c.conrelid = 'public.evaluations'::regclass AND c.conname = 'evaluations_kind_check' AND c.contype = 'c' AND c.convalidated = true AND pg_get_expr(c.conbin, c.conrelid) ~ '^\\(kind = ANY \\(ARRAY\\[' AND (SELECT array_agg((match)[1] ORDER BY (match)[1]) FROM regexp_matches(pg_get_constraintdef(c.oid), '''([^'']+)''', 'g') AS match) = ARRAY['AGENT_MESSAGE_FEEDBACK', 'IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE', 'PRACTICE_TURN_FEEDBACK', 'SESSION_REPORT']::text[];") ||
+    fail 'cannot inspect IELTS evaluation constraint'
+  [[ "$constraint_count" == 1 ]] ||
+    fail 'schema 9 IELTS evaluation kind constraint is invalid'
+  constraint_verified=true
+}
+
+start_server_and_wait() {
+  local name=$1 image_id=$2 attempt state created_id
+
+  created_id=$(docker container create \
+    --pull never \
+    --name "$name" \
+    --network "$network_name" \
+    --cpus "$container_cpus" \
+    --memory "$container_memory" \
+    --pids-limit "$container_pids_limit" \
+    --log-driver local \
+    --log-opt "max-size=$container_log_max_size" \
+    --log-opt "max-file=$container_log_max_file" \
+    --label "$resource_label=true" \
+    --label "$run_label=$run_id" \
+    --env-file "$server_environment" \
+    --env "DATABASE_URL=postgres://$selected_database_user@$postgres_container:5432/$selected_database?sslmode=disable" \
+    --env SERVER_HOST=0.0.0.0 \
+    --env SERVER_PORT=8080 \
+    --env METRICS_HOST=127.0.0.1 \
+    "$image_id") || fail 'cannot create isolated Server image'
+  record_created_container "$name" "$created_id"
+  docker container start "$created_id" >/dev/null ||
+    fail 'cannot start isolated Server image'
+  for ((attempt = 1; attempt <= 60; attempt += 1)); do
+    if docker container exec "$created_id" \
+      wget -q -T 2 --spider http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
+      return
+    fi
+    state=$(docker container inspect --format '{{.State.Status}}' \
+      "$created_id" 2>/dev/null || true)
+    [[ "$state" != exited && "$state" != dead ]] ||
+      fail 'isolated Server image stopped before readiness'
+    sleep 1
+  done
+  fail 'isolated Server image did not pass readiness'
+}
+
+stop_server() {
+  docker container stop --time 5 "$1" >/dev/null ||
+    fail 'cannot stop isolated Server image after readiness'
+}
+
+verify_rollback_guard() {
+  local output
+
+  if output=$("$production_manager" validate-rollback-schema \
+    --current-schema "$target_schema" --target-schema "$source_schema" 2>&1); then
+    fail 'Production rollback guard allowed schema 9 to schema 7'
+  fi
+  [[ "$output" == *'rollback requires the current database schema to match the target release'* ]] ||
+    fail 'Production rollback guard failed for an unexpected reason'
+  rollback_guard_verified=true
+}
+
+run_isolated_rehearsal() {
+  local migration_started candidate_server previous_server
+  local redeploy_migration redeploy_server forward_migration forward_server
+  local forward_identity forward_server_image_id
+
+  phase='image_identity'
+  postgres_image_id=$(image_id_for_reference "$postgres_image" '' '')
+  candidate_server_image_id=$(image_id_for_reference \
+    "$candidate_server_image" "$release_version" "$release_git_sha")
+  previous_server_image_id=$(image_id_for_reference \
+    "$previous_server_image" "$backup_deployment_version" "$backup_git_sha")
+  if [[ -n "$validated_forward_server_image" ]]; then
+    forward_identity=$(forward_image_identity_for_reference \
+      "$validated_forward_server_image")
+    IFS=$'\t' read -r forward_server_image_id \
+      forward_server_image_version forward_server_image_revision \
+      <<<"$forward_identity"
+    [[ "$forward_server_image_id" =~ ^sha256:[a-f0-9]{64}$ &&
+      -n "$forward_server_image_version" &&
+      "$forward_server_image_revision" =~ ^[a-f0-9]{40}$ ]] ||
+      fail 'forward image identity fields are invalid'
+  fi
+  phase='resource_creation'
+  create_isolated_resources
+  start_postgres
+  wait_for_postgres
+  restore_backup
+
+  phase='migration'
+  migration_started=$(now_seconds)
+  run_migration "xe3-speakup-prod-rehearsal-migrate-$run_id" \
+    "$candidate_server_image_id"
+  migration_duration_seconds=$(( $(now_seconds) - migration_started ))
+  phase='schema_verification'
+  verify_target_database
+
+  phase='candidate_readiness'
+  candidate_server="xe3-speakup-prod-rehearsal-candidate-$run_id"
+  start_server_and_wait "$candidate_server" "$candidate_server_image_id"
+  candidate_readiness_verified=true
+  stop_server "$last_created_container_id"
+
+  phase='previous_image_boundary'
+  previous_server="xe3-speakup-prod-rehearsal-previous-$run_id"
+  start_server_and_wait "$previous_server" "$previous_server_image_id"
+  previous_readiness_verified=true
+  stop_server "$last_created_container_id"
+
+  phase='rollback_guard'
+  verify_rollback_guard
+
+  if [[ -n "$validated_forward_server_image" ]]; then
+    phase='forward_hotfix'
+    forward_migration="xe3-speakup-prod-rehearsal-forward-migrate-$run_id"
+    run_migration "$forward_migration" "$forward_server_image_id"
+    verify_target_database
+    forward_server="xe3-speakup-prod-rehearsal-forward-$run_id"
+    start_server_and_wait "$forward_server" "$forward_server_image_id"
+    stop_server "$last_created_container_id"
+    forward_hotfix_status='verified'
+  else
+    phase='same_schema_candidate_redeploy'
+    redeploy_migration="xe3-speakup-prod-rehearsal-redeploy-migrate-$run_id"
+    run_migration "$redeploy_migration" "$candidate_server_image_id"
+    [[ "$(schema_state)" == "$target_schema" ]] ||
+      fail 'same-schema candidate redeploy changed the clean target schema'
+    redeploy_server="xe3-speakup-prod-rehearsal-redeploy-$run_id"
+    start_server_and_wait "$redeploy_server" "$candidate_server_image_id"
+    stop_server "$last_created_container_id"
+    same_schema_candidate_redeploy_verified=true
+  fi
+  phase='complete'
+}
+
+owned_container() {
+  local name=$1 container_id=$2 inspection
+
+  inspection=$(docker container inspect "$container_id" 2>/dev/null) || return 1
+  jq --exit-status \
+    --arg name "$name" --arg container_id "$container_id" \
+    --arg resource_label "$resource_label" \
+    --arg run_label "$run_label" --arg run_id "$run_id" '
+      length == 1 and .[0].Id == $container_id and
+      .[0].Name == ("/" + $name) and
+      .[0].Config.Labels[$resource_label] == "true" and
+      .[0].Config.Labels[$run_label] == $run_id
+    ' <<<"$inspection" >/dev/null
+}
+
+owned_volume() {
+  local inspection
+
+  inspection=$(docker volume inspect "$volume_name" 2>/dev/null) || return 1
+  jq --exit-status \
+    --arg name "$volume_name" --arg resource_label "$resource_label" \
+    --arg run_label "$run_label" --arg run_id "$run_id" '
+      length == 1 and .[0].Name == $name and
+      .[0].Labels[$resource_label] == "true" and
+      .[0].Labels[$run_label] == $run_id
+    ' <<<"$inspection" >/dev/null
+}
+
+owned_network() {
+  local inspection
+
+  inspection=$(docker network inspect "$network_name" 2>/dev/null) || return 1
+  jq --exit-status \
+    --arg name "$network_name" --arg resource_label "$resource_label" \
+    --arg run_label "$run_label" --arg run_id "$run_id" '
+      length == 1 and .[0].Name == $name and .[0].Internal == true and
+      .[0].Labels[$resource_label] == "true" and
+      .[0].Labels[$run_label] == $run_id
+    ' <<<"$inspection" >/dev/null
+}
+
+container_absence_proven() {
+  local expected_name=$1 expected_id=$2 listing listed_id listed_name
+
+  listing=$(docker container ls --all --no-trunc \
+    --format '{{.ID}}\t{{.Names}}') || return 1
+  while IFS=$'\t' read -r listed_id listed_name; do
+    [[ -n "$listed_id" ]] || continue
+    if [[ "$listed_id" == "$expected_id" || "$listed_name" == "$expected_name" ]]; then
+      return 1
+    fi
+  done <<<"$listing"
+  return 0
+}
+
+network_absence_proven() {
+  local expected_name=$1 listing listed_id listed_name
+
+  listing=$(docker network ls --no-trunc --format '{{.ID}}\t{{.Name}}') || return 1
+  while IFS=$'\t' read -r listed_id listed_name; do
+    [[ -n "$listed_id" ]] || continue
+    [[ "$listed_name" != "$expected_name" ]] || return 1
+  done <<<"$listing"
+  return 0
+}
+
+volume_absence_proven() {
+  local expected_name=$1 listing listed_name
+
+  listing=$(docker volume ls --format '{{.Name}}') || return 1
+  while IFS= read -r listed_name; do
+    [[ -n "$listed_name" ]] || continue
+    [[ "$listed_name" != "$expected_name" ]] || return 1
+  done <<<"$listing"
+  return 0
+}
+
+cleanup_owned_resources() {
+  local failed=0 name container_id index
+
+  for ((index = ${#container_names[@]} - 1; index >= 0; index -= 1)); do
+    name=${container_names[index]}
+    container_id=${container_ids[index]}
+    if docker container inspect "$container_id" >/dev/null 2>&1; then
+      if owned_container "$name" "$container_id"; then
+        docker container rm --force "$container_id" >/dev/null 2>&1 || failed=1
+      else
+        failed=1
+      fi
+    elif ! container_absence_proven "$name" "$container_id"; then
+      # Inspect errors and same-name replacements fail closed. Never delete them.
+      failed=1
+    fi
+  done
+  if [[ -n "$network_name" ]]; then
+    if docker network inspect "$network_name" >/dev/null 2>&1; then
+      if owned_network; then
+        docker network rm "$network_name" >/dev/null 2>&1 || failed=1
+      else
+        failed=1
+      fi
+    elif ! network_absence_proven "$network_name"; then
+      failed=1
+    fi
+  fi
+  if [[ -n "$volume_name" ]]; then
+    if docker volume inspect "$volume_name" >/dev/null 2>&1; then
+      if [[ "$volume_name" != "$source_volume" ]] && owned_volume; then
+        docker volume rm "$volume_name" >/dev/null 2>&1 || failed=1
+      else
+        failed=1
+      fi
+    elif ! volume_absence_proven "$volume_name"; then
+      failed=1
+    fi
+  fi
+  ((failed == 0))
+}
+
+parse_arguments() {
+  while (($# > 0)); do
+    case "$1" in
+      --execute)
+        execute=true
+        shift
+        ;;
+      --backup | --manifest | --previous-server-image | --forward-server-image | --server-env-file | --receipt | --lock-timeout-seconds)
+        (($# >= 2)) || fail "$1 requires a value"
+        case "$1" in
+          --backup) backup_directory=$2 ;;
+          --manifest) manifest=$2 ;;
+          --previous-server-image) previous_server_image=$2 ;;
+          --forward-server-image) forward_server_image=$2 ;;
+          --server-env-file) server_environment=$2 ;;
+          --receipt) receipt=$2 ;;
+          --lock-timeout-seconds) lock_timeout_seconds=$2 ;;
+        esac
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *) fail "unknown argument: $1" ;;
+    esac
+  done
+}
+
+validate_inputs() {
+  local name
+
+  for name in backup_directory manifest previous_server_image server_environment receipt lock_timeout_seconds; do
+    [[ -n "${!name}" ]] || fail "required argument is missing: $name"
+  done
+  [[ "$lock_timeout_seconds" =~ ^[1-9][0-9]*$ ]] &&
+    ((lock_timeout_seconds <= 60)) ||
+    fail '--lock-timeout-seconds must be an integer from 1 to 60'
+  require_command jq
+  require_command stat
+  require_command awk
+  require_receipt_target
+  if [[ "$execute" == true ]]; then
+    receipt_ready=true
+  fi
+  if [[ -n "$forward_server_image" ]]; then
+    forward_hotfix_status='not_verified'
+  fi
+  require_command realpath
+  require_command mktemp
+  require_command cp
+  require_regular_file 'Production manager' "$production_manager"
+  phase='environment_validation'
+  require_private_file 'server environment file' "$server_environment"
+  phase='manifest_validation'
+  validate_manifest
+  validate_previous_server_image
+  validate_forward_server_image
+  phase='backup_metadata_validation'
+  validate_backup_metadata
+}
+
+main() {
+  parse_arguments "$@"
+  run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$-$RANDOM"
+  started_at_seconds=$(now_seconds)
+  trap cleanup_on_exit EXIT
+  trap 'exit 130' INT HUP TERM
+  validate_inputs
+  if [[ "$execute" == false ]]; then
+    printf 'backup_id=%s version=%s source_schema=%s target_schema=%s forward_hotfix=%s dry_run=true docker_touched=false\n' \
+      "$selected_backup_id" "$release_version" "$source_schema" "$target_schema" \
+      "$forward_hotfix_status"
+    return
+  fi
+
+  phase='backup_content_validation'
+  validate_backup_content
+  require_command docker
+  require_command date
+  require_command sleep
+  require_command dd
+  run_isolated_rehearsal
+}
+
+main "$@"

--- a/deploy/production/test-rehearsal.sh
+++ b/deploy/production/test-rehearsal.sh
@@ -1,0 +1,1190 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly production_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly rehearsal="$production_directory/rehearse-schema-upgrade.sh"
+readonly postgres_image='postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108'
+readonly candidate_digest="sha256:$(printf 'b%.0s' {1..64})"
+readonly previous_image="ghcr.io/1024xengineer/xe3-esl-server@sha256:$(printf 'a%.0s' {1..64})"
+readonly forward_image="ghcr.io/1024xengineer/xe3-esl-server@sha256:$(printf 'e%.0s' {1..64})"
+readonly secret_value='rehearsal-test-secret-must-not-leak'
+
+fail() {
+  printf 'Production schema rehearsal test: %s\n' "$*" >&2
+  exit 1
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  else
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  fi
+}
+
+file_mode() {
+  if stat -c '%a' -- "$1" >/dev/null 2>&1; then
+    stat -c '%a' -- "$1"
+  else
+    stat -f '%Lp' "$1"
+  fi
+}
+
+expect_failure() {
+  local name=$1
+  shift
+  if "$@" >"$temporary_directory/failure.out" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+  ! grep -Fq "$secret_value" "$temporary_directory/failure.out" ||
+    fail "$name exposed the server environment secret"
+}
+
+verify_failed_receipt() {
+  local selected_receipt=$1 expected_step=$2
+
+  [[ -f "$selected_receipt" && ! -L "$selected_receipt" ]] ||
+    fail "$expected_step did not write a failure receipt"
+  [[ "$(file_mode "$selected_receipt")" == 600 ]] ||
+    fail "$expected_step receipt is not mode 0600"
+  jq --exit-status --arg expected_step "$expected_step" '
+    .receipt_version == 1 and
+    .operation == "production_schema_upgrade_rehearsal" and
+    .environment == "isolated" and .status == "failed" and
+    .failed_step == $expected_step and
+    .checks.owned_resource_cleanup == true
+  ' "$selected_receipt" >/dev/null ||
+    fail "$expected_step receipt is incomplete"
+  ! grep -Fq "$secret_value" "$selected_receipt" ||
+    fail "$expected_step receipt exposed a server secret"
+}
+
+assert_no_rehearsal_resources() {
+  local selected_run=$1
+
+  [[ -z "$(docker container ls --all --quiet \
+    --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$selected_run")" ]] ||
+    fail "$selected_run leaked a container"
+  ! docker network inspect "xe3-speakup-prod-rehearsal-$selected_run" \
+    >/dev/null 2>&1 || fail "$selected_run leaked its network"
+  ! docker volume inspect "xe3-speakup-prod-rehearsal-$selected_run" \
+    >/dev/null 2>&1 || fail "$selected_run leaked its volume"
+}
+
+selected_background_container=''
+selected_background_run_id=''
+
+run_id_belongs_to_pid() {
+  local selected_run=$1 selected_pid=$2
+
+  [[ "$selected_pid" =~ ^[1-9][0-9]*$ &&
+    "$selected_run" =~ ^[0-9]{8}T[0-9]{6}Z-${selected_pid}-[0-9]+$ ]]
+}
+
+verify_pid_rehearsal_container() {
+  local selected_pid=$1 role=$2 selected_name=$3 selected_run=$4
+  local inspection expected_name
+
+  run_id_belongs_to_pid "$selected_run" "$selected_pid" || return 1
+  expected_name="xe3-speakup-prod-rehearsal-$role-$selected_run"
+  [[ "$selected_name" == "$expected_name" ]] || return 1
+  inspection=$(docker container inspect "$selected_name") || return 1
+  jq --exit-status \
+    --arg name "$selected_name" \
+    --arg run "$selected_run" '
+      length == 1 and .[0].Name == ("/" + $name) and
+      .[0].Config.Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+      .[0].Config.Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+    ' <<<"$inspection" >/dev/null
+}
+
+wait_for_pid_rehearsal_container() {
+  local selected_pid=$1 role=$2 attempt name selected_run matches
+
+  selected_background_container=''
+  selected_background_run_id=''
+  for ((attempt = 1; attempt <= 300; attempt += 1)); do
+    matches=0
+    while IFS=$'\t' read -r name selected_run; do
+      [[ -n "$name" && -n "$selected_run" ]] || continue
+      if run_id_belongs_to_pid "$selected_run" "$selected_pid" &&
+        [[ "$name" == "xe3-speakup-prod-rehearsal-$role-$selected_run" ]]; then
+        selected_background_container=$name
+        selected_background_run_id=$selected_run
+        matches=$((matches + 1))
+      fi
+    done < <(docker container ls --all \
+      --filter 'label=com.xengineer.speakup.production-rehearsal=true' \
+      --format '{{.Names}}\t{{.Label "com.xengineer.speakup.production-rehearsal-run-id"}}')
+    ((matches <= 1)) || return 1
+    if ((matches == 1)); then
+      verify_pid_rehearsal_container "$selected_pid" "$role" \
+        "$selected_background_container" "$selected_background_run_id"
+      return
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+wait_for_postgres() {
+  local container=$1 attempt process
+
+  for ((attempt = 1; attempt <= 60; attempt += 1)); do
+    process=$(docker container exec "$container" cat /proc/1/comm 2>/dev/null || true)
+    if [[ "$process" == postgres ]] && docker container exec "$container" pg_isready \
+      --username speakup --dbname speakup >/dev/null 2>&1; then
+      return
+    fi
+    sleep 1
+  done
+  fail "$container did not become ready"
+}
+
+remove_test_container() {
+  local container=$1
+
+  if docker container inspect "$container" >/dev/null 2>&1; then
+    docker container inspect "$container" | jq --exit-status \
+      --arg container "$container" --arg test_id "$test_id" '
+        length == 1 and .[0].Name == ("/" + $container) and
+        .[0].Config.Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker container rm --force "$container" >/dev/null
+  fi
+}
+
+remove_test_volume() {
+  local volume=$1
+
+  if docker volume inspect "$volume" >/dev/null 2>&1; then
+    docker volume inspect "$volume" | jq --exit-status \
+      --arg volume "$volume" --arg test_id "$test_id" '
+        length == 1 and .[0].Name == $volume and
+        .[0].Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker volume rm "$volume" >/dev/null
+  fi
+}
+
+remove_test_image() {
+  local image_id
+
+  for image_id in \
+    "${forward_fixture_image_id:-}" \
+    "${negative_constraint_fixture_image_id:-}" \
+    "${interrupt_fixture_image_id:-}" \
+    "${invalid_constraint_fixture_image_id:-}" \
+    "${missing_constraint_fixture_image_id:-}" \
+    "${missing_view_fixture_image_id:-}" \
+    "${previous_fixture_image_id:-}" \
+    "${fixture_image_id:-}"; do
+    [[ -n "$image_id" ]] || continue
+    docker image inspect "$image_id" >/dev/null 2>&1 || continue
+    docker image inspect "$image_id" | jq --exit-status \
+      --arg test_id "$test_id" '
+        length == 1 and
+        .[0].Config.Labels["com.xengineer.speakup.test-run"] == $test_id
+      ' >/dev/null || return 1
+    docker image rm --force "$image_id" >/dev/null
+  done
+}
+
+remove_rehearsal_run() {
+  local selected_run=$1 resource name
+
+  [[ -n "$selected_run" ]] || return 0
+  while IFS= read -r resource; do
+    [[ -n "$resource" ]] || continue
+    docker container inspect "$resource" | jq --exit-status \
+      --arg run "$selected_run" '
+        length == 1 and
+        .[0].Config.Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+        .[0].Config.Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+      ' >/dev/null || return 1
+    docker container rm --force "$resource" >/dev/null
+  done < <(docker container ls --all --quiet \
+    --filter 'label=com.xengineer.speakup.production-rehearsal=true' \
+    --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$selected_run")
+  name="xe3-speakup-prod-rehearsal-$selected_run"
+  if docker network inspect "$name" >/dev/null 2>&1; then
+    docker network inspect "$name" | jq --exit-status --arg run "$selected_run" '
+      length == 1 and .[0].Internal == true and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+    ' >/dev/null || return 1
+    docker network rm "$name" >/dev/null
+  fi
+  if docker volume inspect "$name" >/dev/null 2>&1; then
+    docker volume inspect "$name" | jq --exit-status --arg run "$selected_run" '
+      length == 1 and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+      .[0].Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+    ' >/dev/null || return 1
+    docker volume rm "$name" >/dev/null
+  fi
+}
+
+write_manifest() {
+  cat >"$manifest" <<EOF
+{
+  "manifest_version": 1,
+  "version": "0.1.6",
+  "version_code": 7,
+  "git_sha": "cccccccccccccccccccccccccccccccccccccccc",
+  "portal_image": "ghcr.io/1024xengineer/xe3-esl-portal",
+  "portal_image_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "server_image": "ghcr.io/1024xengineer/xe3-esl-server",
+  "server_image_digest": "$candidate_digest",
+  "staging_apk_file": "speakup-v0.1.6-staging-arm64.apk",
+  "staging_apk_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "production_apk_file": "speakup-v0.1.6-production-arm64.apk",
+  "production_apk_size_bytes": 123,
+  "production_apk_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "application_id": "com.xengineer.speakup",
+  "minimum_android_api": 24,
+  "abis": ["arm64-v8a"],
+  "apk_certificate_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "database_schema_version": 9,
+  "quality_run_url": "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456"
+}
+EOF
+}
+
+temporary_base=${TMPDIR:-/tmp}
+temporary_base=${temporary_base%/}
+temporary_directory="$(realpath \
+  "$(mktemp -d "$temporary_base/xe3-production-rehearsal-test.XXXXXX")")"
+readonly temporary_directory
+readonly backup_directory="$temporary_directory/20260825T010203Z-predeploy"
+readonly manifest="$temporary_directory/release-manifest.json"
+readonly server_environment="$temporary_directory/server.env"
+readonly receipt="$temporary_directory/receipt.json"
+readonly dump="$backup_directory/database.dump"
+readonly docker_marker="$temporary_directory/docker-called"
+readonly dump_hash_marker="$temporary_directory/dump-hashed"
+readonly wrapper_directory="$temporary_directory/bin"
+readonly test_id="$(basename "$temporary_directory")"
+readonly decoy_run_id="20260825T000000Z-1-$$"
+readonly decoy_candidate="xe3-speakup-prod-rehearsal-candidate-$decoy_run_id"
+readonly decoy_database="xe3-speakup-prod-rehearsal-db-$decoy_run_id"
+readonly source_container="$test_id-source"
+readonly source_volume="$test_id-source-data"
+readonly fixture_builder="$test_id-image-builder"
+readonly fixture_smoke="$test_id-image-smoke"
+readonly previous_fixture_builder="$test_id-previous-image-builder"
+readonly forward_fixture_builder="$test_id-forward-image-builder"
+readonly missing_view_fixture_builder="$test_id-missing-view-image-builder"
+readonly missing_constraint_fixture_builder="$test_id-missing-constraint-image-builder"
+readonly invalid_constraint_fixture_builder="$test_id-invalid-constraint-image-builder"
+readonly negative_constraint_fixture_builder="$test_id-negative-constraint-image-builder"
+readonly interrupt_fixture_builder="$test_id-interrupt-image-builder"
+readonly fixture_image="xe3-speakup-prod-rehearsal-fixture:$test_id"
+readonly previous_fixture_image="xe3-speakup-prod-rehearsal-previous-fixture:$test_id"
+readonly forward_fixture_image="xe3-speakup-prod-rehearsal-forward-fixture:$test_id"
+readonly missing_view_fixture_image="xe3-speakup-prod-rehearsal-missing-view:$test_id"
+readonly missing_constraint_fixture_image="xe3-speakup-prod-rehearsal-missing-constraint:$test_id"
+readonly invalid_constraint_fixture_image="xe3-speakup-prod-rehearsal-invalid-constraint:$test_id"
+readonly negative_constraint_fixture_image="xe3-speakup-prod-rehearsal-negative-constraint:$test_id"
+readonly interrupt_fixture_image="xe3-speakup-prod-rehearsal-interrupt:$test_id"
+fixture_image_id=''
+previous_fixture_image_id=''
+forward_fixture_image_id=''
+missing_view_fixture_image_id=''
+missing_constraint_fixture_image_id=''
+invalid_constraint_fixture_image_id=''
+negative_constraint_fixture_image_id=''
+interrupt_fixture_image_id=''
+declare -a observed_rehearsal_runs=()
+
+cleanup() {
+  local status=$?
+  local observed_run
+  trap - EXIT INT TERM
+  set +e
+  set +u
+  for observed_run in "${observed_rehearsal_runs[@]}"; do
+    remove_rehearsal_run "$observed_run" >/dev/null 2>&1 || status=1
+  done
+  remove_test_container "$source_container" >/dev/null 2>&1 || status=1
+  remove_test_container "$fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$fixture_smoke" >/dev/null 2>&1 || status=1
+  remove_test_container "$previous_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$forward_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$missing_view_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$missing_constraint_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$invalid_constraint_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$negative_constraint_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$interrupt_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$decoy_candidate" >/dev/null 2>&1 || status=1
+  remove_test_container "$decoy_database" >/dev/null 2>&1 || status=1
+  remove_test_volume "$source_volume" >/dev/null 2>&1 || status=1
+  remove_test_image >/dev/null 2>&1 || status=1
+  if [[ "$temporary_directory" == */xe3-production-rehearsal-test.* ]]; then
+    rm -rf -- "$temporary_directory"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -m 0700 "$backup_directory" "$wrapper_directory"
+write_manifest
+printf 'DASHSCOPE_API_KEY=%s\n' "$secret_value" >"$server_environment"
+printf 'PGDMP synthetic dry-run fixture\n' >"$dump"
+dump_sha256=$(sha256_file "$dump")
+dump_size=$(wc -c <"$dump" | tr -d '[:space:]')
+printf '%s  database.dump\n' "$dump_sha256" >"$backup_directory/database.dump.sha256"
+jq --null-input \
+  --arg sha256 "$dump_sha256" \
+  --arg postgres_image "$postgres_image" \
+  --argjson size_bytes "$dump_size" '
+    {
+      format_version: 1,
+      backup_id: "20260825T010203Z-predeploy",
+      created_at: "2026-08-25T01:02:03Z",
+      backup_type: "predeploy",
+      deployment_version: "0.1.4",
+      git_sha: "2222222222222222222222222222222222222222",
+      source_compose_project: "xe3-speakup-production",
+      source_compose_service: "postgres",
+      source_volume: "xe3-speakup-postgres-data",
+      postgres_image: $postgres_image,
+      postgres_version: "18.0",
+      database_name: "speakup",
+      database_user: "speakup",
+      schema_version: 7,
+      schema_dirty: false,
+      size_bytes: $size_bytes,
+      sha256: $sha256
+    }
+  ' >"$backup_directory/metadata.json"
+chmod 0600 \
+  "$manifest" "$server_environment" "$dump" \
+  "$backup_directory/database.dump.sha256" \
+  "$backup_directory/metadata.json"
+
+real_sha256sum=$(command -v sha256sum || true)
+real_shasum=$(command -v shasum || true)
+cat >"$wrapper_directory/docker" <<'EOF'
+#!/usr/bin/env bash
+: >"$TEST_DOCKER_MARKER"
+exit 97
+EOF
+cat >"$wrapper_directory/sha256sum" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  if [[ "$argument" == */database.dump ]]; then
+    : >"$TEST_DUMP_HASH_MARKER"
+    exit 96
+  fi
+done
+exec "$TEST_REAL_SHA256SUM" "$@"
+EOF
+cat >"$wrapper_directory/shasum" <<'EOF'
+#!/usr/bin/env bash
+for argument in "$@"; do
+  if [[ "$argument" == */database.dump ]]; then
+    : >"$TEST_DUMP_HASH_MARKER"
+    exit 96
+  fi
+done
+exec "$TEST_REAL_SHASUM" "$@"
+EOF
+chmod 0700 "$wrapper_directory/docker" "$wrapper_directory/sha256sum" "$wrapper_directory/shasum"
+
+if [[ -n "$real_sha256sum" ]]; then
+  export TEST_REAL_SHA256SUM=$real_sha256sum
+else
+  rm "$wrapper_directory/sha256sum"
+fi
+if [[ -n "$real_shasum" ]]; then
+  export TEST_REAL_SHASUM=$real_shasum
+else
+  rm "$wrapper_directory/shasum"
+fi
+export TEST_DOCKER_MARKER=$docker_marker
+export TEST_DUMP_HASH_MARKER=$dump_hash_marker
+
+invalid_environment="$temporary_directory/invalid-server.env"
+invalid_environment_receipt="$temporary_directory/invalid-env-receipt.json"
+printf 'DASHSCOPE_API_KEY=invalid-mode\n' >"$invalid_environment"
+chmod 0644 "$invalid_environment"
+expect_failure 'invalid environment execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$invalid_environment" \
+    --receipt "$invalid_environment_receipt" \
+    --lock-timeout-seconds 3
+verify_failed_receipt "$invalid_environment_receipt" environment_validation
+[[ ! -e "$docker_marker" ]] || fail 'invalid environment called Docker'
+
+dry_run_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" \
+  --backup "$backup_directory" \
+  --manifest "$manifest" \
+  --previous-server-image "$previous_image" \
+  --server-env-file "$server_environment" \
+  --receipt "$receipt" \
+  --lock-timeout-seconds 3)"
+[[ "$dry_run_output" == \
+  'backup_id=20260825T010203Z-predeploy version=0.1.6 source_schema=7 target_schema=9 forward_hotfix=not_provided dry_run=true docker_touched=false' ]] ||
+  fail 'dry-run returned an unexpected contract'
+[[ ! -e "$docker_marker" ]] || fail 'dry-run called Docker'
+[[ ! -e "$dump_hash_marker" ]] || fail 'dry-run read database.dump'
+[[ ! -e "$receipt" ]] || fail 'dry-run wrote a receipt'
+! grep -Fq "$secret_value" <<<"$dry_run_output" ||
+  fail 'dry-run exposed the server environment secret'
+
+jq '.database_schema_version = 8' "$manifest" >"$temporary_directory/schema8.json"
+chmod 0600 "$temporary_directory/schema8.json"
+expect_failure 'wrong target schema' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" \
+    --backup "$backup_directory" \
+    --manifest "$temporary_directory/schema8.json" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$receipt" \
+    --lock-timeout-seconds 3
+[[ ! -e "$docker_marker" ]] || fail 'invalid manifest called Docker'
+
+invalid_manifest_receipt="$temporary_directory/invalid-manifest-receipt.json"
+expect_failure 'wrong target schema execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$temporary_directory/schema8.json" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$invalid_manifest_receipt" \
+    --lock-timeout-seconds 3
+verify_failed_receipt "$invalid_manifest_receipt" manifest_validation
+
+invalid_backup_directory="$temporary_directory/20260825T010204Z-predeploy"
+invalid_metadata_receipt="$temporary_directory/invalid-metadata-receipt.json"
+mkdir -m 0700 "$invalid_backup_directory"
+cp "$dump" "$backup_directory/database.dump.sha256" \
+  "$invalid_backup_directory/"
+jq '
+  .backup_id = "20260825T010204Z-predeploy" |
+  .created_at = "2026-08-25T01:02:04Z" |
+  .schema_version = 8
+' "$backup_directory/metadata.json" >"$invalid_backup_directory/metadata.json"
+chmod 0600 "$invalid_backup_directory"/*
+expect_failure 'invalid backup metadata execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$invalid_backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$invalid_metadata_receipt" \
+    --lock-timeout-seconds 3
+verify_failed_receipt "$invalid_metadata_receipt" backup_metadata_validation
+[[ ! -e "$docker_marker" ]] || fail 'invalid backup metadata called Docker'
+
+printf 'X' | dd of="$dump" bs=1 seek=6 conv=notrunc 2>/dev/null
+expect_failure 'corrupt dump execute gate' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$receipt" \
+    --lock-timeout-seconds 3
+[[ -e "$dump_hash_marker" ]] || fail 'execute did not verify database.dump'
+[[ ! -e "$docker_marker" ]] || fail 'invalid backup called Docker'
+[[ -f "$receipt" && ! -L "$receipt" ]] ||
+  fail 'failed execute did not write an audit receipt'
+[[ "$(file_mode "$receipt")" == 600 ]] ||
+  fail 'failed execute receipt is not mode 0600'
+jq --exit-status '
+  .receipt_version == 1 and
+  .operation == "production_schema_upgrade_rehearsal" and
+  .environment == "isolated" and
+  .status == "failed" and
+  .failed_step == "backup_content_validation" and
+  .source_schema == 7 and .target_schema == 9 and
+  .checks.owned_resource_cleanup == true
+' "$receipt" >/dev/null || fail 'failed execute receipt is incomplete'
+! grep -Fq "$secret_value" "$receipt" || fail 'receipt exposed a server secret'
+! grep -Fq "$backup_directory" "$receipt" || fail 'receipt exposed the backup path'
+
+[[ "$("$production_directory/manage.sh" validate-rollback-schema \
+  --current-schema 9 --target-schema 9)" == \
+  'current_schema=9 target_schema=9 rollback_allowed=true' ]] ||
+  fail 'Production rollback schema guard rejected an equal schema'
+expect_failure 'Production rollback schema guard mismatch' \
+  "$production_directory/manage.sh" validate-rollback-schema \
+    --current-schema 9 --target-schema 7
+rm -f "$wrapper_directory/sha256sum" "$wrapper_directory/shasum"
+
+# The runtime fixture uses only the already-required PostgreSQL 18 image. Its
+# migration entrypoint applies the repository's real schema 8 and 9 SQL, while
+# its HTTP process exposes only a local readiness endpoint.
+fixture_directory="$temporary_directory/fixture-image"
+mkdir -m 0700 "$fixture_directory"
+cp "$production_directory/../../server/migrations/000008_product_health_views.up.sql" \
+  "$fixture_directory/000008.up.sql"
+cp "$production_directory/../../server/migrations/000009_ielts_incremental_profile.up.sql" \
+  "$fixture_directory/000009.up.sql"
+cat >"$fixture_directory/speakup-migrate" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == up ]] || exit 2
+sleep 2
+version="$(psql "$DATABASE_URL" --no-psqlrc --tuples-only --no-align --quiet \
+  --set ON_ERROR_STOP=1 --command 'SELECT version FROM public.schema_migrations;')"
+case "$version" in
+  7)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --file /fixture/000008.up.sql >/dev/null
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'UPDATE public.schema_migrations SET version = 8;' >/dev/null
+    ;&
+  8)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --file /fixture/000009.up.sql >/dev/null
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'UPDATE public.schema_migrations SET version = 9;' >/dev/null
+    ;;
+  9)
+    ;;
+  *)
+    exit 3
+    ;;
+esac
+case "${REHEARSAL_FIXTURE_FAULT:-}" in
+  '' | server-unready) ;;
+  missing-view)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'DROP VIEW public.product_health_daily_scoreability;' >/dev/null
+    ;;
+  missing-constraint)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER TABLE public.evaluations DROP CONSTRAINT evaluations_kind_check;' \
+      >/dev/null
+    ;;
+  invalid-constraint)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER TABLE public.evaluations DROP CONSTRAINT evaluations_kind_check;' \
+      --command "ALTER TABLE public.evaluations ADD CONSTRAINT evaluations_kind_check CHECK (kind IN ('SESSION_REPORT', 'PRACTICE_TURN_FEEDBACK', 'AGENT_MESSAGE_FEEDBACK', 'IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE', 'UNREVIEWED_EXTRA'));" \
+      >/dev/null
+    ;;
+  negative-constraint)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER TABLE public.evaluations DROP CONSTRAINT evaluations_kind_check;' \
+      --command "ALTER TABLE public.evaluations ADD CONSTRAINT evaluations_kind_check CHECK (kind NOT IN ('SESSION_REPORT', 'PRACTICE_TURN_FEEDBACK', 'AGENT_MESSAGE_FEEDBACK', 'IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE'));" \
+      >/dev/null
+    ;;
+  *) exit 4 ;;
+esac
+EOF
+cat >"$fixture_directory/speakup-server" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${REHEARSAL_FIXTURE_FAULT:-}" == server-unready ]]; then
+  sleep 300
+  exit 5
+fi
+exec perl -MIO::Socket::INET -e '
+  my $server = IO::Socket::INET->new(
+    LocalAddr => "127.0.0.1", LocalPort => 8080, Listen => 5,
+    ReuseAddr => 1, Proto => "tcp"
+  ) or die "listen failed";
+  while (my $client = $server->accept()) {
+    scalar <$client>;
+    print $client "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok";
+    close $client;
+  }
+'
+EOF
+cat >"$fixture_directory/wget" <<'EOF'
+#!/usr/bin/env bash
+exec perl -MIO::Socket::INET -e '
+  my $client = IO::Socket::INET->new(
+    PeerAddr => "127.0.0.1", PeerPort => 8080, Proto => "tcp", Timeout => 2
+  );
+  exit($client ? 0 : 1);
+'
+EOF
+chmod 0755 \
+  "$fixture_directory/speakup-migrate" \
+  "$fixture_directory/speakup-server" \
+  "$fixture_directory/wget"
+docker container create \
+  --name "$fixture_builder" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$postgres_image" >/dev/null
+docker container cp "$fixture_directory" "$fixture_builder:/fixture"
+docker container cp \
+  "$fixture_directory/speakup-migrate" \
+  "$fixture_builder:/usr/local/bin/speakup-migrate"
+docker container cp \
+  "$fixture_directory/speakup-server" \
+  "$fixture_builder:/usr/local/bin/speakup-server"
+docker container cp \
+  "$fixture_directory/wget" \
+  "$fixture_builder:/usr/local/bin/wget"
+docker container commit \
+  --change 'ENTRYPOINT ["/usr/local/bin/speakup-server"]' \
+  --change 'CMD []' \
+  --change 'LABEL org.opencontainers.image.version=0.1.6' \
+  --change 'LABEL org.opencontainers.image.revision=cccccccccccccccccccccccccccccccccccccccc' \
+  --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+  "$fixture_builder" "$fixture_image" >/dev/null
+remove_test_container "$fixture_builder" || fail 'cannot remove fixture image builder'
+fixture_image_id=$(docker image inspect --format '{{.Id}}' "$fixture_image")
+[[ "$fixture_image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+  fail 'fixture image ID is invalid'
+docker container run --detach --pull never \
+  --name "$fixture_smoke" --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$fixture_image_id" >/dev/null
+sleep 1
+if ! docker container exec "$fixture_smoke" \
+  wget -q -T 2 --spider http://127.0.0.1:8080/readyz >/dev/null 2>&1; then
+  docker container inspect "$fixture_smoke" --format \
+    'fixture state={{.State.Status}} exit={{.State.ExitCode}} error={{.State.Error}}' >&2 || true
+  docker container logs "$fixture_smoke" >&2 || true
+  fail 'fixture Server image is not runnable'
+fi
+remove_test_container "$fixture_smoke" || fail 'cannot remove fixture smoke container'
+
+docker container create \
+  --name "$previous_fixture_builder" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$fixture_image_id" >/dev/null
+docker container commit \
+  --change 'ENTRYPOINT ["/usr/local/bin/speakup-server"]' \
+  --change 'CMD []' \
+  --change 'LABEL org.opencontainers.image.version=0.1.4' \
+  --change 'LABEL org.opencontainers.image.revision=2222222222222222222222222222222222222222' \
+  --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+  "$previous_fixture_builder" "$previous_fixture_image" >/dev/null
+previous_fixture_image_id=$(docker image inspect --format '{{.Id}}' \
+  "$previous_fixture_image")
+[[ "$previous_fixture_image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+  fail 'previous fixture image ID is invalid'
+remove_test_container "$previous_fixture_builder" ||
+  fail 'cannot remove previous fixture image builder'
+
+docker container create \
+  --name "$forward_fixture_builder" \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$fixture_image_id" >/dev/null
+docker container commit \
+  --change 'ENTRYPOINT ["/usr/local/bin/speakup-server"]' \
+  --change 'CMD []' \
+  --change 'LABEL org.opencontainers.image.version=0.1.7' \
+  --change 'LABEL org.opencontainers.image.revision=ffffffffffffffffffffffffffffffffffffffff' \
+  --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+  "$forward_fixture_builder" "$forward_fixture_image" >/dev/null
+forward_fixture_image_id=$(docker image inspect --format '{{.Id}}' \
+  "$forward_fixture_image")
+[[ "$forward_fixture_image_id" =~ ^sha256:[a-f0-9]{64}$ &&
+  "$forward_fixture_image_id" != "$fixture_image_id" &&
+  "$forward_fixture_image_id" != "$previous_fixture_image_id" ]] ||
+  fail 'forward fixture must have a distinct immutable image ID'
+remove_test_container "$forward_fixture_builder" ||
+  fail 'cannot remove forward fixture image builder'
+
+create_fixture_variant() {
+  local fault=$1 builder=$2 image=$3 image_id
+
+  docker container create \
+    --name "$builder" \
+    --label "com.xengineer.speakup.test-run=$test_id" \
+    --entrypoint /bin/true \
+    "$fixture_image_id" >/dev/null
+  docker container commit \
+    --change "ENV REHEARSAL_FIXTURE_FAULT=$fault" \
+    --change "LABEL com.xengineer.speakup.test-run=$test_id" \
+    "$builder" "$image" >/dev/null
+  image_id=$(docker image inspect --format '{{.Id}}' "$image")
+  [[ "$image_id" =~ ^sha256:[a-f0-9]{64}$ ]] ||
+    fail "$fault fixture image ID is invalid"
+  remove_test_container "$builder" || fail "cannot remove $fault fixture builder"
+  printf '%s\n' "$image_id"
+}
+
+missing_view_fixture_image_id=$(create_fixture_variant \
+  missing-view "$missing_view_fixture_builder" "$missing_view_fixture_image")
+missing_constraint_fixture_image_id=$(create_fixture_variant \
+  missing-constraint "$missing_constraint_fixture_builder" \
+  "$missing_constraint_fixture_image")
+invalid_constraint_fixture_image_id=$(create_fixture_variant \
+  invalid-constraint "$invalid_constraint_fixture_builder" \
+  "$invalid_constraint_fixture_image")
+negative_constraint_fixture_image_id=$(create_fixture_variant \
+  negative-constraint "$negative_constraint_fixture_builder" \
+  "$negative_constraint_fixture_image")
+interrupt_fixture_image_id=$(create_fixture_variant \
+  server-unready "$interrupt_fixture_builder" "$interrupt_fixture_image")
+
+docker volume create \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  "$source_volume" >/dev/null
+docker container run \
+  --detach \
+  --pull never \
+  --name "$source_container" \
+  --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --mount "type=volume,src=$source_volume,dst=/var/lib/postgresql,volume-nocopy" \
+  --env POSTGRES_DB=speakup \
+  --env POSTGRES_USER=speakup \
+  --env POSTGRES_HOST_AUTH_METHOD=trust \
+  "$postgres_image" >/dev/null
+wait_for_postgres "$source_container"
+for migration in \
+  "$production_directory"/../../server/migrations/00000[1-7]*.up.sql; do
+  docker container exec --interactive "$source_container" \
+    psql --no-psqlrc --set ON_ERROR_STOP=1 \
+      --username speakup --dbname speakup <"$migration" >/dev/null
+done
+docker container exec "$source_container" \
+  psql --no-psqlrc --set ON_ERROR_STOP=1 \
+    --username speakup --dbname speakup \
+    --command 'CREATE TABLE public.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL);' \
+    --command 'INSERT INTO public.schema_migrations (version, dirty) VALUES (7, false);' \
+    >/dev/null
+docker container exec "$source_container" \
+  pg_dump --format custom --no-owner --no-privileges \
+    --username speakup --dbname speakup >"$dump"
+dump_sha256=$(sha256_file "$dump")
+dump_size=$(wc -c <"$dump" | tr -d '[:space:]')
+printf '%s  database.dump\n' "$dump_sha256" >"$backup_directory/database.dump.sha256"
+jq \
+  --arg sha256 "$dump_sha256" \
+  --argjson size_bytes "$dump_size" \
+  '.sha256 = $sha256 | .size_bytes = $size_bytes' \
+  "$backup_directory/metadata.json" >"$temporary_directory/metadata.updated.json"
+mv "$temporary_directory/metadata.updated.json" "$backup_directory/metadata.json"
+chmod 0600 "$dump" "$backup_directory/database.dump.sha256" \
+  "$backup_directory/metadata.json"
+remove_test_container "$source_container" || fail 'cannot remove source fixture container'
+remove_test_volume "$source_volume" || fail 'cannot remove source fixture volume'
+
+command_log="$temporary_directory/docker-runtime.log"
+cat >"$wrapper_directory/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+arguments=("$@")
+if [[ "$#" == 3 && "$1" == container && "$2" == inspect &&
+  -s "$TEST_INSPECT_ERROR_TARGET_FILE" &&
+  "$3" == "$(<"$TEST_INSPECT_ERROR_TARGET_FILE")" ]]; then
+  if [[ ! -e "$TEST_INSPECT_ERROR_INJECTED_FILE" ]]; then
+    (umask 077 && printf '%s\n' "$3" >"$TEST_INSPECT_ERROR_INJECTED_FILE")
+  fi
+  exit 74
+fi
+if [[ "$#" == 3 && "$1" == image && "$2" == inspect &&
+  ("$3" == "$TEST_CANDIDATE_IMAGE" || "$3" == "$TEST_PREVIOUS_IMAGE" ||
+   "$3" == "$TEST_FORWARD_IMAGE") ]]; then
+  selected_image=$TEST_FIXTURE_IMAGE_ID
+  if [[ "$3" == "$TEST_CANDIDATE_IMAGE" ]]; then
+    selected_image=$TEST_CANDIDATE_FIXTURE_IMAGE_ID
+  fi
+  if [[ "$3" == "$TEST_PREVIOUS_IMAGE" ]]; then
+    selected_image=$TEST_PREVIOUS_FIXTURE_IMAGE_ID
+  fi
+  if [[ "$3" == "$TEST_FORWARD_IMAGE" ]]; then
+    selected_image=$TEST_FORWARD_FIXTURE_IMAGE_ID
+  fi
+  "$TEST_REAL_DOCKER" image inspect "$selected_image" |
+    jq --arg reference "$3" '.[0].RepoDigests = [$reference]'
+  exit 0
+fi
+{
+  printf '%q' "$1"
+  shift
+  printf ' %q' "$@"
+  printf '\n'
+} >>"$TEST_DOCKER_COMMAND_LOG"
+exec "$TEST_REAL_DOCKER" "${arguments[@]}"
+EOF
+chmod 0700 "$wrapper_directory/docker"
+export TEST_REAL_DOCKER="$(command -v docker)"
+export TEST_CANDIDATE_IMAGE="ghcr.io/1024xengineer/xe3-esl-server@$candidate_digest"
+export TEST_PREVIOUS_IMAGE="$previous_image"
+export TEST_FORWARD_IMAGE="$forward_image"
+export TEST_FIXTURE_IMAGE_ID="$fixture_image_id"
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID="$fixture_image_id"
+export TEST_PREVIOUS_FIXTURE_IMAGE_ID="$previous_fixture_image_id"
+export TEST_FORWARD_FIXTURE_IMAGE_ID="$forward_fixture_image_id"
+export TEST_DOCKER_COMMAND_LOG="$command_log"
+export TEST_INSPECT_ERROR_TARGET_FILE="$temporary_directory/inspect-error-target"
+export TEST_INSPECT_ERROR_INJECTED_FILE="$temporary_directory/inspect-error-injected"
+
+success_receipt="$temporary_directory/success-receipt.json"
+success_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" --execute \
+  --backup "$backup_directory" \
+  --manifest "$manifest" \
+  --previous-server-image "$previous_image" \
+  --forward-server-image "$forward_image" \
+  --server-env-file "$server_environment" \
+  --receipt "$success_receipt" \
+  --lock-timeout-seconds 2)"
+success_run_id=$(jq --raw-output '.run_id' "$success_receipt")
+observed_rehearsal_runs+=("$success_run_id")
+[[ "$success_output" == *'rehearsal=verified' ]] ||
+  fail 'successful rehearsal returned an invalid contract'
+jq --exit-status '
+  .status == "succeeded" and .failed_step == null and
+  .source_schema == 7 and .target_schema == 9 and
+  .checks.clean_target_schema == true and
+  .checks.product_health_views == true and
+  .checks.ielts_evaluation_constraint == true and
+  .checks.candidate_readiness == true and
+  .checks.previous_image_readiness_only == true and
+  .checks.previous_image_profile_processing == "not_verified" and
+  .checks.schema7_rollback_guard == true and
+  .checks.same_schema_candidate_redeploy == false and
+  .checks.forward_hotfix_image == "verified" and
+  .forward_server_image == "ghcr.io/1024xengineer/xe3-esl-server@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" and
+  .forward_server_image_version == "0.1.7" and
+  .forward_server_image_revision == "ffffffffffffffffffffffffffffffffffffffff" and
+  .checks.owned_resource_cleanup == true
+' "$success_receipt" >/dev/null || fail 'successful rehearsal receipt is incomplete'
+[[ "$(file_mode "$success_receipt")" == 600 ]] ||
+  fail 'successful rehearsal receipt is not mode 0600'
+! grep -Fq "$secret_value" "$success_receipt" ||
+  fail 'successful receipt exposed the server secret'
+! grep -Fq "$backup_directory" "$success_receipt" ||
+  fail 'successful receipt exposed the backup path'
+[[ -z "$(docker container ls --all --quiet \
+  --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$success_run_id")" ]] ||
+  fail 'successful rehearsal leaked a container'
+! docker network inspect "xe3-speakup-prod-rehearsal-$success_run_id" >/dev/null 2>&1 ||
+  fail 'successful rehearsal leaked its network'
+! docker volume inspect "xe3-speakup-prod-rehearsal-$success_run_id" >/dev/null 2>&1 ||
+  fail 'successful rehearsal leaked its volume'
+grep -Eq '^network create --internal ' "$command_log" ||
+  fail 'rehearsal did not create an internal network'
+if grep -Eq -- '--publish|(^|[[:space:]])-p([[:space:]]|$)|xe3-speakup-production_database' \
+  "$command_log"; then
+  fail 'rehearsal used a host port or Production network'
+fi
+container_create_count=$(grep -Ec '^container create ' "$command_log")
+((container_create_count >= 6)) || fail 'rehearsal did not create all isolated containers'
+while IFS= read -r create_command; do
+  [[ "$create_command" == *'--cpus 1.0'* &&
+    "$create_command" == *'--memory 512m'* &&
+    "$create_command" == *'--pids-limit 256'* &&
+    "$create_command" == *'--log-driver local'* &&
+    "$create_command" == *'--log-opt max-size=10m'* &&
+    "$create_command" == *'--log-opt max-file=3'* ]] ||
+    fail 'an isolated container is missing shared-server resource limits'
+done < <(grep -E '^container create ' "$command_log")
+
+run_schema_fault_test() {
+  local fault=$1 fixture_id=$2 expected_views=$3
+  local fault_receipt="$temporary_directory/$fault-receipt.json"
+  local fault_run_id
+
+  export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_id
+  expect_failure "$fault schema verification" env PATH="$wrapper_directory:$PATH" \
+    "$rehearsal" --execute \
+      --backup "$backup_directory" \
+      --manifest "$manifest" \
+      --previous-server-image "$previous_image" \
+      --server-env-file "$server_environment" \
+      --receipt "$fault_receipt" \
+      --lock-timeout-seconds 2
+  verify_failed_receipt "$fault_receipt" schema_verification
+  jq --exit-status --argjson expected_views "$expected_views" '
+    .checks.clean_target_schema == true and
+    .checks.product_health_views == $expected_views and
+    .checks.ielts_evaluation_constraint == false
+  ' "$fault_receipt" >/dev/null || fail "$fault failure receipt has wrong checks"
+  fault_run_id=$(jq --raw-output '.run_id' "$fault_receipt")
+  observed_rehearsal_runs+=("$fault_run_id")
+  assert_no_rehearsal_resources "$fault_run_id"
+}
+
+run_schema_fault_test missing-view "$missing_view_fixture_image_id" false
+run_schema_fault_test missing-constraint "$missing_constraint_fixture_image_id" true
+run_schema_fault_test invalid-constraint "$invalid_constraint_fixture_image_id" true
+run_schema_fault_test negative-constraint "$negative_constraint_fixture_image_id" true
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_image_id
+
+decoy_candidate_id=$(docker container run --detach --pull never \
+  --name "$decoy_candidate" --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --label 'com.xengineer.speakup.production-rehearsal=true' \
+  --label "com.xengineer.speakup.production-rehearsal-run-id=$decoy_run_id" \
+  "$fixture_image_id")
+decoy_database_id=$(docker container run --detach --pull never \
+  --name "$decoy_database" --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --label 'com.xengineer.speakup.production-rehearsal=true' \
+  --label "com.xengineer.speakup.production-rehearsal-run-id=$decoy_run_id" \
+  "$fixture_image_id")
+
+lock_receipt="$temporary_directory/lock-timeout-receipt.json"
+lock_output="$temporary_directory/lock-timeout.out"
+PATH="$wrapper_directory:$PATH" "$rehearsal" --execute \
+  --backup "$backup_directory" \
+  --manifest "$manifest" \
+  --previous-server-image "$previous_image" \
+  --server-env-file "$server_environment" \
+  --receipt "$lock_receipt" \
+  --lock-timeout-seconds 1 >"$lock_output" 2>&1 &
+rehearsal_pid=$!
+if ! wait_for_pid_rehearsal_container "$rehearsal_pid" db; then
+  wait "$rehearsal_pid" || true
+  fail 'lock-timeout rehearsal did not create one PID-owned database'
+fi
+lock_database=$selected_background_container
+lock_run_id=$selected_background_run_id
+observed_rehearsal_runs+=("$lock_run_id")
+
+schema7_ready=false
+for ((attempt = 1; attempt <= 150; attempt += 1)); do
+  if [[ "$(docker container exec --user postgres "$lock_database" \
+    psql --no-psqlrc --tuples-only --no-align --quiet \
+      --username speakup --dbname speakup \
+      --command "SELECT count(*) FROM public.schema_migrations WHERE version = 7 AND dirty = false AND to_regclass('public.evaluations') IS NOT NULL;" \
+      2>/dev/null || true)" == 1 ]]; then
+    schema7_ready=true
+    break
+  fi
+  sleep 0.1
+done
+[[ "$schema7_ready" == true ]] || {
+  wait "$rehearsal_pid" || true
+  fail 'lock-timeout rehearsal did not restore clean schema 7'
+}
+
+verify_pid_rehearsal_container "$rehearsal_pid" db \
+  "$lock_database" "$lock_run_id" ||
+  fail 'lock-timeout database ownership changed before acquiring the test lock'
+
+docker container exec --user postgres "$lock_database" \
+  psql --no-psqlrc --set ON_ERROR_STOP=1 \
+    --username speakup --dbname speakup \
+    --command 'BEGIN; LOCK TABLE public.evaluations IN ACCESS EXCLUSIVE MODE; SELECT pg_sleep(20);' \
+    >"$temporary_directory/lock-holder.out" 2>&1 &
+lock_holder_pid=$!
+lock_granted=false
+for ((attempt = 1; attempt <= 50; attempt += 1)); do
+  if [[ "$(docker container exec --user postgres "$lock_database" \
+    psql --no-psqlrc --tuples-only --no-align --quiet \
+      --username speakup --dbname speakup \
+      --command "SELECT count(*) FROM pg_catalog.pg_locks l JOIN pg_catalog.pg_class c ON c.oid = l.relation WHERE c.relname = 'evaluations' AND l.mode = 'AccessExclusiveLock' AND l.granted;" \
+      2>/dev/null || true)" == 1 ]]; then
+    lock_granted=true
+    break
+  fi
+  sleep 0.1
+done
+[[ "$lock_granted" == true ]] || {
+  kill "$lock_holder_pid" >/dev/null 2>&1 || true
+  wait "$rehearsal_pid" || true
+  fail 'test could not acquire the migration-blocking lock'
+}
+if wait "$rehearsal_pid"; then
+  kill "$lock_holder_pid" >/dev/null 2>&1 || true
+  wait "$lock_holder_pid" >/dev/null 2>&1 || true
+  fail 'lock-timeout rehearsal unexpectedly succeeded'
+fi
+wait "$lock_holder_pid" >/dev/null 2>&1 || true
+[[ -f "$lock_receipt" && "$(file_mode "$lock_receipt")" == 600 ]] ||
+  fail 'lock-timeout failure did not write a mode 0600 receipt'
+jq --exit-status '
+  .status == "failed" and .failed_step == "migration" and
+  .lock_timeout_seconds == 1 and
+  .checks.clean_target_schema == false and
+  .checks.owned_resource_cleanup == true
+' "$lock_receipt" >/dev/null || fail 'lock-timeout receipt is incomplete'
+[[ -z "$(docker container ls --all --quiet \
+  --filter "label=com.xengineer.speakup.production-rehearsal-run-id=$lock_run_id")" ]] ||
+  fail 'lock-timeout rehearsal leaked a container'
+! docker network inspect "xe3-speakup-prod-rehearsal-$lock_run_id" >/dev/null 2>&1 ||
+  fail 'lock-timeout rehearsal leaked its network'
+! docker volume inspect "xe3-speakup-prod-rehearsal-$lock_run_id" >/dev/null 2>&1 ||
+  fail 'lock-timeout rehearsal leaked its volume'
+
+command -v perl >/dev/null 2>&1 || fail 'perl is required for signal tests'
+interruption_pid=''
+interruption_candidate=''
+interruption_run_id=''
+
+start_interruptible_rehearsal() {
+  local selected_receipt=$1 selected_output=$2
+
+  PATH="$wrapper_directory:$PATH" perl -e '
+    $SIG{INT} = "DEFAULT";
+    $SIG{TERM} = "DEFAULT";
+    exec @ARGV or die "exec failed";
+  ' "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$selected_receipt" \
+    --lock-timeout-seconds 2 >"$selected_output" 2>&1 &
+  interruption_pid=$!
+}
+
+wait_for_candidate_container() {
+  wait_for_pid_rehearsal_container "$interruption_pid" candidate || return 1
+  interruption_candidate=$selected_background_container
+  interruption_run_id=$selected_background_run_id
+}
+
+run_signal_cleanup_test() {
+  local signal=$1 suffix=$2
+  local signal_receipt="$temporary_directory/$suffix-receipt.json"
+  local signal_output="$temporary_directory/$suffix.out"
+  local signal_run_id
+
+  start_interruptible_rehearsal "$signal_receipt" "$signal_output"
+  wait_for_candidate_container || {
+    wait "$interruption_pid" >/dev/null 2>&1 || true
+    fail "$signal test did not reach one PID-owned candidate"
+  }
+  signal_run_id=$interruption_run_id
+  observed_rehearsal_runs+=("$signal_run_id")
+  verify_pid_rehearsal_container "$interruption_pid" candidate \
+    "$interruption_candidate" "$signal_run_id" ||
+    fail "$signal candidate ownership changed before $signal"
+  kill -"$signal" "$interruption_pid"
+  if wait "$interruption_pid"; then
+    fail "$signal interruption unexpectedly succeeded"
+  fi
+  verify_failed_receipt "$signal_receipt" candidate_readiness
+  assert_no_rehearsal_resources "$signal_run_id"
+}
+
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$interrupt_fixture_image_id
+run_signal_cleanup_test TERM sigterm
+run_signal_cleanup_test INT sigint
+
+replacement_receipt="$temporary_directory/replacement-receipt.json"
+replacement_output="$temporary_directory/replacement.out"
+start_interruptible_rehearsal "$replacement_receipt" "$replacement_output"
+wait_for_candidate_container || {
+  wait "$interruption_pid" >/dev/null 2>&1 || true
+  fail 'replacement test did not reach one PID-owned candidate'
+}
+replacement_run_id=$interruption_run_id
+observed_rehearsal_runs+=("$replacement_run_id")
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$replacement_run_id" ||
+  fail 'replacement candidate ownership changed before stopping the rehearsal'
+kill -STOP "$interruption_pid"
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$replacement_run_id" ||
+  fail 'replacement candidate ownership changed before queuing termination'
+kill -TERM "$interruption_pid"
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$replacement_run_id" ||
+  fail 'replacement candidate ownership changed before removal'
+original_candidate_id=$(docker container inspect --format '{{.Id}}' \
+  "$interruption_candidate")
+docker container rm --force "$original_candidate_id" >/dev/null
+replacement_id=$(docker container create \
+  --name "$interruption_candidate" \
+  --network none \
+  --label "com.xengineer.speakup.test-run=$test_id" \
+  --entrypoint /bin/true \
+  "$fixture_image_id")
+kill -CONT "$interruption_pid"
+if wait "$interruption_pid"; then
+  fail 'replacement interruption unexpectedly succeeded'
+fi
+[[ -f "$replacement_receipt" && "$(file_mode "$replacement_receipt")" == 600 ]] ||
+  fail 'replacement failure did not write a mode 0600 receipt'
+jq --exit-status '
+  .status == "failed" and .failed_step == "cleanup" and
+  .checks.owned_resource_cleanup == false
+' "$replacement_receipt" >/dev/null ||
+  fail 'replacement failure receipt did not fail closed'
+[[ "$(docker container inspect --format '{{.Id}}' "$replacement_id")" == \
+  "$replacement_id" ]] || fail 'cleanup deleted the replacement container'
+remove_test_container "$interruption_candidate" ||
+  fail 'test could not remove its preserved replacement container'
+assert_no_rehearsal_resources "$replacement_run_id"
+
+inspect_error_receipt="$temporary_directory/inspect-error-receipt.json"
+inspect_error_output="$temporary_directory/inspect-error.out"
+start_interruptible_rehearsal "$inspect_error_receipt" "$inspect_error_output"
+wait_for_candidate_container || {
+  wait "$interruption_pid" >/dev/null 2>&1 || true
+  fail 'inspect-error test did not reach one PID-owned candidate'
+}
+inspect_error_run_id=$interruption_run_id
+observed_rehearsal_runs+=("$inspect_error_run_id")
+verify_pid_rehearsal_container "$interruption_pid" candidate \
+  "$interruption_candidate" "$inspect_error_run_id" ||
+  fail 'inspect-error candidate ownership changed before fault injection'
+inspect_error_candidate_inspection=$(docker container inspect \
+  "$interruption_candidate")
+inspect_error_candidate_id=$(jq --exit-status --raw-output \
+  'if length == 1 then .[0].Id else empty end' \
+  <<<"$inspect_error_candidate_inspection") ||
+  fail 'inspect-error candidate has no immutable ID'
+jq --exit-status \
+  --arg id "$inspect_error_candidate_id" \
+  --arg name "$interruption_candidate" \
+  --arg run "$inspect_error_run_id" '
+    length == 1 and .[0].Id == $id and .[0].Name == ("/" + $name) and
+    .[0].Config.Labels["com.xengineer.speakup.production-rehearsal"] == "true" and
+    .[0].Config.Labels["com.xengineer.speakup.production-rehearsal-run-id"] == $run
+  ' <<<"$inspect_error_candidate_inspection" >/dev/null ||
+  fail 'inspect-error target is not the current PID-owned candidate'
+printf '%s\n' "$inspect_error_candidate_id" >"$TEST_INSPECT_ERROR_TARGET_FILE"
+chmod 0600 "$TEST_INSPECT_ERROR_TARGET_FILE"
+docker container stop --time 2 "$inspect_error_candidate_id" >/dev/null ||
+  fail 'inspect-error test could not stop its verified candidate'
+if wait "$interruption_pid"; then
+  fail 'inspect-error rehearsal unexpectedly succeeded'
+else
+  inspect_error_status=$?
+fi
+[[ "$inspect_error_status" == 1 ]] ||
+  fail "inspect-error rehearsal returned unexpected status $inspect_error_status"
+[[ -f "$TEST_INSPECT_ERROR_INJECTED_FILE" &&
+  ! -L "$TEST_INSPECT_ERROR_INJECTED_FILE" &&
+  "$(file_mode "$TEST_INSPECT_ERROR_INJECTED_FILE")" == 600 &&
+  "$(<"$TEST_INSPECT_ERROR_INJECTED_FILE")" == "$inspect_error_candidate_id" ]] ||
+  fail 'inspect-error wrapper did not inject against the verified candidate ID'
+grep -Fxq \
+  'Production schema rehearsal error: isolated Server image stopped before readiness' \
+  "$inspect_error_output" ||
+  fail 'inspect-error rehearsal did not report the expected natural readiness failure'
+[[ -e "$inspect_error_receipt" || -L "$inspect_error_receipt" ]] ||
+  fail 'inspect-error failure receipt is missing after confirmed injection'
+[[ -f "$inspect_error_receipt" && ! -L "$inspect_error_receipt" ]] ||
+  fail 'inspect-error failure receipt is not a regular file'
+inspect_error_receipt_mode=$(file_mode "$inspect_error_receipt") ||
+  fail 'inspect-error failure receipt mode cannot be inspected'
+[[ "$inspect_error_receipt_mode" == 600 ]] ||
+  fail "inspect-error failure receipt mode is $inspect_error_receipt_mode, expected 600"
+jq --exit-status '
+  .status == "failed" and .failed_step == "cleanup" and
+  .checks.owned_resource_cleanup == false
+' "$inspect_error_receipt" >/dev/null ||
+  fail 'inspect-error cleanup did not fail closed'
+[[ "$(docker container inspect --format '{{.Id}}' \
+  "$inspect_error_candidate_id")" == "$inspect_error_candidate_id" ]] ||
+  fail 'inspect error caused cleanup to delete an unverified container'
+rm "$TEST_INSPECT_ERROR_TARGET_FILE"
+rm "$TEST_INSPECT_ERROR_INJECTED_FILE"
+remove_rehearsal_run "$inspect_error_run_id" ||
+  fail 'test could not remove inspect-error resources after verification'
+assert_no_rehearsal_resources "$inspect_error_run_id"
+[[ "$(docker container inspect --format '{{.Id}}' "$decoy_candidate")" == \
+  "$decoy_candidate_id" ]] || fail 'candidate selection modified the concurrent decoy'
+[[ "$(docker container inspect --format '{{.Id}}' "$decoy_database")" == \
+  "$decoy_database_id" ]] || fail 'database selection modified the concurrent decoy'
+remove_test_container "$decoy_candidate" || fail 'cannot remove candidate decoy'
+remove_test_container "$decoy_database" || fail 'cannot remove database decoy'
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_image_id
+
+printf '%s\n' 'Production schema rehearsal tests passed'

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -230,6 +230,38 @@ services, image digests and OCI labels, networks, ports, and volumes; it then
 runs the migration image with `--pull never` to confirm the live schema before
 checking the three loopback endpoints.
 
+## Release business UAT
+
+Preview the immutable five-session matrix without making any network request:
+
+```sh
+node deploy/staging/uat.mjs
+```
+
+After the candidate is deployed, create a private receipt directory and opt in
+to the real Staging-only run explicitly:
+
+```sh
+receipt_directory="$(mktemp -d)"
+receipt_directory="$(cd "$receipt_directory" && pwd -P)"
+UAT_ENV=staging node deploy/staging/uat.mjs \
+  --execute \
+  --base-url https://staging-api.speak-up.top \
+  --receipt "$receipt_directory/receipt.json"
+```
+
+The executor creates a one-time account, dynamically freezes the current IELTS
+question assignments, and exercises PART 1 text/voice, PART 2 voice, PART 3
+voice, and FULL MOCK text through the terminal session report. Voice cases use
+the repository's fixed WAV fixture only as transport/ASR evidence. The `0600`
+receipt contains hashed resource references and status/timing metadata; it
+does not persist credentials, account identifiers, questions, answers,
+transcripts, audio, or provider payloads. Redirects, non-Staging origins,
+disabled TLS verification, failed evaluations, invalid evidence, and bounded
+polling timeouts fail closed.
+The receipt directory must already exist, be owned by the invoking user, have
+mode `0700`, and resolve without symbolic-link ancestors.
+
 ## 6. Stop or clean up Staging
 
 ```sh

--- a/deploy/staging/uat.mjs
+++ b/deploy/staging/uat.mjs
@@ -1,0 +1,1221 @@
+#!/usr/bin/env node
+
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import {
+  constants,
+  closeSync,
+  fchmodSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+export const STAGING_BASE_URL = "https://staging-api.speak-up.top";
+
+export const UAT_MATRIX = Object.freeze([
+  Object.freeze({ case_id: "part-1-text", mode: "PART_1", input: "text", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "part-1-voice", mode: "PART_1", input: "voice", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "part-2-voice", mode: "PART_2", input: "voice", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "part-3-voice", mode: "PART_3", input: "voice", timeout_seconds: 480 }),
+  Object.freeze({ case_id: "full-mock-text", mode: "FULL_MOCK", input: "text", timeout_seconds: 720 }),
+]);
+
+const voiceFixturePath = fileURLToPath(
+  new URL("../../server/internal/providers/qianwen/testdata/asr-live-fixture.wav", import.meta.url),
+);
+const jsonBodyLimit = 2 * 1024 * 1024;
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const identifierPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const optionByMode = Object.freeze({
+  FULL_MOCK: "option_ielts_speaking_full_mock",
+  PART_1: "option_ielts_speaking_part_1",
+  PART_2: "option_ielts_speaking_part_2",
+  PART_3: "option_ielts_speaking_part_3",
+});
+
+const usage = `Usage:
+  node deploy/staging/uat.mjs [--base-url ${STAGING_BASE_URL}]
+  UAT_ENV=staging node deploy/staging/uat.mjs --execute \\
+    --base-url ${STAGING_BASE_URL} --receipt <private-json-path>`;
+
+export class UatError extends Error {
+  constructor(category, message = category) {
+    super(message);
+    this.name = "UatError";
+    this.category = category;
+  }
+}
+
+class UatSessionError extends UatError {
+  constructor(error, sessionReceipt) {
+    super(error instanceof UatError ? error.category : "unexpected_error");
+    this.sessionReceipt = sessionReceipt;
+  }
+}
+
+class UatRunError extends UatError {
+  constructor(error, receipt) {
+    super(error instanceof UatError ? error.category : "unexpected_error");
+    this.receipt = receipt;
+  }
+}
+
+export function parseCli(arguments_) {
+  const result = {
+    baseUrl: STAGING_BASE_URL,
+    execute: false,
+    help: false,
+    receiptPath: null,
+  };
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--execute") {
+      if (result.execute) throw new UatError("invalid_arguments", usage);
+      result.execute = true;
+      continue;
+    }
+    if (argument === "--help") {
+      result.help = true;
+      continue;
+    }
+    if (argument !== "--base-url" && argument !== "--receipt") {
+      throw new UatError("invalid_arguments", usage);
+    }
+    const value = arguments_[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new UatError("invalid_arguments", usage);
+    }
+    index += 1;
+    if (argument === "--base-url") result.baseUrl = value;
+    if (argument === "--receipt") result.receiptPath = value;
+  }
+  return result;
+}
+
+export function validateExecutionBoundary(options, environment = process.env) {
+  if (!options.execute) {
+    throw new UatError("execute_opt_in_required");
+  }
+  if (environment.UAT_ENV !== "staging") {
+    throw new UatError("staging_environment_required");
+  }
+  if (options.baseUrl !== STAGING_BASE_URL) {
+    throw new UatError("untrusted_base_url");
+  }
+  if (environment.NODE_TLS_REJECT_UNAUTHORIZED === "0") {
+    throw new UatError("tls_verification_disabled");
+  }
+  if (!options.receiptPath) {
+    throw new UatError("receipt_path_required");
+  }
+  return new URL(`${STAGING_BASE_URL}/`);
+}
+
+export function executionPlan(baseUrl = STAGING_BASE_URL) {
+  if (baseUrl !== STAGING_BASE_URL) throw new UatError("untrusted_base_url");
+  return {
+    plan_version: 1,
+    dry_run: true,
+    environment: "staging",
+    base_url: baseUrl,
+    network_requests: 0,
+    writes: 0,
+    sessions: UAT_MATRIX,
+  };
+}
+
+export function createHttpClient({
+  baseUrl,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 30_000,
+}) {
+  const base = new URL(baseUrl);
+  if (typeof fetchImpl !== "function" || !Number.isSafeInteger(timeoutMs) || timeoutMs < 1) {
+    throw new UatError("invalid_http_client_configuration");
+  }
+  return async function request(resourcePath, options = {}) {
+    if (typeof resourcePath !== "string" || !resourcePath.startsWith("/") || resourcePath.startsWith("//")) {
+      throw new UatError("invalid_request_path");
+    }
+    const url = new URL(resourcePath, base);
+    if (url.origin !== base.origin) throw new UatError("untrusted_request_origin");
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        ...options,
+        redirect: "manual",
+        signal: options.signal ?? AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      if (error?.name === "TimeoutError" || error?.name === "AbortError") {
+        throw new UatError("request_timeout");
+      }
+      throw new UatError("network_error");
+    }
+    if (response.status >= 300 && response.status < 400) {
+      throw new UatError("redirect_rejected");
+    }
+    return response;
+  };
+}
+
+function requireObject(value, category) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireArray(value, category, { minimum = 0, maximum = 128 } = {}) {
+  if (!Array.isArray(value) || value.length < minimum || value.length > maximum) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireString(value, category, maximumBytes = 65_536) {
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    value.includes("\0") ||
+    Buffer.byteLength(value) > maximumBytes
+  ) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireUuid(value, category) {
+  if (typeof value !== "string" || !uuidPattern.test(value)) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireIdentifier(value, category) {
+  if (typeof value !== "string" || !identifierPattern.test(value)) {
+    throw new UatError(category);
+  }
+  return value;
+}
+
+function requireInteger(value, category, minimum = 0) {
+  if (!Number.isSafeInteger(value) || value < minimum) throw new UatError(category);
+  return value;
+}
+
+async function readJsonResponse(response, category) {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > jsonBodyLimit) {
+    throw new UatError(category);
+  }
+  let bytes;
+  try {
+    bytes = Buffer.from(await response.arrayBuffer());
+  } catch {
+    throw new UatError("network_error");
+  }
+  if (bytes.length > jsonBodyLimit) throw new UatError(category);
+  try {
+    return JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new UatError(category);
+  }
+}
+
+async function requestJson(request, resourcePath, {
+  method = "GET",
+  token,
+  body,
+  bytes,
+  idempotencyKey,
+  expectedStatuses = [200],
+  retryUncertain = false,
+  timeoutMs,
+  requireNoStore = false,
+  deadlineAt,
+  now = Date.now,
+} = {}) {
+  if (body !== undefined && bytes !== undefined) throw new UatError("invalid_request_body");
+  const headers = { accept: "application/json", "cache-control": "no-store" };
+  if (token) headers.authorization = `Bearer ${token}`;
+  if (idempotencyKey) headers["idempotency-key"] = idempotencyKey;
+  if (body !== undefined) headers["content-type"] = "application/json";
+  if (bytes !== undefined) headers["content-type"] = "audio/wav";
+  const attempts = retryUncertain ? 2 : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      let attemptTimeout = timeoutMs;
+      if (deadlineAt !== undefined) {
+        const remaining = deadlineAt - now();
+        if (!Number.isFinite(remaining) || remaining <= 0) {
+          throw new UatError("session_timeout");
+        }
+        attemptTimeout = Math.min(attemptTimeout ?? remaining, remaining);
+      }
+      const response = await request(resourcePath, {
+        method,
+        headers,
+        body: body === undefined ? bytes : JSON.stringify(body),
+        signal: attemptTimeout === undefined ? undefined : AbortSignal.timeout(attemptTimeout),
+      });
+      if (!expectedStatuses.includes(response.status)) {
+        throw new UatError(`unexpected_http_status_${response.status}`);
+      }
+      if (
+        requireNoStore &&
+        (!response.headers.get("cache-control")?.toLowerCase().split(",").map((value) => value.trim()).includes("no-store") ||
+          response.headers.get("pragma")?.toLowerCase().trim() !== "no-cache")
+      ) {
+        throw new UatError("invalid_auth_cache_control");
+      }
+      if (response.status === 204) return null;
+      return await readJsonResponse(response, "invalid_json_response");
+    } catch (error) {
+      if (
+        attempt === attempts ||
+        !(error instanceof UatError) ||
+        !["network_error", "request_timeout"].includes(error.category)
+      ) {
+        throw error;
+      }
+    }
+  }
+  throw new UatError("network_error");
+}
+
+function idempotencyKey(runId, caseId, operation, position = 0) {
+  return `uat-${runId}-${caseId}-${operation}-${position}`;
+}
+
+function selectQuestions(bank, mode) {
+  const root = requireObject(bank, "invalid_question_bank");
+  requireString(root.bank_id, "invalid_question_bank", 128);
+  const firstPart1 = requireObject(
+    requireArray(root.part1_topics, "invalid_question_bank", { minimum: 1 })[0],
+    "invalid_question_bank",
+  );
+  const firstGroup = requireObject(
+    requireArray(root.topic_groups, "invalid_question_bank", { minimum: 1 })[0],
+    "invalid_question_bank",
+  );
+  const part1Id = requireString(firstPart1.id, "invalid_question_bank", 128);
+  const groupId = requireString(firstGroup.id, "invalid_question_bank", 128);
+  if (mode === "PART_1") return { part_1_set_id: part1Id };
+  if (mode === "PART_2" || mode === "PART_3") return { topic_group_id: groupId };
+  if (mode === "FULL_MOCK") return null;
+  throw new UatError("unsupported_uat_mode");
+}
+
+function parseAssignment(value, expectedMode, expectedBankId) {
+  const assignment = requireObject(value, "invalid_plan_response");
+  if (assignment.mode !== expectedMode || assignment.bank_id !== expectedBankId) {
+    throw new UatError("plan_mode_mismatch");
+  }
+  const normalized = {
+    bank_id: requireString(assignment.bank_id, "invalid_plan_response", 128),
+    season: requireString(assignment.season, "invalid_plan_response", 128),
+    mode: assignment.mode,
+    parts: [],
+  };
+  const parts = requireArray(assignment.parts, "invalid_plan_response", { minimum: 1 });
+  const expectedParts = expectedMode === "FULL_MOCK"
+    ? ["PART_1", "PART_2", "PART_3"]
+    : [expectedMode];
+  if (
+    parts.length !== expectedParts.length ||
+    parts.some((rawPart, index) => rawPart?.part !== expectedParts[index])
+  ) {
+    throw new UatError("plan_mode_mismatch");
+  }
+  const expectedQuestionCount = parts.reduce((total, rawPart) => {
+    const part = requireObject(rawPart, "invalid_plan_response");
+    const normalizedPart = {
+      part: part.part,
+      source_id: requireString(part.source_id, "invalid_plan_response", 128),
+      turn_blueprints: requireArray(
+        part.turn_blueprints,
+        "invalid_plan_response",
+        { minimum: 1, maximum: 64 },
+      ).map((blueprint) => requireString(blueprint, "invalid_plan_response", 16_384)),
+    };
+    for (const optional of ["topic_title", "cue_card"]) {
+      if (Object.hasOwn(part, optional)) {
+        normalizedPart[optional] = requireString(part[optional], "invalid_plan_response", 16_384);
+      }
+    }
+    if (Object.hasOwn(part, "prepared_answers")) {
+      normalizedPart.prepared_answers = requireArray(
+        part.prepared_answers,
+        "invalid_plan_response",
+        { maximum: 64 },
+      ).map((rawAnswer) => {
+        const answer = requireObject(rawAnswer, "invalid_plan_response");
+        if (typeof answer.personalized !== "boolean") throw new UatError("invalid_plan_response");
+        return {
+          question_position: requireInteger(answer.question_position, "invalid_plan_response", 1),
+          answer: requireString(answer.answer, "invalid_plan_response", 16_384),
+          personalized: answer.personalized,
+        };
+      });
+    }
+    normalized.parts.push(normalizedPart);
+    return total + normalizedPart.turn_blueprints.length;
+  }, 0);
+  if (expectedQuestionCount < 1 || expectedQuestionCount > 64) {
+    throw new UatError("invalid_plan_response");
+  }
+  return { assignment: normalized, expectedQuestionCount };
+}
+
+function parsePlan(value, expectedMode, expectedBankId) {
+  const plan = requireObject(value, "invalid_plan_response");
+  const planId = requireUuid(plan.practice_plan_id, "invalid_plan_response");
+  const version = requireInteger(plan.version, "invalid_plan_response", 1);
+  if (plan.practice_plan_status !== "ready") throw new UatError("plan_not_ready");
+  return {
+    planId,
+    version,
+    ...parseAssignment(plan.ielts_assignment, expectedMode, expectedBankId),
+  };
+}
+
+function parseSessionBootstrap(value, plan, expectedMode) {
+  const root = requireObject(value, "invalid_session_response");
+  const session = requireObject(root.practice_session, "invalid_session_response");
+  const sessionId = requireUuid(session.practice_session_id, "invalid_session_response");
+  if (
+    session.practice_plan_id !== plan.planId ||
+    session.plan_version !== plan.version ||
+    session.practice_mode !== expectedMode ||
+    session.practice_session_status !== "starting"
+  ) {
+    throw new UatError("session_binding_mismatch");
+  }
+  const snapshot = requireObject(root.snapshot, "invalid_session_response");
+  const snapshotAssignment = parseAssignment(
+    snapshot.ielts_assignment,
+    expectedMode,
+    plan.assignment.bank_id,
+  ).assignment;
+  if (
+    snapshot.practice_session_id !== sessionId ||
+    snapshot.plan_version !== plan.version ||
+    snapshot.practice_mode !== expectedMode ||
+    !isDeepStrictEqual(snapshotAssignment, plan.assignment)
+  ) {
+    throw new UatError("session_binding_mismatch");
+  }
+  return {
+    sessionId,
+    sessionVersion: requireInteger(session.session_version, "invalid_session_response", 1),
+  };
+}
+
+function parseInteractionState(value, sessionId, mode, plan) {
+  const state = requireObject(value, "invalid_interaction_state");
+  const stateAssignment = parseAssignment(
+    state.ielts_assignment,
+    mode,
+    plan.assignment.bank_id,
+  ).assignment;
+  if (
+    state.practice_session_id !== sessionId ||
+    state.practice_plan_id !== plan.planId ||
+    state.practice_mode !== mode ||
+    !isDeepStrictEqual(stateAssignment, plan.assignment)
+  ) {
+    throw new UatError("interaction_state_mismatch");
+  }
+  requireInteger(state.effective_turns, "invalid_interaction_state");
+  requireInteger(state.turn_limit, "invalid_interaction_state");
+  requireInteger(state.session_version, "invalid_interaction_state", 1);
+  if (typeof state.session_completed !== "boolean") {
+    throw new UatError("invalid_interaction_state");
+  }
+  const terminal = ["completed", "ended_early"].includes(state.practice_session_status);
+  if (
+    !["in_progress", "completed", "ended_early"].includes(state.practice_session_status) ||
+    state.session_completed !== terminal ||
+    state.effective_turns > state.turn_limit ||
+    (terminal && Object.hasOwn(state, "current_question")) ||
+    (state.effective_turns === 0 && Object.hasOwn(state, "current_turn")) ||
+    (state.effective_turns > 0 && !Object.hasOwn(state, "current_turn"))
+  ) {
+    throw new UatError("invalid_interaction_lifecycle");
+  }
+  if (!state.session_completed) {
+    const question = requireObject(state.current_question, "invalid_interaction_state");
+    requireUuid(question.question_id, "invalid_interaction_state");
+    if (question.practice_session_id !== sessionId) {
+      throw new UatError("interaction_state_mismatch");
+    }
+    requireString(question.content, "invalid_interaction_state", 16_384);
+  }
+  return state;
+}
+
+function parseTranscriptionCandidate(value, sessionId, questionId) {
+  const candidate = requireObject(value, "invalid_transcription_candidate");
+  const candidateId = requireUuid(candidate.candidate_id, "invalid_transcription_candidate");
+  const respondentParticipantId = requireUuid(
+    candidate.respondent_participant_id,
+    "invalid_transcription_candidate",
+  );
+  const transcriptId = requireIdentifier(
+    candidate.transcript_id,
+    "invalid_transcription_candidate",
+  );
+  const evidenceVersion = requireInteger(
+    candidate.evidence_version,
+    "invalid_transcription_candidate",
+    1,
+  );
+  if (candidate.practice_session_id !== sessionId || candidate.question_id !== questionId) {
+    throw new UatError("transcription_candidate_mismatch");
+  }
+  return {
+    candidateId,
+    respondentParticipantId,
+    transcriptId,
+    evidenceVersion,
+    transcript: requireString(candidate.transcript, "invalid_transcription_candidate", 16_384),
+  };
+}
+
+function parseConfirmedTurn(state, {
+  expectedQuestionId,
+  expectedTranscript,
+  inputKind,
+  candidate,
+}) {
+  const turn = requireObject(state.current_turn, "invalid_turn_confirmation");
+  const turnId = requireUuid(turn.turn_id, "invalid_turn_confirmation");
+  const candidateId = requireUuid(turn.candidate_id, "invalid_turn_confirmation");
+  const respondentParticipantId = requireUuid(
+    turn.respondent_participant_id,
+    "invalid_turn_confirmation",
+  );
+  const evidenceVersion = requireInteger(
+    turn.evidence_version,
+    "invalid_turn_confirmation",
+    1,
+  );
+  if (
+    turn.practice_session_id !== state.practice_session_id ||
+    turn.question_id !== expectedQuestionId ||
+    turn.answer_text !== expectedTranscript ||
+    turn.effective_turns !== state.effective_turns ||
+    turn.session_completed !== state.session_completed ||
+    turn.counts_toward_effective_turn_limit !== true
+  ) {
+    throw new UatError("turn_confirmation_mismatch");
+  }
+  if (inputKind === "voice") {
+    if (
+      candidateId !== candidate.candidateId ||
+      respondentParticipantId !== candidate.respondentParticipantId ||
+      evidenceVersion !== candidate.evidenceVersion ||
+      !requireUuid(turn.audio_asset_id, "invalid_turn_confirmation")
+    ) {
+      throw new UatError("turn_confirmation_mismatch");
+    }
+  } else if (Object.hasOwn(turn, "audio_asset_id")) {
+    throw new UatError("turn_confirmation_mismatch");
+  }
+  return turnId;
+}
+
+function sessionRequest(request, deadlineAt, now) {
+  return (resourcePath, options = {}) => {
+    const remaining = deadlineAt - now();
+    if (!Number.isFinite(remaining) || remaining <= 0) {
+      throw new UatError("session_timeout");
+    }
+    const requestedTimeout = options.timeoutMs ?? remaining;
+    return requestJson(request, resourcePath, {
+      ...options,
+      timeoutMs: Math.min(requestedTimeout, remaining),
+      deadlineAt,
+      now,
+    });
+  };
+}
+
+function validateEvidence(evidence, transcripts, dimensionRefs) {
+  const item = requireObject(evidence, "invalid_report_evidence");
+  const evidenceRef = requireUuid(item.evidence_ref_id, "invalid_report_evidence");
+  const turnId = requireUuid(item.turn_id, "invalid_report_evidence");
+  if (evidenceRef !== turnId || !transcripts.has(turnId)) {
+    throw new UatError("invalid_report_evidence");
+  }
+  const start = requireInteger(item.start_utf8_byte, "invalid_report_evidence");
+  const end = requireInteger(item.end_utf8_byte, "invalid_report_evidence", 1);
+  const excerpt = requireString(item.original_excerpt, "invalid_report_evidence", 16_384);
+  const transcript = Buffer.from(transcripts.get(turnId), "utf8");
+  if (
+    end <= start ||
+    end > transcript.length ||
+    transcript.subarray(start, end).toString("utf8") !== excerpt
+  ) {
+    throw new UatError("invalid_report_evidence");
+  }
+  dimensionRefs.add(evidenceRef);
+}
+
+function validateReport(result, expectedMode, answeredQuestions) {
+  const report = requireObject(result, "invalid_report");
+  if (
+    report.schema_version !== "evaluation-report/v2" ||
+    report.scene_type !== "IELTS_SPEAKING" ||
+    report.practice_experience !== "IELTS_SPEAKING" ||
+    report.scene_category !== "IELTS_SPEAKING" ||
+    report.practice_mode !== expectedMode
+  ) {
+    throw new UatError("report_contract_mismatch");
+  }
+  if (!["PROVISIONAL", "INSUFFICIENT"].includes(report.scoreability_status)) {
+    throw new UatError("invalid_report");
+  }
+  const questions = requireArray(report.questions, "invalid_report", {
+    minimum: 1,
+    maximum: 128,
+  });
+  if (questions.length !== answeredQuestions.length) {
+    throw new UatError("report_question_count_mismatch");
+  }
+  const transcripts = new Map();
+  for (let index = 0; index < questions.length; index += 1) {
+    const actual = requireObject(questions[index], "invalid_report");
+    const expected = answeredQuestions[index];
+    const answer = requireObject(actual.answer, "invalid_report");
+    if (
+      actual.position !== index + 1 ||
+      actual.question_id !== expected.questionId ||
+      actual.text !== expected.questionText ||
+      answer.turn_id !== expected.turnId ||
+      answer.transcript !== expected.transcript
+    ) {
+      throw new UatError("report_turn_mismatch");
+    }
+    transcripts.set(expected.turnId, expected.transcript);
+  }
+  const dimensions = requireArray(report.dimensions, "invalid_report", {
+    minimum: 1,
+    maximum: 8,
+  });
+  const findingIds = new Set();
+  const improvementIds = new Map();
+  const dimensionKeys = new Set();
+  for (const rawDimension of dimensions) {
+    const dimension = requireObject(rawDimension, "invalid_report");
+    const key = requireIdentifier(dimension.key, "invalid_report");
+    if (!dimensionKeys.add(key) || dimension.scale !== "IELTS_BAND_9") {
+      throw new UatError("invalid_report_dimension");
+    }
+    const score = dimension.score;
+    if (
+      score !== null &&
+      (typeof score !== "number" ||
+        !Number.isFinite(score) ||
+        score < 0 ||
+        score > 9 ||
+        !Number.isInteger(score * 2))
+    ) {
+      throw new UatError("invalid_report_dimension");
+    }
+    for (const ratio of [dimension.coverage, dimension.confidence]) {
+      if (typeof ratio !== "number" || !Number.isFinite(ratio) || ratio < 0 || ratio > 1) {
+        throw new UatError("invalid_report_dimension");
+      }
+    }
+    if (
+      report.scoreability_status === "INSUFFICIENT" &&
+      score !== null
+    ) {
+      throw new UatError("insufficient_report_has_score");
+    }
+    const reasonCodes = requireArray(dimension.reason_codes, "invalid_report", { maximum: 8 });
+    const uniqueReasons = new Set(
+      reasonCodes.map((value) => requireIdentifier(value, "invalid_report")),
+    );
+    if (uniqueReasons.size !== reasonCodes.length) throw new UatError("invalid_report_dimension");
+    const evidenceRefs = requireArray(dimension.evidence_ref_ids, "invalid_report", {
+      maximum: 128,
+    }).map((value) => requireUuid(value, "invalid_report"));
+    const declaredRefs = new Set(
+      evidenceRefs,
+    );
+    if (declaredRefs.size !== evidenceRefs.length) throw new UatError("invalid_report_evidence_refs");
+    const actualRefs = new Set();
+    const improvements = new Set();
+    for (const collectionName of ["strengths", "improvements", "recommended_examples"]) {
+      const findings = requireArray(dimension[collectionName], "invalid_report", { maximum: 5 });
+      for (const rawFinding of findings) {
+        const finding = requireObject(rawFinding, "invalid_report");
+        const findingId = requireIdentifier(finding.finding_id, "invalid_report");
+        if (findingIds.has(findingId)) throw new UatError("invalid_report");
+        findingIds.add(findingId);
+        if (collectionName === "improvements") improvements.add(findingId);
+        for (const evidence of requireArray(finding.evidence, "invalid_report", { maximum: 8 })) {
+          validateEvidence(evidence, transcripts, actualRefs);
+        }
+      }
+    }
+    if (
+      declaredRefs.size !== actualRefs.size ||
+      [...declaredRefs].some((reference) => !actualRefs.has(reference))
+    ) {
+      throw new UatError("invalid_report_evidence_refs");
+    }
+    improvementIds.set(key, improvements);
+  }
+  const actions = requireArray(report.priority_actions, "invalid_report", { maximum: 5 });
+  if (report.scoreability_status === "INSUFFICIENT" && actions.length !== 0) {
+    throw new UatError("insufficient_report_has_priority_actions");
+  }
+  for (const rawAction of actions) {
+    const action = requireObject(rawAction, "invalid_report");
+    if (!improvementIds.get(action.dimension_key)?.has(action.finding_id)) {
+      throw new UatError("invalid_report_priority_action");
+    }
+  }
+  return {
+    schemaVersion: report.schema_version,
+    scoreabilityStatus: report.scoreability_status,
+  };
+}
+
+function parseEvaluation(value, sessionId) {
+  const evaluation = requireObject(value, "invalid_evaluation_response");
+  const evaluationId = requireUuid(evaluation.evaluation_id, "invalid_evaluation_response");
+  if (
+    evaluation.kind !== "SESSION_REPORT" ||
+    evaluation.source_id !== sessionId ||
+    evaluation.context_id !== sessionId ||
+    !["QUEUED", "RUNNING", "READY", "FAILED"].includes(evaluation.status)
+  ) {
+    throw new UatError("evaluation_binding_mismatch");
+  }
+  if (
+    requireArray(evaluation.feedback_items, "invalid_evaluation_response", { maximum: 32 }).length !== 0
+  ) {
+    throw new UatError("invalid_evaluation_response");
+  }
+  const hasResult = Object.hasOwn(evaluation, "result");
+  const hasError = Object.hasOwn(evaluation, "error");
+  if (
+    (["QUEUED", "RUNNING"].includes(evaluation.status) && (hasResult || hasError)) ||
+    (evaluation.status === "READY" && (!hasResult || hasError)) ||
+    (evaluation.status === "FAILED" && (!hasError || hasResult))
+  ) {
+    throw new UatError("invalid_evaluation_state");
+  }
+  if (evaluation.status === "FAILED") {
+    const failure = requireObject(evaluation.error, "invalid_evaluation_state");
+    requireIdentifier(failure.code, "invalid_evaluation_state");
+    requireString(failure.message, "invalid_evaluation_state", 2048);
+    if (typeof failure.retryable !== "boolean") {
+      throw new UatError("invalid_evaluation_state");
+    }
+  }
+  return { evaluation, evaluationId };
+}
+
+async function pollEvaluation({
+  request,
+  token,
+  sessionId,
+  mode,
+  answeredQuestions,
+  deadlineAt,
+  pollIntervalMs,
+  now,
+  sleep,
+  onEvaluationState,
+}) {
+  let stableEvaluationId = null;
+  while (now() < deadlineAt) {
+    const value = await request(
+      `/v1/practice-sessions/${encodeURIComponent(sessionId)}/evaluation`,
+      { token },
+    );
+    const { evaluation, evaluationId } = parseEvaluation(value, sessionId);
+    onEvaluationState(evaluationId, evaluation.status);
+    if (stableEvaluationId !== null && stableEvaluationId !== evaluationId) {
+      throw new UatError("evaluation_identity_changed");
+    }
+    stableEvaluationId = evaluationId;
+    if (evaluation.status === "FAILED") throw new UatError("evaluation_failed");
+    if (evaluation.status === "READY") {
+      return {
+        evaluationId,
+        ...validateReport(evaluation.result, mode, answeredQuestions),
+      };
+    }
+    const remaining = deadlineAt - now();
+    if (remaining <= 0) break;
+    await sleep(Math.min(pollIntervalMs, remaining));
+  }
+  throw new UatError("session_timeout");
+}
+
+async function runSessionInternal({
+  request,
+  token,
+  bank,
+  entry,
+  runId,
+  voiceBytes,
+  now,
+  sleep,
+  pollIntervalMs,
+  startedAt,
+  progress,
+}) {
+  const deadlineAt = startedAt + entry.timeout_seconds * 1000;
+  const requestWithinSession = sessionRequest(request, deadlineAt, now);
+  const selection = selectQuestions(bank, entry.mode);
+  const planValue = await requestWithinSession("/v1/practice-plans", {
+    method: "POST",
+    token,
+    idempotencyKey: idempotencyKey(runId, entry.case_id, "plan"),
+    retryUncertain: true,
+    expectedStatuses: [201],
+    body: {
+      background_summary: "Staging release UAT.",
+      scene_id: "scn_ielts_speaking",
+      scene_version: 1,
+      selected_role_ids: ["role_ielts_speaking_examiner"],
+      practice_option_id: optionByMode[entry.mode],
+      ...(selection === null ? {} : { ielts_selection: selection }),
+    },
+  });
+  const plan = parsePlan(planValue, entry.mode, bank.bank_id);
+  progress.resource_refs.plan = redactResource(plan.planId);
+  const bootstrap = await requestWithinSession(
+    `/v1/practice-plans/${encodeURIComponent(plan.planId)}/practice-sessions`,
+    {
+      method: "POST",
+      token,
+      idempotencyKey: idempotencyKey(runId, entry.case_id, "session"),
+      retryUncertain: true,
+      expectedStatuses: [201],
+      body: { expected_plan_version: plan.version },
+    },
+  );
+  const session = parseSessionBootstrap(bootstrap, plan, entry.mode);
+  const { sessionId } = session;
+  progress.resource_refs.session = redactResource(sessionId);
+  let state = parseInteractionState(
+    await requestWithinSession(
+      `/v1/practice-sessions/${encodeURIComponent(sessionId)}/activation`,
+      {
+        method: "POST",
+        token,
+        idempotencyKey: idempotencyKey(runId, entry.case_id, "activate"),
+        retryUncertain: true,
+      },
+    ),
+    sessionId,
+    entry.mode,
+    plan,
+  );
+  if (
+    state.practice_session_status !== "in_progress" ||
+    state.session_version <= session.sessionVersion ||
+    state.effective_turns !== 0 ||
+    state.session_completed ||
+    Object.hasOwn(state, "current_turn")
+  ) {
+    throw new UatError("invalid_interaction_lifecycle");
+  }
+  const turnLimit = state.turn_limit;
+  if (state.turn_limit !== plan.expectedQuestionCount) {
+    throw new UatError("session_question_count_mismatch");
+  }
+  const answeredQuestions = [];
+  const seenQuestions = new Set();
+  while (!state.session_completed) {
+    if (answeredQuestions.length >= 64) throw new UatError("session_turn_limit_exceeded");
+    const question = state.current_question;
+    const previousSessionVersion = state.session_version;
+    const questionId = question.question_id;
+    if (!seenQuestions.add(questionId)) throw new UatError("repeated_current_question");
+    let transcript;
+    if (entry.input === "voice") {
+      const candidate = requireObject(
+        await requestWithinSession(
+          `/v1/practice-sessions/${encodeURIComponent(sessionId)}/questions/${encodeURIComponent(questionId)}/transcription-candidates`,
+          {
+            method: "POST",
+            token,
+            bytes: voiceBytes,
+            idempotencyKey: idempotencyKey(
+              runId,
+              entry.case_id,
+              "transcribe",
+              answeredQuestions.length + 1,
+            ),
+            retryUncertain: true,
+            expectedStatuses: [201],
+            timeoutMs: 540_000,
+          },
+        ),
+        "invalid_transcription_candidate",
+      );
+      const candidateBinding = parseTranscriptionCandidate(candidate, sessionId, questionId);
+      transcript = candidateBinding.transcript;
+      state = parseInteractionState(
+        await requestWithinSession(
+          `/v1/transcription-candidates/${encodeURIComponent(candidateBinding.candidateId)}/confirmations`,
+          {
+            method: "POST",
+            token,
+            idempotencyKey: idempotencyKey(
+              runId,
+              entry.case_id,
+              "confirm",
+              answeredQuestions.length + 1,
+            ),
+            retryUncertain: true,
+          },
+        ),
+        sessionId,
+        entry.mode,
+        plan,
+      );
+      const turnId = parseConfirmedTurn(state, {
+        expectedQuestionId: questionId,
+        expectedTranscript: transcript,
+        inputKind: entry.input,
+        candidate: candidateBinding,
+      });
+      answeredQuestions.push({ questionId, questionText: question.content, turnId, transcript });
+    } else {
+      transcript = "I can explain this clearly with a concrete example from my experience.";
+      state = parseInteractionState(
+        await requestWithinSession(
+          `/v1/practice-sessions/${encodeURIComponent(sessionId)}/questions/${encodeURIComponent(questionId)}/text-answers`,
+          {
+            method: "POST",
+            token,
+            body: { answer_text: transcript },
+            idempotencyKey: idempotencyKey(
+              runId,
+              entry.case_id,
+              "text",
+              answeredQuestions.length + 1,
+            ),
+            retryUncertain: true,
+          },
+        ),
+        sessionId,
+        entry.mode,
+        plan,
+      );
+      const turnId = parseConfirmedTurn(state, {
+        expectedQuestionId: questionId,
+        expectedTranscript: transcript,
+        inputKind: entry.input,
+      });
+      answeredQuestions.push({ questionId, questionText: question.content, turnId, transcript });
+    }
+    const expectedEffectiveTurns = answeredQuestions.length;
+    const expectedCompleted = expectedEffectiveTurns === turnLimit;
+    if (
+      state.session_version <= previousSessionVersion ||
+      state.turn_limit !== turnLimit ||
+      state.effective_turns !== expectedEffectiveTurns ||
+      state.session_completed !== expectedCompleted ||
+      state.practice_session_status !== (expectedCompleted ? "completed" : "in_progress")
+    ) {
+      throw new UatError("invalid_interaction_lifecycle");
+    }
+  }
+  if (answeredQuestions.length !== plan.expectedQuestionCount) {
+    throw new UatError("session_question_count_mismatch");
+  }
+  const evaluation = await pollEvaluation({
+    request: requestWithinSession,
+    token,
+    sessionId,
+    mode: entry.mode,
+    answeredQuestions,
+    deadlineAt,
+    pollIntervalMs,
+    now,
+    sleep,
+    onEvaluationState: (evaluationId, status) => {
+      progress.resource_refs.evaluation = redactResource(evaluationId);
+      progress.evaluation_status = status;
+    },
+  });
+  return {
+    case_id: entry.case_id,
+    mode: entry.mode,
+    input_kind: entry.input,
+    duration_ms: now() - startedAt,
+    evaluation_status: "READY",
+    schema_version: evaluation.schemaVersion,
+    scoreability_status: evaluation.scoreabilityStatus,
+    error_category: null,
+    resource_refs: {
+      ...progress.resource_refs,
+    },
+  };
+}
+
+async function runSession(arguments_) {
+  const startedAt = arguments_.now();
+  const progress = {
+    case_id: arguments_.entry.case_id,
+    mode: arguments_.entry.mode,
+    input_kind: arguments_.entry.input,
+    resource_refs: {},
+  };
+  try {
+    return await runSessionInternal({ ...arguments_, startedAt, progress });
+  } catch (error) {
+    throw new UatSessionError(error, {
+      ...progress,
+      duration_ms: arguments_.now() - startedAt,
+      evaluation_status: progress.evaluation_status ?? "NOT_REACHED",
+      schema_version: null,
+      scoreability_status: null,
+      error_category: error instanceof UatError ? error.category : "unexpected_error",
+    });
+  }
+}
+
+function redactResource(value) {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export async function runStagingUat({
+  baseUrl = STAGING_BASE_URL,
+  fetchImpl = globalThis.fetch,
+  now = Date.now,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  pollIntervalMs = 5_000,
+  matrix = UAT_MATRIX,
+  voiceBytes = readFileSync(voiceFixturePath),
+} = {}) {
+  const startedAt = new Date(now()).toISOString();
+  const runId = randomUUID();
+  const request = createHttpClient({ baseUrl, fetchImpl });
+  const sessions = [];
+  try {
+    const health = requireObject(
+      await requestJson(request, "/health"),
+      "invalid_health_response",
+    );
+    if (health.status !== "ok") throw new UatError("staging_not_ready");
+    const readiness = requireObject(
+      await requestJson(request, "/readyz"),
+      "invalid_readiness_response",
+    );
+    if (
+      readiness.status !== "ready" ||
+      requireObject(readiness.checks, "invalid_readiness_response").database !== "ready"
+    ) {
+      throw new UatError("staging_not_ready");
+    }
+    const emailNonce = randomBytes(18).toString("hex");
+    const email = `speakup-uat-${emailNonce}@example.invalid`;
+    const password = `Uat-${randomBytes(24).toString("base64url")}`;
+    await requestJson(request, "/v1/auth/register", {
+      method: "POST",
+      expectedStatuses: [201],
+      body: { email, password },
+    });
+    const login = requireObject(
+      await requestJson(request, "/v1/auth/login", {
+        method: "POST",
+        body: { email, password },
+        requireNoStore: true,
+      }),
+      "invalid_login_response",
+    );
+    const token = requireString(login.session_token, "invalid_login_response", 2048);
+    if (!token.startsWith("sess_") || login.token_type !== "Bearer") {
+      throw new UatError("invalid_login_response");
+    }
+    const bank = await requestJson(request, "/v1/ielts-speaking/question-bank", { token });
+    if (requireObject(bank, "invalid_question_bank").schema_version !== 4) {
+      throw new UatError("invalid_question_bank");
+    }
+    for (const entry of matrix) {
+      sessions.push(
+        await runSession({
+          request,
+          token,
+          bank,
+          entry,
+          runId,
+          voiceBytes,
+          now,
+          sleep,
+          pollIntervalMs,
+        }),
+      );
+    }
+    await requestJson(request, "/v1/auth/logout", {
+      method: "POST",
+      token,
+      expectedStatuses: [204],
+    });
+    return {
+      receipt_version: 1,
+      run_id: runId,
+      environment: "staging",
+      base_host: new URL(baseUrl).hostname,
+      started_at: startedAt,
+      completed_at: new Date(now()).toISOString(),
+      outcome: "passed",
+      sessions,
+      error_category: null,
+    };
+  } catch (error) {
+    if (error instanceof UatSessionError) sessions.push(error.sessionReceipt);
+    throw new UatRunError(error, {
+      receipt_version: 1,
+      run_id: runId,
+      environment: "staging",
+      base_host: new URL(baseUrl).hostname,
+      started_at: startedAt,
+      completed_at: new Date(now()).toISOString(),
+      outcome: "failed",
+      sessions,
+      error_category: error instanceof UatError ? error.category : "unexpected_error",
+    });
+  }
+}
+
+const sensitiveKeyPattern = /(?:password|token|email|question|answer|transcript|audio|provider|payload|secret|access.?key)/i;
+const credentialValuePattern = /(?:sess_[A-Za-z0-9._~+/=-]+|[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})/;
+
+export function assertReceiptIsRedacted(value, trail = "receipt") {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertReceiptIsRedacted(entry, `${trail}[${index}]`));
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      if (sensitiveKeyPattern.test(key)) {
+        throw new UatError("receipt_contains_sensitive_field", `${trail}.${key}`);
+      }
+      assertReceiptIsRedacted(entry, `${trail}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === "string" && credentialValuePattern.test(value)) {
+    throw new UatError("receipt_contains_sensitive_value", trail);
+  }
+}
+
+function prepareReceiptTarget(receiptPath) {
+  const resolved = path.resolve(receiptPath);
+  try {
+    lstatSync(resolved);
+    throw new UatError("receipt_already_exists");
+  } catch (error) {
+    if (error instanceof UatError) throw error;
+    if (error?.code !== "ENOENT") throw error;
+  }
+  const parent = path.dirname(resolved);
+  let status;
+  try {
+    status = lstatSync(parent);
+  } catch (error) {
+    if (error?.code === "ENOENT") throw new UatError("receipt_directory_required");
+    throw error;
+  }
+  const wrongOwner = typeof process.getuid === "function" && status.uid !== process.getuid();
+  if (
+    status.isSymbolicLink() ||
+    !status.isDirectory() ||
+    (status.mode & 0o777) !== 0o700 ||
+    wrongOwner ||
+    realpathSync(parent) !== parent
+  ) {
+    throw new UatError("receipt_directory_not_private");
+  }
+  return resolved;
+}
+
+export function writeReceipt(receiptPath, receipt) {
+  assertReceiptIsRedacted(receipt);
+  const resolved = prepareReceiptTarget(receiptPath);
+  let descriptor;
+  try {
+    descriptor = openSync(
+      resolved,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY,
+      0o600,
+    );
+    fchmodSync(descriptor, 0o600);
+    writeFileSync(descriptor, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+export async function runCli({
+  arguments_: argumentsValue,
+  environment = process.env,
+  output = process.stdout,
+  executeUat,
+}) {
+  const options = parseCli(argumentsValue);
+  if (options.help) {
+    output.write(`${usage}\n`);
+    return { kind: "help" };
+  }
+  if (!options.execute) {
+    const plan = executionPlan(options.baseUrl);
+    output.write(`${JSON.stringify(plan, null, 2)}\n`);
+    return { kind: "dry-run", plan };
+  }
+  validateExecutionBoundary(options, environment);
+  prepareReceiptTarget(options.receiptPath);
+  if (typeof executeUat !== "function") {
+    throw new UatError("uat_executor_required");
+  }
+  let receipt;
+  try {
+    receipt = await executeUat(options);
+  } catch (error) {
+    writeReceipt(options.receiptPath, error instanceof UatRunError ? error.receipt : {
+      receipt_version: 1,
+      run_id: randomUUID(),
+      environment: "staging",
+      base_host: new URL(options.baseUrl).hostname,
+      completed_at: new Date().toISOString(),
+      outcome: "failed",
+      sessions: [],
+      error_category: error instanceof UatError ? error.category : "unexpected_error",
+    });
+    throw error;
+  }
+  writeReceipt(options.receiptPath, receipt);
+  output.write(`${JSON.stringify({ outcome: receipt.outcome, receipt: path.resolve(options.receiptPath) })}\n`);
+  return { kind: "executed", receipt };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli({
+    arguments_: process.argv.slice(2),
+    executeUat: (options) => runStagingUat({ baseUrl: options.baseUrl }),
+  }).catch((error) => {
+    const category = error instanceof UatError ? error.category : "unexpected_error";
+    process.stderr.write(`Staging UAT failed: ${category}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/deploy/staging/uat.test.mjs
+++ b/deploy/staging/uat.test.mjs
@@ -1,0 +1,729 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+} from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  STAGING_BASE_URL,
+  UAT_MATRIX,
+  UatError,
+  createHttpClient,
+  runCli,
+  runStagingUat,
+  validateExecutionBoundary,
+  writeReceipt,
+} from "./uat.mjs";
+
+function outputBuffer() {
+  let value = "";
+  return {
+    output: { write: (chunk) => { value += chunk; } },
+    read: () => value,
+  };
+}
+
+function uuid(value) {
+  return `00000000-0000-4000-8000-${value.toString(16).padStart(12, "0")}`;
+}
+
+async function requestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function json(response, status, value, headers = {}) {
+  const body = Buffer.from(JSON.stringify(value));
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": body.length,
+    ...headers,
+  });
+  response.end(body);
+}
+
+async function createUatServer(behavior = "ready") {
+  let sequence = 1;
+  const plans = new Map();
+  const sessions = new Map();
+  const candidates = new Map();
+  const counts = { plans: 0, requests: 0 };
+  const nextId = () => uuid(sequence++);
+  const modeByOption = {
+    option_ielts_speaking_part_1: "PART_1",
+    option_ielts_speaking_part_2: "PART_2",
+    option_ielts_speaking_part_3: "PART_3",
+    option_ielts_speaking_full_mock: "FULL_MOCK",
+  };
+  const totalByMode = { PART_1: 2, PART_2: 1, PART_3: 2, FULL_MOCK: 3 };
+
+  function interaction(session) {
+    const completed = session.answers.length === session.questions.length;
+    return {
+      practice_session_id: session.id,
+      practice_plan_id: behavior === "bad-state-plan" ? nextId() : session.planId,
+      practice_mode: session.mode,
+      ielts_assignment: behavior === "bad-state-assignment"
+        ? {
+            ...session.assignment,
+            parts: session.assignment.parts.map((part, index) => index === 0
+              ? { ...part, source_id: "mutated-state-source" }
+              : part),
+          }
+        : session.assignment,
+      practice_session_status: behavior === "bad-lifecycle" && completed
+        ? "in_progress"
+        : completed ? "completed" : "in_progress",
+      session_version: session.answers.length + 2,
+      effective_turns: session.answers.length,
+      turn_limit: session.questions.length,
+      session_completed: completed,
+      ...(completed
+        ? {}
+        : { current_question: session.questions[session.answers.length] }),
+      ...(session.answers.length === 0
+        ? {}
+        : { current_turn: session.answers.at(-1) }),
+    };
+  }
+
+  function advance(session, questionId, transcript, binding = {}) {
+    assert.equal(session.questions[session.answers.length].question_id, questionId);
+    const nextEffectiveTurns = session.answers.length + 1;
+    session.answers.push({
+      turn_id: nextId(),
+      practice_session_id: session.id,
+      question_id: questionId,
+      respondent_participant_id: binding.respondentParticipantId ?? nextId(),
+      candidate_id: binding.candidateId ?? nextId(),
+      answer_text: transcript,
+      evidence_version: binding.evidenceVersion ?? 1,
+      effective_turns: nextEffectiveTurns,
+      counts_toward_effective_turn_limit: true,
+      session_completed: nextEffectiveTurns === session.questions.length,
+      ...(binding.audioAssetId === undefined ? {} : { audio_asset_id: binding.audioAssetId }),
+    });
+    return interaction(session);
+  }
+
+  function report(session) {
+    const first = session.answers[0];
+    const transcript = first.answer_text;
+    const excerpt = transcript.slice(0, 5);
+    const invalidEnd = behavior === "invalid-evidence" ? 6 : Buffer.byteLength(excerpt);
+    const insufficient = behavior === "insufficient-score";
+    const finding = {
+      finding_id: "finding-1",
+      message: "Use a more specific supporting example.",
+      suggestion: "Add one measurable result.",
+      evidence: [{
+        evidence_ref_id: first.turn_id,
+        turn_id: first.turn_id,
+        start_utf8_byte: 0,
+        end_utf8_byte: invalidEnd,
+        original_excerpt: excerpt,
+      }],
+    };
+    return {
+      schema_version: "evaluation-report/v2",
+      scene_type: "IELTS_SPEAKING",
+      practice_experience: "IELTS_SPEAKING",
+      scene_category: "IELTS_SPEAKING",
+      practice_mode: session.mode,
+      scoreability_status: insufficient ? "INSUFFICIENT" : "PROVISIONAL",
+      summary: "Staging UAT report.",
+      questions: session.questions.map((question, index) => ({
+        question_id: question.question_id,
+        position: index + 1,
+        text: question.content,
+        answer: {
+          turn_id: session.answers[index].turn_id,
+          transcript: session.answers[index].answer_text,
+        },
+      })),
+      dimensions: [{
+        key: "FLUENCY_COHERENCE",
+        score: insufficient ? 6.5 : behavior === "invalid-dimension" ? 6.3 : 6,
+        scale: "IELTS_BAND_9",
+        coverage: 1,
+        confidence: 0.8,
+        reason_codes: [],
+        evidence_ref_ids: [first.turn_id],
+        strengths: [],
+        improvements: [finding],
+        recommended_examples: [],
+      }],
+      priority_actions: insufficient
+        ? []
+        : [{ dimension_key: "FLUENCY_COHERENCE", finding_id: "finding-1" }],
+    };
+  }
+
+  const server = http.createServer(async (request, response) => {
+    counts.requests += 1;
+    const url = new URL(request.url, "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/health") {
+      json(response, 200, {
+        status: behavior === "bad-health" ? "degraded" : "ok",
+        modules: ["practice"],
+      });
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/readyz") {
+      json(response, 200, {
+        status: behavior === "bad-readiness" ? "unavailable" : "ready",
+        checks: {
+          database: behavior === "bad-readiness" ? "unavailable" : "ready",
+        },
+      });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/auth/register") {
+      await requestBody(request);
+      json(response, 201, { user_id: nextId(), email: "redacted@example.invalid" });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/auth/login") {
+      await requestBody(request);
+      json(
+        response,
+        200,
+        { session_token: "sess_test-only-token", token_type: "Bearer" },
+        behavior === "bad-login-cache"
+          ? { "cache-control": "public, max-age=60" }
+          : { "cache-control": "no-store", pragma: "no-cache" },
+      );
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/auth/logout") {
+      response.writeHead(204).end();
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/v1/ielts-speaking/question-bank") {
+      json(response, 200, {
+        schema_version: behavior === "bad-bank-version" ? 3 : 4,
+        bank_id: "bank-current",
+        part1_topics: [{ id: "part-1-current" }],
+        topic_groups: [{ id: "topic-current" }],
+      });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/v1/practice-plans") {
+      const body = JSON.parse((await requestBody(request)).toString("utf8"));
+      const mode = modeByOption[body.practice_option_id];
+      assert.ok(mode);
+      assert.equal(body.scene_id, "scn_ielts_speaking");
+      if (mode === "FULL_MOCK") {
+        assert.equal(Object.hasOwn(body, "ielts_selection"), false);
+      } else {
+        assert.equal(body.ielts_selection.part_1_set_id, mode === "PART_1" ? "part-1-current" : undefined);
+        assert.equal(body.ielts_selection.topic_group_id, mode === "PART_1" ? undefined : "topic-current");
+      }
+      const planId = nextId();
+      const total = totalByMode[mode];
+      const partModes = mode === "FULL_MOCK" ? ["PART_1", "PART_2", "PART_3"] : [mode];
+      const assignment = {
+        bank_id: behavior === "bad-assignment-bank" ? "stale-bank" : "bank-current",
+        season: "2026-08",
+        mode,
+        parts: (behavior === "bad-assignment-parts" ? ["PART_3"] : partModes).map((part) => ({
+          part,
+          source_id: `${part.toLowerCase()}-source-current`,
+          turn_blueprints: Array.from(
+            { length: mode === "FULL_MOCK" ? 1 : total },
+            (_, index) => `${part}-question-${index + 1}`,
+          ),
+        })),
+      };
+      plans.set(planId, { mode, total, assignment });
+      counts.plans += 1;
+      json(response, 201, {
+        practice_plan_id: planId,
+        version: 1,
+        practice_plan_status: "ready",
+        ielts_assignment: assignment,
+      });
+      return;
+    }
+    const sessionCreate = url.pathname.match(/^\/v1\/practice-plans\/([^/]+)\/practice-sessions$/);
+    if (request.method === "POST" && sessionCreate) {
+      await requestBody(request);
+      const planId = sessionCreate[1];
+      const plan = plans.get(planId);
+      assert.ok(plan);
+      const sessionId = nextId();
+      const questions = Array.from({ length: plan.total }, (_, index) => ({
+        question_id: nextId(),
+        practice_session_id: sessionId,
+        content: `Question ${index + 1} for ${plan.mode}`,
+      }));
+      sessions.set(sessionId, {
+        id: sessionId,
+        planId,
+        mode: plan.mode,
+        questions,
+        answers: [],
+        ordinal: sessions.size + 1,
+        assignment: plan.assignment,
+      });
+      json(response, 201, {
+        practice_session: {
+          practice_session_id: sessionId,
+          practice_plan_id: planId,
+          plan_version: 1,
+          practice_mode: plan.mode,
+          practice_session_status: "starting",
+          session_version: 1,
+        },
+        snapshot: {
+          practice_session_id: sessionId,
+          plan_version: 1,
+          practice_mode: plan.mode,
+          ielts_assignment: behavior === "bad-snapshot-freeze"
+            ? {
+                ...plan.assignment,
+                parts: plan.assignment.parts.map((part, index) => index === 0
+                  ? { ...part, source_id: "mutated-source" }
+                  : part),
+              }
+            : plan.assignment,
+        },
+      });
+      return;
+    }
+    const activation = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/activation$/);
+    if (request.method === "POST" && activation) {
+      json(response, 200, interaction(sessions.get(activation[1])));
+      return;
+    }
+    const textAnswer = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/questions\/([^/]+)\/text-answers$/);
+    if (request.method === "POST" && textAnswer) {
+      const body = JSON.parse((await requestBody(request)).toString("utf8"));
+      json(response, 200, advance(sessions.get(textAnswer[1]), textAnswer[2], body.answer_text));
+      return;
+    }
+    const transcription = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/questions\/([^/]+)\/transcription-candidates$/);
+    if (request.method === "POST" && transcription) {
+      assert.ok((await requestBody(request)).length > 0);
+      const candidateId = nextId();
+      const respondentParticipantId = nextId();
+      const transcriptId = `fun-asr-safe-${sequence++}`;
+      candidates.set(candidateId, {
+        sessionId: transcription[1],
+        questionId: transcription[2],
+        transcript: "Voice fixture answer.",
+        respondentParticipantId,
+        transcriptId,
+        evidenceVersion: 1,
+      });
+      json(response, 201, {
+        candidate_id: candidateId,
+        practice_session_id: behavior === "bad-candidate-binding" ? nextId() : transcription[1],
+        question_id: transcription[2],
+        respondent_participant_id: respondentParticipantId,
+        transcript_id: transcriptId,
+        evidence_version: 1,
+        transcript: "Voice fixture answer.",
+      });
+      return;
+    }
+    const confirmation = url.pathname.match(/^\/v1\/transcription-candidates\/([^/]+)\/confirmations$/);
+    if (request.method === "POST" && confirmation) {
+      const candidate = candidates.get(confirmation[1]);
+      json(response, 200, advance(
+        sessions.get(candidate.sessionId),
+        candidate.questionId,
+        candidate.transcript,
+        {
+          candidateId: behavior === "bad-turn-binding" ? nextId() : confirmation[1],
+          respondentParticipantId: candidate.respondentParticipantId,
+          evidenceVersion: candidate.evidenceVersion,
+          audioAssetId: nextId(),
+        },
+      ));
+      return;
+    }
+    const evaluation = url.pathname.match(/^\/v1\/practice-sessions\/([^/]+)\/evaluation$/);
+    if (request.method === "GET" && evaluation) {
+      const session = sessions.get(evaluation[1]);
+      session.evaluationId ??= nextId();
+      const base = {
+        evaluation_id: session.evaluationId,
+        kind: "SESSION_REPORT",
+        source_id: session.id,
+        context_id: session.id,
+        feedback_items: [],
+      };
+      if (behavior === "failed" || (behavior === "fail-second" && session.ordinal === 2)) {
+        json(response, 200, { ...base, status: "FAILED", error: { code: "provider_response", retryable: false, message: "failed" } });
+      } else if (behavior === "queued-with-result") {
+        json(response, 200, { ...base, status: "RUNNING", result: report(session) });
+      } else if (behavior === "timeout") {
+        json(response, 200, { ...base, status: "RUNNING" });
+      } else {
+        json(response, 200, { ...base, status: "READY", result: report(session) });
+      }
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+    counts,
+  };
+}
+
+test("default dry-run prints the five-session plan without invoking the network executor", async () => {
+  const buffer = outputBuffer();
+  let calls = 0;
+  const result = await runCli({
+    arguments_: [],
+    environment: {},
+    output: buffer.output,
+    executeUat: async () => { calls += 1; },
+  });
+  assert.equal(result.kind, "dry-run");
+  assert.equal(calls, 0);
+  const plan = JSON.parse(buffer.read());
+  assert.equal(plan.network_requests, 0);
+  assert.equal(plan.writes, 0);
+  assert.deepEqual(
+    plan.sessions.map(({ mode, input }) => `${mode}:${input}`),
+    ["PART_1:text", "PART_1:voice", "PART_2:voice", "PART_3:voice", "FULL_MOCK:text"],
+  );
+  await assert.rejects(
+    runCli({
+      arguments_: ["--base-url", "https://api.speak-up.top"],
+      environment: {},
+      output: buffer.output,
+      executeUat: async () => { calls += 1; },
+    }),
+    (error) => error instanceof UatError && error.category === "untrusted_base_url",
+  );
+  assert.equal(calls, 0);
+});
+
+test("execution boundary fails closed unless every Staging opt-in is exact", () => {
+  const valid = {
+    execute: true,
+    baseUrl: STAGING_BASE_URL,
+    receiptPath: "/private/tmp/staging-uat-receipt.json",
+  };
+  assert.throws(
+    () => validateExecutionBoundary({ ...valid, execute: false }, { UAT_ENV: "staging" }),
+    (error) => error instanceof UatError && error.category === "execute_opt_in_required",
+  );
+  for (const baseUrl of [
+    "https://api.speak-up.top",
+    "http://staging-api.speak-up.top",
+    "https://149.71.241.71",
+    "http://localhost:8080",
+    `${STAGING_BASE_URL}/`,
+  ]) {
+    assert.throws(
+      () => validateExecutionBoundary({ ...valid, baseUrl }, { UAT_ENV: "staging" }),
+      (error) => error instanceof UatError && error.category === "untrusted_base_url",
+    );
+  }
+  assert.throws(
+    () => validateExecutionBoundary(valid, { UAT_ENV: "production" }),
+    (error) => error instanceof UatError && error.category === "staging_environment_required",
+  );
+  assert.throws(
+    () => validateExecutionBoundary(valid, { UAT_ENV: "staging", NODE_TLS_REJECT_UNAUTHORIZED: "0" }),
+    (error) => error instanceof UatError && error.category === "tls_verification_disabled",
+  );
+  assert.equal(validateExecutionBoundary(valid, { UAT_ENV: "staging" }).origin, STAGING_BASE_URL);
+});
+
+test("HTTP client never follows redirects", async (context) => {
+  let destinationRequests = 0;
+  const server = http.createServer((request, response) => {
+    if (request.url === "/redirect") {
+      response.writeHead(302, { location: "/destination" }).end();
+      return;
+    }
+    destinationRequests += 1;
+    response.writeHead(200).end("unexpected");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  context.after(() => new Promise((resolve) => server.close(resolve)));
+  const { port } = server.address();
+  const request = createHttpClient({ baseUrl: `http://127.0.0.1:${port}` });
+  await assert.rejects(
+    request("/redirect"),
+    (error) => error instanceof UatError && error.category === "redirect_rejected",
+  );
+  assert.equal(destinationRequests, 0);
+});
+
+test("receipt writer creates a redacted private file and refuses sensitive fields", () => {
+  const directory = realpathSync(mkdtempSync(path.join(os.tmpdir(), "speakup-staging-uat-")));
+  try {
+    const privateDirectory = path.join(directory, "private");
+    mkdirSync(privateDirectory, { mode: 0o700 });
+    const receiptPath = path.join(privateDirectory, "receipt.json");
+    const receipt = {
+      receipt_version: 1,
+      outcome: "passed",
+      environment: "staging",
+      resource_refs: ["sha256:" + "a".repeat(64)],
+      sessions: [{ case_id: "part-1-text", error_category: null }],
+    };
+    writeReceipt(receiptPath, receipt);
+    assert.deepEqual(JSON.parse(readFileSync(receiptPath, "utf8")), receipt);
+    assert.equal(statSync(receiptPath).mode & 0o777, 0o600);
+    assert.throws(
+      () => writeReceipt(path.join(directory, "leak.json"), { session_token: "sess_secret" }),
+      (error) => error instanceof UatError && error.category === "receipt_contains_sensitive_field",
+    );
+    assert.throws(
+      () => writeReceipt(path.join(directory, "email.json"), { owner: "person@example.com" }),
+      (error) => error instanceof UatError && error.category === "receipt_contains_sensitive_value",
+    );
+    const publicDirectory = path.join(directory, "public");
+    mkdirSync(publicDirectory, { mode: 0o755 });
+    chmodSync(publicDirectory, 0o755);
+    assert.throws(
+      () => writeReceipt(path.join(publicDirectory, "receipt.json"), receipt),
+      (error) => error instanceof UatError && error.category === "receipt_directory_not_private",
+    );
+    const canonicalDirectory = path.join(directory, "canonical");
+    mkdirSync(canonicalDirectory, { mode: 0o700 });
+    const linkedDirectory = path.join(directory, "linked");
+    symlinkSync(canonicalDirectory, linkedDirectory, "dir");
+    assert.throws(
+      () => writeReceipt(path.join(linkedDirectory, "receipt.json"), receipt),
+      (error) => error instanceof UatError && error.category === "receipt_directory_not_private",
+    );
+    assert.throws(
+      () => writeReceipt(path.join(directory, "missing", "receipt.json"), receipt),
+      (error) => error instanceof UatError && error.category === "receipt_directory_required",
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("an opted-in failed execution still writes only a redacted 0600 receipt", async () => {
+  const directory = realpathSync(mkdtempSync(path.join(os.tmpdir(), "speakup-staging-uat-failed-")));
+  try {
+    const receiptPath = path.join(directory, "receipt.json");
+    await assert.rejects(
+      runCli({
+        arguments_: ["--execute", "--receipt", receiptPath],
+        environment: { UAT_ENV: "staging" },
+        output: outputBuffer().output,
+        executeUat: async () => { throw new UatError("evaluation_failed", "provider payload must not persist"); },
+      }),
+      (error) => error instanceof UatError && error.category === "evaluation_failed",
+    );
+    const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+    assert.equal(receipt.outcome, "failed");
+    assert.equal(receipt.error_category, "evaluation_failed");
+    assert.equal(statSync(receiptPath).mode & 0o777, 0o600);
+    assert.doesNotMatch(JSON.stringify(receipt), /provider payload/);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("five-session driver uses dynamic bank, plan, session, question, turn, and evaluation identities", async (context) => {
+  const fake = await createUatServer();
+  context.after(fake.close);
+  const receipt = await runStagingUat({
+    baseUrl: fake.baseUrl,
+    voiceBytes: Buffer.from("RIFF fixed test WAV"),
+    pollIntervalMs: 1,
+  });
+  assert.equal(receipt.outcome, "passed");
+  assert.equal(fake.counts.plans, 5);
+  assert.deepEqual(
+    receipt.sessions.map(({ mode, input_kind }) => `${mode}:${input_kind}`),
+    ["PART_1:text", "PART_1:voice", "PART_2:voice", "PART_3:voice", "FULL_MOCK:text"],
+  );
+  for (const session of receipt.sessions) {
+    assert.equal(session.evaluation_status, "READY");
+    assert.equal(session.schema_version, "evaluation-report/v2");
+    assert.equal(session.scoreability_status, "PROVISIONAL");
+    assert.match(session.resource_refs.plan, /^sha256:[0-9a-f]{64}$/);
+    assert.match(session.resource_refs.session, /^sha256:[0-9a-f]{64}$/);
+    assert.match(session.resource_refs.evaluation, /^sha256:[0-9a-f]{64}$/);
+  }
+  const serialized = JSON.stringify(receipt);
+  assert.doesNotMatch(serialized, /sess_|example\.invalid|Voice fixture answer|Question 1/);
+});
+
+test("FAILED evaluation is a release-blocking terminal failure", async (context) => {
+  const fake = await createUatServer("failed");
+  context.after(fake.close);
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[0]],
+      voiceBytes: Buffer.from("unused"),
+    }),
+    (error) => error instanceof UatError && error.category === "evaluation_failed",
+  );
+});
+
+test("failed run receipt preserves its run identity and completed case progress", async (context) => {
+  const fake = await createUatServer("fail-second");
+  context.after(fake.close);
+  const directory = realpathSync(mkdtempSync(path.join(os.tmpdir(), "speakup-staging-uat-progress-")));
+  const receiptPath = path.join(directory, "receipt.json");
+  try {
+    let failure;
+    await assert.rejects(
+      runCli({
+        arguments_: ["--execute", "--receipt", receiptPath],
+        environment: { UAT_ENV: "staging" },
+        output: outputBuffer().output,
+        executeUat: () => runStagingUat({
+          baseUrl: fake.baseUrl,
+          matrix: [UAT_MATRIX[0], UAT_MATRIX[1]],
+          voiceBytes: Buffer.from("RIFF fixed test WAV"),
+          pollIntervalMs: 1,
+        }),
+      }),
+      (error) => {
+        failure = error;
+        return error instanceof UatError && error.category === "evaluation_failed";
+      },
+    );
+    const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+    assert.equal(receipt.run_id, failure.receipt.run_id);
+    assert.equal(receipt.sessions.length, 2);
+    assert.equal(receipt.sessions[0].evaluation_status, "READY");
+    assert.equal(receipt.sessions[1].evaluation_status, "FAILED");
+    assert.equal(receipt.sessions[1].error_category, "evaluation_failed");
+    assert.match(receipt.sessions[1].resource_refs.plan, /^sha256:[0-9a-f]{64}$/);
+    assert.match(receipt.sessions[1].resource_refs.session, /^sha256:[0-9a-f]{64}$/);
+    assert.match(receipt.sessions[1].resource_refs.evaluation, /^sha256:[0-9a-f]{64}$/);
+    assert.doesNotMatch(JSON.stringify(receipt), /sess_|example\.invalid|Voice fixture answer|Question 1/);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test("evaluation polling stops at the per-session deadline", async (context) => {
+  const fake = await createUatServer("timeout");
+  context.after(fake.close);
+  let clock = 0;
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [{ ...UAT_MATRIX[0], timeout_seconds: 1 }],
+      voiceBytes: Buffer.from("unused"),
+      now: () => clock,
+      pollIntervalMs: 600,
+      sleep: async (milliseconds) => { clock += milliseconds; },
+    }),
+    (error) => error instanceof UatError && error.category === "session_timeout",
+  );
+});
+
+for (const [name, behavior, category] of [
+  ["voice candidate identity", "bad-candidate-binding", "transcription_candidate_mismatch"],
+  ["confirmed voice turn identity", "bad-turn-binding", "turn_confirmation_mismatch"],
+]) {
+  test(`${name} is bound end to end`, async (context) => {
+    const fake = await createUatServer(behavior);
+    context.after(fake.close);
+    await assert.rejects(
+      runStagingUat({
+        baseUrl: fake.baseUrl,
+        matrix: [UAT_MATRIX[1]],
+        voiceBytes: Buffer.from("RIFF fixed test WAV"),
+      }),
+      (error) => error instanceof UatError && error.category === category,
+    );
+  });
+}
+
+test("failure before evaluation is reported as not reached", async (context) => {
+  const fake = await createUatServer("bad-candidate-binding");
+  context.after(fake.close);
+  let failure;
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[1]],
+      voiceBytes: Buffer.from("RIFF fixed test WAV"),
+    }),
+    (error) => {
+      failure = error;
+      return error instanceof UatError && error.category === "transcription_candidate_mismatch";
+    },
+  );
+  assert.equal(failure.receipt.sessions[0].evaluation_status, "NOT_REACHED");
+  assert.equal(Object.hasOwn(failure.receipt.sessions[0].resource_refs, "evaluation"), false);
+});
+
+test("report evidence must resolve the exact UTF-8 byte range", async (context) => {
+  const fake = await createUatServer("invalid-evidence");
+  context.after(fake.close);
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[0]],
+      voiceBytes: Buffer.from("unused"),
+    }),
+    (error) => error instanceof UatError && error.category === "invalid_report_evidence",
+  );
+});
+
+test("INSUFFICIENT report cannot expose a score", async (context) => {
+  const fake = await createUatServer("insufficient-score");
+  context.after(fake.close);
+  await assert.rejects(
+    runStagingUat({
+      baseUrl: fake.baseUrl,
+      matrix: [UAT_MATRIX[0]],
+      voiceBytes: Buffer.from("unused"),
+    }),
+    (error) => error instanceof UatError && error.category === "insufficient_report_has_score",
+  );
+});
+
+for (const [name, behavior, category] of [
+  ["health JSON status", "bad-health", "staging_not_ready"],
+  ["readiness database check", "bad-readiness", "staging_not_ready"],
+  ["login no-store response", "bad-login-cache", "invalid_auth_cache_control"],
+  ["question bank schema version", "bad-bank-version", "invalid_question_bank"],
+  ["plan assignment bank binding", "bad-assignment-bank", "plan_mode_mismatch"],
+  ["plan assignment part order", "bad-assignment-parts", "plan_mode_mismatch"],
+  ["session frozen assignment", "bad-snapshot-freeze", "session_binding_mismatch"],
+  ["interaction plan identity", "bad-state-plan", "interaction_state_mismatch"],
+  ["interaction frozen assignment", "bad-state-assignment", "interaction_state_mismatch"],
+  ["interaction lifecycle", "bad-lifecycle", "invalid_interaction_lifecycle"],
+  ["nonterminal evaluation payload exclusion", "queued-with-result", "invalid_evaluation_state"],
+  ["IELTS dimension score step", "invalid-dimension", "invalid_report_dimension"],
+]) {
+  test(`${name} is validated fail closed`, async (context) => {
+    const fake = await createUatServer(behavior);
+    context.after(fake.close);
+    await assert.rejects(
+      runStagingUat({
+        baseUrl: fake.baseUrl,
+        matrix: [UAT_MATRIX[0]],
+        voiceBytes: Buffer.from("unused"),
+      }),
+      (error) => error instanceof UatError && error.category === category,
+    );
+  });
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.5+6
+version: 0.1.6+7
 
 environment:
   sdk: ^3.12.2

--- a/server/cmd/server/evaluation_worker.go
+++ b/server/cmd/server/evaluation_worker.go
@@ -104,6 +104,10 @@ type evaluationFailureMetadata interface {
 	EvaluationJobError() evaluation.JobError
 }
 
+type evaluationNormalizeFailure interface {
+	EvaluationNormalizeReason() string
+}
+
 func evaluationErrorAttributes(lane string, err error) []slog.Attr {
 	attributes := []slog.Attr{
 		slog.String("lane", lane),
@@ -118,6 +122,12 @@ func evaluationErrorAttributes(lane string, err error) []slog.Attr {
 			slog.Int("attempt_count", metadata.EvaluationAttemptCount()),
 			slog.String("failure_code", failure.Code),
 			slog.Bool("retryable", failure.Retryable),
+		)
+	}
+	var normalization evaluationNormalizeFailure
+	if errors.As(err, &normalization) && normalization.EvaluationNormalizeReason() != "" {
+		attributes = append(attributes,
+			slog.String("normalize_reason", normalization.EvaluationNormalizeReason()),
 		)
 	}
 	return attributes

--- a/server/cmd/server/evaluation_worker_test.go
+++ b/server/cmd/server/evaluation_worker_test.go
@@ -39,12 +39,13 @@ func TestEvaluationFailureAttributesExposeSafeDiagnosticMetadata(t *testing.T) {
 		values[attribute.Key] = attribute.Value.String()
 	}
 	for key, want := range map[string]string{
-		"lane":            "session",
-		"evaluation_id":   "70000000-0000-4000-8000-000000000001",
-		"evaluation_kind": "SESSION_REPORT",
-		"attempt_count":   "2",
-		"failure_code":    "PROVIDER_RESPONSE_INVALID",
-		"retryable":       "true",
+		"lane":             "session",
+		"evaluation_id":    "70000000-0000-4000-8000-000000000001",
+		"evaluation_kind":  "SESSION_REPORT",
+		"attempt_count":    "2",
+		"failure_code":     "PROVIDER_RESPONSE_INVALID",
+		"normalize_reason": "priority_action_invalid",
+		"retryable":        "true",
 	} {
 		if values[key] != want {
 			t.Fatalf("%s = %q, want %q; attributes=%#v", key, values[key], want, values)
@@ -79,6 +80,9 @@ func (evaluationFailureStub) EvaluationKind() evaluation.Kind {
 	return evaluation.KindSessionReport
 }
 func (evaluationFailureStub) EvaluationAttemptCount() int { return 2 }
+func (evaluationFailureStub) EvaluationNormalizeReason() string {
+	return "priority_action_invalid"
+}
 func (evaluationFailureStub) EvaluationJobError() evaluation.JobError {
 	return evaluation.JobError{
 		Code: "PROVIDER_RESPONSE_INVALID", Retryable: true,

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -429,7 +429,6 @@ func run() int {
 				RetryDelay:                time.Second,
 				DependencyDelay:           evaluationDependencyDelay,
 				AcousticDependencyMaxWait: acousticDependencyMaxWait,
-				ProfileDependencyMaxWait:  20 * time.Second,
 				FinalizeTimeout:           5 * time.Second,
 			},
 		},

--- a/server/internal/coaching/evaluation/ielts_profile_completion_test.go
+++ b/server/internal/coaching/evaluation/ielts_profile_completion_test.go
@@ -134,7 +134,7 @@ func TestSessionCommandBuilderKeepsStandaloneIELTSOnV2(t *testing.T) {
 	builder, err := NewSessionCommandBuilder(SessionLineages{
 		Interview:     lineage(InterviewStrategyRef, "interview-report/v2"),
 		IELTSPractice: lineage(IELTSStrategyRef, "ielts-report/v2"),
-		IELTS:         lineage(IELTSStrategyRef, "ielts-report/v3"),
+		IELTS:         lineage(IELTSStrategyRef, "ielts-report/v4"),
 		General:       lineage(GeneralStrategyRef, "general-report/v2"),
 	}, false)
 	if err != nil {
@@ -145,7 +145,7 @@ func TestSessionCommandBuilderKeepsStandaloneIELTSOnV2(t *testing.T) {
 		t.Fatalf("standalone IELTS lineage = %#v, %v", standalone, err)
 	}
 	fullMock, err := builder.lineageFor(IELTSSpeakingFullMockEvaluationPolicyRef)
-	if err != nil || fullMock.PromptVersion != "ielts-report/v3" {
+	if err != nil || fullMock.PromptVersion != "ielts-report/v4" {
 		t.Fatalf("full mock IELTS lineage = %#v, %v", fullMock, err)
 	}
 }

--- a/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
@@ -1,0 +1,292 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	speechRetryUserID    = "91000000-0000-4000-8000-000000000001"
+	speechRetryTurnID    = "92000000-0000-4000-8000-000000000001"
+	speechRetrySessionID = "93000000-0000-4000-8000-000000000001"
+	speechRetryQuestion  = "94000000-0000-4000-8000-000000000001"
+)
+
+func TestSpeechFeedbackPart1InvalidThenValidReusesAcoustics(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, speechRetryUserID, "speech-retry-part1@example.com")
+	generator := &speechRetryGenerator{contents: []string{
+		`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"missing excerpt","source_occurrence":1,"suggested_text":"read"}]}`,
+		`{"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"这是更自然的表达。","source_text":"read","source_occurrence":1,"suggested_text":"do some reading"}]}`,
+	}}
+	acoustics := &speechRetryAcoustics{}
+	store, worker := speechRetryWorker(t, pool, generator, acoustics)
+	queueSpeechRetry(t, store, "I usually read before work.")
+
+	processed, err := worker.ProcessSpeech(context.Background())
+	if !processed || err == nil {
+		t.Fatalf("first ProcessSpeech = (%t, %v)", processed, err)
+	}
+	queued, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || queued.Status != evaluation.JobQueued ||
+		queued.AttemptCount != 1 || queued.Error != nil {
+		t.Fatalf("queued retry = %#v, %v", queued, err)
+	}
+	var checkpointed evaluation.SpeechInputSnapshot
+	if evaluation.DecodeStrict(queued.InputSnapshot, &checkpointed) != nil ||
+		checkpointed.Acoustic == nil ||
+		checkpointed.Acoustic.Status != evaluation.AcousticAssessed {
+		t.Fatalf("checkpointed input = %#v", checkpointed)
+	}
+
+	processed, err = worker.ProcessSpeech(context.Background())
+	if err != nil || !processed {
+		t.Fatalf("second ProcessSpeech = (%t, %v)", processed, err)
+	}
+	ready, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || ready.Status != evaluation.JobReady ||
+		ready.AttemptCount != 2 || ready.Error != nil ||
+		acoustics.calls != 1 || generator.calls != 2 {
+		t.Fatalf(
+			"ready=%#v err=%v acoustic=%d text=%d",
+			ready, err, acoustics.calls, generator.calls,
+		)
+	}
+	items, err := store.ListFeedbackItems(
+		context.Background(), speechRetryUserID, ready.ID,
+	)
+	if err != nil || len(items) != 1 ||
+		items[0].Category != "RECOMMENDED_EXPRESSION" ||
+		items[0].Evidence.OriginalExcerpt != "read" {
+		t.Fatalf("feedback items = %#v, %v", items, err)
+	}
+}
+
+func TestSpeechFeedbackPart3ThreeInvalidResponsesFailPubliclyNonRetryable(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, speechRetryUserID, "speech-retry-part3@example.com")
+	const invalid = `{"items":[{"kind":"STRENGTH","explanation":"无需修改。","source_text":"technology","source_occurrence":1,"suggested_text":null}]}`
+	generator := &speechRetryGenerator{contents: []string{invalid, invalid, invalid}}
+	acoustics := &speechRetryAcoustics{}
+	store, worker := speechRetryWorker(t, pool, generator, acoustics)
+	const transcript = "I think technology can improve education when teachers guide its use."
+	queueSpeechRetry(t, store, transcript)
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		processed, err := worker.ProcessSpeech(context.Background())
+		if !processed || err == nil {
+			t.Fatalf("ProcessSpeech attempt %d = (%t, %v)", attempt, processed, err)
+		}
+		record, getErr := store.GetRecordBySource(
+			context.Background(), speechRetryUserID,
+			evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+		)
+		if getErr != nil || record.AttemptCount != attempt {
+			t.Fatalf("record attempt %d = %#v, %v", attempt, record, getErr)
+		}
+		if attempt < 3 && (record.Status != evaluation.JobQueued || record.Error != nil) {
+			t.Fatalf("intermediate record %d = %#v", attempt, record)
+		}
+	}
+	failed, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || failed.Status != evaluation.JobFailed ||
+		failed.Error == nil || failed.Error.Code != "PROVIDER_RESPONSE_INVALID" ||
+		failed.Error.Retryable || acoustics.calls != 1 || generator.calls != 3 {
+		t.Fatalf(
+			"failed=%#v err=%v acoustic=%d text=%d",
+			failed, err, acoustics.calls, generator.calls,
+		)
+	}
+	var storedError string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT error::text FROM evaluations WHERE id=$1`, failed.ID,
+	).Scan(&storedError); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(storedError, transcript) || strings.Contains(storedError, invalid) {
+		t.Fatalf("terminal error leaked speech or provider output: %s", storedError)
+	}
+}
+
+func speechRetryWorker(
+	t *testing.T,
+	pool *pgxpool.Pool,
+	generator speechfeedback.TextGenerator,
+	acoustics evaluation.AcousticEvaluator,
+) (*Store, *evaluation.Worker) {
+	t.Helper()
+	store := mustStore(t, pool)
+	speech, err := speechfeedback.NewCompactEvaluator(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker, err := evaluation.NewWorker(
+		store,
+		speechRetrySessions{},
+		speechRetryProfiles{},
+		speech,
+		acoustics,
+		speechRetrySessionAudio{},
+		evaluation.WorkerConfiguration{
+			SessionLane: evaluation.ClaimLane{
+				Kinds:         []evaluation.Kind{evaluation.KindSessionReport},
+				LeaseDuration: 3 * time.Minute, MaxAttempts: 3,
+			},
+			ProfileLane: evaluation.ClaimLane{
+				Kinds: []evaluation.Kind{
+					evaluation.KindIELTSPart1Profile,
+					evaluation.KindIELTSPart2Profile,
+				},
+				LeaseDuration: time.Minute, MaxAttempts: 2,
+			},
+			SpeechLane: evaluation.ClaimLane{
+				Kinds: []evaluation.Kind{
+					evaluation.KindPracticeTurnFeedback,
+					evaluation.KindAgentMessageFeedback,
+				},
+				LeaseDuration: time.Minute, MaxAttempts: 3,
+			},
+			AcousticsEnabled:          true,
+			InterviewDeadline:         30 * time.Second,
+			IELTSDeadline:             110 * time.Second,
+			GeneralDeadline:           30 * time.Second,
+			SpeechDeadline:            30 * time.Second,
+			ProfileDeadline:           30 * time.Second,
+			RetryDelay:                0,
+			DependencyDelay:           time.Second,
+			AcousticDependencyMaxWait: time.Minute,
+			FinalizeTimeout:           5 * time.Second,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store, worker
+}
+
+func queueSpeechRetry(t *testing.T, store *Store, transcript string) {
+	t.Helper()
+	input, inputHash, err := evaluation.EncodeStrict(evaluation.SpeechInputSnapshot{
+		SchemaVersion: evaluation.SpeechInputSchemaVersion,
+		Transcript:    transcript,
+		EvidenceRefID: speechRetryTurnID,
+		QuestionID:    speechRetryQuestion,
+		AudioAssetID:  "speech-retry-audio",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage, err := speechfeedback.Lineage("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, configHash, err := evaluation.EncodeStrict(lineage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.Queue(context.Background(), evaluation.QueueCommand{
+		UserID: speechRetryUserID, Kind: evaluation.KindPracticeTurnFeedback,
+		SourceID: speechRetryTurnID, ContextID: speechRetrySessionID,
+		InputSnapshot: input, InputHash: inputHash,
+		ConfigLineage: config, ConfigHash: configHash,
+		AvailableAt: time.Now().UTC().Add(-time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type speechRetryGenerator struct {
+	contents []string
+	calls    int
+}
+
+func (generator *speechRetryGenerator) Generate(
+	context.Context,
+	speechfeedback.TextGenerationRequest,
+) (speechfeedback.TextGenerationResult, error) {
+	generator.calls++
+	if generator.calls > len(generator.contents) {
+		return speechfeedback.TextGenerationResult{}, errors.New("unexpected generation")
+	}
+	return speechfeedback.TextGenerationResult{
+		RequestID: fmt.Sprintf("speech-retry-request-%d", generator.calls),
+		Content:   generator.contents[generator.calls-1],
+		Provider:  "qianwen",
+		Model:     "qwen-plus",
+	}, nil
+}
+
+type speechRetryAcoustics struct{ calls int }
+
+func (acoustics *speechRetryAcoustics) EvaluateAcoustic(
+	context.Context,
+	evaluation.Record,
+	evaluation.SpeechInputSnapshot,
+) (evaluation.AcousticCheckpoint, error) {
+	acoustics.calls++
+	pronunciation := 86.0
+	return evaluation.AcousticCheckpoint{
+		Status:          evaluation.AcousticAssessed,
+		Pronunciation:   &pronunciation,
+		Provider:        "iflytek",
+		ProviderSession: "speech-retry-ise-1",
+	}, nil
+}
+
+type speechRetrySessions struct{}
+
+func (speechRetrySessions) EvaluateInterview(
+	context.Context, evaluation.Record, evaluation.SessionInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected Interview evaluation")
+}
+
+func (speechRetrySessions) EvaluateIELTS(
+	context.Context, evaluation.Record, evaluation.SessionInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected IELTS evaluation")
+}
+
+func (speechRetrySessions) EvaluateGeneral(
+	context.Context, evaluation.Record, evaluation.SessionInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected General evaluation")
+}
+
+type speechRetryProfiles struct{}
+
+func (speechRetryProfiles) EvaluateProfile(
+	context.Context, evaluation.Record, evaluation.IELTSProfileInputSnapshot,
+	evaluation.ConfigLineage,
+) (json.RawMessage, error) {
+	return nil, errors.New("unexpected IELTS profile evaluation")
+}
+
+type speechRetrySessionAudio struct{}
+
+func (speechRetrySessionAudio) ReadSessionAcoustics(
+	context.Context, string, string, []string,
+) (evaluation.SessionAcousticRead, error) {
+	return evaluation.SessionAcousticRead{}, errors.New("unexpected Session acoustic read")
+}

--- a/server/internal/coaching/evaluation/postgres/store.go
+++ b/server/internal/coaching/evaluation/postgres/store.go
@@ -544,7 +544,7 @@ func (store *Store) FailClaim(
 		WHERE id = $1 AND user_id = $7 AND status = 'RUNNING'
 		  AND lease_token = $2 AND lease_expires_at > transaction_timestamp()`,
 		failure.ID, failure.LeaseToken, failure.RetryAt.UTC(),
-		failure.MaxAttempts, failure.Error.Retryable, failureJSON, failure.UserID)
+		failure.MaxAttempts, failure.AutomaticRetryable, failureJSON, failure.UserID)
 	if err != nil {
 		return fmt.Errorf("fail Evaluation claim: %w", err)
 	}

--- a/server/internal/coaching/evaluation/postgres/store_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/store_integration_test.go
@@ -228,7 +228,8 @@ func TestStoreRetryableFinalAndExpiredClaimsConverge(t *testing.T) {
 		Error: evaluation.JobError{
 			Code: "PROVIDER_UNAVAILABLE", Retryable: true, Message: "retry",
 		},
-		RetryAt: time.Now().UTC().Add(-time.Second), MaxAttempts: 3,
+		AutomaticRetryable: true,
+		RetryAt:            time.Now().UTC().Add(-time.Second), MaxAttempts: 3,
 	}); err != nil {
 		t.Fatalf("FailClaim(retryable): %v", err)
 	}

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -30,8 +30,13 @@ const (
 	ieltsPromptVersionV1     = "ielts-report/v1"
 	ieltsPromptVersionV2     = "ielts-report/v2"
 	ieltsPromptVersionV3     = "ielts-report/v3"
+	ieltsPromptVersionV4     = "ielts-report/v4"
 	generalPromptVersionV1   = "general-report/v1"
 	generalPromptVersionV2   = "general-report/v2"
+
+	ieltsInputSchemaVersionV4            = "ielts-report-input/v4"
+	ieltsInputCumulativeParts12PlusPart3 = "CUMULATIVE_PARTS_1_2_PLUS_PART_3"
+	ieltsInputFullRawFallback            = "FULL_RAW_FALLBACK"
 )
 
 func Lineages(
@@ -52,7 +57,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.IELTSStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   ieltsPromptVersionV3,
+			PromptVersion:   ieltsPromptVersionV4,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -166,7 +171,7 @@ func (evaluator *InterviewEvaluator) Evaluate(
 			"INTERVIEW_EVIDENCE",
 			"INTERVIEW_PROFESSIONAL",
 			"INTERVIEW_INTERACTION",
-		}, report.ReportScalePercentage100, false, nil)
+		}, report.ReportScalePercentage100, false, nil, nil)
 }
 
 func (evaluator *IELTSEvaluator) Evaluate(
@@ -189,6 +194,13 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		}
 		err = nil
 	}
+	if lineage.PromptVersion == ieltsPromptVersionV4 {
+		prompt = reportPrompt{
+			system:              ieltsSystemPromptV4,
+			insufficientSummary: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		}
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +214,13 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		dimensions = append(dimensions, "PRONUNCIATION")
 	}
 	var payloadOverride any
-	if snapshot.CumulativeProfile != nil {
+	var evidencePolicy *providerEvidencePolicy
+	if lineage.PromptVersion == ieltsPromptVersionV4 {
+		payloadOverride, evidencePolicy, err = ieltsV4Payload(snapshot, dimensions)
+		if err != nil {
+			return nil, err
+		}
+	} else if snapshot.CumulativeProfile != nil {
 		payloadOverride, err = incrementalIELTSPayload(snapshot, dimensions)
 		if err != nil {
 			return nil, err
@@ -210,7 +228,7 @@ func (evaluator *IELTSEvaluator) Evaluate(
 	}
 	return evaluate(ctx, evaluator.generator, snapshot, lineage,
 		prompt.system, prompt.insufficientSummary, evaluation.SceneIELTSSpeaking,
-		dimensions, report.ReportScaleIELTSBand, true, payloadOverride)
+		dimensions, report.ReportScaleIELTSBand, true, payloadOverride, evidencePolicy)
 }
 
 func (evaluator *GeneralEvaluator) Evaluate(
@@ -252,7 +270,7 @@ func (evaluator *GeneralEvaluator) Evaluate(
 			"CLARITY_COHERENCE",
 			"LANGUAGE_CONTROL",
 			"INTERACTION",
-		}, report.ReportScalePercentage100, false, nil)
+		}, report.ReportScalePercentage100, false, nil, nil)
 }
 
 func evaluate(
@@ -267,6 +285,7 @@ func evaluate(
 	scale report.ReportScoreScale,
 	allowRepair bool,
 	payloadOverride any,
+	evidencePolicy *providerEvidencePolicy,
 ) (json.RawMessage, error) {
 	if generator == nil || ctx == nil || strings.TrimSpace(systemPrompt) == "" ||
 		strings.TrimSpace(insufficientSummary) == "" ||
@@ -283,6 +302,10 @@ func evaluate(
 		return encodeReport(insufficientReport(
 			snapshot, sceneType, dimensionKeys, scale, insufficientSummary,
 		))
+	}
+	if evidencePolicy == nil {
+		value := fullRawProviderEvidencePolicy(snapshot)
+		evidencePolicy = &value
 	}
 	payloadSource := payloadOverride
 	if payloadSource == nil {
@@ -305,7 +328,7 @@ func evaluate(
 	}
 	formal, normalizeErr := normalizeProviderReport(
 		generated, snapshot, sceneType, dimensionKeys, scale,
-		lineage.Provider, lineage.Model,
+		lineage.Provider, lineage.Model, *evidencePolicy,
 	)
 	if normalizeErr == nil {
 		return encodeReport(formal)
@@ -338,7 +361,7 @@ func evaluate(
 	}
 	formal, err = normalizeProviderReport(
 		repaired, snapshot, sceneType, dimensionKeys, scale,
-		lineage.Provider, lineage.Model,
+		lineage.Provider, lineage.Model, *evidencePolicy,
 	)
 	if err != nil {
 		return nil, err
@@ -361,6 +384,65 @@ type incrementalIELTSProviderInput struct {
 	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
 	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
 	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+}
+
+type resolvedIELTSProviderInputV4 struct {
+	SchemaVersion     string                               `json:"schema_version"`
+	EvidenceMode      string                               `json:"evidence_mode"`
+	SceneType         evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode      string                               `json:"practice_mode"`
+	DimensionKeys     []string                             `json:"dimension_keys"`
+	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
+	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
+	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+}
+
+type fallbackIELTSProviderInputV4 struct {
+	SchemaVersion string                               `json:"schema_version"`
+	EvidenceMode  string                               `json:"evidence_mode"`
+	SceneType     evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode  string                               `json:"practice_mode"`
+	DimensionKeys []string                             `json:"dimension_keys"`
+	Questions     []evaluation.SessionEvidenceQuestion `json:"questions"`
+	Turns         []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
+}
+
+func ieltsV4Payload(
+	snapshot evaluation.SessionInputSnapshot,
+	dimensionKeys []string,
+) (any, *providerEvidencePolicy, error) {
+	switch snapshot.ProfileResolution {
+	case evaluation.IELTSFinalProfileResolved:
+		incremental, err := incrementalIELTSPayload(snapshot, dimensionKeys)
+		if err != nil {
+			return nil, nil, err
+		}
+		policy := resolvedIELTSProviderEvidencePolicy(snapshot, incremental)
+		return resolvedIELTSProviderInputV4{
+			SchemaVersion: ieltsInputSchemaVersionV4,
+			EvidenceMode:  ieltsInputCumulativeParts12PlusPart3,
+			SceneType:     incremental.SceneType, PracticeMode: incremental.PracticeMode,
+			DimensionKeys:     incremental.DimensionKeys,
+			CumulativeProfile: incremental.CumulativeProfile,
+			Questions:         incremental.Questions, Turns: incremental.Turns,
+		}, &policy, nil
+	case evaluation.IELTSFinalProfileFallback:
+		effectiveTurns := make([]evaluation.SessionEvidenceTurn, 0, len(snapshot.Turns))
+		for _, turn := range snapshot.Turns {
+			if turn.Effective {
+				effectiveTurns = append(effectiveTurns, turn)
+			}
+		}
+		return fallbackIELTSProviderInputV4{
+			SchemaVersion: ieltsInputSchemaVersionV4,
+			EvidenceMode:  ieltsInputFullRawFallback,
+			SceneType:     evaluation.SceneIELTSSpeaking,
+			PracticeMode:  snapshot.PracticeMode, DimensionKeys: dimensionKeys,
+			Questions: snapshot.Questions, Turns: effectiveTurns,
+		}, nil, nil
+	default:
+		return nil, nil, evaluation.ErrInvalidRequest
+	}
 }
 
 func incrementalIELTSPayload(
@@ -446,6 +528,82 @@ type providerEvidence struct {
 	Occurrence int    `json:"occurrence"`
 }
 
+type providerEvidenceKey struct {
+	TurnID     string
+	Quote      string
+	Occurrence int
+}
+
+type providerEvidencePolicy struct {
+	transcripts map[string]string
+	rawTurns    map[string]struct{}
+	exact       map[providerEvidenceKey]struct{}
+}
+
+func fullRawProviderEvidencePolicy(
+	snapshot evaluation.SessionInputSnapshot,
+) providerEvidencePolicy {
+	policy := providerEvidencePolicy{
+		transcripts: make(map[string]string, len(snapshot.Turns)),
+		rawTurns:    make(map[string]struct{}, len(snapshot.Turns)),
+		exact:       map[providerEvidenceKey]struct{}{},
+	}
+	for _, turn := range snapshot.Turns {
+		if turn.Effective {
+			policy.transcripts[turn.ID] = turn.Transcript
+			policy.rawTurns[turn.ID] = struct{}{}
+		}
+	}
+	return policy
+}
+
+func resolvedIELTSProviderEvidencePolicy(
+	snapshot evaluation.SessionInputSnapshot,
+	payload incrementalIELTSProviderInput,
+) providerEvidencePolicy {
+	policy := providerEvidencePolicy{
+		transcripts: make(map[string]string, len(snapshot.Turns)),
+		rawTurns:    make(map[string]struct{}, len(payload.Turns)),
+		exact:       map[providerEvidenceKey]struct{}{},
+	}
+	for _, turn := range snapshot.Turns {
+		if turn.Effective {
+			policy.transcripts[turn.ID] = turn.Transcript
+		}
+	}
+	for _, turn := range payload.Turns {
+		policy.rawTurns[turn.ID] = struct{}{}
+	}
+	for _, dimension := range payload.CumulativeProfile.Dimensions {
+		for _, observation := range dimension.Observations {
+			for _, evidence := range observation.Evidence {
+				policy.exact[providerEvidenceKey{
+					TurnID: evidence.TurnID, Quote: strings.TrimSpace(evidence.Quote),
+					Occurrence: evidence.Occurrence,
+				}] = struct{}{}
+			}
+		}
+	}
+	return policy
+}
+
+func (policy providerEvidencePolicy) byteOffset(source providerEvidence) (int, bool) {
+	transcript, exists := policy.transcripts[source.TurnID]
+	quote := strings.TrimSpace(source.Quote)
+	if !exists || quote == "" || source.Occurrence < 1 {
+		return -1, false
+	}
+	if _, raw := policy.rawTurns[source.TurnID]; !raw {
+		if _, exact := policy.exact[providerEvidenceKey{
+			TurnID: source.TurnID, Quote: quote, Occurrence: source.Occurrence,
+		}]; !exact {
+			return -1, false
+		}
+	}
+	start := byteOccurrence(transcript, quote, source.Occurrence)
+	return start, start >= 0
+}
+
 type providerPriorityAction struct {
 	DimensionKey     string `json:"dimension_key"`
 	ImprovementIndex int    `json:"improvement_index"`
@@ -459,6 +617,7 @@ func normalizeProviderReport(
 	scale report.ReportScoreScale,
 	expectedProvider string,
 	expectedModel string,
+	evidencePolicy providerEvidencePolicy,
 ) (report.FormalReport, error) {
 	if generated.Provider != expectedProvider || generated.Model != expectedModel ||
 		generated.RequestID == "" || len(generated.Content) == 0 ||
@@ -485,12 +644,6 @@ func normalizeProviderReport(
 		return report.FormalReport{}, providerResponseError(
 			normalizeReasonDimensionCountInvalid,
 		)
-	}
-	turns := make(map[string]string, len(snapshot.Turns))
-	for _, turn := range snapshot.Turns {
-		if turn.Effective {
-			turns[turn.ID] = turn.Transcript
-		}
 	}
 	formal := report.FormalReport{
 		SchemaVersion:      report.FormalReportSchemaVersion,
@@ -531,19 +684,19 @@ func normalizeProviderReport(
 		}
 		var err error
 		dimension.Strengths, err = normalizeFindings(
-			expectedKey, "strength", providedDimension.Strengths, turns,
+			expectedKey, "strength", providedDimension.Strengths, evidencePolicy,
 		)
 		if err != nil {
 			return report.FormalReport{}, err
 		}
 		dimension.Improvements, err = normalizeFindings(
-			expectedKey, "improvement", providedDimension.Improvements, turns,
+			expectedKey, "improvement", providedDimension.Improvements, evidencePolicy,
 		)
 		if err != nil {
 			return report.FormalReport{}, err
 		}
 		dimension.Examples, err = normalizeFindings(
-			expectedKey, "example", providedDimension.Examples, turns,
+			expectedKey, "example", providedDimension.Examples, evidencePolicy,
 		)
 		if err != nil {
 			return report.FormalReport{}, err
@@ -709,7 +862,7 @@ func normalizeFindings(
 	dimensionKey string,
 	kind string,
 	provided []providerFinding,
-	turns map[string]string,
+	evidencePolicy providerEvidencePolicy,
 ) ([]report.ReportFinding, error) {
 	if provided == nil || len(provided) > 5 {
 		return nil, providerResponseError(normalizeReasonFindingCountInvalid)
@@ -726,10 +879,9 @@ func normalizeFindings(
 			return nil, providerResponseError(normalizeReasonEvidenceCountInvalid)
 		}
 		for evidenceIndex, source := range item.Evidence {
-			transcript, exists := turns[source.TurnID]
 			quote := strings.TrimSpace(source.Quote)
-			start := byteOccurrence(transcript, quote, source.Occurrence)
-			if !exists || source.Occurrence < 1 || start < 0 {
+			start, allowed := evidencePolicy.byteOffset(source)
+			if !allowed {
 				return nil, providerResponseError(normalizeReasonEvidenceInvalid)
 			}
 			finding.Evidence[evidenceIndex] = report.ReportEvidence{
@@ -846,6 +998,8 @@ const ieltsSystemPromptV1 = `You are an evidence-bound IELTS Speaking practice e
 const ieltsSystemPromptV2 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
 
 const ieltsSystemPromptV3 = `You are an evidence-bound IELTS Speaking practice evaluator. Score the candidate's average performance across the whole test, not separate Part scores. The input may contain a provisional cumulative_profile for Parts 1 and 2 plus raw Part 3 evidence. Treat the profile as provisional evidence: preserve its exact cited quotes, then recalibrate every requested dimension using Part 3. Never mechanically average Parts or copy provisional bands without reconsideration. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote present either in cumulative_profile evidence or Part 3 turns, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Base PRONUNCIATION only on acoustic checkpoints and the provisional pronunciation profile, never on transcript spelling.`
+
+const ieltsSystemPromptV4 = `You are an evidence-bound IELTS Speaking practice evaluator. The input schema_version is ielts-report-input/v4 and evidence_mode is exactly one of CUMULATIVE_PARTS_1_2_PLUS_PART_3 or FULL_RAW_FALLBACK. For CUMULATIVE_PARTS_1_2_PLUS_PART_3, score the candidate's average performance across the whole test using the provisional cumulative_profile for Parts 1 and 2 plus only part_3_questions and part_3_effective_turns as raw evidence. Preserve exact profile quotes, then recalibrate every requested dimension using Part 3; never mechanically average Parts or copy provisional bands without reconsideration. For FULL_RAW_FALLBACK, use only questions and effective_turns as the complete raw evidence for all Parts. Never infer or combine fields from the other evidence mode. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote present in the evidence allowed by evidence_mode, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Base PRONUNCIATION only on acoustic checkpoints and, in CUMULATIVE_PARTS_1_2_PLUS_PART_3 mode, the provisional pronunciation profile; never on transcript spelling.`
 
 const generalSystemPromptV1 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -17,7 +17,7 @@ import (
 )
 
 var ErrProviderResponse error = providerResponseFailure{
-	message: "evaluation: report provider response invalid",
+	reason: normalizeReasonNormalizedReportInvalid,
 }
 
 const pipelineVersion = "session-evaluation/v1"
@@ -316,11 +316,15 @@ func evaluate(
 	repairPayload, err := json.Marshal(struct {
 		Input          json.RawMessage `json:"input"`
 		RejectedOutput string          `json:"rejected_output"`
+		Violation      normalizeReason `json:"violation"`
 		Instruction    string          `json:"instruction"`
 	}{
 		Input:          payload,
 		RejectedOutput: generated.Content,
-		Instruction:    "Return a complete corrected JSON object that obeys the contract exactly.",
+		Violation:      normalizeReasonFromError(normalizeErr),
+		Instruction: "Return a complete corrected JSON object that obeys the contract exactly. " +
+			"For INSUFFICIENT, every score must be null and priority_actions must be empty. " +
+			"For PROVISIONAL, each priority action must reference an existing improvement in the same dimension.",
 	})
 	if err != nil {
 		return nil, evaluation.ErrInvalidRequest
@@ -337,7 +341,7 @@ func evaluate(
 		lineage.Provider, lineage.Model,
 	)
 	if err != nil {
-		return nil, errors.Join(ErrProviderResponse, err)
+		return nil, err
 	}
 	return encodeReport(formal)
 }
@@ -459,20 +463,28 @@ func normalizeProviderReport(
 	if generated.Provider != expectedProvider || generated.Model != expectedModel ||
 		generated.RequestID == "" || len(generated.Content) == 0 ||
 		len(generated.Content) > 256*1024 {
-		return report.FormalReport{}, ErrProviderResponse
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonResponseMetadataInvalid,
+		)
 	}
 	decoder := json.NewDecoder(bytes.NewBufferString(generated.Content))
 	decoder.DisallowUnknownFields()
 	var provided providerReport
 	if err := decoder.Decode(&provided); err != nil {
-		return report.FormalReport{}, fmt.Errorf("%w: decode: %v", ErrProviderResponse, err)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonResponseJSONInvalid,
+		)
 	}
 	var extra any
 	if err := decoder.Decode(&extra); err != io.EOF {
-		return report.FormalReport{}, fmt.Errorf("%w: trailing JSON", ErrProviderResponse)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonResponseJSONInvalid,
+		)
 	}
 	if len(provided.Dimensions) != len(dimensionKeys) {
-		return report.FormalReport{}, fmt.Errorf("%w: dimension count", ErrProviderResponse)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonDimensionCountInvalid,
+		)
 	}
 	turns := make(map[string]string, len(snapshot.Turns))
 	for _, turn := range snapshot.Turns {
@@ -496,11 +508,18 @@ func normalizeProviderReport(
 	for index, expectedKey := range dimensionKeys {
 		providedDimension := provided.Dimensions[index]
 		if providedDimension.Key != expectedKey {
-			return report.FormalReport{}, fmt.Errorf("%w: dimension order", ErrProviderResponse)
+			return report.FormalReport{}, providerResponseError(
+				normalizeReasonDimensionOrderInvalid,
+			)
+		}
+		score := providedDimension.Score
+		if provided.ScoreabilityStatus == report.ReportScoreabilityInsufficient &&
+			score != nil {
+			score = nil
 		}
 		dimension := report.ReportDimension{
 			Key:          expectedKey,
-			Score:        providedDimension.Score,
+			Score:        score,
 			Scale:        scale,
 			Coverage:     providedDimension.Coverage,
 			Confidence:   providedDimension.Confidence,
@@ -548,22 +567,28 @@ func normalizeProviderReport(
 		}
 		formal.Dimensions[index] = dimension
 	}
-	for _, action := range provided.PriorityActions {
-		ids, exists := improvementIDs[action.DimensionKey]
-		if !exists || action.ImprovementIndex < 1 || action.ImprovementIndex > len(ids) {
-			return report.FormalReport{}, fmt.Errorf("%w: priority action", ErrProviderResponse)
+	// Evidence-insufficient reports must not expose provider-generated
+	// priorities, even when those references happen to resolve.
+	if provided.ScoreabilityStatus != report.ReportScoreabilityInsufficient {
+		for _, action := range provided.PriorityActions {
+			ids, exists := improvementIDs[action.DimensionKey]
+			if !exists || action.ImprovementIndex < 1 || action.ImprovementIndex > len(ids) {
+				return report.FormalReport{}, providerResponseError(
+					normalizeReasonPriorityActionInvalid,
+				)
+			}
+			formal.PriorityActions = append(formal.PriorityActions, report.ReportPriorityAction{
+				DimensionKey: action.DimensionKey,
+				FindingID:    ids[action.ImprovementIndex-1],
+			})
 		}
-		formal.PriorityActions = append(formal.PriorityActions, report.ReportPriorityAction{
-			DimensionKey: action.DimensionKey,
-			FindingID:    ids[action.ImprovementIndex-1],
-		})
 	}
 	if sceneType == evaluation.SceneIELTSSpeaking &&
 		slices.Contains(dimensionKeys, "PRONUNCIATION") {
 		available, coverage, _ := pronunciationAvailability(snapshot)
 		if !available {
-			return report.FormalReport{}, fmt.Errorf(
-				"%w: pronunciation coverage changed", ErrProviderResponse,
+			return report.FormalReport{}, providerResponseError(
+				normalizeReasonPronunciationCoverageChanged,
 			)
 		}
 		for index := range formal.Dimensions {
@@ -604,7 +629,9 @@ func normalizeProviderReport(
 		})
 	}
 	if !formal.Valid() {
-		return report.FormalReport{}, fmt.Errorf("%w: normalized report", ErrProviderResponse)
+		return report.FormalReport{}, providerResponseError(
+			normalizeReasonNormalizedReportInvalid,
+		)
 	}
 	return formal, nil
 }
@@ -685,7 +712,7 @@ func normalizeFindings(
 	turns map[string]string,
 ) ([]report.ReportFinding, error) {
 	if provided == nil || len(provided) > 5 {
-		return nil, fmt.Errorf("%w: finding count", ErrProviderResponse)
+		return nil, providerResponseError(normalizeReasonFindingCountInvalid)
 	}
 	result := make([]report.ReportFinding, len(provided))
 	for index, item := range provided {
@@ -696,14 +723,14 @@ func normalizeFindings(
 			Evidence:   make([]report.ReportEvidence, len(item.Evidence)),
 		}
 		if len(item.Evidence) > 8 {
-			return nil, fmt.Errorf("%w: evidence count", ErrProviderResponse)
+			return nil, providerResponseError(normalizeReasonEvidenceCountInvalid)
 		}
 		for evidenceIndex, source := range item.Evidence {
 			transcript, exists := turns[source.TurnID]
 			quote := strings.TrimSpace(source.Quote)
 			start := byteOccurrence(transcript, quote, source.Occurrence)
 			if !exists || source.Occurrence < 1 || start < 0 {
-				return nil, fmt.Errorf("%w: evidence quote", ErrProviderResponse)
+				return nil, providerResponseError(normalizeReasonEvidenceInvalid)
 			}
 			finding.Evidence[evidenceIndex] = report.ReportEvidence{
 				EvidenceRefID:   source.TurnID,
@@ -824,10 +851,67 @@ const generalSystemPromptV1 = `You are an evidence-bound everyday or workplace E
 
 const generalSystemPromptV2 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
 
-func (failure providerResponseFailure) Error() string          { return failure.message }
-func (failure providerResponseFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }
-func (failure providerResponseFailure) Retryable() bool        { return true }
+type normalizeReason string
 
-type providerResponseFailure struct{ message string }
+const (
+	normalizeReasonResponseMetadataInvalid      normalizeReason = "response_metadata_invalid"
+	normalizeReasonResponseJSONInvalid          normalizeReason = "response_json_invalid"
+	normalizeReasonDimensionCountInvalid        normalizeReason = "dimension_count_invalid"
+	normalizeReasonDimensionOrderInvalid        normalizeReason = "dimension_order_invalid"
+	normalizeReasonFindingCountInvalid          normalizeReason = "finding_count_invalid"
+	normalizeReasonEvidenceCountInvalid         normalizeReason = "evidence_count_invalid"
+	normalizeReasonEvidenceInvalid              normalizeReason = "evidence_invalid"
+	normalizeReasonPriorityActionInvalid        normalizeReason = "priority_action_invalid"
+	normalizeReasonPronunciationCoverageChanged normalizeReason = "pronunciation_coverage_changed"
+	normalizeReasonNormalizedReportInvalid      normalizeReason = "normalized_report_invalid"
+)
+
+func (reason normalizeReason) valid() bool {
+	switch reason {
+	case normalizeReasonResponseMetadataInvalid,
+		normalizeReasonResponseJSONInvalid,
+		normalizeReasonDimensionCountInvalid,
+		normalizeReasonDimensionOrderInvalid,
+		normalizeReasonFindingCountInvalid,
+		normalizeReasonEvidenceCountInvalid,
+		normalizeReasonEvidenceInvalid,
+		normalizeReasonPriorityActionInvalid,
+		normalizeReasonPronunciationCoverageChanged,
+		normalizeReasonNormalizedReportInvalid:
+		return true
+	default:
+		return false
+	}
+}
+
+func providerResponseError(reason normalizeReason) error {
+	if !reason.valid() {
+		reason = normalizeReasonNormalizedReportInvalid
+	}
+	return providerResponseFailure{reason: reason}
+}
+
+func normalizeReasonFromError(err error) normalizeReason {
+	var failure providerResponseFailure
+	if errors.As(err, &failure) && failure.reason.valid() {
+		return failure.reason
+	}
+	return normalizeReasonNormalizedReportInvalid
+}
+
+type providerResponseFailure struct{ reason normalizeReason }
+
+func (providerResponseFailure) Error() string {
+	return "evaluation: report provider response invalid"
+}
+func (providerResponseFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }
+func (providerResponseFailure) Retryable() bool        { return true }
+func (failure providerResponseFailure) EvaluationNormalizeReason() string {
+	return string(failure.reason)
+}
+func (providerResponseFailure) Is(target error) bool {
+	_, ok := target.(providerResponseFailure)
+	return ok
+}
 
 var _ evaluation.SessionEvaluators = (*Evaluators)(nil)

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -31,6 +31,7 @@ func TestInvalidProviderReportRemainsRetryableAtTheJobBoundary(t *testing.T) {
 
 func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) {
 	score := 7.0
+	snapshot := sessionSnapshotFixture()
 	generated := mustProviderResult(t, providerReport{
 		ScoreabilityStatus: report.ReportScoreabilityInsufficient,
 		Summary:            "The available evidence is insufficient.",
@@ -43,9 +44,9 @@ func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) 
 	})
 
 	formal, err := normalizeProviderReport(
-		generated, sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		generated, snapshot, evaluation.SceneIELTSSpeaking,
 		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
-		"qianwen", "qwen-plus",
+		"qianwen", "qwen-plus", fullRawProviderEvidencePolicy(snapshot),
 	)
 	if err != nil {
 		t.Fatalf("normalizeProviderReport() error = %v", err)
@@ -62,11 +63,12 @@ func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) 
 
 func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T) {
 	score := 7.0
+	snapshot := sessionSnapshotFixture()
 	dimension := providerDimensionFixture("FLUENCY_COHERENCE", &score)
 	dimension.Strengths = []providerFinding{{
 		Message: "Unsupported strength",
 		Evidence: []providerEvidence{{
-			TurnID: sessionSnapshotFixture().Turns[0].ID,
+			TurnID: snapshot.Turns[0].ID,
 			Quote:  "provider-invented quote", Occurrence: 1,
 		}},
 	}}
@@ -76,9 +78,9 @@ func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T)
 			Summary:            "The available evidence is insufficient.", Dimensions: []providerDimension{dimension},
 			PriorityActions: []providerPriorityAction{},
 		}),
-		sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		snapshot, evaluation.SceneIELTSSpeaking,
 		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
-		"qianwen", "qwen-plus",
+		"qianwen", "qwen-plus", fullRawProviderEvidencePolicy(snapshot),
 	)
 	if !errors.Is(err, ErrProviderResponse) ||
 		normalizeReasonFromError(err) != normalizeReasonEvidenceInvalid {
@@ -127,11 +129,12 @@ func TestProvisionalProviderReportRemainsFailClosed(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			snapshot := sessionSnapshotFixture()
 			_, err := normalizeProviderReport(
 				mustProviderResult(t, test.report),
-				sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+				snapshot, evaluation.SceneIELTSSpeaking,
 				[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
-				"qianwen", "qwen-plus",
+				"qianwen", "qwen-plus", fullRawProviderEvidencePolicy(snapshot),
 			)
 			if !errors.Is(err, ErrProviderResponse) ||
 				normalizeReasonFromError(err) != test.wantReason {
@@ -263,42 +266,263 @@ func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	snapshot := sessionSnapshotFixture()
-	now := snapshot.CompletedAt
-	snapshot.PlanSnapshot = json.RawMessage(`{"ielts_assignment":{"parts":[{"turn_blueprints":["p1"]},{"turn_blueprints":["p2"]},{"turn_blueprints":["p3"]}]}}`)
-	snapshot.Questions[0].Text = "Part 1 question"
-	snapshot.Turns[0].Transcript = "PART_ONE_RAW_TRANSCRIPT"
-	for index, transcript := range []string{"PART_TWO_RAW_TRANSCRIPT", "PART_THREE_RAW_TRANSCRIPT"} {
-		position := index + 2
-		questionID := fmt.Sprintf("40000000-0000-4000-8000-%012d", position)
-		turnID := fmt.Sprintf("30000000-0000-4000-8000-%012d", position)
-		snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
-			ID: questionID, Position: position, Text: fmt.Sprintf("Part %d question", position),
-			SpeakerParticipantID: "assistant-1", AddresseeParticipantIDs: []string{"user-1"},
-		})
-		snapshot.Turns = append(snapshot.Turns, evaluation.SessionEvidenceTurn{
-			ID: turnID, Position: position, QuestionID: questionID,
-			RespondentParticipantID: "user-1", Transcript: transcript,
-			Effective: true, ConfirmedAt: now,
-		})
-	}
-	snapshot.CumulativeProfile = &evaluation.IELTSCumulativeProfile{
-		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
-		SessionID:     snapshot.SessionID, CompletedParts: []int{1, 2},
-		Dimensions: cumulativeProfileDimensions(), Provider: "qianwen", Model: "qwen-plus",
-	}
-	snapshot.ProfileResolution = evaluation.IELTSFinalProfileResolved
+	snapshot := resolvedFullMockSnapshot()
 
 	if _, err := evaluators.EvaluateIELTS(
 		context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
 	); err != nil {
 		t.Fatalf("EvaluateIELTS() error = %v", err)
 	}
-	if strings.Contains(generator.last.UserPrompt, "PART_ONE_RAW_TRANSCRIPT") ||
-		strings.Contains(generator.last.UserPrompt, "PART_TWO_RAW_TRANSCRIPT") ||
-		!strings.Contains(generator.last.UserPrompt, "PART_THREE_RAW_TRANSCRIPT") ||
-		!strings.Contains(generator.last.UserPrompt, `"cumulative_profile"`) {
-		t.Fatalf("final incremental payload = %s", generator.last.UserPrompt)
+	var payload resolvedIELTSProviderInputV4
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode resolved v4 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if lineages.IELTS.PromptVersion != ieltsPromptVersionV4 ||
+		payload.SchemaVersion != ieltsInputSchemaVersionV4 ||
+		payload.EvidenceMode != ieltsInputCumulativeParts12PlusPart3 ||
+		len(payload.CumulativeProfile.CompletedParts) != 2 ||
+		len(payload.Questions) != 1 || len(payload.Turns) != 1 ||
+		payload.Turns[0].Transcript != "PART_THREE_RAW_TRANSCRIPT" ||
+		strings.Contains(generator.last.UserPrompt, "PART_ONE_HIDDEN_RAW") ||
+		strings.Contains(generator.last.UserPrompt, "PART_TWO_RAW_TRANSCRIPT") {
+		t.Fatalf("resolved v4 payload = %#v: %s", payload, generator.last.UserPrompt)
+	}
+}
+
+func TestIELTSEvaluatorV4ResolvedRejectsPart12RawEvidenceOutsideProfile(t *testing.T) {
+	snapshot := resolvedFullMockSnapshot()
+	for _, test := range []struct {
+		name     string
+		evidence providerEvidence
+	}{
+		{
+			name: "Part 1 raw outside profile",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[0].ID, Quote: "PART_ONE_HIDDEN_RAW", Occurrence: 1,
+			},
+		},
+		{
+			name: "Part 2 raw outside profile",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[1].ID, Quote: "PART_TWO_RAW_TRANSCRIPT", Occurrence: 1,
+			},
+		},
+		{
+			name: "profile quote with different occurrence",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[0].ID, Quote: "PROFILE_ALLOWED_QUOTE", Occurrence: 2,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			generator := &reportGeneratorFake{evidence: &test.evidence}
+			evaluators, err := New(generator)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lineages, err := Lineages("qianwen", "qwen-plus")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = evaluators.EvaluateIELTS(
+				context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+			)
+			if !errors.Is(err, ErrProviderResponse) || generator.calls != 2 {
+				t.Fatalf(
+					"EvaluateIELTS() error = %v, generator calls = %d",
+					err, generator.calls,
+				)
+			}
+		})
+	}
+}
+
+func TestIELTSEvaluatorV4ResolvedAcceptsOnlyProfileOrPart3Evidence(t *testing.T) {
+	snapshot := resolvedFullMockSnapshot()
+	tests := []struct {
+		name      string
+		evidence  providerEvidence
+		turnIndex int
+	}{
+		{
+			name: "cumulative profile evidence",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[0].ID, Quote: "PROFILE_ALLOWED_QUOTE", Occurrence: 1,
+			}, turnIndex: 0,
+		},
+		{
+			name: "Part 3 raw evidence",
+			evidence: providerEvidence{
+				TurnID: snapshot.Turns[2].ID, Quote: "THREE_RAW", Occurrence: 1,
+			}, turnIndex: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generator := &reportGeneratorFake{evidence: &test.evidence}
+			evaluators, err := New(generator)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lineages, err := Lineages("qianwen", "qwen-plus")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			encoded, err := evaluators.EvaluateIELTS(
+				context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+			)
+			if err != nil {
+				t.Fatalf("EvaluateIELTS() error = %v", err)
+			}
+			var formal report.FormalReport
+			if err := evaluation.DecodeStrict(encoded, &formal); err != nil {
+				t.Fatal(err)
+			}
+			got := formal.Dimensions[0].Strengths[0].Evidence[0]
+			wantStart := strings.Index(
+				snapshot.Turns[test.turnIndex].Transcript, test.evidence.Quote,
+			)
+			if got.TurnID != test.evidence.TurnID ||
+				got.OriginalExcerpt != test.evidence.Quote || got.StartUTF8Byte != wantStart {
+				t.Fatalf("normalized evidence = %#v, want start %d", got, wantStart)
+			}
+		})
+	}
+}
+
+func TestIELTSEvaluatorV4FallbackKeepsFullRawEvidence(t *testing.T) {
+	snapshot := sessionSnapshotFixture()
+	generator := &reportGeneratorFake{evidence: &providerEvidence{
+		TurnID: snapshot.Turns[0].ID, Quote: "small engineering", Occurrence: 1,
+	}}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+}
+
+func TestIELTSEvaluatorUsesTaggedFullRawFallbackPayload(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := sessionSnapshotFixture()
+	snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
+		ID: "40000000-0000-4000-8000-000000000002", Position: 2,
+		Text: "Unused question", SpeakerParticipantID: "assistant-1",
+		AddresseeParticipantIDs: []string{"user-1"},
+	})
+	snapshot.Turns = append(snapshot.Turns, evaluation.SessionEvidenceTurn{
+		ID: "30000000-0000-4000-8000-000000000002", Position: 2,
+		QuestionID:              "40000000-0000-4000-8000-000000000002",
+		RespondentParticipantID: "user-1", Transcript: "INEFFECTIVE_RAW_TRANSCRIPT",
+		Effective: false, ConfirmedAt: snapshot.CompletedAt,
+	})
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, snapshot, lineages.IELTS,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	var payload fallbackIELTSProviderInputV4
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode fallback v4 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if payload.SchemaVersion != ieltsInputSchemaVersionV4 ||
+		payload.EvidenceMode != ieltsInputFullRawFallback ||
+		len(payload.Questions) != 2 || len(payload.Turns) != 1 ||
+		payload.Turns[0].Transcript != snapshot.Turns[0].Transcript ||
+		strings.Contains(generator.last.UserPrompt, "INEFFECTIVE_RAW_TRANSCRIPT") ||
+		strings.Contains(generator.last.UserPrompt, `"cumulative_profile"`) ||
+		strings.Contains(generator.last.UserPrompt, `"part_3_effective_turns"`) {
+		t.Fatalf("fallback v4 payload = %#v: %s", payload, generator.last.UserPrompt)
+	}
+}
+
+func TestIELTSEvaluatorPreservesHistoricalV3FallbackContract(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage := lineages.IELTS
+	lineage.PromptVersion = ieltsPromptVersionV3
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, sessionSnapshotFixture(), lineage,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	var payload providerInput
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode historical v3 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if generator.last.SystemPrompt != ieltsSystemPromptV3 ||
+		strings.Contains(generator.last.UserPrompt, `"schema_version"`) ||
+		strings.Contains(generator.last.UserPrompt, `"evidence_mode"`) ||
+		len(payload.Questions) != 1 || len(payload.Turns) != 1 {
+		t.Fatalf("historical v3 contract changed: %#v: %s", payload, generator.last.UserPrompt)
+	}
+}
+
+func TestIELTSEvaluatorPreservesHistoricalV3ResolvedContract(t *testing.T) {
+	snapshot := resolvedFullMockSnapshot()
+	generator := &reportGeneratorFake{evidence: &providerEvidence{
+		TurnID: snapshot.Turns[0].ID, Quote: "PART_ONE_HIDDEN_RAW", Occurrence: 1,
+	}}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage := lineages.IELTS
+	lineage.PromptVersion = ieltsPromptVersionV3
+
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, snapshot, lineage,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	var payload incrementalIELTSProviderInput
+	if err := evaluation.DecodeStrict(
+		json.RawMessage(generator.last.UserPrompt), &payload,
+	); err != nil {
+		t.Fatalf("decode historical resolved v3 payload: %v: %s", err, generator.last.UserPrompt)
+	}
+	if generator.last.SystemPrompt != ieltsSystemPromptV3 ||
+		len(payload.CumulativeProfile.CompletedParts) != 2 ||
+		len(payload.Questions) != 1 || len(payload.Turns) != 1 {
+		t.Fatalf("historical resolved v3 contract changed: %#v", payload)
 	}
 }
 
@@ -473,7 +697,7 @@ func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *te
 		version string
 	}{
 		{name: "interview", prompt: interviewSystemPromptV2, version: interviewPromptVersionV2},
-		{name: "IELTS", prompt: ieltsSystemPromptV3, version: ieltsPromptVersionV3},
+		{name: "IELTS", prompt: ieltsSystemPromptV4, version: ieltsPromptVersionV4},
 		{name: "general", prompt: generalSystemPromptV2, version: generalPromptVersionV2},
 	}
 	lineages, err := Lineages("qianwen", "qwen-plus")
@@ -635,7 +859,9 @@ func TestInsufficientReportFollowsRecordedVersionAndPreservesOriginalText(t *tes
 }
 
 type reportGeneratorFake struct {
-	last textgeneration.Request
+	last     textgeneration.Request
+	evidence *providerEvidence
+	calls    int
 }
 
 type repairReportGeneratorFake struct {
@@ -717,6 +943,7 @@ func (generator *reportGeneratorFake) Generate(
 	_ context.Context,
 	request textgeneration.Request,
 ) (textgeneration.Result, error) {
+	generator.calls++
 	generator.last = request
 	var input struct {
 		DimensionKeys []string `json:"dimension_keys"`
@@ -726,9 +953,16 @@ func (generator *reportGeneratorFake) Generate(
 	}
 	dimensions := make([]map[string]any, len(input.DimensionKeys))
 	for index, key := range input.DimensionKeys {
+		strengths := []any{}
+		if index == 0 && generator.evidence != nil {
+			strengths = []any{map[string]any{
+				"message": "有明确证据。", "suggestion": "继续保持。",
+				"evidence": []providerEvidence{*generator.evidence},
+			}}
+		}
 		dimensions[index] = map[string]any{
 			"key": key, "score": 7.0, "coverage": 1.0, "confidence": 0.8,
-			"reason_codes": []string{}, "strengths": []any{},
+			"reason_codes": []string{}, "strengths": strengths,
 			"improvements": []any{}, "recommended_examples": []any{},
 		}
 	}
@@ -749,6 +983,43 @@ func (generator *reportGeneratorFake) Generate(
 	}, nil
 }
 
+func resolvedFullMockSnapshot() evaluation.SessionInputSnapshot {
+	snapshot := sessionSnapshotFixture()
+	now := snapshot.CompletedAt
+	snapshot.PlanSnapshot = json.RawMessage(`{"ielts_assignment":{"parts":[{"turn_blueprints":["p1"]},{"turn_blueprints":["p2"]},{"turn_blueprints":["p3"]}]}}`)
+	snapshot.Questions[0].Text = "Part 1 question"
+	snapshot.Turns[0].Transcript = "PROFILE_ALLOWED_QUOTE PART_ONE_HIDDEN_RAW"
+	for index, transcript := range []string{"PART_TWO_RAW_TRANSCRIPT", "PART_THREE_RAW_TRANSCRIPT"} {
+		position := index + 2
+		questionID := fmt.Sprintf("40000000-0000-4000-8000-%012d", position)
+		turnID := fmt.Sprintf("30000000-0000-4000-8000-%012d", position)
+		snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
+			ID: questionID, Position: position, Text: fmt.Sprintf("Part %d question", position),
+			SpeakerParticipantID: "assistant-1", AddresseeParticipantIDs: []string{"user-1"},
+		})
+		snapshot.Turns = append(snapshot.Turns, evaluation.SessionEvidenceTurn{
+			ID: turnID, Position: position, QuestionID: questionID,
+			RespondentParticipantID: "user-1", Transcript: transcript,
+			Effective: true, ConfirmedAt: now,
+		})
+	}
+	dimensions := cumulativeProfileDimensions()
+	dimensions[0].Observations = []evaluation.IELTSProfileObservation{{
+		Kind: "STRENGTH", ReasonCode: "PROFILE_EVIDENCE",
+		Evidence: []evaluation.IELTSProfileEvidence{{
+			TurnID: snapshot.Turns[0].ID, Quote: "PROFILE_ALLOWED_QUOTE",
+			Occurrence: 1, Part: 1,
+		}},
+	}}
+	snapshot.CumulativeProfile = &evaluation.IELTSCumulativeProfile{
+		SchemaVersion: evaluation.IELTSCumulativeProfileSchemaVersion,
+		SessionID:     snapshot.SessionID, CompletedParts: []int{1, 2},
+		Dimensions: dimensions, Provider: "qianwen", Model: "qwen-plus",
+	}
+	snapshot.ProfileResolution = evaluation.IELTSFinalProfileResolved
+	return snapshot
+}
+
 func sessionSnapshotFixture() evaluation.SessionInputSnapshot {
 	now := time.Now().UTC()
 	return evaluation.SessionInputSnapshot{
@@ -759,6 +1030,7 @@ func sessionSnapshotFixture() evaluation.SessionInputSnapshot {
 		PracticeExperience:  "IELTS_SPEAKING",
 		SceneCategory:       "IELTS_SPEAKING",
 		PracticeMode:        "FULL_MOCK",
+		ProfileResolution:   evaluation.IELTSFinalProfileFallback,
 		CompletedAt:         now,
 		AcousticCapability:  evaluation.AcousticCapabilityNotConfigured,
 		PlanSnapshot:        json.RawMessage(`{}`),

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -19,11 +19,158 @@ func TestInvalidProviderReportRemainsRetryableAtTheJobBoundary(t *testing.T) {
 	var failure interface {
 		StableCategory() string
 		Retryable() bool
+		EvaluationNormalizeReason() string
 	}
 	if !errors.As(ErrProviderResponse, &failure) ||
 		failure.StableCategory() != "PROVIDER_RESPONSE_INVALID" ||
+		failure.EvaluationNormalizeReason() != "normalized_report_invalid" ||
 		!failure.Retryable() {
 		t.Fatalf("provider response failure = %#v", failure)
+	}
+}
+
+func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) {
+	score := 7.0
+	generated := mustProviderResult(t, providerReport{
+		ScoreabilityStatus: report.ReportScoreabilityInsufficient,
+		Summary:            "The available evidence is insufficient.",
+		Dimensions: []providerDimension{
+			providerDimensionFixture("FLUENCY_COHERENCE", &score),
+		},
+		PriorityActions: []providerPriorityAction{{
+			DimensionKey: "UNKNOWN", ImprovementIndex: 99,
+		}},
+	})
+
+	formal, err := normalizeProviderReport(
+		generated, sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
+		"qianwen", "qwen-plus",
+	)
+	if err != nil {
+		t.Fatalf("normalizeProviderReport() error = %v", err)
+	}
+	for _, dimension := range formal.Dimensions {
+		if dimension.Score != nil {
+			t.Fatalf("INSUFFICIENT dimension retained score: %#v", dimension)
+		}
+	}
+	if len(formal.PriorityActions) != 0 {
+		t.Fatalf("INSUFFICIENT priority actions = %#v", formal.PriorityActions)
+	}
+}
+
+func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T) {
+	score := 7.0
+	dimension := providerDimensionFixture("FLUENCY_COHERENCE", &score)
+	dimension.Strengths = []providerFinding{{
+		Message: "Unsupported strength",
+		Evidence: []providerEvidence{{
+			TurnID: sessionSnapshotFixture().Turns[0].ID,
+			Quote:  "provider-invented quote", Occurrence: 1,
+		}},
+	}}
+	_, err := normalizeProviderReport(
+		mustProviderResult(t, providerReport{
+			ScoreabilityStatus: report.ReportScoreabilityInsufficient,
+			Summary:            "The available evidence is insufficient.", Dimensions: []providerDimension{dimension},
+			PriorityActions: []providerPriorityAction{},
+		}),
+		sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+		[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
+		"qianwen", "qwen-plus",
+	)
+	if !errors.Is(err, ErrProviderResponse) ||
+		normalizeReasonFromError(err) != normalizeReasonEvidenceInvalid {
+		t.Fatalf("invalid INSUFFICIENT evidence error = %v", err)
+	}
+}
+
+func TestProvisionalProviderReportRemainsFailClosed(t *testing.T) {
+	tests := []struct {
+		name       string
+		report     providerReport
+		wantReason normalizeReason
+	}{
+		{
+			name: "invalid score",
+			report: func() providerReport {
+				score := 9.5
+				return providerReport{
+					ScoreabilityStatus: report.ReportScoreabilityProvisional,
+					Summary:            "Provisional report.",
+					Dimensions: []providerDimension{
+						providerDimensionFixture("FLUENCY_COHERENCE", &score),
+					},
+					PriorityActions: []providerPriorityAction{},
+				}
+			}(),
+			wantReason: normalizeReasonNormalizedReportInvalid,
+		},
+		{
+			name: "invalid priority action",
+			report: func() providerReport {
+				score := 7.0
+				return providerReport{
+					ScoreabilityStatus: report.ReportScoreabilityProvisional,
+					Summary:            "Provisional report.",
+					Dimensions: []providerDimension{
+						providerDimensionFixture("FLUENCY_COHERENCE", &score),
+					},
+					PriorityActions: []providerPriorityAction{{
+						DimensionKey: "FLUENCY_COHERENCE", ImprovementIndex: 1,
+					}},
+				}
+			}(),
+			wantReason: normalizeReasonPriorityActionInvalid,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := normalizeProviderReport(
+				mustProviderResult(t, test.report),
+				sessionSnapshotFixture(), evaluation.SceneIELTSSpeaking,
+				[]string{"FLUENCY_COHERENCE"}, report.ReportScaleIELTSBand,
+				"qianwen", "qwen-plus",
+			)
+			if !errors.Is(err, ErrProviderResponse) ||
+				normalizeReasonFromError(err) != test.wantReason {
+				t.Fatalf("normalizeProviderReport() error = %v, reason = %q", err, normalizeReasonFromError(err))
+			}
+		})
+	}
+}
+
+func TestIELTSRepairReceivesBoundedNormalizeReason(t *testing.T) {
+	generator := &repairReportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := evaluators.EvaluateIELTS(
+		context.Background(), evaluation.Record{}, sessionSnapshotFixture(), lineages.IELTS,
+	); err != nil {
+		t.Fatalf("EvaluateIELTS() error = %v", err)
+	}
+	if len(generator.requests) != 2 {
+		t.Fatalf("generation requests = %d", len(generator.requests))
+	}
+	var repair struct {
+		Violation   normalizeReason `json:"violation"`
+		Instruction string          `json:"instruction"`
+	}
+	if err := json.Unmarshal([]byte(generator.requests[1].UserPrompt), &repair); err != nil {
+		t.Fatal(err)
+	}
+	if repair.Violation != normalizeReasonPriorityActionInvalid ||
+		!repair.Violation.valid() ||
+		!strings.Contains(repair.Instruction, "For INSUFFICIENT, every score must be null") ||
+		!strings.Contains(repair.Instruction, "existing improvement in the same dimension") {
+		t.Fatalf("repair contract = %#v", repair)
 	}
 }
 
@@ -491,6 +638,81 @@ type reportGeneratorFake struct {
 	last textgeneration.Request
 }
 
+type repairReportGeneratorFake struct {
+	requests []textgeneration.Request
+}
+
+func (generator *repairReportGeneratorFake) Generate(
+	_ context.Context,
+	request textgeneration.Request,
+) (textgeneration.Result, error) {
+	generator.requests = append(generator.requests, request)
+	var dimensionKeys []string
+	if len(generator.requests) == 1 {
+		var input struct {
+			DimensionKeys []string `json:"dimension_keys"`
+		}
+		if err := json.Unmarshal([]byte(request.UserPrompt), &input); err != nil {
+			return textgeneration.Result{}, err
+		}
+		dimensionKeys = input.DimensionKeys
+	} else {
+		var repair struct {
+			Input struct {
+				DimensionKeys []string `json:"dimension_keys"`
+			} `json:"input"`
+		}
+		if err := json.Unmarshal([]byte(request.UserPrompt), &repair); err != nil {
+			return textgeneration.Result{}, err
+		}
+		dimensionKeys = repair.Input.DimensionKeys
+	}
+	score := 7.0
+	dimensions := make([]providerDimension, len(dimensionKeys))
+	for index, key := range dimensionKeys {
+		dimensions[index] = providerDimensionFixture(key, &score)
+	}
+	actions := []providerPriorityAction{}
+	if len(generator.requests) == 1 {
+		actions = append(actions, providerPriorityAction{
+			DimensionKey: dimensionKeys[0], ImprovementIndex: 1,
+		})
+	}
+	content, err := json.Marshal(providerReport{
+		ScoreabilityStatus: report.ReportScoreabilityProvisional,
+		Summary:            "Provisional report.",
+		Dimensions:         dimensions,
+		PriorityActions:    actions,
+	})
+	if err != nil {
+		return textgeneration.Result{}, err
+	}
+	return textgeneration.Result{
+		RequestID: fmt.Sprintf("request-%d", len(generator.requests)),
+		Content:   string(content), Provider: "qianwen", Model: "qwen-plus",
+	}, nil
+}
+
+func providerDimensionFixture(key string, score *float64) providerDimension {
+	return providerDimension{
+		Key: key, Score: score, Coverage: 1, Confidence: 0.8,
+		ReasonCodes: []string{}, Strengths: []providerFinding{},
+		Improvements: []providerFinding{}, Examples: []providerFinding{},
+	}
+}
+
+func mustProviderResult(t *testing.T, value providerReport) textgeneration.Result {
+	t.Helper()
+	content, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return textgeneration.Result{
+		RequestID: "request-1", Content: string(content),
+		Provider: "qianwen", Model: "qwen-plus",
+	}
+}
+
 func (generator *reportGeneratorFake) Generate(
 	_ context.Context,
 	request textgeneration.Request,
@@ -557,3 +779,4 @@ func sessionSnapshotFixture() evaluation.SessionInputSnapshot {
 }
 
 var _ textgeneration.Generator = (*reportGeneratorFake)(nil)
+var _ textgeneration.Generator = (*repairReportGeneratorFake)(nil)

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
@@ -382,9 +382,10 @@ func encodeCompactSpeechResult(
 
 type compactProviderFailure struct{ message string }
 
-func (failure compactProviderFailure) Error() string          { return failure.message }
-func (failure compactProviderFailure) StableCategory() string { return "PROVIDER_RESPONSE_INVALID" }
-func (failure compactProviderFailure) Retryable() bool        { return false }
+func (failure compactProviderFailure) Error() string            { return failure.message }
+func (failure compactProviderFailure) StableCategory() string   { return "PROVIDER_RESPONSE_INVALID" }
+func (failure compactProviderFailure) Retryable() bool          { return false }
+func (failure compactProviderFailure) AutomaticRetryable() bool { return true }
 
 func compactProviderError(message string) error {
 	return compactProviderFailure{message: message}

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
@@ -3,10 +3,37 @@ package speechfeedback
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 )
+
+func TestCompactProviderSemanticFailureIsAutomaticOnly(t *testing.T) {
+	snapshot := evaluation.SpeechInputSnapshot{
+		Transcript:    "I usually read before work.",
+		EvidenceRefID: "30000000-0000-4000-8000-000000000001",
+	}
+	_, err := compactFeedbackItems(
+		compactResult(`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"missing excerpt","source_occurrence":1,"suggested_text":"read"}]}`),
+		snapshot,
+		snapshot.Transcript,
+		"SAME_QUESTION",
+	)
+	if err == nil {
+		t.Fatal("semantic-invalid provider response was accepted")
+	}
+	var publicFailure GenerationFailure
+	if !errors.As(err, &publicFailure) ||
+		publicFailure.StableCategory() != "PROVIDER_RESPONSE_INVALID" ||
+		publicFailure.Retryable() {
+		t.Fatalf("public failure = %#v", publicFailure)
+	}
+	var automatic interface{ AutomaticRetryable() bool }
+	if !errors.As(err, &automatic) || !automatic.AutomaticRetryable() {
+		t.Fatalf("automatic retry contract missing from %T", err)
+	}
+}
 
 func TestCompactEvaluatorUsesOralReferenceWithoutChangingEvidence(t *testing.T) {
 	generator := &recordingCompactGenerator{

--- a/server/internal/coaching/evaluation/state.go
+++ b/server/internal/coaching/evaluation/state.go
@@ -112,12 +112,15 @@ func (completion Completion) Valid() bool {
 }
 
 type Failure struct {
-	UserID      string
-	ID          string
-	LeaseToken  string
-	Error       JobError
-	RetryAt     time.Time
-	MaxAttempts int
+	UserID     string
+	ID         string
+	LeaseToken string
+	Error      JobError
+	// AutomaticRetryable controls worker requeueing independently from the
+	// public/manual retry contract carried by Error.Retryable.
+	AutomaticRetryable bool
+	RetryAt            time.Time
+	MaxAttempts        int
 }
 
 func (failure Failure) Valid() bool {

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -9,6 +9,12 @@ import (
 
 const MinimumIELTSTwoRoundDeadline = 2*45*time.Second + 10*time.Second
 
+const (
+	previousProfileLifecycleStages = 1
+	finalProfileLifecycleStages    = 2
+	maximumProfileLifecycleWait    = 30 * time.Minute
+)
+
 const acousticDependencyTimeoutReason = "ACOUSTIC_DEPENDENCY_TIMEOUT"
 
 var ErrAcousticDependencyFailed error = acousticDependencyFailure{}
@@ -103,7 +109,6 @@ type WorkerConfiguration struct {
 	RetryDelay                time.Duration
 	DependencyDelay           time.Duration
 	AcousticDependencyMaxWait time.Duration
-	ProfileDependencyMaxWait  time.Duration
 	FinalizeTimeout           time.Duration
 }
 
@@ -134,10 +139,22 @@ func (configuration WorkerConfiguration) Valid() bool {
 		configuration.DependencyDelay <= time.Minute &&
 		configuration.AcousticDependencyMaxWait >= configuration.DependencyDelay &&
 		configuration.AcousticDependencyMaxWait <= 5*time.Minute &&
-		configuration.ProfileDependencyMaxWait >= configuration.DependencyDelay &&
-		configuration.ProfileDependencyMaxWait <= 5*time.Minute &&
+		configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages) <=
+			maximumProfileLifecycleWait &&
 		configuration.FinalizeTimeout >= time.Second &&
 		configuration.FinalizeTimeout <= 30*time.Second
+}
+
+func (configuration WorkerConfiguration) profileLifecycleWaitBudget(stages int) time.Duration {
+	attempts := time.Duration(configuration.ProfileLane.MaxAttempts)
+	processing := attempts*configuration.ProfileDeadline +
+		(attempts-1)*configuration.RetryDelay + configuration.DependencyDelay
+	// A crashed worker can retain each attempt until its lease expires. The
+	// lease margin extends, rather than duplicates, the provider deadline.
+	leaseRecoveryMargin := attempts *
+		(configuration.ProfileLane.LeaseDuration - configuration.ProfileDeadline)
+	perStage := configuration.AcousticDependencyMaxWait + processing + leaseRecoveryMargin
+	return time.Duration(stages) * perStage
 }
 
 type Worker struct {
@@ -246,7 +263,9 @@ func (worker *Worker) resolvePreviousProfile(
 		ctx, claim.UserID, KindIELTSPart1Profile, snapshot.SessionID,
 	)
 	if err == nil && (record.Status == JobQueued || record.Status == JobRunning) &&
-		time.Since(claim.CreatedAt) < worker.configuration.ProfileDependencyMaxWait {
+		time.Now().UTC().Before(record.CreatedAt.Add(
+			worker.configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages),
+		)) {
 		finalizeContext, cancel := worker.finalizeContext(ctx)
 		defer cancel()
 		return true, worker.store.DeferClaim(finalizeContext, Deferral{
@@ -455,7 +474,9 @@ func (worker *Worker) resolveFinalProfile(
 		ctx, claim.UserID, KindIELTSPart2Profile, snapshot.SessionID,
 	)
 	if err == nil && (record.Status == JobQueued || record.Status == JobRunning) &&
-		time.Since(claim.CreatedAt) < worker.configuration.ProfileDependencyMaxWait {
+		time.Now().UTC().Before(record.CreatedAt.Add(
+			worker.configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages),
+		)) {
 		finalizeContext, cancel := worker.finalizeContext(ctx)
 		defer cancel()
 		return true, worker.store.DeferClaim(finalizeContext, Deferral{

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -716,12 +716,13 @@ func (worker *Worker) fail(ctx context.Context, claim Claim, cause error) error 
 	finalizeContext, cancel := worker.finalizeContext(ctx)
 	defer cancel()
 	err := worker.store.FailClaim(finalizeContext, Failure{
-		UserID:      claim.UserID,
-		ID:          claim.ID,
-		LeaseToken:  claim.LeaseToken,
-		Error:       failure,
-		RetryAt:     time.Now().UTC().Add(worker.configuration.RetryDelay),
-		MaxAttempts: maxAttemptsFor(claim.Kind, worker.configuration),
+		UserID:             claim.UserID,
+		ID:                 claim.ID,
+		LeaseToken:         claim.LeaseToken,
+		Error:              failure,
+		AutomaticRetryable: automaticRetryable(cause, failure),
+		RetryAt:            time.Now().UTC().Add(worker.configuration.RetryDelay),
+		MaxAttempts:        maxAttemptsFor(claim.Kind, worker.configuration),
 	})
 	if err != nil {
 		return errors.Join(processing, err)
@@ -740,6 +741,18 @@ type stableFailure interface {
 	error
 	StableCategory() string
 	Retryable() bool
+}
+
+type automaticRetryableFailure interface {
+	AutomaticRetryable() bool
+}
+
+func automaticRetryable(err error, publicFailure JobError) bool {
+	var automatic automaticRetryableFailure
+	if errors.As(err, &automatic) {
+		return automatic.AutomaticRetryable()
+	}
+	return publicFailure.Retryable
 }
 
 func stableJobError(err error) JobError {

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -40,6 +40,84 @@ func TestWorkerConfigurationRejectsIELTSDeadlineThatCutsRepairRound(t *testing.T
 	}
 }
 
+func TestWorkerConfigurationDerivesProfileWaitFromLaneLifecycle(t *testing.T) {
+	configuration := workerConfigurationFixture()
+	attempts := time.Duration(configuration.ProfileLane.MaxAttempts)
+	perStage := configuration.AcousticDependencyMaxWait +
+		attempts*configuration.ProfileLane.LeaseDuration +
+		(attempts-1)*configuration.RetryDelay + configuration.DependencyDelay
+	if got := configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages); got != perStage {
+		t.Fatalf("single-stage profile wait = %s, want %s", got, perStage)
+	}
+	if got := configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages); got != 2*perStage {
+		t.Fatalf("two-stage profile wait = %s, want %s", got, 2*perStage)
+	}
+	if !configuration.Valid() {
+		t.Fatal("production-sized profile lifecycle should remain valid")
+	}
+	configuration.ProfileLane.MaxAttempts = 10
+	if configuration.Valid() {
+		t.Fatal("profile lifecycle beyond the bounded maximum should be invalid")
+	}
+}
+
+func TestWorkerPart2ProfileWaitsForFullLifecycleBudget(t *testing.T) {
+	configuration := workerConfigurationFixture()
+	fullBudget := configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages)
+	for _, test := range []struct {
+		name     string
+		age      time.Duration
+		fallback bool
+	}{
+		{name: "past legacy 96 second budget", age: 97 * time.Second},
+		{name: "immediately before full budget", age: fullBudget - time.Second},
+		{name: "after full budget", age: fullBudget + time.Second, fallback: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			claim := profileClaimFixture(t, now, IELTSProfileStagePart2)
+			store := &workerStoreFake{
+				claims: []Claim{claim},
+				records: map[Kind]Record{
+					KindIELTSPart1Profile: {
+						Status: JobRunning, AttemptCount: configuration.ProfileLane.MaxAttempts,
+						CreatedAt: now.Add(-test.age),
+					},
+				},
+			}
+			profiles := &profileEvaluatorsFake{}
+			worker, err := NewWorker(
+				store, &sessionEvaluatorsFake{}, profiles, &speechEvaluatorsFake{},
+				&acousticEvaluatorFake{}, store, configuration,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			processed, err := worker.ProcessProfile(context.Background())
+			wantDeferred := 1
+			wantCompleted := 0
+			wantProfileCalls := 0
+			if test.fallback {
+				wantDeferred = 0
+				wantCompleted = 1
+				wantProfileCalls = 1
+			}
+			if err != nil || !processed || profiles.calls != wantProfileCalls ||
+				len(store.deferrals) != wantDeferred || len(store.checkpoints) != wantCompleted ||
+				len(store.completions) != wantCompleted || len(store.failures) != 0 ||
+				(test.fallback && profiles.last.DependencyResolution != IELTSProfileDependencyFallback) {
+				t.Fatalf(
+					"ProcessProfile=(%t,%v), calls=%d resolution=%s deferrals=%d checkpoints=%d completions=%d failures=%d",
+					processed, err, profiles.calls, profiles.last.DependencyResolution,
+					len(store.deferrals), len(store.checkpoints), len(store.completions),
+					len(store.failures),
+				)
+			}
+		})
+	}
+}
+
 func TestWorkerPart2ProfileReusesReadyPart1Profile(t *testing.T) {
 	now := time.Now().UTC()
 	claim := profileClaimFixture(t, now, IELTSProfileStagePart2)
@@ -81,7 +159,7 @@ func TestWorkerPart2ProfileDefersWhilePart1IsRunning(t *testing.T) {
 	store := &workerStoreFake{
 		claims: []Claim{claim},
 		records: map[Kind]Record{
-			KindIELTSPart1Profile: {Status: JobRunning},
+			KindIELTSPart1Profile: {Status: JobRunning, CreatedAt: now},
 		},
 	}
 	profiles := &profileEvaluatorsFake{}
@@ -127,7 +205,7 @@ func TestWorkerPart2ProfileFallsBackWhenPart1IsMissing(t *testing.T) {
 	}
 }
 
-func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
+func TestWorkerFinalReportResolvesPart2ProfileReadyAfter45Seconds(t *testing.T) {
 	now := time.Now().UTC()
 	claim := sessionClaimFixture(t, now, IELTSStrategyRef)
 	part2 := cumulativeProfileFixture(claim.SourceID, []int{1, 2})
@@ -138,7 +216,10 @@ func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
 	store := &workerStoreFake{
 		claims: []Claim{claim},
 		records: map[Kind]Record{
-			KindIELTSPart2Profile: {Status: JobReady, Result: part2Result},
+			KindIELTSPart2Profile: {
+				Status: JobReady, Result: part2Result,
+				CreatedAt: now.Add(-45 * time.Second),
+			},
 		},
 	}
 	sessions := &sessionEvaluatorsFake{}
@@ -157,6 +238,63 @@ func TestWorkerFinalReportReusesReadyPart2Profile(t *testing.T) {
 	}
 }
 
+func TestWorkerFinalReportDefersThroughNormalPart2ProfileRuntime(t *testing.T) {
+	configuration := workerConfigurationFixture()
+	for _, test := range []struct {
+		name     string
+		age      time.Duration
+		attempts int
+	}{
+		{name: "ready-window-28s", age: 28 * time.Second, attempts: 1},
+		{name: "ready-window-45s", age: 45 * time.Second, attempts: 1},
+		{
+			name:     "past-legacy-two-stage-budget",
+			age:      193 * time.Second,
+			attempts: configuration.ProfileLane.MaxAttempts,
+		},
+		{
+			name:     "second-attempt-after-upstream-stage",
+			age:      configuration.profileLifecycleWaitBudget(previousProfileLifecycleStages) + time.Second,
+			attempts: 2,
+		},
+		{
+			name: "immediately-before-full-two-stage-budget",
+			age: configuration.profileLifecycleWaitBudget(finalProfileLifecycleStages) -
+				time.Second,
+			attempts: configuration.ProfileLane.MaxAttempts,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			claim := sessionClaimFixture(t, now, IELTSStrategyRef)
+			store := &workerStoreFake{
+				claims: []Claim{claim},
+				records: map[Kind]Record{
+					KindIELTSPart2Profile: {
+						Status: JobRunning, AttemptCount: test.attempts,
+						CreatedAt: now.Add(-test.age),
+					},
+				},
+			}
+			sessions := &sessionEvaluatorsFake{}
+			worker := workerFixture(
+				t, store, sessions, &speechEvaluatorsFake{}, &acousticEvaluatorFake{},
+			)
+
+			processed, err := worker.ProcessSession(context.Background())
+			if err != nil || !processed || sessions.ieltsCalls != 0 ||
+				len(store.deferrals) != 1 || len(store.checkpoints) != 0 ||
+				len(store.completions) != 0 || len(store.failures) != 0 {
+				t.Fatalf(
+					"ProcessSession=(%t,%v), calls=%d deferrals=%d checkpoints=%d completions=%d failures=%d",
+					processed, err, sessions.ieltsCalls, len(store.deferrals),
+					len(store.checkpoints), len(store.completions), len(store.failures),
+				)
+			}
+		})
+	}
+}
+
 func TestWorkerFinalReportFallsBackWhenPart2ProfileIsUnavailable(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -165,7 +303,7 @@ func TestWorkerFinalReportFallsBackWhenPart2ProfileIsUnavailable(t *testing.T) {
 	}{
 		{
 			name:     "dependency timeout",
-			record:   Record{Status: JobRunning},
+			record:   Record{Status: JobRunning, AttemptCount: 2},
 			timedOut: true,
 		},
 		{
@@ -185,10 +323,9 @@ func TestWorkerFinalReportFallsBackWhenPart2ProfileIsUnavailable(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			now := time.Now().UTC()
 			claim := sessionClaimFixture(t, now, IELTSStrategyRef)
-			claim.CreatedAt = now
 			if test.timedOut {
-				claim.CreatedAt = now.Add(
-					-workerConfigurationFixture().ProfileDependencyMaxWait - time.Second,
+				test.record.CreatedAt = now.Add(
+					-workerConfigurationFixture().profileLifecycleWaitBudget(finalProfileLifecycleStages) - time.Second,
 				)
 			}
 			store := &workerStoreFake{
@@ -974,7 +1111,6 @@ func workerConfigurationFixture() WorkerConfiguration {
 		RetryDelay:                time.Second,
 		DependencyDelay:           5 * time.Second,
 		AcousticDependencyMaxWait: 150 * time.Second,
-		ProfileDependencyMaxWait:  20 * time.Second,
 		FinalizeTimeout:           5 * time.Second,
 	}
 }

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -411,7 +411,8 @@ func TestWorkerRetriesTransientAcousticFailureWhileAttemptsRemain(t *testing.T) 
 	processed, err := worker.ProcessSpeech(context.Background())
 	if !processed || err == nil || acoustics.calls != 1 || speech.practiceCalls != 0 ||
 		len(store.checkpoints) != 0 || len(store.completions) != 0 ||
-		len(store.failures) != 1 || !store.failures[0].Error.Retryable {
+		len(store.failures) != 1 || !store.failures[0].Error.Retryable ||
+		!store.failures[0].AutomaticRetryable {
 		t.Fatalf(
 			"ProcessSpeech=(%v,%v) acoustic=%d text=%d checkpoints=%d completions=%d failures=%#v",
 			processed, err, acoustics.calls, speech.practiceCalls,

--- a/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
+++ b/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
@@ -373,7 +373,6 @@ func customLifecycleWorkerConfiguration() evaluation.WorkerConfiguration {
 		RetryDelay:                time.Second,
 		DependencyDelay:           time.Second,
 		AcousticDependencyMaxWait: 150 * time.Second,
-		ProfileDependencyMaxWait:  20 * time.Second,
 		FinalizeTimeout:           5 * time.Second,
 	}
 }

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -982,7 +982,6 @@ func migrationEvaluationWorkerConfiguration() evaluation.WorkerConfiguration {
 		RetryDelay:                time.Second,
 		DependencyDelay:           time.Second,
 		AcousticDependencyMaxWait: 150 * time.Second,
-		ProfileDependencyMaxWait:  20 * time.Second,
 		FinalizeTimeout:           5 * time.Second,
 	}
 }


### PR DESCRIPTION
## 功能说明

将经独立 Issue、Review 和门禁验证的 v0.1.6 候选范围从 `dev` 提升到 `main`，为后续创建唯一的 `v0.1.6` Tag 和构建 Release Candidate 建立正式发布提交。

本次候选范围包括：

- 证据不足报告的确定性规范化：清除不可信分数和优先项，并保留稳定、脱敏的安全拒绝子因。
- FULL_MOCK 累计画像的有界等待与版本化 fallback 契约，避免固定等待时间导致的确定性竞态。
- 语音反馈语义规范化失败的有界自动重试；复用已完成的声学 checkpoint，不重复调用讯飞评测，最终失败仍保持 fail-closed。
- 只允许显式 Staging 执行、默认 dry-run 的真实业务 UAT 执行器，覆盖 PART_1 文本/语音、PART_2 语音、PART_3 语音和 FULL_MOCK 文本，并输出脱敏回执。
- 使用指定 finalized 备份、不可变镜像和 manifest 的 Production schema 7→9 隔离升级演练；不连接或修改正式数据库。
- 将 Flutter/Android 权威版本冻结为 `0.1.6+7`，保持 application ID 与正式签名证书不变。

本 PR 保留既有 `v0.1.5` Tag、manifest 和制品，不移动、不覆盖也不重写其发布历史。

## 实现思路

- 只通过 GitHub Release PR 将官方 `dev` 合入受保护的 `main`，不直接推送 `dev` 或 `main`。
- 本 PR 不在合并过程中重新实现功能，也不从本地临时目录构建发布制品；候选内容以最终 `dev` tree 为唯一来源。
- 合并后，管理员在准确的 `main` Release merge commit 上另行创建唯一、不可变的 annotated `v0.1.6` Tag。
- Tag 触发 Release Candidate Workflow，再次执行完整 Quality 与 Database 检查，并从同一提交构建固定 digest 的 Portal/Server 镜像、同证书签名的 Staging/Production arm64 APK 和 `release-manifest.json`。
- 只使用 manifest 中的 digest 和 SHA-256 部署 Staging；先完成真实 UAT、官网/API/APK 下载检查和 Android 真机验收，再决定是否进入 Production 审批。

## 可复现测试

已合入的 #950、#951、#952、#957、#958 与 #954 均在各自最终提交上通过了对应 CI 与 Review。本 Release PR 仍必须以最终 head 重新运行面向 `main` 的全部检查，不能用早期分支结果代替。

本地/Review 可复现入口：

```bash
git diff --check upstream/main...HEAD
make check
make check-release-candidate
make check-android-download
make check-staging-deploy
make check-production-rehearsal
```

GitHub 合入门禁必须全部完成且成功：

- Quality：Flutter、Android release signing fixture、Go、API contracts、Portal、Deployment contracts、Go/Flutter coverage gate 与最终 Quality gate。
- Database：PostgreSQL migration lifecycle、Go/PostgreSQL 集成、readiness 与可达漏洞检查。
- Review：所有意见已解决，最终 diff 可由 Reviewer 复现并解释。

Tag 创建后的正式签名、镜像 digest、APK SHA-256 与 manifest 属于 Release Candidate 阶段；在该 Workflow 实际成功前，本 PR 不宣称这些制品已经生成或通过验收。

## 风险与回滚

- 报告规范化会改变证据不足结果的可见内容，但只删除不可信分数/建议，不生成替代数据；`PROVISIONAL` 报告继续严格校验。
- FULL_MOCK 在画像仍为 QUEUED/RUNNING 时会等待更完整的有界预算，可能增加正常完成时间，但不会无限排队。
- 语音反馈语义失败最多使用既有有限尝试，可能增加文本模型调用次数；声学结果复用，不重复调用讯飞。
- 后续 Production 会从 schema 7 升到 schema 9。现有 down migration 会 fail-closed，旧镜像不能视为处理新增 profile 数据的无条件回滚方案。

回滚边界：

1. Tag 前发现问题：停止合并或通过新的修复 PR 修正；不会影响 Staging/Production。
2. Tag 后、Production 前发现问题：停止候选晋升，保留不可变 Tag 和制品作为审计记录；修复后使用更高版本号重新发布，不移动或覆盖 `v0.1.6`。
3. Production migration 后发现问题：优先使用已审核的同 schema 前向修复镜像；只有明确接受丢弃备份时间点之后全部新写入时，才恢复上线前 finalized 数据库快照；不得执行未经审核的 down migration。
4. APK 公开入口只有在 Production 冒烟通过后才原子切换；已安装更高 `versionCode` 的设备不能被远程降级。

## 不授权范围

合并本 PR 仅建立 `main` 上的 v0.1.6 发布提交，不等于授权或完成以下动作：

- 不自动创建 Tag、GitHub Release或任何正式制品。
- 不部署或修改 Staging/Production 容器、数据库、Nginx、DNS、证书或监控。
- 不执行 Production migration，不切换正式流量，不更新公开 APK 下载入口。
- 未完成 v0.1.6 Staging UAT、v0.1.5→v0.1.6 真机更新链路并取得用户明确的 Production go 前，Production 必须保持不变。

Relates #953
Related #947
Related #948
Related #949
Related #955
Related #956
