### PR TITLE
fix(mobile): 同步 iOS 模拟器 AvatarKit stub 契约

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SHELL := /bin/bash
 	check-flutter-analyze \
 	check-flutter-test \
 	check-flutter-coverage \
+	check-ios-simulator-stub \
 	check-android-release-guard \
 	check-go \
 	check-go-coverage \
@@ -48,6 +49,7 @@ help:
 		'  make check          Run Flutter, Go, and API checks' \
 		'  make check-flutter  Run Flutter dependency, format, analysis, and test checks' \
 		'  make check-flutter-coverage  Run Flutter checks and write mobile/coverage/lcov.info' \
+		'  make check-ios-simulator-stub  Verify the Intel simulator AvatarKit contract' \
 		'  make check-android-release-guard  Verify release signing fails closed' \
 		'  make check-go       Run Go format, vet, and test checks' \
 		'  make check-go-coverage  Run Go checks and write server/coverage.out' \
@@ -87,11 +89,20 @@ check-flutter-format: check-flutter-dependencies
 check-flutter-analyze: check-flutter-format
 	cd mobile && flutter analyze --no-pub
 
-check-flutter-test: check-flutter-analyze
+check-flutter-test: check-flutter-analyze check-ios-simulator-stub
 	cd mobile && flutter test --no-pub
 
-check-flutter-coverage: check-flutter-analyze check-android-release-guard
+check-flutter-coverage: check-flutter-analyze check-android-release-guard check-ios-simulator-stub
 	cd mobile && flutter test --no-pub --coverage
+
+check-ios-simulator-stub:
+	@set -euo pipefail; \
+	stub_dir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$stub_dir"' EXIT; \
+	cp -R tools/ios-simulator-dev/avatar_kit_stub/. "$$stub_dir/"; \
+	cd "$$stub_dir"; \
+	flutter pub get; \
+	flutter test --no-pub
 
 check-android-release-guard: check-flutter-dependencies
 	@set -euo pipefail; \

--- a/tools/ios-simulator-dev/avatar_kit_stub/lib/avatar_kit.dart
+++ b/tools/ios-simulator-dev/avatar_kit_stub/lib/avatar_kit.dart
@@ -67,7 +67,10 @@ class AvatarManager {
 
   static final AvatarManager shared = AvatarManager._();
 
-  Future<Avatar> load({required String id}) =>
+  Future<Avatar> load({
+    required String id,
+    bool useCompressedModel = false,
+  }) =>
       Future<Avatar>.error(_unsupported());
 
   Future<void> cancelLoading({required String id}) async {}

--- a/tools/ios-simulator-dev/avatar_kit_stub/pubspec.yaml
+++ b/tools/ios-simulator-dev/avatar_kit_stub/pubspec.yaml
@@ -9,3 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter

--- a/tools/ios-simulator-dev/avatar_kit_stub/test/avatar_kit_contract_test.dart
+++ b/tools/ios-simulator-dev/avatar_kit_stub/test/avatar_kit_contract_test.dart
@@ -1,0 +1,14 @@
+import 'package:avatar_kit/avatar_kit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('load mirrors the compressed-model call used by SpeakUp', () async {
+    await expectLater(
+      AvatarManager.shared.load(
+        id: 'avatar-contract-test',
+        useCompressedModel: true,
+      ),
+      throwsA(isA<UnsupportedError>()),
+    );
+  });
+}


### PR DESCRIPTION
## 功能描述

修复 Intel Mac 上 `make dev-ios-simulator` 因 AvatarKit stub 缺少 `useCompressedModel` 命名参数而无法编译的问题。

Closes #962

## 实现思路

- 让本地 `avatar_kit_stub` 的 `AvatarManager.load` 签名与移动端当前 SDK 调用一致。
- 增加独立 stub 契约测试，真实调用 `useCompressedModel: true` 并确认模拟器适配器保持 fail-closed。
- 将契约测试接入 Flutter test/coverage 质量入口；测试在临时目录运行，不向仓库写入 lockfile 或构建产物。

## 可复现测试

- `make check-ios-simulator-stub`
- `SPEAKUP_DEV_PORT=18082 IOS_SIMULATOR_ID=A3FAFF9C-7311-4C22-8BF8-E15154CF54FA make dev-ios-simulator`
  - PostgreSQL healthy
  - migrations unchanged
  - Flutter Xcode build 成功
  - 出现 Flutter run key commands 与 Dart VM Service URL
  - `/health` 返回 `status: ok`
  - `/readyz` 返回数据库 `ready`
- `git diff --check`

## 已知本地环境情况

`make check-flutter-analyze` 在分析前被当前 `mobile/pubspec.lock` 与本机 Flutter 3.44.8 的 `--enforce-lockfile` 解析差异阻断；没有产生分析结果或仓库改动，交由仓库固定 CI 工具链复核。