### PR TITLE
fix(mobile): Tips 展开后自动滚动到对话底部

### DIFF
--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -97,13 +97,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     widget.speechFeedbackController?.addListener(_handleFeedbackState);
     _syncSpeechFeedbackSources();
     _syncRecordingTimer();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted && _conversationScrollController.hasClients) {
-        _conversationScrollController.jumpTo(
-          _conversationScrollController.position.maxScrollExtent,
-        );
-      }
-    });
+    _scheduleConversationScrollToBottom(animated: false);
   }
 
   @override
@@ -170,6 +164,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       return;
     }
     setState(() => _visibleTipQuestionId = tip.questionId);
+    _scheduleConversationScrollToBottom();
   }
 
   Future<void> _speakQuestionTip() async {
@@ -319,19 +314,28 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     _syncSpeechFeedbackSources();
     setState(() {});
     if (shouldFollowConversation) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || !_conversationScrollController.hasClients) {
-          return;
-        }
-        unawaited(
-          _conversationScrollController.animateTo(
-            _conversationScrollController.position.maxScrollExtent,
-            duration: const Duration(milliseconds: 220),
-            curve: Curves.easeOutCubic,
-          ),
-        );
-      });
+      _scheduleConversationScrollToBottom();
     }
+  }
+
+  void _scheduleConversationScrollToBottom({bool animated = true}) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_conversationScrollController.hasClients) {
+        return;
+      }
+      final target = _conversationScrollController.position.maxScrollExtent;
+      if (!animated) {
+        _conversationScrollController.jumpTo(target);
+        return;
+      }
+      unawaited(
+        _conversationScrollController.animateTo(
+          target,
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOutCubic,
+        ),
+      );
+    });
   }
 
   void _syncSpeechFeedbackSources() {

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -291,6 +291,7 @@ void main() {
       practiceClient: _TranslationPracticeClient(),
     );
     addTearDown(controller.dispose);
+    await controller.submitPracticeText('I have a reservation under Chen.');
 
     await tester.pumpWidget(
       MaterialApp(home: ScenarioPracticePage(practiceController: controller)),
@@ -299,11 +300,24 @@ void main() {
 
     final questionId = controller.currentQuestion!.id;
     final tipButton = find.byKey(Key('scenario-question-tip-$questionId'));
+    final conversation = tester.widget<ListView>(
+      find.byKey(const Key('scenario-conversation-history')),
+    );
+    final scrollController = conversation.controller!;
+    final offsetBeforeTip = scrollController.offset;
     expect(tipButton, findsOneWidget);
     await tester.tap(tipButton);
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('practice-question-tip-card')), findsOneWidget);
+    expect(
+      scrollController.position.maxScrollExtent,
+      greaterThan(offsetBeforeTip),
+    );
+    expect(
+      scrollController.offset,
+      moreOrLessEquals(scrollController.position.maxScrollExtent),
+    );
     expect(
       find.text('I would describe the situation and my specific role.'),
       findsOneWidget,


### PR DESCRIPTION
## 功能描述

场景练习中，用户点击当前问题的 Tips 并成功展开参考回答后，对话列表会在卡片完成布局后平滑滚动到新的底部，避免参考回答落在当前视口外。

Closes #961

## 实现思路

- 提取统一的场景对话滚底调度方法。
- 在下一帧读取更新后的最大滚动范围，避免使用 Tips 展开前的旧布局数据。
- Tips 成功显示和新消息追加复用同一滚动实现。
- 初始页面恢复仍使用无动画跳转，不改变现有进入页面行为。
- Tips 请求失败、关闭、朗读和缓存语义保持不变。

## 可复现测试

1. 进入场景练习并产生至少一轮历史对话。
2. 点击当前问题的 Tips。
3. 等待参考回答显示。
4. 确认列表平滑滚动到新底部，参考回答可见，底部录音控件仍可操作。

## 验证结果

- dart format：通过。
- flutter analyze（相关实现与测试）：通过，No issues found。
- flutter test test/coaching/practice/scenario_practice_test.dart：18/18 通过。
- iPhone 17 模拟器 + 18082 真实后端：人工验收通过。
- 数字人已在 Intel 模拟器临时运行副本中禁用，未修改仓库配置。