### PR TITLE
feat(evaluation): 增加 Staging 讯飞 ISE Relay

### DIFF
--- a/deploy/ise-relay/README.md
+++ b/deploy/ise-relay/README.md
@@ -1,0 +1,47 @@
+# SpeakUp ISE Relay
+
+This isolated service keeps iFlytek ISE credentials in mainland China and
+accepts evaluation requests only from the SpeakUp Staging backend over mTLS.
+It stores PCM input in memory only and does not expose provider raw responses.
+
+## Trust boundary
+
+- Publish TCP `18443`; restrict the Tencent Cloud security group source to
+  `149.71.241.71/32`.
+- Use a dedicated private CA and client certificate for the Staging backend.
+- Include `122.51.24.153` as an IP SAN in the relay server certificate.
+- Do not publish the container-internal `18080` health and metrics port.
+- Keep the populated environment file and private keys outside the repository.
+- Do not configure both direct XFYUN credentials and `ISE_RELAY_*` client
+  settings in the Staging backend. Startup fails closed if both are present.
+
+## Runtime files
+
+```text
+/opt/speakup-ise-relay/
+├── deploy.env
+├── relay.env
+└── secrets/
+    ├── client-ca.pem
+    ├── server-key.pem
+    └── server.pem
+```
+
+The secrets directory must be readable by container UID `10001` and must not
+contain the Staging client private key. The client certificate, client key and
+CA certificate belong on the Singapore server.
+
+## Deploy and verify
+
+```bash
+docker compose --env-file /opt/speakup-ise-relay/deploy.env \
+  -f deploy/ise-relay/compose.yaml config --quiet
+docker compose --env-file /opt/speakup-ise-relay/deploy.env \
+  -f deploy/ise-relay/compose.yaml up -d
+docker compose --env-file /opt/speakup-ise-relay/deploy.env \
+  -f deploy/ise-relay/compose.yaml ps
+```
+
+Verify the public endpoint from the Singapore server with its mTLS client
+certificate. A request without a trusted client certificate must fail during
+the TLS handshake.

--- a/deploy/ise-relay/compose.yaml
+++ b/deploy/ise-relay/compose.yaml
@@ -1,0 +1,51 @@
+name: xe3-speakup-ise-relay
+
+x-speakup-logging: &speakup-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+services:
+  relay:
+    image: ${ISE_RELAY_IMAGE:?ISE_RELAY_IMAGE is required}
+    restart: unless-stopped
+    init: true
+    read_only: true
+    logging: *speakup-logging
+    env_file:
+      - ${ISE_RELAY_ENV_FILE:?ISE_RELAY_ENV_FILE is required}
+    environment:
+      ISE_RELAY_ADDRESS: :18443
+      ISE_RELAY_INTERNAL_ADDRESS: :18080
+      ISE_RELAY_SERVER_CERT_FILE: /run/secrets/server.pem
+      ISE_RELAY_SERVER_KEY_FILE: /run/secrets/server-key.pem
+      ISE_RELAY_CLIENT_CA_FILE: /run/secrets/client-ca.pem
+    ports:
+      - "18443:18443"
+    volumes:
+      - ${ISE_RELAY_SECRETS_DIR:?ISE_RELAY_SECRETS_DIR is required}:/run/secrets:ro
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=16m
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 384m
+    cpus: 1.0
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "-q",
+          "-T",
+          "2",
+          "--spider",
+          "http://127.0.0.1:18080/healthz",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s

--- a/deploy/ise-relay/deploy.env.example
+++ b/deploy/ise-relay/deploy.env.example
@@ -1,0 +1,4 @@
+# Copy outside the repository and use an immutable image reference.
+ISE_RELAY_IMAGE=speakup-ise-relay:issue-965
+ISE_RELAY_ENV_FILE=/opt/speakup-ise-relay/relay.env
+ISE_RELAY_SECRETS_DIR=/opt/speakup-ise-relay/secrets

--- a/deploy/ise-relay/relay.env.example
+++ b/deploy/ise-relay/relay.env.example
@@ -1,0 +1,12 @@
+# Keep the populated file outside the repository with mode 0600.
+APPID=
+APIKey=
+APISecret=
+XFYUN_ISE_ENDPOINT=wss://ise-api.xfyun.cn/v2/open-ise
+XFYUN_ISE_TIMEOUT=150s
+
+# Runtime bounds. The provider timeout includes queue wait.
+ISE_RELAY_RETENTION=5m
+ISE_RELAY_MAX_JOBS=16
+ISE_RELAY_MAX_IN_FLIGHT=2
+LOG_LEVEL=info

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -40,6 +40,8 @@ and server environment are externally injected and are not committed.
 - A certificate whose SANs are exactly both Staging hostnames, issued and
   verified through [`deploy/tls/`](../tls/README.md).
 - A populated htpasswd file and a real Staging Server environment file.
+- A dedicated `/etc/speakup/staging-ise-relay` directory containing the mTLS
+  CA, client certificate and client private key when the ISE Relay is enabled.
 - Registry credentials with read access to the two GHCR images.
 - A real, current-UID-owned `STAGING_PUBLIC_ROOT` that is not group- or
   world-writable.
@@ -49,6 +51,24 @@ configuration required by the application. Use the repository `.env.example`
 only as a key reference; do not copy local defaults as deployment values and do
 not disable OSS or OCR to bypass missing configuration. It must not define
 `DATABASE_URL`, `SERVER_HOST`, or `SERVER_PORT`; Compose owns those three values.
+
+For the ISE Relay, create the files for the Server image's non-root UID and set
+the following values in the Staging Server environment:
+
+```text
+ISE_RELAY_ENDPOINT=https://122.51.24.153:18443
+ISE_RELAY_CA_FILE=/run/secrets/ise-relay/ca.pem
+ISE_RELAY_CLIENT_CERT_FILE=/run/secrets/ise-relay/client.pem
+ISE_RELAY_CLIENT_KEY_FILE=/run/secrets/ise-relay/client-key.pem
+ISE_RELAY_POLL_INTERVAL=500ms
+ISE_RELAY_TIMEOUT=165s
+```
+
+Install the three files outside the repository with directory mode `0500`,
+file mode `0400`, and numeric owner/group `10001:10001`. Remove `APPID`,
+`APIKey`, `APISecret`, `XFYUN_ISE_ENDPOINT`, and `XFYUN_ISE_TIMEOUT` from the
+Staging Server environment when enabling the Relay; configuring both direct
+ISE and Relay settings fails closed. Production is not changed by this mount.
 
 ## 1. Acquire a manifest and configuration
 

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -64,6 +64,8 @@ services:
       METRICS_HOST: 0.0.0.0
     ports:
       - "127.0.0.1:28083:8080"
+    volumes:
+      - /etc/speakup/staging-ise-relay:/run/secrets/ise-relay:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/staging/manage.sh
+++ b/deploy/staging/manage.sh
@@ -943,7 +943,11 @@ verify_runtime() {
         env.STAGING_POSTGRES_DB + "?sslmode=disable") and
       exact_env("SERVER_HOST"; "0.0.0.0") and
       exact_env("SERVER_PORT"; "8080") and
-      (.Mounts | length == 0) and
+      (.Mounts | length == 1) and
+      .Mounts[0].Type == "bind" and
+      .Mounts[0].Source == "/etc/speakup/staging-ise-relay" and
+      .Mounts[0].Destination == "/run/secrets/ise-relay" and
+      .Mounts[0].RW == false and
       .NetworkSettings.Ports == {
         "8080/tcp": [{"HostIp": "127.0.0.1", "HostPort": "28083"}]
       } and

--- a/deploy/staging/test.sh
+++ b/deploy/staging/test.sh
@@ -697,7 +697,7 @@ if [[ "${1:-}" == inspect && "$#" == 2 ]]; then
       id=$server_id
       service=server
       image="ghcr.io/1024xengineer/xe3-esl-server@${TEST_RUNTIME_SERVER_DIGEST:-sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}"
-      mounts='[]'
+      mounts='[{"Type":"bind","Source":"/etc/speakup/staging-ise-relay","Destination":"/run/secrets/ise-relay","RW":false}]'
       ports='{"8080/tcp":[{"HostIp":"127.0.0.1","HostPort":"28083"}]}'
       networks='{"xe3-speakup-staging_database":{},"xe3-speakup-staging_server_edge":{}}'
       environment='["TEXT_GENERATION_PROVIDER=test-fixture","DATABASE_URL=postgres://speakup_staging:0123456789abcdef0123456789abcdef@postgres:5432/speakup_staging?sslmode=disable","SERVER_HOST=0.0.0.0","SERVER_PORT=8080"]'
@@ -1108,6 +1108,7 @@ wrong Portal loopback port|TEST_BAD_PORT_SERVICE|portal
 wrong Server network membership|TEST_BAD_NETWORK_SERVICE|server
 public database network|TEST_DATABASE_NETWORK_PUBLIC|1
 wrong Portal volume mount|TEST_BAD_VOLUME_SERVICE|portal
+wrong Server Relay certificate mount|TEST_BAD_VOLUME_SERVICE|server
 wrong PostgreSQL volume label|TEST_BAD_VOLUME_LABEL|postgres_data
 EOF
 

--- a/server/Dockerfile.ise-relay
+++ b/server/Dockerfile.ise-relay
@@ -1,0 +1,30 @@
+FROM golang:1.26.6-alpine3.23@sha256:e57c41c1d5864341031181b0db34b9a537bb5773eb6428e4e5bdaea0f9135406 AS build
+
+WORKDIR /src
+ENV CGO_ENABLED=0
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY cmd ./cmd
+COPY internal ./internal
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -mod=readonly -trimpath -buildvcs=false -ldflags="-s -w" \
+        -o /out/speakup-ise-relay ./cmd/ise-relay
+
+FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS runtime
+
+RUN addgroup -S -g 10001 speakup && \
+    adduser -S -D -H -u 10001 -G speakup speakup
+
+COPY --from=build --chown=10001:10001 /out/speakup-ise-relay /usr/local/bin/speakup-ise-relay
+
+USER 10001:10001
+EXPOSE 18443
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget -q -T 2 --spider "http://127.0.0.1:18080/healthz" || exit 1
+
+CMD ["/usr/local/bin/speakup-ise-relay"]

--- a/server/cmd/ise-relay/main.go
+++ b/server/cmd/ise-relay/main.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/logging"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/iserelay"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/xfyun"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const relayShutdownTimeout = 10 * time.Second
+
+type runtimeConfig struct {
+	Address         string
+	InternalAddress string
+	ServerCertFile  string
+	ServerKeyFile   string
+	ClientCAFile    string
+	Retention       time.Duration
+	MaxJobs         int
+	MaxInFlight     int
+	LogLevel        string
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	if err := config.LoadDotEnvUpwards(); err != nil {
+		_, _ = os.Stderr.WriteString("load .env failed\n")
+		return 1
+	}
+	runtimeConfiguration, err := loadRuntimeConfig()
+	if err != nil {
+		_, _ = os.Stderr.WriteString("ISE relay configuration failed\n")
+		return 1
+	}
+	logger := logging.New(runtimeConfiguration.LogLevel)
+	slog.SetDefault(logger)
+	iseConfiguration, err := config.LoadISE()
+	if err != nil {
+		logger.Error("iFlytek ISE configuration failed")
+		return 1
+	}
+	registry := prometheus.NewRegistry()
+	observer, err := providerobservability.New(registry)
+	if err != nil {
+		logger.Error("provider observability startup failed")
+		return 1
+	}
+	evaluator, err := xfyun.NewSpeechFeedbackEvaluator(
+		xfyun.ISEConfig{
+			Endpoint: iseConfiguration.Endpoint,
+			Timeout:  iseConfiguration.Timeout,
+			Observer: observer,
+		},
+		iseConfiguration.AppID.Reveal(),
+		iseConfiguration.APIKey.Reveal(),
+		iseConfiguration.APISecret.Reveal(),
+	)
+	if err != nil {
+		logger.Error("iFlytek ISE provider startup failed")
+		return 1
+	}
+	handler, err := iserelay.NewHandler(evaluator, iserelay.HandlerConfig{
+		ProviderTimeout: iseConfiguration.Timeout,
+		Retention:       runtimeConfiguration.Retention,
+		MaxJobs:         runtimeConfiguration.MaxJobs,
+		MaxInFlight:     runtimeConfiguration.MaxInFlight,
+		Logger:          logger,
+	})
+	if err != nil {
+		logger.Error("ISE relay handler startup failed")
+		return 1
+	}
+	tlsConfiguration, err := loadTLSConfig(runtimeConfiguration)
+	if err != nil {
+		logger.Error("ISE relay TLS startup failed")
+		return 1
+	}
+	server := &http.Server{
+		Addr:              runtimeConfiguration.Address,
+		Handler:           handler.Routes(),
+		TLSConfig:         tlsConfiguration,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		MaxHeaderBytes:    16 * 1024,
+	}
+	internalMux := http.NewServeMux()
+	internalMux.HandleFunc("GET /healthz", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("content-type", "application/json")
+		_, _ = writer.Write([]byte("{\"status\":\"ok\"}\n"))
+	})
+	internalMux.Handle("GET /metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	internalServer := &http.Server{
+		Addr:              runtimeConfiguration.InternalAddress,
+		Handler:           internalMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	errorsChannel := make(chan error, 2)
+	go func() { errorsChannel <- server.ListenAndServeTLS("", "") }()
+	go func() { errorsChannel <- internalServer.ListenAndServe() }()
+	logger.Info("ISE relay started", slog.String("address", runtimeConfiguration.Address))
+
+	exitCode := 0
+	select {
+	case serveErr := <-errorsChannel:
+		if !errors.Is(serveErr, http.ErrServerClosed) {
+			logger.Error("ISE relay stopped unexpectedly")
+			exitCode = 1
+		}
+	case <-ctx.Done():
+		logger.Info("ISE relay shutdown requested")
+	}
+	stop()
+	shutdownContext, cancel := context.WithTimeout(context.Background(), relayShutdownTimeout)
+	defer cancel()
+	if err := server.Shutdown(shutdownContext); err != nil {
+		exitCode = 1
+	}
+	if err := internalServer.Shutdown(shutdownContext); err != nil {
+		exitCode = 1
+	}
+	return exitCode
+}
+
+func loadRuntimeConfig() (runtimeConfig, error) {
+	configuration := runtimeConfig{
+		Address:         valueOrDefault("ISE_RELAY_ADDRESS", ":18443"),
+		InternalAddress: valueOrDefault("ISE_RELAY_INTERNAL_ADDRESS", ":18080"),
+		ServerCertFile:  strings.TrimSpace(os.Getenv("ISE_RELAY_SERVER_CERT_FILE")),
+		ServerKeyFile:   strings.TrimSpace(os.Getenv("ISE_RELAY_SERVER_KEY_FILE")),
+		ClientCAFile:    strings.TrimSpace(os.Getenv("ISE_RELAY_CLIENT_CA_FILE")),
+		LogLevel:        valueOrDefault("LOG_LEVEL", "info"),
+	}
+	if configuration.ServerCertFile == "" || configuration.ServerKeyFile == "" ||
+		configuration.ClientCAFile == "" {
+		return runtimeConfig{}, errors.New("ISE relay TLS files are required")
+	}
+	var err error
+	configuration.Retention, err = durationOrDefault("ISE_RELAY_RETENTION", 15*time.Minute)
+	if err != nil || configuration.Retention < time.Minute || configuration.Retention > time.Hour {
+		return runtimeConfig{}, errors.New("ISE_RELAY_RETENTION must be between 1m and 1h")
+	}
+	configuration.MaxJobs, err = positiveIntOrDefault("ISE_RELAY_MAX_JOBS", 16)
+	if err != nil || configuration.MaxJobs > 64 {
+		return runtimeConfig{}, errors.New("ISE_RELAY_MAX_JOBS must be between 1 and 64")
+	}
+	configuration.MaxInFlight, err = positiveIntOrDefault("ISE_RELAY_MAX_IN_FLIGHT", 2)
+	if err != nil || configuration.MaxInFlight > configuration.MaxJobs {
+		return runtimeConfig{}, errors.New("ISE_RELAY_MAX_IN_FLIGHT must not exceed max jobs")
+	}
+	return configuration, nil
+}
+
+func loadTLSConfig(configuration runtimeConfig) (*tls.Config, error) {
+	certificate, err := tls.LoadX509KeyPair(
+		configuration.ServerCertFile,
+		configuration.ServerKeyFile,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load ISE relay server certificate: %w", err)
+	}
+	clientCAPEM, err := os.ReadFile(configuration.ClientCAFile)
+	if err != nil {
+		return nil, fmt.Errorf("read ISE relay client CA: %w", err)
+	}
+	clientCAs := x509.NewCertPool()
+	if !clientCAs.AppendCertsFromPEM(clientCAPEM) {
+		return nil, errors.New("ISE relay client CA is invalid")
+	}
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{certificate},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+	}, nil
+}
+
+func valueOrDefault(name string, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func durationOrDefault(name string, fallback time.Duration) (time.Duration, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback, nil
+	}
+	return time.ParseDuration(value)
+}
+
+func positiveIntOrDefault(name string, fallback int) (int, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return 0, errors.New("value must be a positive integer")
+	}
+	return parsed, nil
+}

--- a/server/cmd/ise-relay/main.go
+++ b/server/cmd/ise-relay/main.go
@@ -99,7 +99,7 @@ func run() int {
 		Addr:              runtimeConfiguration.Address,
 		Handler:           handler.Routes(),
 		TLSConfig:         tlsConfiguration,
-		ReadHeaderTimeout: 5 * time.Second,
+		ReadHeaderTimeout: 15 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       30 * time.Second,

--- a/server/cmd/ise-relay/main_test.go
+++ b/server/cmd/ise-relay/main_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRelayTLSRequiresTrustedClientCertificate(t *testing.T) {
+	caCertificate, caKey, caPEM := newTestCA(t, "relay-test-ca")
+	serverCertificate, serverKey := newTestCertificate(
+		t, caCertificate, caKey, 2, "relay-server",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		[]net.IP{net.ParseIP("127.0.0.1")},
+	)
+	clientCertificate, clientKey := newTestCertificate(
+		t, caCertificate, caKey, 3, "staging-client",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil,
+	)
+	rogueCA, rogueCAKey, _ := newTestCA(t, "rogue-ca")
+	rogueCertificate, rogueKey := newTestCertificate(
+		t, rogueCA, rogueCAKey, 4, "rogue-client",
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil,
+	)
+
+	directory := t.TempDir()
+	serverCertificateFile := writeTestPEM(t, directory, "server.pem", serverCertificate)
+	serverKeyFile := writeTestPEM(t, directory, "server-key.pem", serverKey)
+	clientCAFile := filepath.Join(directory, "client-ca.pem")
+	if err := os.WriteFile(clientCAFile, caPEM, 0o600); err != nil {
+		t.Fatalf("write client CA: %v", err)
+	}
+	configuration, err := loadTLSConfig(runtimeConfig{
+		ServerCertFile: serverCertificateFile,
+		ServerKeyFile:  serverKeyFile,
+		ClientCAFile:   clientCAFile,
+	})
+	if err != nil {
+		t.Fatalf("load TLS configuration: %v", err)
+	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(
+		func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(http.StatusNoContent)
+		},
+	))
+	server.TLS = configuration
+	server.StartTLS()
+	defer server.Close()
+
+	rootCAs := x509.NewCertPool()
+	rootCAs.AppendCertsFromPEM(caPEM)
+	tests := []struct {
+		name        string
+		certificate *tls.Certificate
+		wantSuccess bool
+	}{
+		{name: "missing certificate"},
+		{name: "untrusted certificate", certificate: testTLSCertificate(t, rogueCertificate, rogueKey)},
+		{name: "trusted certificate", certificate: testTLSCertificate(t, clientCertificate, clientKey), wantSuccess: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tlsConfiguration := &tls.Config{
+				MinVersion: tls.VersionTLS13,
+				RootCAs:    rootCAs,
+			}
+			if test.certificate != nil {
+				tlsConfiguration.Certificates = []tls.Certificate{*test.certificate}
+			}
+			client := &http.Client{
+				Transport: &http.Transport{TLSClientConfig: tlsConfiguration},
+			}
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+			if err != nil {
+				t.Fatalf("create request: %v", err)
+			}
+			response, err := client.Do(request)
+			if !test.wantSuccess {
+				if err == nil {
+					response.Body.Close()
+					t.Fatal("untrusted client unexpectedly passed mTLS")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("trusted client failed mTLS: %v", err)
+			}
+			response.Body.Close()
+			if response.StatusCode != http.StatusNoContent {
+				t.Fatalf("trusted client status = %d", response.StatusCode)
+			}
+		})
+	}
+}
+
+func newTestCA(
+	t *testing.T,
+	commonName string,
+) (*x509.Certificate, *rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA certificate: %v", err)
+	}
+	certificate, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+	return certificate, key, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func newTestCertificate(
+	t *testing.T,
+	ca *x509.Certificate,
+	caKey *rsa.PrivateKey,
+	serial int64,
+	commonName string,
+	usages []x509.ExtKeyUsage,
+	ipAddresses []net.IP,
+) ([]byte, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate certificate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  usages,
+		IPAddresses:  ipAddresses,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	return certificatePEM, keyPEM
+}
+
+func writeTestPEM(t *testing.T, directory string, name string, value []byte) string {
+	t.Helper()
+	path := filepath.Join(directory, name)
+	if err := os.WriteFile(path, value, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func testTLSCertificate(t *testing.T, certificate []byte, key []byte) *tls.Certificate {
+	t.Helper()
+	parsed, err := tls.X509KeyPair(certificate, key)
+	if err != nil {
+		t.Fatalf("parse test certificate: %v", err)
+	}
+	return &parsed
+}

--- a/server/cmd/ise-relay/main_test.go
+++ b/server/cmd/ise-relay/main_test.go
@@ -17,6 +17,111 @@ import (
 	"time"
 )
 
+func TestLoadRuntimeConfigDefaultsAndOverrides(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		setRuntimeConfigEnvironment(t)
+
+		configuration, err := loadRuntimeConfig()
+		if err != nil {
+			t.Fatalf("load runtime configuration: %v", err)
+		}
+		if configuration.Address != ":18443" ||
+			configuration.InternalAddress != ":18080" ||
+			configuration.Retention != 15*time.Minute ||
+			configuration.MaxJobs != 16 || configuration.MaxInFlight != 2 ||
+			configuration.LogLevel != "info" {
+			t.Fatalf("unexpected default configuration: %#v", configuration)
+		}
+	})
+
+	t.Run("overrides", func(t *testing.T) {
+		setRuntimeConfigEnvironment(t)
+		t.Setenv("ISE_RELAY_ADDRESS", "127.0.0.1:19443")
+		t.Setenv("ISE_RELAY_INTERNAL_ADDRESS", "127.0.0.1:19080")
+		t.Setenv("ISE_RELAY_RETENTION", "30m")
+		t.Setenv("ISE_RELAY_MAX_JOBS", "32")
+		t.Setenv("ISE_RELAY_MAX_IN_FLIGHT", "4")
+		t.Setenv("LOG_LEVEL", "debug")
+
+		configuration, err := loadRuntimeConfig()
+		if err != nil {
+			t.Fatalf("load runtime configuration: %v", err)
+		}
+		if configuration.Address != "127.0.0.1:19443" ||
+			configuration.InternalAddress != "127.0.0.1:19080" ||
+			configuration.Retention != 30*time.Minute ||
+			configuration.MaxJobs != 32 || configuration.MaxInFlight != 4 ||
+			configuration.LogLevel != "debug" {
+			t.Fatalf("unexpected overridden configuration: %#v", configuration)
+		}
+	})
+}
+
+func TestLoadRuntimeConfigRejectsUnsafeSettings(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(*testing.T)
+	}{
+		{
+			name: "missing TLS file",
+			apply: func(t *testing.T) {
+				t.Setenv("ISE_RELAY_SERVER_CERT_FILE", "")
+			},
+		},
+		{
+			name: "short retention",
+			apply: func(t *testing.T) {
+				t.Setenv("ISE_RELAY_RETENTION", "30s")
+			},
+		},
+		{
+			name: "non-positive max jobs",
+			apply: func(t *testing.T) {
+				t.Setenv("ISE_RELAY_MAX_JOBS", "0")
+			},
+		},
+		{
+			name: "excessive max jobs",
+			apply: func(t *testing.T) {
+				t.Setenv("ISE_RELAY_MAX_JOBS", "65")
+			},
+		},
+		{
+			name: "max in flight exceeds max jobs",
+			apply: func(t *testing.T) {
+				t.Setenv("ISE_RELAY_MAX_JOBS", "2")
+				t.Setenv("ISE_RELAY_MAX_IN_FLIGHT", "3")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setRuntimeConfigEnvironment(t)
+			test.apply(t)
+			if _, err := loadRuntimeConfig(); err == nil {
+				t.Fatal("expected unsafe runtime configuration to be rejected")
+			}
+		})
+	}
+}
+
+func setRuntimeConfigEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"ISE_RELAY_ADDRESS",
+		"ISE_RELAY_INTERNAL_ADDRESS",
+		"ISE_RELAY_RETENTION",
+		"ISE_RELAY_MAX_JOBS",
+		"ISE_RELAY_MAX_IN_FLIGHT",
+		"LOG_LEVEL",
+	} {
+		t.Setenv(name, "")
+	}
+	t.Setenv("ISE_RELAY_SERVER_CERT_FILE", "/run/secrets/server.pem")
+	t.Setenv("ISE_RELAY_SERVER_KEY_FILE", "/run/secrets/server-key.pem")
+	t.Setenv("ISE_RELAY_CLIENT_CA_FILE", "/run/secrets/client-ca.pem")
+}
+
 func TestRelayTLSRequiresTrustedClientCertificate(t *testing.T) {
 	caCertificate, caKey, caPEM := newTestCA(t, "relay-test-ca")
 	serverCertificate, serverKey := newTestCertificate(

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -335,30 +335,51 @@ func run() int {
 	var acousticEvaluator evaluation.AcousticEvaluator
 	var acousticProviderTimeout time.Duration
 	iseConfigured := config.ISEConfigured()
-	if iseConfigured && recordingStore == nil {
+	iseRelayConfigured := config.ISERelayConfigured()
+	if iseConfigured && iseRelayConfigured {
+		logger.Error(
+			"Multiple Evaluation acoustic providers configured",
+			slog.String("error_kind", "configuration"),
+		)
+		return 1
+	}
+	acousticProviderConfigured := iseConfigured || iseRelayConfigured
+	if acousticProviderConfigured && recordingStore == nil {
 		logger.Error(
 			"Evaluation acoustics configured without object storage",
 			slog.String("error_kind", "configuration"),
 		)
 		return 1
 	}
-	acousticsEnabled := recordingStore != nil && iseConfigured
+	acousticsEnabled := recordingStore != nil && acousticProviderConfigured
 	if acousticsEnabled {
-		iseConfig, configurationErr := config.LoadISE()
-		if configurationErr != nil {
-			logger.Error(
-				"iFlytek ISE configuration failed",
-				slog.String("error_kind", "configuration"),
+		if iseRelayConfigured {
+			relayConfig, configurationErr := config.LoadISERelay()
+			if configurationErr != nil {
+				logger.Error(
+					"ISE relay configuration failed",
+					slog.String("error_kind", "configuration"),
+				)
+				return 1
+			}
+			acousticProviderTimeout = relayConfig.Timeout
+			acousticEvaluator, err = providerFactory.EvaluationAcousticRelayEvaluator(
+				databasePool.Native(), recordingStore, relayConfig,
 			)
-			return 1
+		} else {
+			iseConfig, configurationErr := config.LoadISE()
+			if configurationErr != nil {
+				logger.Error(
+					"iFlytek ISE configuration failed",
+					slog.String("error_kind", "configuration"),
+				)
+				return 1
+			}
+			acousticProviderTimeout = iseConfig.Timeout
+			acousticEvaluator, err = providerFactory.EvaluationAcousticEvaluator(
+				databasePool.Native(), recordingStore, iseConfig,
+			)
 		}
-		acousticProviderTimeout = iseConfig.Timeout
-		acousticEvaluator, err =
-			providerFactory.EvaluationAcousticEvaluator(
-				databasePool.Native(),
-				recordingStore,
-				iseConfig,
-			)
 		if err != nil {
 			logger.Error(
 				"Evaluation acoustic provider failed",

--- a/server/internal/app/ai_acoustic.go
+++ b/server/internal/app/ai_acoustic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/objectstore"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/iserelay"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/xfyun"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -54,6 +55,39 @@ func newEvaluationAcousticEvaluator(
 	)
 	if err != nil {
 		return nil, err
+	}
+	return newEvaluationAcousticEvaluatorWithProvider(database, store, provider)
+}
+
+func (factory *ProviderFactory) EvaluationAcousticRelayEvaluator(
+	database *pgxpool.Pool,
+	store objectstore.Store,
+	configuration config.ISERelayConfig,
+) (evaluation.AcousticEvaluator, error) {
+	if database == nil || store == nil {
+		return nil, errors.New("bootstrap: Evaluation acoustic dependencies are required")
+	}
+	provider, err := iserelay.NewClient(iserelay.ClientConfig{
+		Endpoint:       configuration.Endpoint,
+		CAFile:         configuration.CAFile,
+		ClientCertFile: configuration.ClientCertFile,
+		ClientKeyFile:  configuration.ClientKeyFile,
+		PollInterval:   configuration.PollInterval,
+		Observer:       factory.observer,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newEvaluationAcousticEvaluatorWithProvider(database, store, provider)
+}
+
+func newEvaluationAcousticEvaluatorWithProvider(
+	database *pgxpool.Pool,
+	store objectstore.Store,
+	provider speechfeedback.AcousticEvaluator,
+) (evaluation.AcousticEvaluator, error) {
+	if database == nil || store == nil || provider == nil {
+		return nil, errors.New("bootstrap: Evaluation acoustic dependencies are required")
 	}
 	repository, err := mediapostgres.New(database)
 	if err != nil {

--- a/server/internal/coaching/evaluation/speechfeedback/acoustics.go
+++ b/server/internal/coaching/evaluation/speechfeedback/acoustics.go
@@ -11,6 +11,7 @@ const (
 )
 
 type AcousticAssessmentRequest struct {
+	RequestID     string
 	Audio         []byte
 	ReferenceText string
 	TopicTitle    string

--- a/server/internal/coaching/evaluation/speechfeedback/assessment.go
+++ b/server/internal/coaching/evaluation/speechfeedback/assessment.go
@@ -46,6 +46,7 @@ func (evaluator *CompactAcousticEvaluator) EvaluateAcoustic(
 	reference := speechFeedbackEnglishReferenceText(snapshot.Transcript)
 	category := speechFeedbackAcousticCategory(reference)
 	result, err := evaluator.evaluator.Evaluate(ctx, AcousticAssessmentRequest{
+		RequestID:     record.LeaseToken,
 		Audio:         pcm,
 		ReferenceText: reference,
 		Category:      category,

--- a/server/internal/coaching/evaluation/speechfeedback/assessment_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/assessment_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestCompactAcousticEvaluatorAcceptsOpaqueProviderSession(t *testing.T) {
 	score, rejected := 75.2, false
+	var providerRequest AcousticAssessmentRequest
 	evaluator, err := NewCompactAcousticEvaluator(
 		acousticAudioReaderFake{audio: acousticTestWAV()},
 		acousticProviderFake{result: AcousticAssessmentResult{
@@ -21,14 +22,17 @@ func TestCompactAcousticEvaluatorAcceptsOpaqueProviderSession(t *testing.T) {
 				IntegrityScore: &score,
 				Rejected:       &rejected,
 			},
-		}},
+		}, request: &providerRequest},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	checkpoint, err := evaluator.EvaluateAcoustic(
 		context.Background(),
-		evaluation.Record{Kind: evaluation.KindPracticeTurnFeedback},
+		evaluation.Record{
+			Kind:       evaluation.KindPracticeTurnFeedback,
+			LeaseToken: "20000000-0000-4000-8000-000000000001",
+		},
 		evaluation.SpeechInputSnapshot{
 			Transcript:   "I enjoy upbeat music.",
 			AudioAssetID: "10000000-0000-4000-8000-000000000001",
@@ -38,7 +42,8 @@ func TestCompactAcousticEvaluatorAcceptsOpaqueProviderSession(t *testing.T) {
 		t.Fatalf("EvaluateAcoustic() error = %v", err)
 	}
 	if !checkpoint.Valid() ||
-		checkpoint.ProviderSession != "ise000da9a8@gz1a0092fc5e55075812" {
+		checkpoint.ProviderSession != "ise000da9a8@gz1a0092fc5e55075812" ||
+		providerRequest.RequestID != "20000000-0000-4000-8000-000000000001" {
 		t.Fatalf("checkpoint = %#v", checkpoint)
 	}
 }
@@ -63,7 +68,10 @@ func TestCompactAcousticEvaluatorAcceptsWordAssessmentWithoutSentenceDimensions(
 	}
 	checkpoint, err := evaluator.EvaluateAcoustic(
 		context.Background(),
-		evaluation.Record{Kind: evaluation.KindPracticeTurnFeedback},
+		evaluation.Record{
+			Kind:       evaluation.KindPracticeTurnFeedback,
+			LeaseToken: "20000000-0000-4000-8000-000000000002",
+		},
 		evaluation.SpeechInputSnapshot{
 			Transcript:   "No.",
 			AudioAssetID: "10000000-0000-4000-8000-000000000002",
@@ -86,12 +94,18 @@ func (reader acousticAudioReaderFake) ReadOwnedAudio(
 	return reader.audio, nil
 }
 
-type acousticProviderFake struct{ result AcousticAssessmentResult }
+type acousticProviderFake struct {
+	result  AcousticAssessmentResult
+	request *AcousticAssessmentRequest
+}
 
 func (provider acousticProviderFake) Evaluate(
-	context.Context,
-	AcousticAssessmentRequest,
+	_ context.Context,
+	request AcousticAssessmentRequest,
 ) (AcousticAssessmentResult, error) {
+	if provider.request != nil {
+		*provider.request = request
+	}
 	return provider.result, nil
 }
 

--- a/server/internal/platform/config/ise_relay.go
+++ b/server/internal/platform/config/ise_relay.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultISERelayPollInterval = 500 * time.Millisecond
+	defaultISERelayTimeout      = 165 * time.Second
+)
+
+type ISERelayConfig struct {
+	Endpoint       string
+	CAFile         string
+	ClientCertFile string
+	ClientKeyFile  string
+	PollInterval   time.Duration
+	Timeout        time.Duration
+}
+
+// ISERelayConfigured reports whether any relay setting was provided. LoadISERelay
+// rejects partial settings so a broken relay cannot silently disable acoustics.
+func ISERelayConfigured() bool {
+	for _, name := range []string{
+		"ISE_RELAY_ENDPOINT",
+		"ISE_RELAY_CA_FILE",
+		"ISE_RELAY_CLIENT_CERT_FILE",
+		"ISE_RELAY_CLIENT_KEY_FILE",
+	} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func LoadISERelay() (ISERelayConfig, error) {
+	configuration := ISERelayConfig{
+		Endpoint:       strings.TrimSpace(os.Getenv("ISE_RELAY_ENDPOINT")),
+		CAFile:         strings.TrimSpace(os.Getenv("ISE_RELAY_CA_FILE")),
+		ClientCertFile: strings.TrimSpace(os.Getenv("ISE_RELAY_CLIENT_CERT_FILE")),
+		ClientKeyFile:  strings.TrimSpace(os.Getenv("ISE_RELAY_CLIENT_KEY_FILE")),
+	}
+	for _, value := range []string{
+		configuration.Endpoint,
+		configuration.CAFile,
+		configuration.ClientCertFile,
+		configuration.ClientKeyFile,
+	} {
+		if value == "" {
+			return ISERelayConfig{}, errors.New("ISE relay configuration is incomplete")
+		}
+	}
+	endpoint, err := url.Parse(configuration.Endpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" ||
+		endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" ||
+		(endpoint.Path != "" && endpoint.Path != "/") {
+		return ISERelayConfig{}, errors.New("ISE_RELAY_ENDPOINT must be an HTTPS origin")
+	}
+	configuration.PollInterval, err = durationOrDefault(
+		"ISE_RELAY_POLL_INTERVAL",
+		defaultISERelayPollInterval,
+	)
+	if err != nil || configuration.PollInterval < 100*time.Millisecond ||
+		configuration.PollInterval > 10*time.Second {
+		return ISERelayConfig{}, errors.New("ISE_RELAY_POLL_INTERVAL must be between 100ms and 10s")
+	}
+	configuration.Timeout, err = durationOrDefault(
+		"ISE_RELAY_TIMEOUT",
+		defaultISERelayTimeout,
+	)
+	if err != nil || configuration.Timeout <= 0 || configuration.Timeout > 5*time.Minute {
+		return ISERelayConfig{}, errors.New("ISE_RELAY_TIMEOUT must be greater than zero and at most 5m")
+	}
+	return configuration, nil
+}

--- a/server/internal/platform/config/ise_relay_test.go
+++ b/server/internal/platform/config/ise_relay_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadISERelay(t *testing.T) {
+	setISERelayEnvironment(t)
+	configuration, err := LoadISERelay()
+	if err != nil {
+		t.Fatalf("load ISE relay: %v", err)
+	}
+	if configuration.Endpoint != "https://relay.example.test" ||
+		configuration.PollInterval != defaultISERelayPollInterval ||
+		configuration.Timeout != defaultISERelayTimeout {
+		t.Fatalf("unexpected ISE relay config: %#v", configuration)
+	}
+}
+
+func TestISERelayConfiguredRejectsPartialAndUnsafeConfiguration(t *testing.T) {
+	for _, name := range []string{
+		"ISE_RELAY_ENDPOINT",
+		"ISE_RELAY_CA_FILE",
+		"ISE_RELAY_CLIENT_CERT_FILE",
+		"ISE_RELAY_CLIENT_KEY_FILE",
+	} {
+		t.Setenv(name, "")
+	}
+	if ISERelayConfigured() {
+		t.Fatal("empty ISE relay configuration must be disabled")
+	}
+	t.Setenv("ISE_RELAY_ENDPOINT", "https://relay.example.test")
+	if !ISERelayConfigured() {
+		t.Fatal("partial relay configuration must be detected")
+	}
+	if _, err := LoadISERelay(); err == nil {
+		t.Fatal("partial relay configuration must fail closed")
+	}
+
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "plain HTTP", key: "ISE_RELAY_ENDPOINT", value: "http://relay.example.test"},
+		{name: "endpoint path", key: "ISE_RELAY_ENDPOINT", value: "https://relay.example.test/api"},
+		{name: "fast polling", key: "ISE_RELAY_POLL_INTERVAL", value: "10ms"},
+		{name: "slow polling", key: "ISE_RELAY_POLL_INTERVAL", value: "11s"},
+		{name: "excessive timeout", key: "ISE_RELAY_TIMEOUT", value: "301s"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setISERelayEnvironment(t)
+			t.Setenv(test.key, test.value)
+			if _, err := LoadISERelay(); err == nil {
+				t.Fatal("expected configuration error")
+			}
+		})
+	}
+}
+
+func TestLoadISERelayAcceptsExplicitDurations(t *testing.T) {
+	setISERelayEnvironment(t)
+	t.Setenv("ISE_RELAY_POLL_INTERVAL", "750ms")
+	t.Setenv("ISE_RELAY_TIMEOUT", "2m")
+	configuration, err := LoadISERelay()
+	if err != nil {
+		t.Fatalf("load ISE relay: %v", err)
+	}
+	if configuration.PollInterval != 750*time.Millisecond ||
+		configuration.Timeout != 2*time.Minute {
+		t.Fatalf("unexpected durations: %#v", configuration)
+	}
+}
+
+func setISERelayEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("ISE_RELAY_ENDPOINT", "https://relay.example.test")
+	t.Setenv("ISE_RELAY_CA_FILE", "/run/secrets/relay-ca.pem")
+	t.Setenv("ISE_RELAY_CLIENT_CERT_FILE", "/run/secrets/relay-client.pem")
+	t.Setenv("ISE_RELAY_CLIENT_KEY_FILE", "/run/secrets/relay-client-key.pem")
+	t.Setenv("ISE_RELAY_POLL_INTERVAL", "")
+	t.Setenv("ISE_RELAY_TIMEOUT", "")
+}

--- a/server/internal/providers/iserelay/client.go
+++ b/server/internal/providers/iserelay/client.go
@@ -76,8 +76,13 @@ func NewClient(configuration ClientConfig) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load ISE relay client certificate: %w", err)
 	}
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
 	transport := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
 		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS13, RootCAs: rootCAs, Certificates: []tls.Certificate{certificate}},
 		TLSHandshakeTimeout:   15 * time.Second,
 		ResponseHeaderTimeout: 15 * time.Second,

--- a/server/internal/providers/iserelay/client.go
+++ b/server/internal/providers/iserelay/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,6 +20,11 @@ import (
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+)
+
+const (
+	requestMaxAttempts = 3
+	requestRetryDelay  = 200 * time.Millisecond
 )
 
 type ClientConfig struct {
@@ -73,7 +79,7 @@ func NewClient(configuration ClientConfig) (*Client, error) {
 	transport := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS13, RootCAs: rootCAs, Certificates: []tls.Certificate{certificate}},
-		TLSHandshakeTimeout:   10 * time.Second,
+		TLSHandshakeTimeout:   15 * time.Second,
 		ResponseHeaderTimeout: 15 * time.Second,
 		IdleConnTimeout:       30 * time.Second,
 	}
@@ -166,17 +172,15 @@ func (client *Client) create(
 	if err := writer.Close(); err != nil {
 		return StatusResponse{}, err
 	}
-	request, err := http.NewRequestWithContext(
+	return client.doWithRetry(
 		ctx,
 		http.MethodPost,
 		client.resolve("/v1/evaluations"),
-		&body,
+		body.Bytes(),
+		writer.FormDataContentType(),
+		http.StatusAccepted,
+		http.StatusOK,
 	)
-	if err != nil {
-		return StatusResponse{}, err
-	}
-	request.Header.Set("content-type", writer.FormDataContentType())
-	return client.do(request, http.StatusAccepted, http.StatusOK)
 }
 
 func (client *Client) poll(
@@ -195,19 +199,19 @@ func (client *Client) poll(
 			return StatusResponse{}, ctx.Err()
 		case <-timer.C:
 		}
-		request, err := http.NewRequestWithContext(
+		polled, err := client.doWithRetry(
 			ctx,
 			http.MethodGet,
 			client.resolve("/v1/evaluations/"+url.PathEscape(requestID)),
 			nil,
+			"",
+			http.StatusOK,
+			http.StatusAccepted,
 		)
 		if err != nil {
 			return StatusResponse{}, err
 		}
-		response, err = client.do(request, http.StatusOK, http.StatusAccepted)
-		if err != nil {
-			return StatusResponse{}, err
-		}
+		response = polled
 		if response.RequestID != requestID {
 			return StatusResponse{}, relayResponseMismatch()
 		}
@@ -220,6 +224,69 @@ func (client *Client) poll(
 		}
 	}
 	return response, nil
+}
+
+func (client *Client) doWithRetry(
+	ctx context.Context,
+	method string,
+	target string,
+	body []byte,
+	contentType string,
+	allowed ...int,
+) (StatusResponse, error) {
+	for attempt := 1; ; attempt++ {
+		request, err := http.NewRequestWithContext(
+			ctx,
+			method,
+			target,
+			bytes.NewReader(body),
+		)
+		if err != nil {
+			return StatusResponse{}, err
+		}
+		if contentType != "" {
+			request.Header.Set("content-type", contentType)
+		}
+		response, err := client.do(request, allowed...)
+		if err == nil {
+			return response, nil
+		}
+		if ctx.Err() != nil {
+			return StatusResponse{}, ctx.Err()
+		}
+		if !retryableRequestError(err) {
+			return StatusResponse{}, err
+		}
+		if attempt == requestMaxAttempts {
+			return StatusResponse{}, RelayError{
+				code:      FailureProviderUnavailable,
+				retryable: true,
+			}
+		}
+		timer := time.NewTimer(requestRetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return StatusResponse{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func retryableRequestError(err error) bool {
+	var relayFailure RelayError
+	if errors.As(err, &relayFailure) {
+		return relayFailure.Retryable()
+	}
+	var urlFailure *url.Error
+	if errors.As(err, &urlFailure) {
+		err = urlFailure.Err
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var networkFailure net.Error
+	return errors.As(err, &networkFailure)
 }
 
 func (client *Client) do(
@@ -289,7 +356,9 @@ func (client *Client) record(startedAt time.Time, err error) {
 	kind := providerobservability.ErrorNone
 	if err != nil {
 		kind = providerobservability.ErrorProviderUnavailable
-		if errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.Canceled) {
+			kind = providerobservability.ErrorCancelled
+		} else if errors.Is(err, context.DeadlineExceeded) {
 			kind = providerobservability.ErrorTimeout
 		}
 		var relayFailure RelayError

--- a/server/internal/providers/iserelay/client.go
+++ b/server/internal/providers/iserelay/client.go
@@ -1,0 +1,324 @@
+package iserelay
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
+)
+
+type ClientConfig struct {
+	Endpoint       string
+	CAFile         string
+	ClientCertFile string
+	ClientKeyFile  string
+	PollInterval   time.Duration
+	Observer       providerobservability.Recorder
+}
+
+type Client struct {
+	endpoint     *url.URL
+	httpClient   *http.Client
+	pollInterval time.Duration
+	observer     providerobservability.Recorder
+}
+
+type RelayError struct {
+	code      string
+	retryable bool
+}
+
+func (failure RelayError) Error() string          { return "ISE relay request failed" }
+func (failure RelayError) StableCategory() string { return failure.code }
+func (failure RelayError) Retryable() bool        { return failure.retryable }
+
+func NewClient(configuration ClientConfig) (*Client, error) {
+	endpoint, err := normalizeEndpoint(configuration.Endpoint)
+	if err != nil || strings.TrimSpace(configuration.CAFile) == "" ||
+		strings.TrimSpace(configuration.ClientCertFile) == "" ||
+		strings.TrimSpace(configuration.ClientKeyFile) == "" ||
+		configuration.PollInterval < 100*time.Millisecond ||
+		configuration.PollInterval > 10*time.Second {
+		return nil, errors.New("ISE relay client configuration is invalid")
+	}
+	caPEM, err := os.ReadFile(configuration.CAFile)
+	if err != nil {
+		return nil, fmt.Errorf("read ISE relay CA: %w", err)
+	}
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(caPEM) {
+		return nil, errors.New("ISE relay CA is invalid")
+	}
+	certificate, err := tls.LoadX509KeyPair(
+		configuration.ClientCertFile,
+		configuration.ClientKeyFile,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load ISE relay client certificate: %w", err)
+	}
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS13, RootCAs: rootCAs, Certificates: []tls.Certificate{certificate}},
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 15 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
+	}
+	return &Client{
+		endpoint:     endpoint,
+		httpClient:   &http.Client{Transport: transport},
+		pollInterval: configuration.PollInterval,
+		observer:     configuration.Observer,
+	}, nil
+}
+
+func newClientForTest(
+	endpoint string,
+	httpClient *http.Client,
+	pollInterval time.Duration,
+) (*Client, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Host == "" ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") ||
+		httpClient == nil || pollInterval <= 0 {
+		return nil, errors.New("ISE relay test client configuration is invalid")
+	}
+	return &Client{endpoint: parsed, httpClient: httpClient, pollInterval: pollInterval}, nil
+}
+
+func (client *Client) Evaluate(
+	ctx context.Context,
+	request speechfeedback.AcousticAssessmentRequest,
+) (speechfeedback.AcousticAssessmentResult, error) {
+	if client == nil || client.endpoint == nil || client.httpClient == nil ||
+		ctx == nil || !validRequest(request) {
+		return speechfeedback.AcousticAssessmentResult{},
+			RelayError{code: FailureInvalidRequest, retryable: false}
+	}
+	startedAt := time.Now()
+	response, err := client.create(ctx, request)
+	if err == nil {
+		response, err = client.poll(ctx, request.RequestID, response)
+	}
+	client.record(startedAt, err)
+	if err != nil {
+		return speechfeedback.AcousticAssessmentResult{}, err
+	}
+	if !response.valid() || response.Status != StatusSucceeded || response.Result == nil {
+		return speechfeedback.AcousticAssessmentResult{},
+			RelayError{code: FailureProviderUnavailable, retryable: true}
+	}
+	return speechfeedback.AcousticAssessmentResult{
+		Provider:  response.Result.Provider,
+		SessionID: response.Result.SessionID,
+		Summary: speechfeedback.AcousticAssessmentSummary{
+			AccuracyScore:  response.Result.Summary.AccuracyScore,
+			FluencyScore:   response.Result.Summary.FluencyScore,
+			IntegrityScore: response.Result.Summary.IntegrityScore,
+			PhoneScore:     response.Result.Summary.PhoneScore,
+			SpeakingSpeed:  response.Result.Summary.SpeakingSpeed,
+			Rejected:       response.Result.Summary.Rejected,
+			ExceptionInfo:  response.Result.Summary.ExceptionInfo,
+		},
+	}, nil
+}
+
+func (client *Client) create(
+	ctx context.Context,
+	assessment speechfeedback.AcousticAssessmentRequest,
+) (StatusResponse, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{name: "request_id", value: assessment.RequestID},
+		{name: "reference_text", value: assessment.ReferenceText},
+		{name: "topic_title", value: assessment.TopicTitle},
+		{name: "category", value: string(assessment.Category)},
+	}
+	for _, field := range fields {
+		if err := writer.WriteField(field.name, field.value); err != nil {
+			return StatusResponse{}, err
+		}
+	}
+	audio, err := writer.CreateFormFile("audio", "audio.pcm")
+	if err != nil {
+		return StatusResponse{}, err
+	}
+	if _, err := audio.Write(assessment.Audio); err != nil {
+		return StatusResponse{}, err
+	}
+	if err := writer.Close(); err != nil {
+		return StatusResponse{}, err
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		client.resolve("/v1/evaluations"),
+		&body,
+	)
+	if err != nil {
+		return StatusResponse{}, err
+	}
+	request.Header.Set("content-type", writer.FormDataContentType())
+	return client.do(request, http.StatusAccepted, http.StatusOK)
+}
+
+func (client *Client) poll(
+	ctx context.Context,
+	requestID string,
+	response StatusResponse,
+) (StatusResponse, error) {
+	if response.RequestID != requestID {
+		return StatusResponse{}, relayResponseMismatch()
+	}
+	for response.Status == StatusProcessing {
+		timer := time.NewTimer(client.pollInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return StatusResponse{}, ctx.Err()
+		case <-timer.C:
+		}
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			client.resolve("/v1/evaluations/"+url.PathEscape(requestID)),
+			nil,
+		)
+		if err != nil {
+			return StatusResponse{}, err
+		}
+		response, err = client.do(request, http.StatusOK, http.StatusAccepted)
+		if err != nil {
+			return StatusResponse{}, err
+		}
+		if response.RequestID != requestID {
+			return StatusResponse{}, relayResponseMismatch()
+		}
+	}
+	if response.Status == StatusFailed && response.Failure != nil &&
+		response.Failure.valid() {
+		return StatusResponse{}, RelayError{
+			code:      response.Failure.Code,
+			retryable: response.Failure.Retryable,
+		}
+	}
+	return response, nil
+}
+
+func (client *Client) do(
+	request *http.Request,
+	allowed ...int,
+) (StatusResponse, error) {
+	response, err := client.httpClient.Do(request)
+	if err != nil {
+		return StatusResponse{}, err
+	}
+	defer response.Body.Close()
+	accepted := false
+	for _, status := range allowed {
+		if response.StatusCode == status {
+			accepted = true
+			break
+		}
+	}
+	if !accepted {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+		return StatusResponse{}, RelayError{
+			code: FailureProviderUnavailable,
+			retryable: response.StatusCode >= 500 ||
+				(request.Method == http.MethodGet && response.StatusCode == http.StatusNotFound),
+		}
+	}
+	body, readErr := io.ReadAll(io.LimitReader(response.Body, 64*1024+1))
+	if readErr != nil || len(body) > 64*1024 {
+		return StatusResponse{}, RelayError{
+			code:      FailureProviderUnavailable,
+			retryable: true,
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var decoded StatusResponse
+	if err := decoder.Decode(&decoded); err != nil || !decoded.valid() {
+		return StatusResponse{}, RelayError{
+			code:      FailureProviderUnavailable,
+			retryable: true,
+		}
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return StatusResponse{}, RelayError{
+			code:      FailureProviderUnavailable,
+			retryable: true,
+		}
+	}
+	return decoded, nil
+}
+
+func relayResponseMismatch() RelayError {
+	return RelayError{code: FailureProviderUnavailable, retryable: true}
+}
+
+func (client *Client) resolve(relative string) string {
+	resolved := *client.endpoint
+	resolved.Path = path.Join(client.endpoint.Path, relative)
+	return resolved.String()
+}
+
+func (client *Client) record(startedAt time.Time, err error) {
+	if client.observer == nil {
+		return
+	}
+	kind := providerobservability.ErrorNone
+	if err != nil {
+		kind = providerobservability.ErrorProviderUnavailable
+		if errors.Is(err, context.DeadlineExceeded) {
+			kind = providerobservability.ErrorTimeout
+		}
+		var relayFailure RelayError
+		if errors.As(err, &relayFailure) {
+			switch relayFailure.code {
+			case FailureInvalidRequest:
+				kind = providerobservability.ErrorInvalidRequest
+			case FailureProcessingTimeout:
+				kind = providerobservability.ErrorTimeout
+			}
+		}
+	}
+	client.observer.Record(providerobservability.Observation{
+		Provider:   providerobservability.ProviderXFYunISE,
+		Capability: providerobservability.CapabilitySpeechEvaluation,
+		Duration:   time.Since(startedAt),
+		ErrorKind:  kind,
+	})
+}
+
+func normalizeEndpoint(value string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" ||
+		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" ||
+		(parsed.Path != "" && parsed.Path != "/") {
+		return nil, errors.New("ISE relay endpoint must be an HTTPS origin")
+	}
+	parsed.Path = ""
+	return parsed, nil
+}
+
+var _ speechfeedback.AcousticEvaluator = (*Client)(nil)

--- a/server/internal/providers/iserelay/client_test.go
+++ b/server/internal/providers/iserelay/client_test.go
@@ -2,6 +2,7 @@ package iserelay
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -10,7 +11,11 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
+	"io"
 	"math/big"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,6 +25,7 @@ import (
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/providerobservability"
 )
 
 func TestNewClientLoadsMTLSConfiguration(t *testing.T) {
@@ -38,6 +44,7 @@ func TestNewClientLoadsMTLSConfiguration(t *testing.T) {
 	transport, ok := client.httpClient.Transport.(*http.Transport)
 	if !ok || transport.TLSClientConfig == nil ||
 		transport.TLSClientConfig.MinVersion != tls.VersionTLS13 ||
+		transport.TLSHandshakeTimeout != 15*time.Second ||
 		len(transport.TLSClientConfig.Certificates) != 1 ||
 		len(transport.TLSClientConfig.RootCAs.Subjects()) != 1 {
 		t.Fatalf("unexpected mTLS transport: %#v", client.httpClient.Transport)
@@ -162,6 +169,217 @@ func TestClientCreatesAndPollsEvaluation(t *testing.T) {
 	}
 	if polls.Load() != 1 || result.Provider != "xfyun_ise" || result.RawResult != "" {
 		t.Fatalf("unexpected relay result: %#v, polls=%d", result, polls.Load())
+	}
+}
+
+func TestClientRetriesLostCreateResponseWithIdenticalRequest(t *testing.T) {
+	var requestBodies [][]byte
+	var contentTypes []string
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method == http.MethodGet {
+			return clientResponse(
+				t,
+				request,
+				http.StatusOK,
+				resultResponse(testRequestID, testResult()),
+			), nil
+		}
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatalf("read create request: %v", err)
+		}
+		requestBodies = append(requestBodies, body)
+		contentTypes = append(contentTypes, request.Header.Get("content-type"))
+		if len(requestBodies) == 1 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		return clientResponse(
+			t,
+			request,
+			http.StatusAccepted,
+			processingResponse(testRequestID),
+		), nil
+	})
+	client, err := newClientForTest(
+		"http://relay.example.test",
+		&http.Client{Transport: transport},
+		time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if _, err := client.Evaluate(t.Context(), validAssessment()); err != nil {
+		t.Fatalf("evaluate after lost create response: %v", err)
+	}
+	if len(requestBodies) != 2 || !bytes.Equal(requestBodies[0], requestBodies[1]) ||
+		contentTypes[0] != contentTypes[1] {
+		t.Fatalf("create retry changed request: bodies=%d content-types=%v", len(requestBodies), contentTypes)
+	}
+	_, parameters, err := mime.ParseMediaType(contentTypes[0])
+	if err != nil {
+		t.Fatalf("parse multipart content type: %v", err)
+	}
+	form, err := multipart.NewReader(
+		bytes.NewReader(requestBodies[0]),
+		parameters["boundary"],
+	).ReadForm(int64(len(requestBodies[0])))
+	if err != nil {
+		t.Fatalf("parse create request: %v", err)
+	}
+	defer form.RemoveAll()
+	if values := form.Value["request_id"]; len(values) != 1 || values[0] != testRequestID {
+		t.Fatalf("create retry request_id = %v", values)
+	}
+}
+
+func TestClientRetriesTransientPollFailure(t *testing.T) {
+	var polls int
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method == http.MethodPost {
+			return clientResponse(
+				t,
+				request,
+				http.StatusAccepted,
+				processingResponse(testRequestID),
+			), nil
+		}
+		polls++
+		if polls == 1 {
+			return nil, io.EOF
+		}
+		return clientResponse(
+			t,
+			request,
+			http.StatusOK,
+			resultResponse(testRequestID, testResult()),
+		), nil
+	})
+	client, err := newClientForTest(
+		"http://relay.example.test",
+		&http.Client{Transport: transport},
+		time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if _, err := client.Evaluate(t.Context(), validAssessment()); err != nil {
+		t.Fatalf("evaluate after transient poll failure: %v", err)
+	}
+	if polls != 2 {
+		t.Fatalf("poll attempts = %d, want 2", polls)
+	}
+}
+
+func TestClientDoesNotRetryConflictResponse(t *testing.T) {
+	var attempts int
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		attempts++
+		return clientResponse(
+			t,
+			request,
+			http.StatusConflict,
+			map[string]string{"error": "IDEMPOTENCY_CONFLICT"},
+		), nil
+	})
+	client, err := newClientForTest(
+		"http://relay.example.test",
+		&http.Client{Transport: transport},
+		time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	_, err = client.Evaluate(t.Context(), validAssessment())
+	failure, ok := err.(RelayError)
+	if !ok || failure.Retryable() || attempts != 1 {
+		t.Fatalf("conflict response: error=%#v attempts=%d", err, attempts)
+	}
+}
+
+func TestClientNormalizesExhaustedTransportRetries(t *testing.T) {
+	var attempts int
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return nil, io.EOF
+	})
+	client, err := newClientForTest(
+		"http://relay.example.test",
+		&http.Client{Transport: transport},
+		time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	_, err = client.Evaluate(t.Context(), validAssessment())
+	failure, ok := err.(RelayError)
+	if !ok || failure.StableCategory() != FailureProviderUnavailable ||
+		!failure.Retryable() || attempts != requestMaxAttempts {
+		t.Fatalf("exhausted retries: error=%#v attempts=%d", err, attempts)
+	}
+}
+
+func TestClientStopsRetryingWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	recorder := &relayProviderRecorder{}
+	var attempts int
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		cancel()
+		return nil, io.EOF
+	})
+	client, err := newClientForTest(
+		"http://relay.example.test",
+		&http.Client{Transport: transport},
+		time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	client.observer = recorder
+	_, err = client.Evaluate(ctx, validAssessment())
+	if !errors.Is(err, context.Canceled) || attempts != 1 {
+		t.Fatalf("canceled request: error=%v attempts=%d", err, attempts)
+	}
+	if len(recorder.observations) != 1 ||
+		recorder.observations[0].ErrorKind != providerobservability.ErrorCancelled {
+		t.Fatalf("canceled observation: %#v", recorder.observations)
+	}
+}
+
+type relayProviderRecorder struct {
+	observations []providerobservability.Observation
+}
+
+func (recorder *relayProviderRecorder) Record(
+	observation providerobservability.Observation,
+) {
+	recorder.observations = append(recorder.observations, observation)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (roundTrip roundTripFunc) RoundTrip(
+	request *http.Request,
+) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+func clientResponse(
+	t *testing.T,
+	request *http.Request,
+	status int,
+	value any,
+) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal relay response: %v", err)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"content-type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    request,
 	}
 }
 

--- a/server/internal/providers/iserelay/client_test.go
+++ b/server/internal/providers/iserelay/client_test.go
@@ -1,0 +1,156 @@
+package iserelay
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+)
+
+func TestClientCreatesAndPollsEvaluation(t *testing.T) {
+	var polls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodPost {
+			if err := request.ParseMultipartForm(1024); err != nil {
+				t.Errorf("parse multipart: %v", err)
+			}
+			writeJSON(writer, http.StatusAccepted, processingResponse(testRequestID))
+			return
+		}
+		polls.Add(1)
+		result := resultResponse(testRequestID, testResult())
+		writeJSON(writer, http.StatusOK, result)
+	}))
+	defer server.Close()
+	client, err := newClientForTest(server.URL, server.Client(), time.Millisecond)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	result, err := client.Evaluate(t.Context(), validAssessment())
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if polls.Load() != 1 || result.Provider != "xfyun_ise" || result.RawResult != "" {
+		t.Fatalf("unexpected relay result: %#v, polls=%d", result, polls.Load())
+	}
+}
+
+func testResult() speechfeedback.AcousticAssessmentResult {
+	return speechfeedback.AcousticAssessmentResult{
+		Provider:  "xfyun_ise",
+		SessionID: "session-1",
+	}
+}
+
+func TestClientReturnsStableRelayFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		response := failureResponse(testRequestID, FailureProcessingTimeout, true)
+		writeJSON(writer, http.StatusOK, response)
+	}))
+	defer server.Close()
+	client, err := newClientForTest(server.URL, server.Client(), time.Millisecond)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	_, err = client.Evaluate(t.Context(), validAssessment())
+	failure, ok := err.(RelayError)
+	if !ok || failure.StableCategory() != FailureProcessingTimeout || !failure.Retryable() {
+		t.Fatalf("unexpected relay error: %#v", err)
+	}
+}
+
+func TestClientRejectsMalformedSuccessResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(writer).Encode(map[string]string{"status": StatusSucceeded})
+	}))
+	defer server.Close()
+	client, err := newClientForTest(server.URL, server.Client(), time.Millisecond)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if _, err := client.Evaluate(t.Context(), validAssessment()); err == nil {
+		t.Fatal("malformed response must fail closed")
+	}
+}
+
+func TestClientRejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("content-type", "application/json")
+		_, _ = writer.Write(append(
+			[]byte(`{"schema_version":"ise-relay/v1","request_id":"`+testRequestID+`","status":"PROCESSING"}`),
+			bytes.Repeat([]byte(" "), 64*1024)...,
+		))
+	}))
+	defer server.Close()
+	client, err := newClientForTest(server.URL, server.Client(), time.Millisecond)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	if _, err := client.Evaluate(t.Context(), validAssessment()); err == nil {
+		t.Fatal("oversized response must fail closed")
+	}
+}
+
+func TestClientRejectsMismatchedResponseRequestID(t *testing.T) {
+	otherRequestID := "f7023b34-0000-4000-8000-000000000099"
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "create response",
+			handler: func(writer http.ResponseWriter, _ *http.Request) {
+				writeJSON(writer, http.StatusAccepted, processingResponse(otherRequestID))
+			},
+		},
+		{
+			name: "poll response",
+			handler: func(writer http.ResponseWriter, request *http.Request) {
+				if request.Method == http.MethodPost {
+					writeJSON(writer, http.StatusAccepted, processingResponse(testRequestID))
+					return
+				}
+				writeJSON(writer, http.StatusOK, resultResponse(otherRequestID, testResult()))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(test.handler)
+			defer server.Close()
+			client, err := newClientForTest(server.URL, server.Client(), time.Millisecond)
+			if err != nil {
+				t.Fatalf("new client: %v", err)
+			}
+			if _, err := client.Evaluate(t.Context(), validAssessment()); err == nil {
+				t.Fatal("mismatched request ID must fail closed")
+			}
+		})
+	}
+}
+
+func TestClientTreatsMissingPolledJobAsRetryable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodPost {
+			writeJSON(writer, http.StatusAccepted, processingResponse(testRequestID))
+			return
+		}
+		writeJSON(writer, http.StatusNotFound, map[string]string{"error": "NOT_FOUND"})
+	}))
+	defer server.Close()
+	client, err := newClientForTest(server.URL, server.Client(), time.Millisecond)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	_, err = client.Evaluate(t.Context(), validAssessment())
+	failure, ok := err.(RelayError)
+	if !ok || !failure.Retryable() {
+		t.Fatalf("missing polled job must be retryable: %#v", err)
+	}
+}

--- a/server/internal/providers/iserelay/client_test.go
+++ b/server/internal/providers/iserelay/client_test.go
@@ -2,15 +2,140 @@ package iserelay
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
 )
+
+func TestNewClientLoadsMTLSConfiguration(t *testing.T) {
+	directory := t.TempDir()
+	certificateFile, keyFile := writeClientCertificate(t, directory)
+	client, err := NewClient(ClientConfig{
+		Endpoint:       "https://relay.example.test/",
+		CAFile:         certificateFile,
+		ClientCertFile: certificateFile,
+		ClientKeyFile:  keyFile,
+		PollInterval:   time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	if !ok || transport.TLSClientConfig == nil ||
+		transport.TLSClientConfig.MinVersion != tls.VersionTLS13 ||
+		len(transport.TLSClientConfig.Certificates) != 1 ||
+		len(transport.TLSClientConfig.RootCAs.Subjects()) != 1 {
+		t.Fatalf("unexpected mTLS transport: %#v", client.httpClient.Transport)
+	}
+	if client.endpoint.String() != "https://relay.example.test" ||
+		client.pollInterval != time.Second {
+		t.Fatalf("unexpected relay client: %#v", client)
+	}
+}
+
+func TestNewClientRejectsInvalidTLSConfiguration(t *testing.T) {
+	directory := t.TempDir()
+	invalidCAFile := filepath.Join(directory, "invalid-ca.pem")
+	if err := os.WriteFile(invalidCAFile, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("write invalid CA: %v", err)
+	}
+	tests := []struct {
+		name          string
+		configuration ClientConfig
+	}{
+		{
+			name: "HTTP endpoint",
+			configuration: ClientConfig{
+				Endpoint:       "http://relay.example.test",
+				CAFile:         invalidCAFile,
+				ClientCertFile: "client.pem",
+				ClientKeyFile:  "client-key.pem",
+				PollInterval:   time.Second,
+			},
+		},
+		{
+			name: "missing CA file",
+			configuration: ClientConfig{
+				Endpoint:       "https://relay.example.test",
+				CAFile:         filepath.Join(directory, "missing.pem"),
+				ClientCertFile: "client.pem",
+				ClientKeyFile:  "client-key.pem",
+				PollInterval:   time.Second,
+			},
+		},
+		{
+			name: "invalid CA file",
+			configuration: ClientConfig{
+				Endpoint:       "https://relay.example.test",
+				CAFile:         invalidCAFile,
+				ClientCertFile: "client.pem",
+				ClientKeyFile:  "client-key.pem",
+				PollInterval:   time.Second,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := NewClient(test.configuration); err == nil {
+				t.Fatal("expected invalid mTLS configuration to be rejected")
+			}
+		})
+	}
+}
+
+func writeClientCertificate(t *testing.T, directory string) (string, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate client key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "relay-client"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create client certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal client key: %v", err)
+	}
+	certificateFile := filepath.Join(directory, "client.pem")
+	keyFile := filepath.Join(directory, "client-key.pem")
+	if err := os.WriteFile(certificateFile, pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE", Bytes: der,
+	}), 0o600); err != nil {
+		t.Fatalf("write client certificate: %v", err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{
+		Type: "PRIVATE KEY", Bytes: keyDER,
+	}), 0o600); err != nil {
+		t.Fatalf("write client key: %v", err)
+	}
+	return certificateFile, keyFile
+}
 
 func TestClientCreatesAndPollsEvaluation(t *testing.T) {
 	var polls atomic.Int32

--- a/server/internal/providers/iserelay/client_test.go
+++ b/server/internal/providers/iserelay/client_test.go
@@ -16,11 +16,13 @@ import (
 	"math/big"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -43,6 +45,7 @@ func TestNewClientLoadsMTLSConfiguration(t *testing.T) {
 	}
 	transport, ok := client.httpClient.Transport.(*http.Transport)
 	if !ok || transport.TLSClientConfig == nil ||
+		transport.DialContext == nil ||
 		transport.TLSClientConfig.MinVersion != tls.VersionTLS13 ||
 		transport.TLSHandshakeTimeout != 15*time.Second ||
 		len(transport.TLSClientConfig.Certificates) != 1 ||
@@ -315,6 +318,39 @@ func TestClientNormalizesExhaustedTransportRetries(t *testing.T) {
 	if !ok || failure.StableCategory() != FailureProviderUnavailable ||
 		!failure.Retryable() || attempts != requestMaxAttempts {
 		t.Fatalf("exhausted retries: error=%#v attempts=%d", err, attempts)
+	}
+}
+
+func TestClientRetriesBoundedDialTimeouts(t *testing.T) {
+	var dials int
+	transport := &http.Transport{
+		DialContext: func(
+			context.Context,
+			string,
+			string,
+		) (net.Conn, error) {
+			dials++
+			return nil, &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: syscall.ETIMEDOUT,
+			}
+		},
+	}
+	defer transport.CloseIdleConnections()
+	client, err := newClientForTest(
+		"http://relay.example.test",
+		&http.Client{Transport: transport},
+		time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	_, err = client.Evaluate(t.Context(), validAssessment())
+	failure, ok := err.(RelayError)
+	if !ok || failure.StableCategory() != FailureProviderUnavailable ||
+		!failure.Retryable() || dials != requestMaxAttempts {
+		t.Fatalf("dial timeout retries: error=%#v dials=%d", err, dials)
 	}
 }
 

--- a/server/internal/providers/iserelay/contract.go
+++ b/server/internal/providers/iserelay/contract.go
@@ -1,0 +1,219 @@
+package iserelay
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"math"
+	"regexp"
+	"strings"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+)
+
+const (
+	SchemaVersion = "ise-relay/v1"
+
+	StatusProcessing = "PROCESSING"
+	StatusSucceeded  = "SUCCEEDED"
+	StatusFailed     = "FAILED"
+
+	FailureInvalidRequest      = "INVALID_REQUEST"
+	FailureProviderUnavailable = "PROVIDER_UNAVAILABLE"
+	FailureProcessingTimeout   = "PROCESSING_TIMEOUT"
+	FailureOverloaded          = "OVERLOADED"
+
+	maxAudioBytes      = 9_600_000
+	maxReferenceBytes  = 16 * 1024
+	maxTopicTitleBytes = 1024
+)
+
+var requestIDPattern = regexp.MustCompile(
+	`^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$`,
+)
+
+type StatusResponse struct {
+	SchemaVersion string   `json:"schema_version"`
+	RequestID     string   `json:"request_id"`
+	Status        string   `json:"status"`
+	Result        *Result  `json:"result,omitempty"`
+	Failure       *Failure `json:"failure,omitempty"`
+}
+
+type Result struct {
+	Provider  string  `json:"provider"`
+	SessionID string  `json:"session_id"`
+	Summary   Summary `json:"summary"`
+}
+
+type Summary struct {
+	AccuracyScore  *float64 `json:"accuracy_score,omitempty"`
+	FluencyScore   *float64 `json:"fluency_score,omitempty"`
+	IntegrityScore *float64 `json:"integrity_score,omitempty"`
+	PhoneScore     *float64 `json:"phone_score,omitempty"`
+	SpeakingSpeed  *float64 `json:"speaking_speed,omitempty"`
+	Rejected       *bool    `json:"rejected,omitempty"`
+	ExceptionInfo  string   `json:"exception_info,omitempty"`
+}
+
+type Failure struct {
+	Code      string `json:"code"`
+	Retryable bool   `json:"retryable"`
+}
+
+func processingResponse(requestID string) StatusResponse {
+	return StatusResponse{
+		SchemaVersion: SchemaVersion,
+		RequestID:     requestID,
+		Status:        StatusProcessing,
+	}
+}
+
+func resultResponse(
+	requestID string,
+	assessment speechfeedback.AcousticAssessmentResult,
+) StatusResponse {
+	return StatusResponse{
+		SchemaVersion: SchemaVersion,
+		RequestID:     requestID,
+		Status:        StatusSucceeded,
+		Result: &Result{
+			Provider:  assessment.Provider,
+			SessionID: assessment.SessionID,
+			Summary: Summary{
+				AccuracyScore:  assessment.Summary.AccuracyScore,
+				FluencyScore:   assessment.Summary.FluencyScore,
+				IntegrityScore: assessment.Summary.IntegrityScore,
+				PhoneScore:     assessment.Summary.PhoneScore,
+				SpeakingSpeed:  assessment.Summary.SpeakingSpeed,
+				Rejected:       assessment.Summary.Rejected,
+				ExceptionInfo:  assessment.Summary.ExceptionInfo,
+			},
+		},
+	}
+}
+
+func failureResponse(requestID string, code string, retryable bool) StatusResponse {
+	return StatusResponse{
+		SchemaVersion: SchemaVersion,
+		RequestID:     requestID,
+		Status:        StatusFailed,
+		Failure:       &Failure{Code: code, Retryable: retryable},
+	}
+}
+
+func (response StatusResponse) valid() bool {
+	if response.SchemaVersion != SchemaVersion ||
+		!validRequestID(response.RequestID) {
+		return false
+	}
+	switch response.Status {
+	case StatusProcessing:
+		return response.Result == nil && response.Failure == nil
+	case StatusSucceeded:
+		return response.Result != nil && response.Result.valid() &&
+			response.Failure == nil
+	case StatusFailed:
+		return response.Result == nil && response.Failure != nil &&
+			response.Failure.valid()
+	default:
+		return false
+	}
+}
+
+func (result Result) valid() bool {
+	return validIdentifier(result.Provider) &&
+		validIdentifier(result.SessionID) &&
+		validSummary(result.Summary)
+}
+
+func validSummary(summary Summary) bool {
+	if len(summary.ExceptionInfo) > 1024 ||
+		strings.ContainsRune(summary.ExceptionInfo, '\x00') {
+		return false
+	}
+	for _, value := range []*float64{
+		summary.AccuracyScore,
+		summary.FluencyScore,
+		summary.IntegrityScore,
+		summary.PhoneScore,
+	} {
+		if value != nil && (!finite(*value) || *value < 0 || *value > 100) {
+			return false
+		}
+	}
+	return summary.SpeakingSpeed == nil ||
+		(finite(*summary.SpeakingSpeed) && *summary.SpeakingSpeed >= 0)
+}
+
+func finite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}
+
+func (failure Failure) valid() bool {
+	switch failure.Code {
+	case FailureInvalidRequest, FailureProviderUnavailable,
+		FailureProcessingTimeout, FailureOverloaded:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRequestID(value string) bool {
+	return requestIDPattern.MatchString(value)
+}
+
+func validIdentifier(value string) bool {
+	if value == "" || len(value) > 256 || value != strings.TrimSpace(value) {
+		return false
+	}
+	for _, character := range value {
+		if character < 0x21 || character == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func validRequest(request speechfeedback.AcousticAssessmentRequest) bool {
+	if !validRequestID(request.RequestID) || len(request.Audio) == 0 ||
+		len(request.Audio) > maxAudioBytes || len(request.Audio)%2 != 0 ||
+		strings.TrimSpace(request.ReferenceText) == "" ||
+		request.ReferenceText != strings.TrimSpace(request.ReferenceText) ||
+		len(request.ReferenceText) > maxReferenceBytes ||
+		len(request.TopicTitle) > maxTopicTitleBytes {
+		return false
+	}
+	switch request.Category {
+	case speechfeedback.AcousticCategoryReadWord,
+		speechfeedback.AcousticCategoryReadSentence:
+		return request.TopicTitle == ""
+	case speechfeedback.AcousticCategoryTopic:
+		return strings.TrimSpace(request.TopicTitle) != "" &&
+			request.TopicTitle == strings.TrimSpace(request.TopicTitle)
+	default:
+		return false
+	}
+}
+
+func requestDigest(request speechfeedback.AcousticAssessmentRequest) ([sha256.Size]byte, error) {
+	if !validRequest(request) {
+		return [sha256.Size]byte{}, errors.New("ISE relay request is invalid")
+	}
+	hash := sha256.New()
+	for _, value := range [][]byte{
+		request.Audio,
+		[]byte(request.ReferenceText),
+		[]byte(request.TopicTitle),
+		[]byte(request.Category),
+	} {
+		var length [8]byte
+		binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+		_, _ = hash.Write(length[:])
+		_, _ = hash.Write(value)
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], hash.Sum(nil))
+	return digest, nil
+}

--- a/server/internal/providers/iserelay/contract_test.go
+++ b/server/internal/providers/iserelay/contract_test.go
@@ -1,0 +1,31 @@
+package iserelay
+
+import (
+	"math"
+	"testing"
+)
+
+func TestValidSummaryRejectsNonFiniteValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		summary Summary
+	}{
+		{name: "NaN score", summary: Summary{AccuracyScore: pointer(math.NaN())}},
+		{name: "positive infinite score", summary: Summary{FluencyScore: pointer(math.Inf(1))}},
+		{name: "negative infinite speed", summary: Summary{SpeakingSpeed: pointer(math.Inf(-1))}},
+		{name: "positive infinite speed", summary: Summary{SpeakingSpeed: pointer(math.Inf(1))}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if validSummary(test.summary) {
+				t.Fatal("expected non-finite summary value to be rejected")
+			}
+		})
+	}
+}
+
+func pointer(value float64) *float64 {
+	return &value
+}

--- a/server/internal/providers/iserelay/handler.go
+++ b/server/internal/providers/iserelay/handler.go
@@ -1,0 +1,335 @@
+package iserelay
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+)
+
+const maxMultipartOverhead = 64 * 1024
+
+type HandlerConfig struct {
+	ProviderTimeout time.Duration
+	Retention       time.Duration
+	MaxJobs         int
+	MaxInFlight     int
+	Logger          *slog.Logger
+}
+
+type acousticEvaluator interface {
+	Evaluate(
+		context.Context,
+		speechfeedback.AcousticAssessmentRequest,
+	) (speechfeedback.AcousticAssessmentResult, error)
+}
+
+type Handler struct {
+	evaluator  acousticEvaluator
+	config     HandlerConfig
+	submission chan struct{}
+	sem        chan struct{}
+	mu         sync.Mutex
+	jobs       map[string]*relayJob
+}
+
+type relayJob struct {
+	digest      [sha256.Size]byte
+	response    StatusResponse
+	completedAt time.Time
+}
+
+func NewHandler(
+	evaluator acousticEvaluator,
+	configuration HandlerConfig,
+) (*Handler, error) {
+	if evaluator == nil || configuration.ProviderTimeout <= 0 ||
+		configuration.ProviderTimeout > 5*time.Minute ||
+		configuration.Retention < time.Minute ||
+		configuration.Retention > time.Hour ||
+		configuration.MaxJobs < 1 || configuration.MaxJobs > 64 ||
+		configuration.MaxInFlight < 1 ||
+		configuration.MaxInFlight > configuration.MaxJobs ||
+		configuration.Logger == nil {
+		return nil, errors.New("ISE relay handler configuration is invalid")
+	}
+	return &Handler{
+		evaluator:  evaluator,
+		config:     configuration,
+		submission: make(chan struct{}, configuration.MaxJobs),
+		sem:        make(chan struct{}, configuration.MaxInFlight),
+		jobs:       make(map[string]*relayJob),
+	}, nil
+}
+
+func (handler *Handler) Routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", handler.health)
+	mux.HandleFunc("POST /v1/evaluations", handler.create)
+	mux.HandleFunc("GET /v1/evaluations/{request_id}", handler.get)
+	return mux
+}
+
+func (handler *Handler) health(writer http.ResponseWriter, _ *http.Request) {
+	writeJSON(writer, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (handler *Handler) create(writer http.ResponseWriter, request *http.Request) {
+	select {
+	case handler.submission <- struct{}{}:
+		defer func() { <-handler.submission }()
+	default:
+		writeJSON(writer, http.StatusServiceUnavailable, map[string]string{"error": FailureOverloaded})
+		return
+	}
+	assessment, err := decodeMultipartRequest(writer, request)
+	if err != nil {
+		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "INVALID_REQUEST"})
+		return
+	}
+	digest, err := requestDigest(assessment)
+	if err != nil {
+		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "INVALID_REQUEST"})
+		return
+	}
+
+	handler.mu.Lock()
+	handler.pruneCompleted(time.Now().UTC())
+	if existing, exists := handler.jobs[assessment.RequestID]; exists {
+		if existing.digest != digest {
+			handler.mu.Unlock()
+			writeJSON(writer, http.StatusConflict, map[string]string{"error": "IDEMPOTENCY_CONFLICT"})
+			return
+		}
+		response := existing.response
+		handler.mu.Unlock()
+		writeStatus(writer, response)
+		return
+	}
+	if handler.processingJobCount() >= handler.config.MaxJobs {
+		handler.mu.Unlock()
+		writeJSON(writer, http.StatusServiceUnavailable, map[string]string{"error": FailureOverloaded})
+		return
+	}
+	handler.evictOldestCompleted(handler.config.MaxJobs * 8)
+	job := &relayJob{
+		digest:   digest,
+		response: processingResponse(assessment.RequestID),
+	}
+	response := job.response
+	handler.jobs[assessment.RequestID] = job
+	handler.mu.Unlock()
+
+	go handler.evaluate(assessment)
+	writeJSON(writer, http.StatusAccepted, response)
+}
+
+func (handler *Handler) evictOldestCompleted(limit int) {
+	for len(handler.jobs) >= limit {
+		var oldestID string
+		var oldestTime time.Time
+		for requestID, job := range handler.jobs {
+			if job.completedAt.IsZero() ||
+				(!oldestTime.IsZero() && !job.completedAt.Before(oldestTime)) {
+				continue
+			}
+			oldestID = requestID
+			oldestTime = job.completedAt
+		}
+		if oldestID == "" {
+			return
+		}
+		delete(handler.jobs, oldestID)
+	}
+}
+
+func (handler *Handler) get(writer http.ResponseWriter, request *http.Request) {
+	requestID := request.PathValue("request_id")
+	if !validRequestID(requestID) {
+		writeJSON(writer, http.StatusBadRequest, map[string]string{"error": "INVALID_REQUEST"})
+		return
+	}
+	handler.mu.Lock()
+	handler.pruneCompleted(time.Now().UTC())
+	job, exists := handler.jobs[requestID]
+	if !exists {
+		handler.mu.Unlock()
+		writeJSON(writer, http.StatusNotFound, map[string]string{"error": "NOT_FOUND"})
+		return
+	}
+	response := job.response
+	handler.mu.Unlock()
+	writeStatus(writer, response)
+}
+
+func (handler *Handler) evaluate(request speechfeedback.AcousticAssessmentRequest) {
+	startedAt := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), handler.config.ProviderTimeout)
+	select {
+	case handler.sem <- struct{}{}:
+		defer func() { <-handler.sem }()
+		if ctx.Err() != nil {
+			cancel()
+			handler.complete(
+				request.RequestID,
+				failureResponse(request.RequestID, FailureProcessingTimeout, true),
+				startedAt,
+			)
+			return
+		}
+	case <-ctx.Done():
+		cancel()
+		handler.complete(
+			request.RequestID,
+			failureResponse(request.RequestID, FailureProcessingTimeout, true),
+			startedAt,
+		)
+		return
+	}
+	result, err := handler.evaluator.Evaluate(ctx, request)
+	timedOut := errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(ctx.Err(), context.DeadlineExceeded)
+	cancel()
+
+	response := resultResponse(request.RequestID, result)
+	if err != nil {
+		code := FailureProviderUnavailable
+		if timedOut {
+			code = FailureProcessingTimeout
+		}
+		response = failureResponse(request.RequestID, code, true)
+	} else if !response.valid() {
+		response = failureResponse(request.RequestID, FailureProviderUnavailable, true)
+	}
+	handler.complete(request.RequestID, response, startedAt)
+}
+
+func (handler *Handler) complete(
+	requestID string,
+	response StatusResponse,
+	startedAt time.Time,
+) {
+	handler.mu.Lock()
+	if job, exists := handler.jobs[requestID]; exists {
+		job.response = response
+		job.completedAt = time.Now().UTC()
+	}
+	handler.mu.Unlock()
+	handler.config.Logger.Info(
+		"ISE relay evaluation completed",
+		slog.String("request_id", requestID),
+		slog.String("status", response.Status),
+		slog.Duration("duration", time.Since(startedAt)),
+	)
+}
+
+func (handler *Handler) processingJobCount() int {
+	count := 0
+	for _, job := range handler.jobs {
+		if job.response.Status == StatusProcessing {
+			count++
+		}
+	}
+	return count
+}
+
+func (handler *Handler) pruneCompleted(now time.Time) {
+	for requestID, job := range handler.jobs {
+		if !job.completedAt.IsZero() &&
+			!now.Before(job.completedAt.Add(handler.config.Retention)) {
+			delete(handler.jobs, requestID)
+		}
+	}
+}
+
+func decodeMultipartRequest(
+	writer http.ResponseWriter,
+	request *http.Request,
+) (speechfeedback.AcousticAssessmentRequest, error) {
+	request.Body = http.MaxBytesReader(
+		writer,
+		request.Body,
+		maxAudioBytes+maxReferenceBytes+maxTopicTitleBytes+maxMultipartOverhead,
+	)
+	reader, err := request.MultipartReader()
+	if err != nil {
+		return speechfeedback.AcousticAssessmentRequest{}, err
+	}
+	values := make(map[string][]byte, 5)
+	for {
+		part, partErr := reader.NextPart()
+		if errors.Is(partErr, io.EOF) {
+			break
+		}
+		if partErr != nil {
+			return speechfeedback.AcousticAssessmentRequest{}, partErr
+		}
+		name := part.FormName()
+		limit, accepted := multipartPartLimit(name)
+		if !accepted || part.FileName() != "" && name != "audio" {
+			part.Close()
+			return speechfeedback.AcousticAssessmentRequest{}, errors.New("invalid multipart field")
+		}
+		if _, duplicate := values[name]; duplicate {
+			part.Close()
+			return speechfeedback.AcousticAssessmentRequest{}, errors.New("duplicate multipart field")
+		}
+		value, readErr := io.ReadAll(io.LimitReader(part, limit+1))
+		part.Close()
+		if readErr != nil || int64(len(value)) > limit {
+			return speechfeedback.AcousticAssessmentRequest{}, errors.New("multipart field is too large")
+		}
+		values[name] = value
+	}
+	assessment := speechfeedback.AcousticAssessmentRequest{
+		RequestID:     string(values["request_id"]),
+		Audio:         values["audio"],
+		ReferenceText: string(values["reference_text"]),
+		TopicTitle:    string(values["topic_title"]),
+		Category: speechfeedback.AcousticAssessmentCategory(
+			string(values["category"]),
+		),
+	}
+	if !validRequest(assessment) {
+		return speechfeedback.AcousticAssessmentRequest{}, errors.New("invalid assessment")
+	}
+	return assessment, nil
+}
+
+func multipartPartLimit(name string) (int64, bool) {
+	switch name {
+	case "request_id":
+		return 36, true
+	case "audio":
+		return maxAudioBytes, true
+	case "reference_text":
+		return maxReferenceBytes, true
+	case "topic_title":
+		return maxTopicTitleBytes, true
+	case "category":
+		return 32, true
+	default:
+		return 0, false
+	}
+}
+
+func writeStatus(writer http.ResponseWriter, response StatusResponse) {
+	status := http.StatusOK
+	if response.Status == StatusProcessing {
+		status = http.StatusAccepted
+	}
+	writeJSON(writer, status, response)
+}
+
+func writeJSON(writer http.ResponseWriter, status int, value any) {
+	writer.Header().Set("content-type", "application/json")
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(value)
+}

--- a/server/internal/providers/iserelay/handler_test.go
+++ b/server/internal/providers/iserelay/handler_test.go
@@ -1,0 +1,339 @@
+package iserelay
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
+)
+
+const testRequestID = "f7023b34-0000-4000-8000-000000000001"
+
+type evaluatorStub struct {
+	mu            sync.Mutex
+	calls         int
+	result        speechfeedback.AcousticAssessmentResult
+	err           error
+	wait          <-chan struct{}
+	ignoreContext bool
+}
+
+func (stub *evaluatorStub) Evaluate(
+	ctx context.Context,
+	_ speechfeedback.AcousticAssessmentRequest,
+) (speechfeedback.AcousticAssessmentResult, error) {
+	stub.mu.Lock()
+	stub.calls++
+	stub.mu.Unlock()
+	if stub.wait != nil {
+		if stub.ignoreContext {
+			<-stub.wait
+			return stub.result, stub.err
+		}
+		select {
+		case <-ctx.Done():
+			return speechfeedback.AcousticAssessmentResult{}, ctx.Err()
+		case <-stub.wait:
+		}
+	}
+	return stub.result, stub.err
+}
+
+func (stub *evaluatorStub) callCount() int {
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	return stub.calls
+}
+
+func TestHandlerCreatesPollsAndDeduplicatesEvaluation(t *testing.T) {
+	accuracy := 91.5
+	stub := &evaluatorStub{result: speechfeedback.AcousticAssessmentResult{
+		Provider:  "xfyun_ise",
+		SessionID: "session-1",
+		Summary: speechfeedback.AcousticAssessmentSummary{
+			AccuracyScore: &accuracy,
+		},
+	}}
+	handler := newTestHandler(t, stub, time.Second, 8, 2)
+	server := httptest.NewServer(handler.Routes())
+	defer server.Close()
+
+	first := postAssessment(t, server.URL, validAssessment())
+	if first.StatusCode != http.StatusAccepted {
+		t.Fatalf("create status = %d, want 202", first.StatusCode)
+	}
+	first.Body.Close()
+
+	var completed StatusResponse
+	for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); {
+		response, err := http.Get(server.URL + "/v1/evaluations/" + testRequestID)
+		if err != nil {
+			t.Fatalf("poll evaluation: %v", err)
+		}
+		if err := json.NewDecoder(response.Body).Decode(&completed); err != nil {
+			response.Body.Close()
+			t.Fatalf("decode poll response: %v", err)
+		}
+		response.Body.Close()
+		if completed.Status == StatusSucceeded {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if completed.Status != StatusSucceeded || completed.Result == nil ||
+		completed.Result.Summary.AccuracyScore == nil ||
+		*completed.Result.Summary.AccuracyScore != accuracy {
+		t.Fatalf("unexpected completed response: %#v", completed)
+	}
+
+	duplicate := postAssessment(t, server.URL, validAssessment())
+	defer duplicate.Body.Close()
+	if duplicate.StatusCode != http.StatusOK || stub.callCount() != 1 {
+		t.Fatalf("duplicate status/calls = %d/%d, want 200/1", duplicate.StatusCode, stub.callCount())
+	}
+}
+
+func TestHandlerRejectsIdempotencyConflictAndCapacityOverflow(t *testing.T) {
+	wait := make(chan struct{})
+	stub := &evaluatorStub{wait: wait, ignoreContext: true}
+	handler := newTestHandler(t, stub, time.Second, 1, 1)
+	server := httptest.NewServer(handler.Routes())
+	defer server.Close()
+
+	created := postAssessment(t, server.URL, validAssessment())
+	created.Body.Close()
+	conflictAssessment := validAssessment()
+	conflictAssessment.ReferenceText = "Different reference"
+	conflict := postAssessment(t, server.URL, conflictAssessment)
+	conflict.Body.Close()
+	if conflict.StatusCode != http.StatusConflict {
+		t.Fatalf("conflict status = %d, want 409", conflict.StatusCode)
+	}
+
+	overflowAssessment := validAssessment()
+	overflowAssessment.RequestID = "f7023b34-0000-4000-8000-000000000002"
+	overflow := postAssessment(t, server.URL, overflowAssessment)
+	defer overflow.Body.Close()
+	if overflow.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("overflow status = %d, want 503", overflow.StatusCode)
+	}
+	close(wait)
+}
+
+func TestHandlerRejectsInvalidCategoryAndOversizedAudio(t *testing.T) {
+	stub := &evaluatorStub{}
+	handler := newTestHandler(t, stub, time.Second, 2, 1)
+	server := httptest.NewServer(handler.Routes())
+	defer server.Close()
+
+	invalidCategory := validAssessment()
+	invalidCategory.Category = "unsupported"
+	response := postAssessment(t, server.URL, invalidCategory)
+	response.Body.Close()
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid category status = %d, want 400", response.StatusCode)
+	}
+
+	oversized := validAssessment()
+	oversized.Audio = make([]byte, maxAudioBytes+2)
+	response = postAssessment(t, server.URL, oversized)
+	response.Body.Close()
+	if response.StatusCode != http.StatusBadRequest || stub.callCount() != 0 {
+		t.Fatalf("oversized status/calls = %d/%d, want 400/0", response.StatusCode, stub.callCount())
+	}
+}
+
+func TestHandlerTreatsNewAttemptIDAsNewProviderCall(t *testing.T) {
+	stub := &evaluatorStub{result: testResult()}
+	handler := newTestHandler(t, stub, time.Second, 2, 1)
+	server := httptest.NewServer(handler.Routes())
+	defer server.Close()
+
+	for index, requestID := range []string{
+		testRequestID,
+		"f7023b34-0000-4000-8000-000000000002",
+	} {
+		assessment := validAssessment()
+		assessment.RequestID = requestID
+		response := postAssessment(t, server.URL, assessment)
+		response.Body.Close()
+		for deadline := time.Now().Add(time.Second); stub.callCount() != index+1; {
+			if time.Now().After(deadline) {
+				t.Fatalf("provider calls = %d, want %d", stub.callCount(), index+1)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func TestHandlerMapsProviderDeadlineToStableFailure(t *testing.T) {
+	wait := make(chan struct{})
+	stub := &evaluatorStub{wait: wait}
+	handler := newTestHandler(t, stub, 10*time.Millisecond, 2, 1)
+	server := httptest.NewServer(handler.Routes())
+	defer server.Close()
+	response := postAssessment(t, server.URL, validAssessment())
+	response.Body.Close()
+
+	var completed StatusResponse
+	for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); {
+		polled, err := http.Get(server.URL + "/v1/evaluations/" + testRequestID)
+		if err != nil {
+			t.Fatalf("poll evaluation: %v", err)
+		}
+		_ = json.NewDecoder(polled.Body).Decode(&completed)
+		polled.Body.Close()
+		if completed.Status == StatusFailed {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if completed.Failure == nil || completed.Failure.Code != FailureProcessingTimeout {
+		t.Fatalf("unexpected timeout response: %#v", completed)
+	}
+}
+
+func TestHandlerMapsInvalidProviderResultToFailure(t *testing.T) {
+	stub := &evaluatorStub{result: speechfeedback.AcousticAssessmentResult{
+		Provider:  "xfyun_ise",
+		SessionID: "",
+	}}
+	handler := newTestHandler(t, stub, time.Second, 2, 1)
+	server := httptest.NewServer(handler.Routes())
+	defer server.Close()
+	response := postAssessment(t, server.URL, validAssessment())
+	response.Body.Close()
+
+	var completed StatusResponse
+	for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); {
+		polled, err := http.Get(server.URL + "/v1/evaluations/" + testRequestID)
+		if err != nil {
+			t.Fatalf("poll evaluation: %v", err)
+		}
+		_ = json.NewDecoder(polled.Body).Decode(&completed)
+		polled.Body.Close()
+		if completed.Status == StatusFailed {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if completed.Failure == nil || completed.Failure.Code != FailureProviderUnavailable {
+		t.Fatalf("unexpected invalid-result response: %#v", completed)
+	}
+}
+
+func TestHandlerBoundsQueueWaitAndDoesNotInvokeProviderAfterDeadline(t *testing.T) {
+	wait := make(chan struct{})
+	stub := &evaluatorStub{wait: wait, ignoreContext: true}
+	handler := newTestHandler(t, stub, 10*time.Millisecond, 2, 1)
+	server := httptest.NewServer(handler.Routes())
+	defer server.Close()
+
+	first := postAssessment(t, server.URL, validAssessment())
+	first.Body.Close()
+	for deadline := time.Now().Add(time.Second); stub.callCount() != 1; {
+		if time.Now().After(deadline) {
+			t.Fatal("first evaluation did not acquire the provider slot")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	secondAssessment := validAssessment()
+	secondAssessment.RequestID = "f7023b34-0000-4000-8000-000000000002"
+	second := postAssessment(t, server.URL, secondAssessment)
+	second.Body.Close()
+	time.Sleep(30 * time.Millisecond)
+
+	response, err := http.Get(server.URL + "/v1/evaluations/" + secondAssessment.RequestID)
+	if err != nil {
+		t.Fatalf("poll queued evaluation: %v", err)
+	}
+	defer response.Body.Close()
+	var completed StatusResponse
+	if err := json.NewDecoder(response.Body).Decode(&completed); err != nil {
+		t.Fatalf("decode queued evaluation: %v", err)
+	}
+	if completed.Failure == nil || completed.Failure.Code != FailureProcessingTimeout ||
+		stub.callCount() != 1 {
+		t.Fatalf("unexpected queued timeout: %#v, calls=%d", completed, stub.callCount())
+	}
+	close(wait)
+}
+
+func newTestHandler(
+	t *testing.T,
+	evaluator acousticEvaluator,
+	timeout time.Duration,
+	maxJobs int,
+	maxInFlight int,
+) *Handler {
+	t.Helper()
+	handler, err := NewHandler(evaluator, HandlerConfig{
+		ProviderTimeout: timeout,
+		Retention:       time.Minute,
+		MaxJobs:         maxJobs,
+		MaxInFlight:     maxInFlight,
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+	return handler
+}
+
+func validAssessment() speechfeedback.AcousticAssessmentRequest {
+	return speechfeedback.AcousticAssessmentRequest{
+		RequestID:     testRequestID,
+		Audio:         []byte{0, 1, 2, 3},
+		ReferenceText: "Hello world",
+		Category:      speechfeedback.AcousticCategoryReadSentence,
+	}
+}
+
+func postAssessment(
+	t *testing.T,
+	baseURL string,
+	assessment speechfeedback.AcousticAssessmentRequest,
+) *http.Response {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for name, value := range map[string]string{
+		"request_id":     assessment.RequestID,
+		"reference_text": assessment.ReferenceText,
+		"topic_title":    assessment.TopicTitle,
+		"category":       string(assessment.Category),
+	} {
+		if err := writer.WriteField(name, value); err != nil {
+			t.Fatalf("write field: %v", err)
+		}
+	}
+	audio, err := writer.CreateFormFile("audio", "audio.pcm")
+	if err != nil {
+		t.Fatalf("create audio field: %v", err)
+	}
+	if _, err := audio.Write(assessment.Audio); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	request, err := http.NewRequest(http.MethodPost, baseURL+"/v1/evaluations", &body)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	request.Header.Set("content-type", writer.FormDataContentType())
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("post evaluation: %v", err)
+	}
+	return response
+}


### PR DESCRIPTION
## 功能描述

为 Staging 增加独立的讯飞口语评测 Relay，使新加坡 Staging 后端可通过上海 Relay 调用讯飞 ISE，避免当前跨境直连的高延迟和超时。Android App 接口保持不变，Production 配置不在本 PR 范围内。

## 实现思路

- 新增异步 Relay 协议：提交评测返回 `202`，后端按 `request_id` 轮询结果。
- Relay 使用 mTLS，只接收受信 Staging 客户端；讯飞凭据仅保存在 Relay 主机。
- 相同 `request_id` 与相同请求幂等；冲突请求拒绝；队列、处理时间、请求体和响应体均有硬限制。
- Staging 后端在 Relay 模式与讯飞直连模式之间强制互斥，Relay 失败时 fail closed，不静默回退直连。
- 增加 Relay 独立镜像、Compose、非 root/只读容器配置以及 Staging 客户端证书挂载。
- 每次 Worker claim 使用新的 lease token 作为 Relay 请求 ID，既保证单次重试幂等，也允许后续 claim 重新尝试。
- 对 Relay 合同和 provider 结果做严格校验，包括拒绝 `NaN`、`Inf`、超长响应和尾随 JSON。

## 测试方式

1. `GOCACHE=/tmp/xe3-go-cache make check-go`
2. `make check-staging-deploy`
3. `docker build --platform linux/amd64 -f server/Dockerfile.ise-relay -t speakup-ise-relay:test server`
4. 预期：Go vet 与全量 Go 测试通过；Staging 26 项 UAT 和 Docker 部署契约通过；镜像构建为 `linux/amd64`。
5. 已额外执行关键 Relay 包 `go test -race`，并完成真实临时证书的 mTLS 握手测试：无证书和非受信证书被拒绝，受信客户端通过。

## 相关 Issue / 备注

Closes #965

- 本 PR 只交付 Staging Relay 能力，不切换 Production。
- Staging 实际切换及短音频、长音频、4 并发验收会单独留下部署回执；通过后再请产品验收。
- Production 是否切换必须另行确认。

## AI 辅助说明

使用 AI 辅助审查 Relay 协议、并发边界、失败语义和部署安全性；已人工逐项核对差异、测试结果、Staging/Production 边界，并修复复审发现的有限数校验问题。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
