### PR TITLE
feat(mobile): 将教练记忆迁入个人页更多菜单

### DIFF
--- a/mobile/lib/features/coaching/profile/coaching_profile.dart
+++ b/mobile/lib/features/coaching/profile/coaching_profile.dart
@@ -1,10 +1,8 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
 
@@ -250,84 +248,6 @@ final class CoachingProfileController extends ChangeNotifier {
   }
 }
 
-class CoachingProfileCard extends StatefulWidget {
-  const CoachingProfileCard({required this.controller, super.key});
-
-  final CoachingProfileController controller;
-
-  @override
-  State<CoachingProfileCard> createState() => _CoachingProfileCardState();
-}
-
-class _CoachingProfileCardState extends State<CoachingProfileCard> {
-  @override
-  void initState() {
-    super.initState();
-    unawaited(widget.controller.load());
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: widget.controller,
-      builder: (context, _) {
-        final profile = widget.controller.profile;
-        return InkWell(
-          key: const Key('coaching-profile-card'),
-          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
-          onTap: profile == null
-              ? widget.controller.load
-              : () => Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) =>
-                        CoachingProfilePage(controller: widget.controller),
-                  ),
-                ),
-          child: Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              border: Border.all(color: const Color(0xFFE5E5E5)),
-              borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
-            ),
-            child: Row(
-              children: [
-                const Icon(Icons.psychology_alt_outlined, size: 28),
-                const SizedBox(width: 14),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Text('教练记忆', style: SpeakUpDesign.sectionTitle),
-                      const SizedBox(height: 4),
-                      Text(
-                        widget.controller.loading
-                            ? '正在读取…'
-                            : profile == null
-                            ? widget.controller.errorMessage ?? '点按重试'
-                            : !profile.memoryEnabled
-                            ? '已关闭，不会注入 Agent 对话'
-                            : profile.data.isEmpty
-                            ? '尚未保存称呼、职业或偏好'
-                            : _profileSummary(profile.data),
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: SpeakUpDesign.body.copyWith(
-                          color: SpeakUpDesign.secondary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const Icon(Icons.chevron_right_rounded),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
 class CoachingProfilePage extends StatefulWidget {
   const CoachingProfilePage({required this.controller, super.key});
 
@@ -564,13 +484,4 @@ CoachingProfile _decodeProfile(String body) {
           : const <String>[],
     ),
   );
-}
-
-String _profileSummary(CoachingProfileData data) {
-  final values = <String>[
-    if (data.formOfAddress.isNotEmpty) data.formOfAddress,
-    if (data.occupation.isNotEmpty) data.occupation,
-    ...data.interests.take(2),
-  ];
-  return values.isEmpty ? '已保存个性化偏好' : values.join(' · ');
 }

--- a/mobile/lib/features/profile/profile_page.dart
+++ b/mobile/lib/features/profile/profile_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -135,22 +136,13 @@ class ProfilePage extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (user != null)
+                if (user != null &&
+                    (onLogout != null || coachingProfileController != null))
                   Align(
                     alignment: Alignment.topRight,
-                    child: PopupMenuButton<String>(
-                      key: const Key('profile-account-menu'),
-                      tooltip: '账号菜单',
-                      enabled: onLogout != null,
-                      icon: const Icon(Icons.more_horiz_rounded),
-                      onSelected: (_) => onLogout?.call(),
-                      itemBuilder: (_) => const [
-                        PopupMenuItem<String>(
-                          key: Key('profile-logout-button'),
-                          value: 'logout',
-                          child: Text('退出登录'),
-                        ),
-                      ],
+                    child: _ProfileMoreMenu(
+                      coachingProfileController: coachingProfileController,
+                      onLogout: onLogout,
                     ),
                   ),
               ],
@@ -164,10 +156,6 @@ class ProfilePage extends StatelessWidget {
               ),
             ],
             const SizedBox(height: SpeakUpDesign.space32),
-            if (coachingProfileController != null) ...[
-              CoachingProfileCard(controller: coachingProfileController!),
-              const SizedBox(height: SpeakUpDesign.space24),
-            ],
             CurrentIeltsAbilityProfile(
               historyController: reviewHistoryController,
             ),
@@ -268,6 +256,246 @@ class ProfilePage extends StatelessWidget {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+class _ProfileMoreMenu extends StatefulWidget {
+  const _ProfileMoreMenu({
+    required this.coachingProfileController,
+    required this.onLogout,
+  });
+
+  final CoachingProfileController? coachingProfileController;
+  final VoidCallback? onLogout;
+
+  @override
+  State<_ProfileMoreMenu> createState() => _ProfileMoreMenuState();
+}
+
+class _ProfileMoreMenuState extends State<_ProfileMoreMenu> {
+  Future<void>? _coachingProfileLoad;
+
+  @override
+  void initState() {
+    super.initState();
+    _coachingProfileLoad = widget.coachingProfileController?.load();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ProfileMoreMenu oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(
+      oldWidget.coachingProfileController,
+      widget.coachingProfileController,
+    )) {
+      _coachingProfileLoad = widget.coachingProfileController?.load();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasCoachingProfile = widget.coachingProfileController != null;
+    final hasLogout = widget.onLogout != null;
+    return MenuAnchor(
+      key: const Key('profile-more-menu-anchor'),
+      animated: true,
+      reservedPadding: const EdgeInsets.all(SpeakUpDesign.space16),
+      alignmentOffset: const Offset(-184, SpeakUpDesign.space4),
+      style: MenuStyle(
+        alignment: AlignmentDirectional.bottomEnd,
+        backgroundColor: const WidgetStatePropertyAll(SpeakUpDesign.surface),
+        surfaceTintColor: const WidgetStatePropertyAll(Colors.transparent),
+        shadowColor: const WidgetStatePropertyAll(Color(0x26000000)),
+        elevation: const WidgetStatePropertyAll(6),
+        padding: const WidgetStatePropertyAll(
+          EdgeInsets.fromLTRB(
+            SpeakUpDesign.space8,
+            SpeakUpDesign.space16,
+            SpeakUpDesign.space8,
+            SpeakUpDesign.space8,
+          ),
+        ),
+        minimumSize: const WidgetStatePropertyAll(Size(184, 0)),
+        maximumSize: const WidgetStatePropertyAll(Size(184, double.infinity)),
+        side: const WidgetStatePropertyAll(
+          BorderSide(color: SpeakUpDesign.border),
+        ),
+        shape: const WidgetStatePropertyAll(_ProfileMenuCalloutBorder()),
+      ),
+      menuChildren: [
+        if (hasCoachingProfile)
+          MenuItemButton(
+            key: const Key('profile-coaching-memory-button'),
+            leadingIcon: const Icon(Icons.psychology_alt_outlined, size: 20),
+            style: _menuItemStyle(),
+            onPressed: () => unawaited(_openCoachingProfile()),
+            child: const Text('教练记忆'),
+          ),
+        if (hasCoachingProfile && hasLogout)
+          const Divider(
+            height: 1,
+            indent: SpeakUpDesign.space12,
+            endIndent: SpeakUpDesign.space12,
+          ),
+        if (hasLogout)
+          MenuItemButton(
+            key: const Key('profile-logout-button'),
+            leadingIcon: const Icon(Icons.logout_rounded, size: 20),
+            style: _menuItemStyle(destructive: true),
+            onPressed: widget.onLogout,
+            child: const Text('退出登录'),
+          ),
+      ],
+      builder: (context, controller, _) => IconButton(
+        key: const Key('profile-account-menu'),
+        tooltip: '更多',
+        constraints: const BoxConstraints.tightFor(
+          width: SpeakUpDesign.minTapTarget,
+          height: SpeakUpDesign.minTapTarget,
+        ),
+        style: ButtonStyle(
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          shape: WidgetStatePropertyAll(
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+            ),
+          ),
+          overlayColor: const WidgetStatePropertyAll(
+            SpeakUpDesign.primaryMuted,
+          ),
+        ),
+        onPressed: hasCoachingProfile || hasLogout
+            ? () => controller.isOpen ? controller.close() : controller.open()
+            : null,
+        icon: const Icon(Icons.more_horiz_rounded),
+      ),
+    );
+  }
+
+  ButtonStyle _menuItemStyle({bool destructive = false}) {
+    final foreground = destructive ? SpeakUpDesign.error : SpeakUpDesign.ink;
+    return ButtonStyle(
+      minimumSize: const WidgetStatePropertyAll(Size(168, 48)),
+      padding: const WidgetStatePropertyAll(
+        EdgeInsets.symmetric(horizontal: SpeakUpDesign.space12),
+      ),
+      alignment: Alignment.centerLeft,
+      foregroundColor: WidgetStatePropertyAll(foreground),
+      iconColor: WidgetStatePropertyAll(foreground),
+      textStyle: WidgetStatePropertyAll(
+        SpeakUpDesign.body.copyWith(fontWeight: FontWeight.w600),
+      ),
+      shape: WidgetStatePropertyAll(
+        RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openCoachingProfile() async {
+    final controller = widget.coachingProfileController;
+    if (controller == null) return;
+    await _coachingProfileLoad;
+    if (!mounted || !identical(controller, widget.coachingProfileController)) {
+      return;
+    }
+    if (controller.profile == null) {
+      _coachingProfileLoad = controller.load();
+      await _coachingProfileLoad;
+    }
+    if (!mounted || !identical(controller, widget.coachingProfileController)) {
+      return;
+    }
+    if (controller.profile == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(controller.errorMessage ?? '记忆暂时无法读取，请重试。')),
+      );
+      return;
+    }
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => CoachingProfilePage(controller: controller),
+      ),
+    );
+  }
+}
+
+class _ProfileMenuCalloutBorder extends OutlinedBorder {
+  const _ProfileMenuCalloutBorder({
+    super.side,
+    this.radius = SpeakUpDesign.radiusCard,
+    this.arrowHeight = SpeakUpDesign.space8,
+    this.arrowWidth = SpeakUpDesign.space16,
+    this.arrowEndInset = SpeakUpDesign.minTapTarget / 2,
+  });
+
+  final double radius;
+  final double arrowHeight;
+  final double arrowWidth;
+  final double arrowEndInset;
+
+  @override
+  EdgeInsetsGeometry get dimensions {
+    final inset = side.strokeInset > 0 ? side.strokeInset : 0.0;
+    return EdgeInsets.fromLTRB(inset, arrowHeight + inset, inset, inset);
+  }
+
+  @override
+  _ProfileMenuCalloutBorder copyWith({
+    BorderSide? side,
+    double? radius,
+    double? arrowHeight,
+    double? arrowWidth,
+    double? arrowEndInset,
+  }) => _ProfileMenuCalloutBorder(
+    side: side ?? this.side,
+    radius: radius ?? this.radius,
+    arrowHeight: arrowHeight ?? this.arrowHeight,
+    arrowWidth: arrowWidth ?? this.arrowWidth,
+    arrowEndInset: arrowEndInset ?? this.arrowEndInset,
+  );
+
+  @override
+  ShapeBorder scale(double t) => _ProfileMenuCalloutBorder(
+    side: side.scale(t),
+    radius: radius * t,
+    arrowHeight: arrowHeight * t,
+    arrowWidth: arrowWidth * t,
+    arrowEndInset: arrowEndInset * t,
+  );
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) {
+    return getOuterPath(rect.deflate(side.strokeInset));
+  }
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
+    final bodyTop = rect.top + arrowHeight;
+    final body = Path()
+      ..addRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTRB(rect.left, bodyTop, rect.right, rect.bottom),
+          Radius.circular(radius),
+        ),
+      );
+    final arrowCenter = rect.right - arrowEndInset;
+    final arrow = Path()
+      ..moveTo(arrowCenter - arrowWidth / 2, bodyTop)
+      ..lineTo(arrowCenter, rect.top)
+      ..lineTo(arrowCenter + arrowWidth / 2, bodyTop)
+      ..close();
+    return Path.combine(PathOperation.union, body, arrow);
+  }
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    if (side.style == BorderStyle.none) return;
+    canvas.drawPath(
+      getOuterPath(rect.deflate(side.strokeInset)),
+      side.toPaint(),
+    );
   }
 }
 

--- a/mobile/lib/features/profile/profile_page.dart
+++ b/mobile/lib/features/profile/profile_page.dart
@@ -273,6 +273,9 @@ class _ProfileMoreMenu extends StatefulWidget {
 }
 
 class _ProfileMoreMenuState extends State<_ProfileMoreMenu> {
+  static const double _menuWidth = 184;
+  static const double _menuItemWidth = _menuWidth - SpeakUpDesign.space8 * 2;
+
   Future<void>? _coachingProfileLoad;
 
   @override
@@ -299,8 +302,11 @@ class _ProfileMoreMenuState extends State<_ProfileMoreMenu> {
     return MenuAnchor(
       key: const Key('profile-more-menu-anchor'),
       animated: true,
+      crossAxisUnconstrained: false,
       reservedPadding: const EdgeInsets.all(SpeakUpDesign.space16),
-      alignmentOffset: const Offset(-184, SpeakUpDesign.space4),
+      // MenuAnchor positions the menu's leading edge at bottomEnd in LTR.
+      // Shift by its width so the callout end stays attached to the trigger.
+      alignmentOffset: const Offset(-_menuWidth, SpeakUpDesign.space4),
       style: MenuStyle(
         alignment: AlignmentDirectional.bottomEnd,
         backgroundColor: const WidgetStatePropertyAll(SpeakUpDesign.surface),
@@ -315,8 +321,10 @@ class _ProfileMoreMenuState extends State<_ProfileMoreMenu> {
             SpeakUpDesign.space8,
           ),
         ),
-        minimumSize: const WidgetStatePropertyAll(Size(184, 0)),
-        maximumSize: const WidgetStatePropertyAll(Size(184, double.infinity)),
+        minimumSize: const WidgetStatePropertyAll(Size(_menuWidth, 0)),
+        maximumSize: const WidgetStatePropertyAll(
+          Size(_menuWidth, double.infinity),
+        ),
         side: const WidgetStatePropertyAll(
           BorderSide(color: SpeakUpDesign.border),
         ),
@@ -375,7 +383,7 @@ class _ProfileMoreMenuState extends State<_ProfileMoreMenu> {
   ButtonStyle _menuItemStyle({bool destructive = false}) {
     final foreground = destructive ? SpeakUpDesign.error : SpeakUpDesign.ink;
     return ButtonStyle(
-      minimumSize: const WidgetStatePropertyAll(Size(168, 48)),
+      minimumSize: const WidgetStatePropertyAll(Size(_menuItemWidth, 48)),
       padding: const WidgetStatePropertyAll(
         EdgeInsets.symmetric(horizontal: SpeakUpDesign.space12),
       ),

--- a/mobile/test/coaching/profile/coaching_profile_test.dart
+++ b/mobile/test/coaching/profile/coaching_profile_test.dart
@@ -1,32 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 
 void main() {
-  testWidgets('loads coaching memory and opens its editor', (tester) async {
-    final client = _ProfileClient();
-    final controller = CoachingProfileController(client: client);
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(body: CoachingProfileCard(controller: controller)),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('Alex · 工程师 · 音乐'), findsOneWidget);
-    expect(
-      tester
-          .widget<InkWell>(find.byKey(const Key('coaching-profile-card')))
-          .borderRadius,
-      BorderRadius.circular(SpeakUpDesign.radiusCard),
-    );
-    await tester.tap(find.byKey(const Key('coaching-profile-card')));
-    await tester.pumpAndSettle();
-    expect(find.text('教练记忆'), findsWidgets);
-    expect(find.widgetWithText(TextFormField, '职业'), findsOneWidget);
-  });
-
   test('clear and memory toggle preserve the server version chain', () async {
     final client = _ProfileClient();
     final controller = CoachingProfileController(client: client);

--- a/mobile/test/profile/profile_menu_test.dart
+++ b/mobile/test/profile/profile_menu_test.dart
@@ -37,11 +37,26 @@ void main() {
         .getTopLeft(find.byKey(const Key('profile-coaching-memory-button')))
         .dy;
     expect(menuTop, greaterThan(buttonBottom));
+    final triggerRect = tester.getRect(
+      find.byKey(const Key('profile-account-menu')),
+    );
+    final firstItemRect = tester.getRect(
+      find.byKey(const Key('profile-coaching-memory-button')),
+    );
+    expect(
+      firstItemRect.right + SpeakUpDesign.space8,
+      closeTo(triggerRect.right, 0.01),
+    );
+    expect(
+      firstItemRect.left - SpeakUpDesign.space8,
+      greaterThanOrEqualTo(SpeakUpDesign.space16),
+    );
 
     final anchor = tester.widget<MenuAnchor>(
       find.byKey(const Key('profile-more-menu-anchor')),
     );
     expect(anchor.style!.alignment, AlignmentDirectional.bottomEnd);
+    expect(anchor.crossAxisUnconstrained, isFalse);
     expect(anchor.reservedPadding, const EdgeInsets.all(SpeakUpDesign.space16));
     expect(anchor.alignmentOffset, const Offset(-184, SpeakUpDesign.space4));
     expect(
@@ -85,6 +100,10 @@ void main() {
   testWidgets('more menu remains usable on a narrow large-text screen', (
     tester,
   ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(320, 700);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
     await tester.pumpWidget(
       _app(
         controller: CoachingProfileController(client: _ProfileClient()),
@@ -102,6 +121,20 @@ void main() {
 
     expect(find.text('教练记忆'), findsOneWidget);
     expect(find.text('退出登录'), findsOneWidget);
+    final triggerRect = tester.getRect(
+      find.byKey(const Key('profile-account-menu')),
+    );
+    final firstItemRect = tester.getRect(
+      find.byKey(const Key('profile-coaching-memory-button')),
+    );
+    expect(
+      firstItemRect.right + SpeakUpDesign.space8,
+      closeTo(triggerRect.right, 0.01),
+    );
+    expect(
+      firstItemRect.left - SpeakUpDesign.space8,
+      greaterThanOrEqualTo(SpeakUpDesign.space16),
+    );
     expect(tester.takeException(), isNull);
   });
 }

--- a/mobile/test/profile/profile_menu_test.dart
+++ b/mobile/test/profile/profile_menu_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/speak_up_theme.dart';
+import 'package:speakup/features/coaching/profile/coaching_profile.dart';
+import 'package:speakup/features/profile/profile_page.dart';
+import 'package:speakup/identity/model/identity_models.dart';
+
+void main() {
+  testWidgets('more menu owns coaching memory and opens its existing editor', (
+    tester,
+  ) async {
+    final client = _ProfileClient();
+    final controller = CoachingProfileController(client: client);
+    var loggedOut = false;
+    await tester.pumpWidget(
+      _app(controller: controller, onLogout: () => loggedOut = true),
+    );
+    await tester.pumpAndSettle();
+
+    expect(client.loads, 1);
+    expect(find.byKey(const Key('coaching-profile-card')), findsNothing);
+    expect(find.text('当前 IELTS 能力'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('profile-account-menu')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('profile-coaching-memory-button')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('profile-logout-button')), findsOneWidget);
+    final buttonBottom = tester
+        .getBottomRight(find.byKey(const Key('profile-account-menu')))
+        .dy;
+    final menuTop = tester
+        .getTopLeft(find.byKey(const Key('profile-coaching-memory-button')))
+        .dy;
+    expect(menuTop, greaterThan(buttonBottom));
+
+    final anchor = tester.widget<MenuAnchor>(
+      find.byKey(const Key('profile-more-menu-anchor')),
+    );
+    expect(anchor.style!.alignment, AlignmentDirectional.bottomEnd);
+    expect(anchor.reservedPadding, const EdgeInsets.all(SpeakUpDesign.space16));
+    expect(anchor.alignmentOffset, const Offset(-184, SpeakUpDesign.space4));
+    expect(
+      anchor.style!.maximumSize!.resolve(<WidgetState>{}),
+      const Size(184, double.infinity),
+    );
+    final shape = anchor.style!.shape!.resolve(<WidgetState>{});
+    expect(shape!.dimensions.vertical, SpeakUpDesign.space8);
+    final menuPath = shape.getOuterPath(const Rect.fromLTWH(0, 0, 184, 120));
+    expect(menuPath.contains(const Offset(162, 4)), isTrue);
+
+    await tester.tap(find.byKey(const Key('profile-coaching-memory-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('教练记忆'), findsOneWidget);
+    expect(find.widgetWithText(TextFormField, '职业'), findsOneWidget);
+    expect(loggedOut, isFalse);
+  });
+
+  testWidgets('logout remains a distinct destructive menu action', (
+    tester,
+  ) async {
+    var loggedOut = false;
+    await tester.pumpWidget(_app(onLogout: () => loggedOut = true));
+
+    await tester.tap(find.byKey(const Key('profile-account-menu')));
+    await tester.pumpAndSettle();
+
+    final logout = tester.widget<MenuItemButton>(
+      find.byKey(const Key('profile-logout-button')),
+    );
+    expect(
+      logout.style!.foregroundColor!.resolve(<WidgetState>{}),
+      SpeakUpDesign.error,
+    );
+    await tester.tap(find.byKey(const Key('profile-logout-button')));
+    await tester.pumpAndSettle();
+    expect(loggedOut, isTrue);
+  });
+
+  testWidgets('more menu remains usable on a narrow large-text screen', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        controller: CoachingProfileController(client: _ProfileClient()),
+        onLogout: () {},
+        mediaQuery: const MediaQueryData(
+          size: Size(320, 700),
+          textScaler: TextScaler.linear(3),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('profile-account-menu')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('教练记忆'), findsOneWidget);
+    expect(find.text('退出登录'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Widget _app({
+  CoachingProfileController? controller,
+  required VoidCallback onLogout,
+  MediaQueryData? mediaQuery,
+}) {
+  final profilePage = ProfilePage(
+    showBackButton: false,
+    user: const User(id: 'user-1', email: 'learner@example.com'),
+    profile: _profile(),
+    profileErrorMessage: null,
+    profileSaving: false,
+    onSaveDisplayName: (_) async => null,
+    avatarBytes: null,
+    avatarSaving: false,
+    onUploadAvatar: (_) async => null,
+    onUseDefaultAvatar: () async => null,
+    onLogout: onLogout,
+    reviewHistoryController: null,
+    coachingProfileController: controller,
+  );
+  return MaterialApp(
+    theme: SpeakUpTheme.light,
+    home: mediaQuery == null
+        ? profilePage
+        : MediaQuery(data: mediaQuery, child: profilePage),
+  );
+}
+
+UserProfile _profile() {
+  final createdAt = DateTime.utc(2026, 8, 25, 8);
+  return UserProfile(
+    userId: 'user-1',
+    displayName: '小林',
+    profileVersion: 1,
+    createdAt: createdAt,
+    updatedAt: createdAt,
+  );
+}
+
+final class _ProfileClient implements CoachingProfileClient {
+  int loads = 0;
+
+  @override
+  Future<CoachingProfile> getProfile() async {
+    loads++;
+    return const CoachingProfile(
+      memoryEnabled: true,
+      version: 1,
+      data: CoachingProfileData(
+        formOfAddress: 'Alex',
+        occupation: '工程师',
+        interests: ['音乐'],
+      ),
+    );
+  }
+
+  @override
+  Future<CoachingProfile> updateProfile({
+    required int expectedVersion,
+    CoachingProfileData? updates,
+    List<String> forgetFields = const <String>[],
+    bool clearProfile = false,
+    bool? memoryEnabled,
+  }) => throw UnimplementedError();
+}


### PR DESCRIPTION
## 功能描述

- 将“教练记忆”从个人页主内容迁移到右上角更多菜单。
- 保持原有教练记忆编辑流程与退出登录操作逻辑不变。
- 优化更多菜单的视觉层级：统一圆角、描边、阴影和顶部指向三角，并与屏幕右侧保留安全间距。

## 实现思路

- 使用 Material 3 `MenuAnchor` 承载教练记忆与退出登录操作。
- 复用现有 `CoachingProfilePage` 和控制器，保留进入个人页时的预加载行为。
- 通过自定义 `OutlinedBorder` 将菜单面板与顶部三角合成同一路径，并固定菜单宽度与锚点偏移。
- 删除个人页中不再使用的教练记忆卡片及对应过时测试。
- 新增菜单行为、退出操作、窄屏大字体和定位样式测试。

## 可复现测试

- `dart analyze`
- `flutter test --no-pub`（811 项全部通过）
- `flutter test --no-pub test/profile/profile_menu_test.dart test/coaching/profile/coaching_profile_test.dart test/profile/profile_avatar_test.dart`（6 项全部通过）
- `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`，iPhone 17 Pro / iOS 26.5，真实本地后端、数字人禁用：确认入口迁移、三角指向、右侧留白、编辑跳转与退出登录操作正常。

Closes #963