### PR TITLE
style(mobile): 优化教练记忆编辑页视觉层级

### DIFF
--- a/mobile/lib/features/coaching/profile/coaching_profile.dart
+++ b/mobile/lib/features/coaching/profile/coaching_profile.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/identity/auth_state.dart';
 import 'package:speakup/identity/network/identity_http_transport.dart';
 
@@ -291,74 +292,100 @@ class _CoachingProfilePageState extends State<CoachingProfilePage> {
   Widget build(BuildContext context) {
     final profile = widget.controller.profile!;
     return Scaffold(
-      appBar: AppBar(title: const Text('教练记忆')),
+      key: const Key('coaching-profile-page'),
+      appBar: AppBar(
+        leading: IconButton(
+          key: const Key('coaching-profile-back-button'),
+          tooltip: '返回',
+          onPressed: () => Navigator.of(context).maybePop(),
+          icon: const Icon(Icons.arrow_back_rounded),
+        ),
+        title: const Text('教练记忆'),
+      ),
       body: AnimatedBuilder(
         animation: widget.controller,
-        builder: (context, _) => ListView(
-          padding: const EdgeInsets.fromLTRB(20, 12, 20, 40),
-          children: [
-            SwitchListTile.adaptive(
-              contentPadding: EdgeInsets.zero,
-              title: const Text('在 Agent 对话中使用这些记忆'),
-              subtitle: const Text('关闭后仍保留内容，但不会注入对话上下文。'),
-              value: widget.controller.profile?.memoryEnabled ?? false,
-              onChanged: widget.controller.saving
-                  ? null
-                  : widget.controller.setMemoryEnabled,
+        builder: (context, _) => Form(
+          key: _formKey,
+          child: ListView(
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            padding: EdgeInsets.fromLTRB(
+              SpeakUpDesign.horizontalInset(context),
+              SpeakUpDesign.space8,
+              SpeakUpDesign.horizontalInset(context),
+              MediaQuery.viewPaddingOf(context).bottom + SpeakUpDesign.space24,
             ),
-            const SizedBox(height: 16),
-            Form(
-              key: _formKey,
-              child: Column(
-                children: [
-                  _field(_fields[0], '希望怎么称呼你', 64),
-                  _field(_fields[1], '职业', 120),
-                  _field(_fields[2], '职业背景', 500, maxLines: 4),
-                  _field(_fields[3], '母语', 64),
-                  _field(_fields[4], '讲解语言', 64),
-                  DropdownButtonFormField<CoachingResponseDetail?>(
-                    initialValue: _detail,
-                    decoration: const InputDecoration(labelText: '回答详细程度'),
-                    items: const [
-                      DropdownMenuItem(value: null, child: Text('未设置')),
-                      DropdownMenuItem(
-                        value: CoachingResponseDetail.concise,
-                        child: Text('简洁'),
-                      ),
-                      DropdownMenuItem(
-                        value: CoachingResponseDetail.balanced,
-                        child: Text('适中'),
-                      ),
-                      DropdownMenuItem(
-                        value: CoachingResponseDetail.detailed,
-                        child: Text('详细'),
-                      ),
-                    ],
-                    onChanged: (value) => _detail = value,
-                  ),
-                  _field(_interests, '兴趣（用逗号或顿号分隔，最多 8 个）', 520),
-                ],
+            children: [
+              _MemoryStatusPanel(
+                enabled: widget.controller.profile?.memoryEnabled ?? false,
+                saving: widget.controller.saving,
+                onChanged: widget.controller.setMemoryEnabled,
               ),
-            ),
-            if (widget.controller.errorMessage case final error?) ...[
-              const SizedBox(height: 12),
-              Text(
-                error,
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              const SizedBox(height: SpeakUpDesign.space32),
+              const _ProfileSectionHeading(
+                key: Key('coaching-profile-about-section'),
+                title: '关于你',
+                subtitle: '让教练更准确地理解你的背景。',
+              ),
+              const SizedBox(height: SpeakUpDesign.space16),
+              _field(_fields[0], '希望怎么称呼你', 64),
+              _field(_fields[1], '职业', 120),
+              _field(_fields[2], '职业背景', 500, maxLines: 4),
+              const SizedBox(height: SpeakUpDesign.space16),
+              const _ProfileSectionHeading(
+                key: Key('coaching-profile-preferences-section'),
+                title: '沟通偏好',
+                subtitle: '调整教练与你交流和讲解的方式。',
+              ),
+              const SizedBox(height: SpeakUpDesign.space16),
+              _field(_fields[3], '母语', 64),
+              _field(_fields[4], '讲解语言', 64),
+              _ProfileSelectField<CoachingResponseDetail?>(
+                label: '回答详细程度',
+                value: _detail,
+                items: const [
+                  DropdownMenuItem(value: null, child: Text('未设置')),
+                  DropdownMenuItem(
+                    value: CoachingResponseDetail.concise,
+                    child: Text('简洁'),
+                  ),
+                  DropdownMenuItem(
+                    value: CoachingResponseDetail.balanced,
+                    child: Text('适中'),
+                  ),
+                  DropdownMenuItem(
+                    value: CoachingResponseDetail.detailed,
+                    child: Text('详细'),
+                  ),
+                ],
+                onChanged: (value) => _detail = value,
+              ),
+              _field(_interests, '兴趣', 520, hint: '用逗号或顿号分隔，最多 8 个'),
+              if (widget.controller.errorMessage case final error?) ...[
+                const SizedBox(height: SpeakUpDesign.space4),
+                _ProfileError(message: error),
+              ],
+              const SizedBox(height: SpeakUpDesign.space24),
+              FilledButton(
+                key: const Key('coaching-profile-save-button'),
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size.fromHeight(52),
+                ),
+                onPressed: widget.controller.saving ? null : _save,
+                child: Text(widget.controller.saving ? '正在保存…' : '保存'),
+              ),
+              const SizedBox(height: SpeakUpDesign.space4),
+              TextButton(
+                key: const Key('coaching-profile-clear-button'),
+                style: TextButton.styleFrom(
+                  foregroundColor: SpeakUpDesign.error,
+                ),
+                onPressed: widget.controller.saving || profile.data.isEmpty
+                    ? null
+                    : _clear,
+                child: const Text('清空教练记忆'),
               ),
             ],
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: widget.controller.saving ? null : _save,
-              child: Text(widget.controller.saving ? '正在保存…' : '保存'),
-            ),
-            TextButton(
-              onPressed: widget.controller.saving || profile.data.isEmpty
-                  ? null
-                  : _clear,
-              child: const Text('清空教练记忆'),
-            ),
-          ],
+          ),
         ),
       ),
     );
@@ -369,9 +396,11 @@ class _CoachingProfilePageState extends State<CoachingProfilePage> {
     String label,
     int maxLength, {
     int maxLines = 1,
-  }) => TextFormField(
+    String? hint,
+  }) => _ProfileTextField(
     controller: controller,
-    decoration: InputDecoration(labelText: label),
+    label: label,
+    hint: hint,
     maxLength: maxLength,
     maxLines: maxLines,
   );
@@ -424,6 +453,213 @@ class _CoachingProfilePageState extends State<CoachingProfilePage> {
     if (confirmed == true && await widget.controller.clear() && mounted) {
       Navigator.of(context).pop();
     }
+  }
+}
+
+class _MemoryStatusPanel extends StatelessWidget {
+  const _MemoryStatusPanel({
+    required this.enabled,
+    required this.saving,
+    required this.onChanged,
+  });
+
+  final bool enabled;
+  final bool saving;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('coaching-profile-memory-panel'),
+      padding: const EdgeInsets.fromLTRB(
+        SpeakUpDesign.space16,
+        SpeakUpDesign.space16,
+        SpeakUpDesign.space12,
+        SpeakUpDesign.space16,
+      ),
+      decoration: BoxDecoration(
+        color: SpeakUpDesign.surfaceMuted,
+        borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('在 Agent 对话中使用这些记忆', style: SpeakUpDesign.cardTitle),
+                const SizedBox(height: SpeakUpDesign.space4),
+                Text(
+                  '关闭后仍保留内容，但不会注入对话上下文。',
+                  style: SpeakUpDesign.body.copyWith(fontSize: 13),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: SpeakUpDesign.space12),
+          Switch.adaptive(
+            key: const Key('coaching-profile-memory-switch'),
+            value: enabled,
+            onChanged: saving ? null : onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileSectionHeading extends StatelessWidget {
+  const _ProfileSectionHeading({
+    required this.title,
+    required this.subtitle,
+    super.key,
+  });
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: SpeakUpDesign.sectionTitle),
+        const SizedBox(height: SpeakUpDesign.space4),
+        Text(subtitle, style: SpeakUpDesign.body),
+      ],
+    );
+  }
+}
+
+class _ProfileTextField extends StatelessWidget {
+  const _ProfileTextField({
+    required this.controller,
+    required this.label,
+    required this.maxLength,
+    required this.maxLines,
+    this.hint,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final String? hint;
+  final int maxLength;
+  final int maxLines;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SpeakUpDesign.space16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(child: Text(label, style: SpeakUpDesign.label)),
+              ValueListenableBuilder<TextEditingValue>(
+                valueListenable: controller,
+                builder: (context, value, _) => Text(
+                  '${value.text.length}/$maxLength',
+                  style: SpeakUpDesign.meta.copyWith(
+                    color: value.text.length == maxLength
+                        ? SpeakUpDesign.ink
+                        : SpeakUpDesign.tertiary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: SpeakUpDesign.space8),
+          TextFormField(
+            controller: controller,
+            maxLength: maxLength,
+            maxLines: maxLines,
+            minLines: maxLines > 1 ? 3 : 1,
+            textInputAction: maxLines > 1
+                ? TextInputAction.newline
+                : TextInputAction.next,
+            decoration: InputDecoration(
+              hintText: hint,
+              counterText: '',
+              alignLabelWithHint: maxLines > 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileSelectField<T> extends StatelessWidget {
+  const _ProfileSelectField({
+    required this.label,
+    required this.value,
+    required this.items,
+    required this.onChanged,
+  });
+
+  final String label;
+  final T value;
+  final List<DropdownMenuItem<T>> items;
+  final ValueChanged<T?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: SpeakUpDesign.space16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: SpeakUpDesign.label),
+          const SizedBox(height: SpeakUpDesign.space8),
+          DropdownButtonFormField<T>(
+            key: const Key('coaching-profile-detail-field'),
+            initialValue: value,
+            isExpanded: true,
+            decoration: const InputDecoration(),
+            items: items,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileError extends StatelessWidget {
+  const _ProfileError({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      liveRegion: true,
+      child: Container(
+        key: const Key('coaching-profile-error'),
+        padding: const EdgeInsets.all(SpeakUpDesign.space12),
+        decoration: BoxDecoration(
+          color: SpeakUpDesign.errorMuted,
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+        ),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.error_outline_rounded,
+              size: 20,
+              color: SpeakUpDesign.error,
+            ),
+            const SizedBox(width: SpeakUpDesign.space8),
+            Expanded(
+              child: Text(
+                message,
+                style: SpeakUpDesign.body.copyWith(color: SpeakUpDesign.error),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/mobile/test/coaching/profile/coaching_profile_test.dart
+++ b/mobile/test/coaching/profile/coaching_profile_test.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/design/speak_up_theme.dart';
 import 'package:speakup/features/coaching/profile/coaching_profile.dart';
 
 void main() {
@@ -12,7 +15,76 @@ void main() {
     expect(controller.profile!.version, 3);
     expect(controller.profile!.data.isEmpty, isTrue);
   });
+
+  testWidgets('editor groups memory, identity, and communication settings', (
+    tester,
+  ) async {
+    final controller = CoachingProfileController(client: _ProfileClient());
+    await controller.load();
+    await tester.pumpWidget(_app(controller));
+
+    expect(find.byKey(const Key('coaching-profile-memory-panel')), findsOne);
+    expect(find.text('关于你'), findsOne);
+    expect(find.text('沟通偏好'), findsOne);
+    expect(find.text('希望怎么称呼你'), findsOne);
+    expect(find.text('职业'), findsOne);
+    expect(find.text('职业背景'), findsOne);
+
+    final panel = tester.widget<Container>(
+      find.byKey(const Key('coaching-profile-memory-panel')),
+    );
+    final decoration = panel.decoration! as BoxDecoration;
+    expect(decoration.color, SpeakUpDesign.surfaceMuted);
+    expect(
+      decoration.borderRadius,
+      BorderRadius.circular(SpeakUpDesign.radiusCard),
+    );
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('coaching-profile-save-button')),
+      300,
+      scrollable: find.byType(Scrollable).first,
+    );
+    expect(find.byKey(const Key('coaching-profile-save-button')), findsOne);
+    expect(find.byKey(const Key('coaching-profile-clear-button')), findsOne);
+  });
+
+  testWidgets('editor stays usable on a narrow large-text screen', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(320, 700);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final controller = CoachingProfileController(client: _ProfileClient());
+    await controller.load();
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(
+          size: Size(320, 700),
+          textScaler: TextScaler.linear(2),
+        ),
+        child: _app(controller),
+      ),
+    );
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('coaching-profile-save-button')),
+      320,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('coaching-profile-save-button')), findsOne);
+    expect(find.byKey(const Key('coaching-profile-clear-button')), findsOne);
+    expect(tester.takeException(), isNull);
+  });
 }
+
+Widget _app(CoachingProfileController controller) => MaterialApp(
+  theme: SpeakUpTheme.light,
+  home: CoachingProfilePage(controller: controller),
+);
 
 final class _ProfileClient implements CoachingProfileClient {
   CoachingProfile value = const CoachingProfile(

--- a/mobile/test/profile/profile_menu_test.dart
+++ b/mobile/test/profile/profile_menu_test.dart
@@ -72,7 +72,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('教练记忆'), findsOneWidget);
-    expect(find.widgetWithText(TextFormField, '职业'), findsOneWidget);
+    expect(find.byKey(const Key('coaching-profile-page')), findsOneWidget);
+    expect(find.text('关于你'), findsOneWidget);
     expect(loggedOut, isFalse);
   });
 


### PR DESCRIPTION
## 功能描述

- 重构教练记忆编辑页的视觉层级，将内容组织为记忆状态、关于你和沟通偏好。
- 使用全局 SpeakUp 设计令牌统一留白、字体、圆角、颜色、输入框和操作按钮。
- 将字符计数器移到字段标签行并弱化显示，减少连续输入框带来的视觉噪音。
- 保持记忆开关、全部字段、详细度选择、保存和清空操作逻辑不变。

## 实现思路

- 复用 `SpeakUpDesign` 的白底、灰阶、间距、圆角和文字样式，不引入新的页面级设计系统。
- 仅用一个弱底色状态面板强调记忆开关，其余表单采用开放布局，避免堆叠卡片。
- 抽取页面内私有的分区标题、文本字段、选择字段和错误提示组件，统一字段解剖结构。
- 保留 `ListView` 滚动与拖动收起键盘，底部操作位于滚动内容内，不遮挡最后一个字段。

## 可复现测试

- `dart analyze`
- `flutter test --no-pub`（813 项全部通过）
- `flutter test --no-pub test/profile/profile_menu_test.dart test/coaching/profile/coaching_profile_test.dart`（6 项全部通过）
- `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`，iPhone 17 Pro / iOS 26.5，真实本地后端、数字人禁用；已验证页面滚动、字段、开关和操作区域，用户已完成视觉与交互确认。

> 上游当前的 iOS 模拟器 avatar stub 尚未接收 `AvatarManager.load(useCompressedModel:)`，本地验证时仅临时补齐 stub 签名，验证后已还原，未包含在本 PR。

Closes #970