### PR TITLE
fix(evaluation): 隔离声学评测与文本反馈重试预算

### DIFF
--- a/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
@@ -77,6 +77,214 @@ func TestSpeechFeedbackPart1InvalidThenValidReusesAcoustics(t *testing.T) {
 	}
 }
 
+func TestSpeechFeedbackAcousticAndTextRetriesHaveIndependentBudgets(t *testing.T) {
+	tests := []struct {
+		name           string
+		acousticErrors []error
+		wantStatus     evaluation.AcousticAssessmentStatus
+	}{
+		{
+			name: "acoustic succeeds on its final attempt",
+			acousticErrors: []error{
+				speechRetryAcousticFailure{},
+				speechRetryAcousticFailure{},
+			},
+			wantStatus: evaluation.AcousticAssessed,
+		},
+		{
+			name: "acoustic exhausts its budget and degrades",
+			acousticErrors: []error{
+				speechRetryAcousticFailure{},
+				speechRetryAcousticFailure{},
+				speechRetryAcousticFailure{},
+			},
+			wantStatus: evaluation.AcousticNotAssessed,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pool := evaluationTestDatabase(t)
+			insertEvaluationTestUser(
+				t,
+				pool,
+				speechRetryUserID,
+				"speech-independent-retries@example.com",
+			)
+			generator := &speechRetryGenerator{contents: []string{
+				`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"missing excerpt","source_occurrence":1,"suggested_text":"read"}]}`,
+				`{"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"这是更自然的表达。","source_text":"read","source_occurrence":1,"suggested_text":"do some reading"}]}`,
+			}}
+			acoustics := &speechRetryAcoustics{errors: test.acousticErrors}
+			store, worker := speechRetryWorker(t, pool, generator, acoustics)
+			queueSpeechRetry(t, store, "I usually read before work.")
+
+			for attempt := 1; attempt <= 2; attempt++ {
+				processed, err := worker.ProcessSpeech(context.Background())
+				if !processed || err == nil {
+					t.Fatalf(
+						"acoustic ProcessSpeech attempt %d = (%t, %v)",
+						attempt,
+						processed,
+						err,
+					)
+				}
+				record, getErr := store.GetRecordBySource(
+					context.Background(),
+					speechRetryUserID,
+					evaluation.KindPracticeTurnFeedback,
+					speechRetryTurnID,
+				)
+				if getErr != nil || record.Status != evaluation.JobQueued ||
+					record.AttemptCount != attempt || record.Error != nil ||
+					generator.calls != 0 {
+					t.Fatalf(
+						"acoustic retry %d = %#v, err=%v text=%d",
+						attempt,
+						record,
+						getErr,
+						generator.calls,
+					)
+				}
+			}
+
+			processed, err := worker.ProcessSpeech(context.Background())
+			if !processed || err == nil {
+				t.Fatalf("first text ProcessSpeech = (%t, %v)", processed, err)
+			}
+			queued, getErr := store.GetRecordBySource(
+				context.Background(),
+				speechRetryUserID,
+				evaluation.KindPracticeTurnFeedback,
+				speechRetryTurnID,
+			)
+			if getErr != nil || queued.Status != evaluation.JobQueued ||
+				queued.AttemptCount != 1 || queued.Error != nil {
+				t.Fatalf("queued text retry = %#v, %v", queued, getErr)
+			}
+			var checkpointed evaluation.SpeechInputSnapshot
+			if evaluation.DecodeStrict(queued.InputSnapshot, &checkpointed) != nil ||
+				checkpointed.Acoustic == nil ||
+				checkpointed.Acoustic.Status != test.wantStatus {
+				t.Fatalf("checkpointed input = %#v", checkpointed)
+			}
+
+			processed, err = worker.ProcessSpeech(context.Background())
+			if err != nil || !processed {
+				t.Fatalf("second text ProcessSpeech = (%t, %v)", processed, err)
+			}
+			ready, getErr := store.GetRecordBySource(
+				context.Background(),
+				speechRetryUserID,
+				evaluation.KindPracticeTurnFeedback,
+				speechRetryTurnID,
+			)
+			if getErr != nil || ready.Status != evaluation.JobReady ||
+				ready.AttemptCount != 2 || ready.Error != nil ||
+				acoustics.calls != 3 || generator.calls != 2 {
+				t.Fatalf(
+					"ready=%#v err=%v acoustic=%d text=%d",
+					ready,
+					getErr,
+					acoustics.calls,
+					generator.calls,
+				)
+			}
+		})
+	}
+}
+
+func TestSpeechFeedbackResumesTextStageAfterAcousticCheckpointCrash(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(
+		t,
+		pool,
+		speechRetryUserID,
+		"speech-checkpoint-crash@example.com",
+	)
+	generator := &speechRetryGenerator{contents: []string{
+		`{"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"这是更自然的表达。","source_text":"read","source_occurrence":1,"suggested_text":"do some reading"}]}`,
+	}}
+	acoustics := &speechRetryAcoustics{errors: []error{
+		speechRetryAcousticFailure{},
+		speechRetryAcousticFailure{},
+	}}
+	store, worker := speechRetryWorker(t, pool, generator, acoustics)
+	queueSpeechRetry(t, store, "I usually read before work.")
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		processed, err := worker.ProcessSpeech(context.Background())
+		if !processed || err == nil {
+			t.Fatalf("acoustic ProcessSpeech attempt %d = (%t, %v)", attempt, processed, err)
+		}
+	}
+	lane := evaluation.ClaimLane{
+		Kinds: []evaluation.Kind{
+			evaluation.KindPracticeTurnFeedback,
+			evaluation.KindAgentMessageFeedback,
+		},
+		LeaseDuration: time.Minute,
+		MaxAttempts:   3,
+	}
+	claim, err := store.ClaimNext(context.Background(), lane)
+	if err != nil || claim.AttemptCount != 3 {
+		t.Fatalf("third acoustic claim = %#v, %v", claim, err)
+	}
+	var snapshot evaluation.SpeechInputSnapshot
+	if err := evaluation.DecodeStrict(claim.InputSnapshot, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, err := acoustics.EvaluateAcoustic(
+		context.Background(),
+		claim.Record,
+		snapshot,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot.Acoustic = &checkpoint
+	encoded, digest, err := evaluation.EncodeStrict(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpointed, err := store.CheckpointSnapshot(
+		context.Background(),
+		evaluation.SnapshotCheckpoint{
+			UserID:               claim.UserID,
+			ID:                   claim.ID,
+			LeaseToken:           claim.LeaseToken,
+			InputSnapshot:        encoded,
+			InputHash:            digest,
+			RestartAttemptBudget: true,
+		},
+	)
+	if err != nil || checkpointed.AttemptCount != 1 {
+		t.Fatalf("acoustic checkpoint = %#v, %v", checkpointed, err)
+	}
+
+	expireClaim(t, pool, claim.ID)
+	processed, err := worker.ProcessSpeech(context.Background())
+	if err != nil || !processed {
+		t.Fatalf("ProcessSpeech after checkpoint crash = (%t, %v)", processed, err)
+	}
+	ready, err := store.GetRecordBySource(
+		context.Background(),
+		speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback,
+		speechRetryTurnID,
+	)
+	if err != nil || ready.Status != evaluation.JobReady ||
+		ready.AttemptCount != 2 || acoustics.calls != 3 || generator.calls != 1 {
+		t.Fatalf(
+			"ready=%#v err=%v acoustic=%d text=%d",
+			ready,
+			err,
+			acoustics.calls,
+			generator.calls,
+		)
+	}
+}
+
 func TestSpeechFeedbackPart3ThreeInvalidResponsesFailPubliclyNonRetryable(t *testing.T) {
 	pool := evaluationTestDatabase(t)
 	insertEvaluationTestUser(t, pool, speechRetryUserID, "speech-retry-part3@example.com")
@@ -123,6 +331,90 @@ func TestSpeechFeedbackPart3ThreeInvalidResponsesFailPubliclyNonRetryable(t *tes
 	}
 	if strings.Contains(storedError, transcript) || strings.Contains(storedError, invalid) {
 		t.Fatalf("terminal error leaked speech or provider output: %s", storedError)
+	}
+}
+
+func TestSpeechFeedbackCombinedRetryBudgetsTerminate(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(
+		t,
+		pool,
+		speechRetryUserID,
+		"speech-combined-retries@example.com",
+	)
+	const invalid = `{"items":[{"kind":"STRENGTH","explanation":"无需修改。","source_text":"technology","source_occurrence":1,"suggested_text":null}]}`
+	generator := &speechRetryGenerator{contents: []string{invalid, invalid, invalid}}
+	acoustics := &speechRetryAcoustics{errors: []error{
+		speechRetryAcousticFailure{},
+		speechRetryAcousticFailure{},
+		speechRetryAcousticFailure{},
+	}}
+	store, worker := speechRetryWorker(t, pool, generator, acoustics)
+	const transcript = "I think technology can improve education when teachers guide its use."
+	queueSpeechRetry(t, store, transcript)
+
+	wantAttemptCounts := []int{1, 2, 1, 2, 3}
+	for processingAttempt, wantAttemptCount := range wantAttemptCounts {
+		processed, err := worker.ProcessSpeech(context.Background())
+		if !processed || err == nil {
+			t.Fatalf(
+				"ProcessSpeech attempt %d = (%t, %v)",
+				processingAttempt+1,
+				processed,
+				err,
+			)
+		}
+		record, getErr := store.GetRecordBySource(
+			context.Background(),
+			speechRetryUserID,
+			evaluation.KindPracticeTurnFeedback,
+			speechRetryTurnID,
+		)
+		if getErr != nil {
+			t.Fatalf("record attempt %d = %v", processingAttempt+1, getErr)
+		}
+		if record.AttemptCount != wantAttemptCount {
+			t.Fatalf(
+				"record attempt %d count = %d, want %d",
+				processingAttempt+1,
+				record.AttemptCount,
+				wantAttemptCount,
+			)
+		}
+		if processingAttempt < len(wantAttemptCounts)-1 &&
+			(record.Status != evaluation.JobQueued || record.Error != nil) {
+			t.Fatalf("intermediate record %d = %#v", processingAttempt+1, record)
+		}
+	}
+
+	failed, err := store.GetRecordBySource(
+		context.Background(),
+		speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback,
+		speechRetryTurnID,
+	)
+	if err != nil || failed.Status != evaluation.JobFailed ||
+		failed.AttemptCount != 3 || failed.Error == nil ||
+		failed.Error.Code != "PROVIDER_RESPONSE_INVALID" ||
+		failed.Error.Retryable || acoustics.calls != 3 || generator.calls != 3 {
+		t.Fatalf(
+			"failed=%#v err=%v acoustic=%d text=%d",
+			failed,
+			err,
+			acoustics.calls,
+			generator.calls,
+		)
+	}
+	var checkpointed evaluation.SpeechInputSnapshot
+	if evaluation.DecodeStrict(failed.InputSnapshot, &checkpointed) != nil ||
+		checkpointed.Acoustic == nil ||
+		checkpointed.Acoustic.Status != evaluation.AcousticNotAssessed ||
+		checkpointed.Acoustic.Reason != "ACOUSTIC_ASSESSMENT_FAILED" {
+		t.Fatalf("terminal checkpoint = %#v", checkpointed)
+	}
+	processed, err := worker.ProcessSpeech(context.Background())
+	if processed || err != nil {
+		t.Fatalf("ProcessSpeech after terminal failure = (%t, %v)", processed, err)
 	}
 }
 
@@ -234,7 +526,10 @@ func (generator *speechRetryGenerator) Generate(
 	}, nil
 }
 
-type speechRetryAcoustics struct{ calls int }
+type speechRetryAcoustics struct {
+	errors []error
+	calls  int
+}
 
 func (acoustics *speechRetryAcoustics) EvaluateAcoustic(
 	context.Context,
@@ -242,6 +537,10 @@ func (acoustics *speechRetryAcoustics) EvaluateAcoustic(
 	evaluation.SpeechInputSnapshot,
 ) (evaluation.AcousticCheckpoint, error) {
 	acoustics.calls++
+	if acoustics.calls <= len(acoustics.errors) &&
+		acoustics.errors[acoustics.calls-1] != nil {
+		return evaluation.AcousticCheckpoint{}, acoustics.errors[acoustics.calls-1]
+	}
 	pronunciation := 86.0
 	return evaluation.AcousticCheckpoint{
 		Status:          evaluation.AcousticAssessed,
@@ -250,6 +549,12 @@ func (acoustics *speechRetryAcoustics) EvaluateAcoustic(
 		ProviderSession: "speech-retry-ise-1",
 	}, nil
 }
+
+type speechRetryAcousticFailure struct{}
+
+func (speechRetryAcousticFailure) Error() string          { return "acoustic unavailable" }
+func (speechRetryAcousticFailure) StableCategory() string { return "PROVIDER_UNAVAILABLE" }
+func (speechRetryAcousticFailure) Retryable() bool        { return true }
 
 type speechRetrySessions struct{}
 

--- a/server/internal/coaching/evaluation/postgres/store.go
+++ b/server/internal/coaching/evaluation/postgres/store.go
@@ -300,12 +300,18 @@ func (store *Store) CheckpointSnapshot(
 	}
 	record, err := scanRecord(tx.QueryRow(ctx, `UPDATE evaluations
 		SET input_snapshot = $3::json, input_hash = $4,
+			attempt_count = CASE WHEN $6 THEN 1 ELSE attempt_count END,
 			updated_at = transaction_timestamp()
 		WHERE id = $1 AND user_id = $5 AND status = 'RUNNING'
 		  AND lease_token = $2 AND lease_expires_at > transaction_timestamp()
+		  AND (NOT $6 OR (
+			kind = 'PRACTICE_TURN_FEEDBACK'
+			AND COALESCE(input_snapshot->>'acoustic', '') = ''
+		  ))
 		RETURNING `+evaluationColumns,
 		checkpoint.ID, checkpoint.LeaseToken,
-		checkpoint.InputSnapshot, checkpoint.InputHash[:], checkpoint.UserID))
+		checkpoint.InputSnapshot, checkpoint.InputHash[:], checkpoint.UserID,
+		checkpoint.RestartAttemptBudget))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return evaluation.Record{}, evaluation.ErrClaimLost
 	}

--- a/server/internal/coaching/evaluation/postgres/store_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/store_integration_test.go
@@ -153,7 +153,8 @@ func TestStoreQueueClaimCheckpointDeferCompleteAndItems(t *testing.T) {
 			InputSnapshot: checkpointInput, InputHash: checkpointHash,
 		},
 	)
-	if err != nil || checkpointed.InputHash != checkpointHash {
+	if err != nil || checkpointed.InputHash != checkpointHash ||
+		checkpointed.AttemptCount != 1 {
 		t.Fatalf("CheckpointSnapshot = %#v, %v", checkpointed, err)
 	}
 	if err := store.DeferClaim(context.Background(), evaluation.Deferral{
@@ -207,6 +208,170 @@ func TestStoreQueueClaimCheckpointDeferCompleteAndItems(t *testing.T) {
 			"Queue(changed config after checkpoint) = %#v, %v, %v",
 			afterCheckpoint, replayed, err,
 		)
+	}
+}
+
+func TestCheckpointSnapshotAtomicallyRestartsAndFencesAttemptBudget(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, testUserA, "evaluation-checkpoint@example.com")
+	store := mustStore(t, pool)
+	command := speechQueueCommand(t, testUserA, testTurnA, testSessionA, nil)
+	if _, _, err := store.Queue(context.Background(), command); err != nil {
+		t.Fatal(err)
+	}
+	lane := speechLane(3)
+	first, err := store.ClaimNext(context.Background(), lane)
+	if err != nil || first.AttemptCount != 1 {
+		t.Fatalf("first ClaimNext = %#v, %v", first, err)
+	}
+	if err := store.FailClaim(context.Background(), evaluation.Failure{
+		UserID:     first.UserID,
+		ID:         first.ID,
+		LeaseToken: first.LeaseToken,
+		Error: evaluation.JobError{
+			Code:      "PROVIDER_UNAVAILABLE",
+			Retryable: true,
+			Message:   "Evaluation provider is temporarily unavailable.",
+		},
+		AutomaticRetryable: true,
+		RetryAt:            time.Now().UTC().Add(-time.Second),
+		MaxAttempts:        3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.ClaimNext(context.Background(), lane)
+	if err != nil || second.AttemptCount != 2 {
+		t.Fatalf("second ClaimNext = %#v, %v", second, err)
+	}
+	pronunciation := 91.0
+	checkpointInput, checkpointHash := speechInput(t, testTurnA,
+		&evaluation.AcousticCheckpoint{
+			Status:          evaluation.AcousticAssessed,
+			Pronunciation:   &pronunciation,
+			Provider:        "iflytek",
+			ProviderSession: "ise-session-restart",
+		})
+	checkpointed, err := store.CheckpointSnapshot(
+		context.Background(),
+		evaluation.SnapshotCheckpoint{
+			UserID:               second.UserID,
+			ID:                   second.ID,
+			LeaseToken:           second.LeaseToken,
+			InputSnapshot:        checkpointInput,
+			InputHash:            checkpointHash,
+			RestartAttemptBudget: true,
+		},
+	)
+	if err != nil || checkpointed.AttemptCount != 1 ||
+		checkpointed.InputHash != checkpointHash {
+		t.Fatalf("CheckpointSnapshot restart = %#v, %v", checkpointed, err)
+	}
+	_, err = store.CheckpointSnapshot(
+		context.Background(),
+		evaluation.SnapshotCheckpoint{
+			UserID:               second.UserID,
+			ID:                   second.ID,
+			LeaseToken:           second.LeaseToken,
+			InputSnapshot:        checkpointInput,
+			InputHash:            checkpointHash,
+			RestartAttemptBudget: true,
+		},
+	)
+	if !errors.Is(err, evaluation.ErrClaimLost) {
+		t.Fatalf("repeated attempt restart error = %v", err)
+	}
+
+	fallbackInput, fallbackHash := speechInput(t, testTurnA,
+		&evaluation.AcousticCheckpoint{
+			Status: evaluation.AcousticNotAssessed,
+			Reason: "ACOUSTIC_ASSESSMENT_FAILED",
+		})
+	_, err = store.CheckpointSnapshot(
+		context.Background(),
+		evaluation.SnapshotCheckpoint{
+			UserID:               second.UserID,
+			ID:                   second.ID,
+			LeaseToken:           first.LeaseToken,
+			InputSnapshot:        fallbackInput,
+			InputHash:            fallbackHash,
+			RestartAttemptBudget: true,
+		},
+	)
+	if !errors.Is(err, evaluation.ErrClaimLost) {
+		t.Fatalf("stale checkpoint error = %v", err)
+	}
+
+	expireClaim(t, pool, second.ID)
+	_, err = store.CheckpointSnapshot(
+		context.Background(),
+		evaluation.SnapshotCheckpoint{
+			UserID:               second.UserID,
+			ID:                   second.ID,
+			LeaseToken:           second.LeaseToken,
+			InputSnapshot:        fallbackInput,
+			InputHash:            fallbackHash,
+			RestartAttemptBudget: true,
+		},
+	)
+	if !errors.Is(err, evaluation.ErrClaimLost) {
+		t.Fatalf("expired checkpoint error = %v", err)
+	}
+	var attemptCount int
+	var storedHash []byte
+	if err := pool.QueryRow(context.Background(), `SELECT attempt_count, input_hash
+		FROM evaluations WHERE id=$1`, second.ID).Scan(&attemptCount, &storedHash); err != nil {
+		t.Fatal(err)
+	}
+	if attemptCount != 1 || hex.EncodeToString(storedHash) !=
+		hex.EncodeToString(checkpointHash[:]) {
+		t.Fatalf("expired checkpoint changed row: count=%d hash=%x", attemptCount, storedHash)
+	}
+}
+
+func TestCheckpointSnapshotRejectsAttemptRestartForSessionKind(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, testUserA, "evaluation-session-checkpoint@example.com")
+	store := mustStore(t, pool)
+	command := sessionQueueCommand(t, testUserA, testSessionA)
+	queued, _, err := store.Queue(context.Background(), command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.ClaimNext(context.Background(), sessionLane(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pronunciation := 91.0
+	checkpointInput, checkpointHash := speechInput(t, testTurnA,
+		&evaluation.AcousticCheckpoint{
+			Status:          evaluation.AcousticAssessed,
+			Pronunciation:   &pronunciation,
+			Provider:        "iflytek",
+			ProviderSession: "ise-session-wrong-kind",
+		})
+	_, err = store.CheckpointSnapshot(
+		context.Background(),
+		evaluation.SnapshotCheckpoint{
+			UserID:               claim.UserID,
+			ID:                   claim.ID,
+			LeaseToken:           claim.LeaseToken,
+			InputSnapshot:        checkpointInput,
+			InputHash:            checkpointHash,
+			RestartAttemptBudget: true,
+		},
+	)
+	if !errors.Is(err, evaluation.ErrClaimLost) {
+		t.Fatalf("session attempt restart error = %v", err)
+	}
+	var attemptCount int
+	var storedHash []byte
+	if err := pool.QueryRow(context.Background(), `SELECT attempt_count, input_hash
+		FROM evaluations WHERE id=$1`, claim.ID).Scan(&attemptCount, &storedHash); err != nil {
+		t.Fatal(err)
+	}
+	if attemptCount != 1 || hex.EncodeToString(storedHash) !=
+		hex.EncodeToString(queued.InputHash[:]) {
+		t.Fatalf("session checkpoint changed row: count=%d hash=%x", attemptCount, storedHash)
 	}
 }
 

--- a/server/internal/coaching/evaluation/state.go
+++ b/server/internal/coaching/evaluation/state.go
@@ -136,6 +136,9 @@ type SnapshotCheckpoint struct {
 	LeaseToken    string
 	InputSnapshot json.RawMessage
 	InputHash     [sha256.Size]byte
+	// RestartAttemptBudget marks the first durable acoustic checkpoint as the
+	// start of the speech text-feedback retry stage.
+	RestartAttemptBudget bool
 }
 
 type RetrySource struct {
@@ -151,10 +154,16 @@ func (source RetrySource) Valid() bool {
 }
 
 func (checkpoint SnapshotCheckpoint) Valid() bool {
-	return validUUID(checkpoint.UserID) && validUUID(checkpoint.ID) &&
+	valid := validUUID(checkpoint.UserID) && validUUID(checkpoint.ID) &&
 		validUUID(checkpoint.LeaseToken) &&
 		len(checkpoint.InputSnapshot) > 0 &&
 		sha256.Sum256(checkpoint.InputSnapshot) == checkpoint.InputHash
+	if !valid || !checkpoint.RestartAttemptBudget {
+		return valid
+	}
+	var snapshot SpeechInputSnapshot
+	return DecodeStrict(checkpoint.InputSnapshot, &snapshot) == nil &&
+		snapshot.Valid(KindPracticeTurnFeedback) && snapshot.Acoustic != nil
 }
 
 type Store interface {

--- a/server/internal/coaching/evaluation/worker.go
+++ b/server/internal/coaching/evaluation/worker.go
@@ -633,11 +633,12 @@ func (worker *Worker) evaluateSpeech(
 		updated, checkpointErr := worker.store.CheckpointSnapshot(
 			finalizeContext,
 			SnapshotCheckpoint{
-				UserID:        claim.UserID,
-				ID:            claim.ID,
-				LeaseToken:    claim.LeaseToken,
-				InputSnapshot: encoded,
-				InputHash:     digest,
+				UserID:               claim.UserID,
+				ID:                   claim.ID,
+				LeaseToken:           claim.LeaseToken,
+				InputSnapshot:        encoded,
+				InputHash:            digest,
+				RestartAttemptBudget: true,
 			},
 		)
 		finalizeCancel()

--- a/server/internal/coaching/evaluation/worker_v2_test.go
+++ b/server/internal/coaching/evaluation/worker_v2_test.go
@@ -150,6 +150,9 @@ func TestWorkerPart2ProfileReusesReadyPart1Profile(t *testing.T) {
 			processed, err, profiles.calls, profiles.last,
 			len(store.checkpoints), len(store.completions))
 	}
+	if store.checkpoints[0].RestartAttemptBudget {
+		t.Fatal("profile checkpoint must preserve its attempt budget")
+	}
 }
 
 func TestWorkerPart2ProfileDefersWhilePart1IsRunning(t *testing.T) {
@@ -235,6 +238,9 @@ func TestWorkerFinalReportResolvesPart2ProfileReadyAfter45Seconds(t *testing.T) 
 		t.Fatalf("ProcessSession=(%t,%v), calls=%d snapshot=%#v checkpoints=%d completions=%d",
 			processed, err, sessions.ieltsCalls, sessions.lastIELTSSnapshot,
 			len(store.checkpoints), len(store.completions))
+	}
+	if store.checkpoints[0].RestartAttemptBudget {
+		t.Fatal("session checkpoint must preserve its attempt budget")
 	}
 }
 
@@ -381,6 +387,9 @@ func TestWorkerReusesAcousticCheckpointAfterTextEvaluationRetry(t *testing.T) {
 			len(store.failures),
 		)
 	}
+	if !store.checkpoints[0].RestartAttemptBudget {
+		t.Fatal("speech acoustic checkpoint must restart the text attempt budget")
+	}
 	store.claims[1].InputSnapshot = store.checkpoints[0].InputSnapshot
 	store.claims[1].InputHash = store.checkpoints[0].InputHash
 
@@ -397,6 +406,94 @@ func TestWorkerReusesAcousticCheckpointAfterTextEvaluationRetry(t *testing.T) {
 			speech.practiceCalls,
 			len(store.completions),
 		)
+	}
+}
+
+func TestWorkerRestartsTextBudgetAfterFinalAcousticAttempt(t *testing.T) {
+	now := time.Now().UTC()
+	claim := speechClaimFixture(t, now, KindPracticeTurnFeedback, nil)
+	claim.AttemptCount = workerConfigurationFixture().SpeechLane.MaxAttempts
+	store := &workerStoreFake{claims: []Claim{claim}}
+	speech := &speechEvaluatorsFake{failFirst: true}
+	acoustics := &acousticEvaluatorFake{err: errors.New("provider unavailable")}
+	worker := workerFixture(t, store, &sessionEvaluatorsFake{}, speech, acoustics)
+
+	processed, err := worker.ProcessSpeech(context.Background())
+	var processing *processingFailure
+	if !processed || !errors.As(err, &processing) ||
+		processing.record.AttemptCount != 1 || acoustics.calls != 1 ||
+		speech.practiceCalls != 1 || len(store.checkpoints) != 1 ||
+		!store.checkpoints[0].RestartAttemptBudget ||
+		len(store.completions) != 0 || len(store.failures) != 1 ||
+		store.failures[0].MaxAttempts != worker.configuration.SpeechLane.MaxAttempts ||
+		!store.failures[0].AutomaticRetryable {
+		t.Fatalf(
+			"ProcessSpeech=(%t,%v) processing=%#v acoustic=%d text=%d checkpoints=%#v failures=%#v",
+			processed, err, processing, acoustics.calls, speech.practiceCalls,
+			store.checkpoints, store.failures,
+		)
+	}
+}
+
+func TestSpeechCheckpointRemainsReadableByV016(t *testing.T) {
+	pronunciation := 84.0
+	snapshot := speechSnapshotFixture(&AcousticCheckpoint{
+		Status:          AcousticAssessed,
+		Pronunciation:   &pronunciation,
+		Provider:        "iflytek",
+		ProviderSession: "ise-session-1",
+	})
+	encoded, _, err := EncodeStrict(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var legacy struct {
+		SchemaVersion string              `json:"schema_version"`
+		Transcript    string              `json:"transcript"`
+		EvidenceRefID string              `json:"evidence_ref_id"`
+		QuestionID    string              `json:"question_id,omitempty"`
+		PromptText    string              `json:"prompt_text,omitempty"`
+		AudioAssetID  string              `json:"audio_asset_id,omitempty"`
+		Acoustic      *AcousticCheckpoint `json:"acoustic,omitempty"`
+	}
+	if err := DecodeStrict(encoded, &legacy); err != nil {
+		t.Fatalf("v0.1.6 SpeechInputSnapshot cannot decode checkpoint: %v", err)
+	}
+	if legacy.SchemaVersion != SpeechInputSchemaVersion ||
+		legacy.Acoustic == nil || legacy.Acoustic.Status != AcousticAssessed {
+		t.Fatalf("v0.1.6 checkpoint = %#v", legacy)
+	}
+}
+
+func TestSnapshotCheckpointRequiresAcousticBeforeRestartingAttemptBudget(t *testing.T) {
+	now := time.Now().UTC()
+	claim := speechClaimFixture(t, now, KindPracticeTurnFeedback, nil)
+	withoutAcoustic := SnapshotCheckpoint{
+		UserID:               claim.UserID,
+		ID:                   claim.ID,
+		LeaseToken:           claim.LeaseToken,
+		InputSnapshot:        claim.InputSnapshot,
+		InputHash:            claim.InputHash,
+		RestartAttemptBudget: true,
+	}
+	if withoutAcoustic.Valid() {
+		t.Fatal("attempt budget restart without a durable acoustic checkpoint is invalid")
+	}
+	pronunciation := 84.0
+	withAcoustic := speechSnapshotFixture(&AcousticCheckpoint{
+		Status:          AcousticAssessed,
+		Pronunciation:   &pronunciation,
+		Provider:        "iflytek",
+		ProviderSession: "ise-session-1",
+	})
+	encoded, digest, err := EncodeStrict(withAcoustic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutAcoustic.InputSnapshot = encoded
+	withoutAcoustic.InputHash = digest
+	if !withoutAcoustic.Valid() {
+		t.Fatal("durable acoustic checkpoint should allow one attempt budget restart")
 	}
 }
 
@@ -924,10 +1021,16 @@ func (store *workerStoreFake) CheckpointSnapshot(
 	_ context.Context,
 	checkpoint SnapshotCheckpoint,
 ) (Record, error) {
-	store.checkpoints = append(store.checkpoints, checkpoint)
 	record := store.claims[store.claimIndex-1].Record
+	if checkpoint.RestartAttemptBudget && record.Kind != KindPracticeTurnFeedback {
+		return Record{}, ErrClaimLost
+	}
+	store.checkpoints = append(store.checkpoints, checkpoint)
 	record.InputSnapshot = checkpoint.InputSnapshot
 	record.InputHash = checkpoint.InputHash
+	if checkpoint.RestartAttemptBudget {
+		record.AttemptCount = 1
+	}
 	return record, nil
 }
 


### PR DESCRIPTION
## 功能描述

- 将练习语音反馈的声学评测与文本反馈重试预算隔离。
- 声学阶段最多尝试 3 次；无论最终成功还是明确降级为 `NOT_ASSESSED`，文本阶段仍拥有独立的最多 3 次尝试。
- 已完成的声学 checkpoint 会被复用，文本重试不会再次调用讯飞。

## 实现思路

- 不修改 `speech-evaluation-input/v1` JSON，也不增加数据库 migration，保持 v0.1.6/schema 9 回滚读取兼容。
- 首次持久化声学 checkpoint 时，在同一条 PostgreSQL `UPDATE` 中原子写入 snapshot/hash，并把现有 `attempt_count` 重置为文本阶段的第 1 次。
- 重置只允许用于 `PRACTICE_TURN_FEEDBACK`、有效 lease、当前尚无声学 checkpoint 的记录；重复调用、错误 kind、旧 lease 和过期 lease均 fail closed。
- 每个阶段仍使用既有 3 次上限，不提高全局重试数，也不引入无限重试。

## 可复现测试

- `TEST_DATABASE_URL=<local-postgres-url> go test -count=1 ./internal/coaching/evaluation/...`
- `TEST_DATABASE_URL=<local-postgres-url> go test -race -count=1 ./internal/coaching/evaluation ./internal/coaching/evaluation/postgres`
- `go vet ./internal/coaching/evaluation/...`
- `TEST_DATABASE_URL=<local-postgres-url> make check-go-test`
- `TEST_DATABASE_URL=<local-postgres-url> make check-go-coverage`

本地结果：真实 PostgreSQL 独立预算、双阶段耗尽、checkpoint 后崩溃恢复、lease/kind fencing 均通过；全量 Go 测试通过；总覆盖率 64.6%。

## 范围说明

本 PR 只修复 #960 的阶段重试预算问题，不宣称解决纯文本 `AGENT_MESSAGE_FEEDBACK` 的 `PROVIDER_RESPONSE_INVALID`；后者由 #976 独立跟踪。

Fixes #960
Related #953
Related #976
