### PR TITLE
fix(mobile): 修复断网后语音无法再次录音

### DIFF
--- a/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
@@ -1519,16 +1519,24 @@ final class AgentVoiceController extends ChangeNotifier
       notifyListeners();
     }
     final cleanup = Future<void>.sync(() async {
-      await _startWorkflowCleanup(
+      final workflowCleanup = _startWorkflowCleanup(
         realtime: staleRealtime,
         operation: staleOperation,
         recording: staleRecording,
         draft: staleDraft,
       );
       await Future.wait<void>([
+        workflowCleanup,
         Future<void>.sync(recorder.clearAccountState),
         Future<void>.sync(audioPlayer.clearAccountState),
         if (clearClient) Future<void>.sync(client.clearAccountState),
+      ]);
+      // A fenced operation may finish after the first account clear. Make a
+      // final strict pass so no late local recording or playback survives the
+      // account boundary.
+      await Future.wait<void>([
+        Future<void>.sync(recorder.clearAccountState),
+        Future<void>.sync(audioPlayer.clearAccountState),
       ]);
     });
     _cleanupFuture = cleanup;

--- a/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_controller.dart
@@ -46,12 +46,16 @@ final class AgentVoiceController extends ChangeNotifier
     this.maximumDraftPolls = 75,
     this.maximumRunPolls = 75,
     this.recordingLimit = const Duration(seconds: 58),
+    this.realtimeCompletionTimeout = const Duration(seconds: 75),
+    this.workflowCleanupTimeout = const Duration(seconds: 2),
   }) {
     if (pollInterval.isNegative ||
         maximumDraftPolls < 1 ||
         maximumRunPolls < 1 ||
         recordingLimit <= Duration.zero ||
-        recordingLimit > const Duration(seconds: 60)) {
+        recordingLimit > const Duration(seconds: 60) ||
+        realtimeCompletionTimeout <= Duration.zero ||
+        workflowCleanupTimeout <= Duration.zero) {
       throw ArgumentError('Agent voice controller configuration is invalid.');
     }
     _completionSubscription = audioPlayer.onComplete.listen((_) {
@@ -76,6 +80,8 @@ final class AgentVoiceController extends ChangeNotifier
   final int maximumDraftPolls;
   final int maximumRunPolls;
   final Duration recordingLimit;
+  final Duration realtimeCompletionTimeout;
+  final Duration workflowCleanupTimeout;
 
   String? _threadId;
   AgentVoiceComposerState _state = AgentVoiceComposerState.idle;
@@ -104,7 +110,8 @@ final class AgentVoiceController extends ChangeNotifier
   bool _backgrounded = false;
   int _lifecycleGeneration = 0;
   Future<void>? _workflowOperation;
-  Future<_RealtimeDraftResult>? _realtimeDraft;
+  _RealtimeDraftSession? _realtimeSession;
+  Future<void>? _workflowCleanup;
   Future<void>? _cleanupFuture;
 
   bool _draftPlaying = false;
@@ -123,6 +130,8 @@ final class AgentVoiceController extends ChangeNotifier
   bool get canStartRecording =>
       !_disposed &&
       !_backgrounded &&
+      _workflowCleanup == null &&
+      _workflowOperation == null &&
       _threadId != null &&
       _state == AgentVoiceComposerState.idle;
   bool get canStopRecording => _state == AgentVoiceComposerState.recording;
@@ -143,11 +152,24 @@ final class AgentVoiceController extends ChangeNotifier
   /// A local playback cleanup failure is surfaced as retryable Composer state;
   /// it never rolls back or desynchronizes the server-confirmed Thread focus.
   Future<void> bindThread(String? threadId) async {
+    final cleanup = _workflowCleanup;
+    if (cleanup != null) {
+      await cleanup;
+    }
     if (threadId == _threadId) {
+      // A concurrent bind may have installed cleanup after the first await.
+      // Starting capture must wait for that cleanup instead of becoming a
+      // silent no-op behind [canStartRecording].
+      final concurrentCleanup = _workflowCleanup;
+      if (concurrentCleanup != null) {
+        await concurrentCleanup;
+      }
       return;
     }
     final staleRecording = _recording;
     final staleDraft = _draft;
+    final staleRealtime = _realtimeSession;
+    final staleOperation = _workflowOperation;
     _workflowGeneration++;
     _draftPlaybackGeneration++;
     _cancelRecordingTimers();
@@ -158,13 +180,12 @@ final class AgentVoiceController extends ChangeNotifier
       notifyListeners();
     }
     try {
-      await Future.wait<void>([
-        _discardCurrentBestEffort(),
-        if (staleRecording != null) _discardRecordingBestEffort(staleRecording),
-        Future<void>.sync(audioPlayer.stop),
-        if (staleDraft != null && !_isConfirmed(staleDraft))
-          _deleteDraftBestEffort(staleDraft.id),
-      ]);
+      await _startWorkflowCleanup(
+        realtime: staleRealtime,
+        operation: staleOperation,
+        recording: staleRecording,
+        draft: staleDraft,
+      );
     } catch (_) {
       if (!_disposed && _threadId == threadId) {
         _state = AgentVoiceComposerState.failed;
@@ -209,14 +230,18 @@ final class AgentVoiceController extends ChangeNotifier
           when client is AgentVoiceRealtimeInputClient) {
         final idempotencyKey = _newId('voice-upload');
         final chunks = await streamingRecorder.startAudioStream();
+        if (!_isWorkflowCurrent(fence)) {
+          await recorder.discardCurrent();
+          return;
+        }
         _uploadIdempotencyKey = idempotencyKey;
-        _realtimeDraft = _collectRealtimeDraft(
-          fence,
-          (client as AgentVoiceRealtimeInputClient).createDraftRealtime(
+        _realtimeSession = _RealtimeDraftSession(
+          events: (client as AgentVoiceRealtimeInputClient).createDraftRealtime(
             threadId: fence.threadId,
             audioChunks: chunks,
             idempotencyKey: idempotencyKey,
           ),
+          collect: (events) => _collectRealtimeDraft(fence, events),
         );
       } else {
         await recorder.start();
@@ -268,9 +293,9 @@ final class AgentVoiceController extends ChangeNotifier
   }
 
   Future<void> _stopRecording(_WorkflowFence fence) async {
-    final usedRealtimeInput = _realtimeDraft != null;
+    final realtime = _realtimeSession;
+    final usedRealtimeInput = realtime != null;
     try {
-      final realtime = _realtimeDraft;
       final recording =
           realtime != null && recorder is AgentVoiceStreamingRecorder
           ? await (recorder as AgentVoiceStreamingRecorder).stopAudioStream()
@@ -287,8 +312,24 @@ final class AgentVoiceController extends ChangeNotifier
       } else {
         _state = AgentVoiceComposerState.transcribing;
         notifyListeners();
-        final result = await realtime;
-        _realtimeDraft = null;
+        final result = await realtime.result.timeout(
+          realtimeCompletionTimeout,
+          onTimeout: () async {
+            await _cancelRealtimeBestEffort(realtime);
+            return const _RealtimeDraftResult(
+              error: AgentClientException(
+                kind: AgentClientFailureKind.network,
+                retryable: true,
+              ),
+            );
+          },
+        );
+        if (identical(_realtimeSession, realtime)) {
+          _realtimeSession = null;
+        }
+        if (!_isWorkflowCurrent(fence)) {
+          return;
+        }
         if (result.error case final error?) {
           throw error;
         }
@@ -311,7 +352,9 @@ final class AgentVoiceController extends ChangeNotifier
       _retry = null;
     } catch (error) {
       if (_isWorkflowCurrent(fence)) {
-        _realtimeDraft = null;
+        if (identical(_realtimeSession, realtime)) {
+          _realtimeSession = null;
+        }
         _state = AgentVoiceComposerState.failed;
         if (usedRealtimeInput && _recording != null) {
           _errorMessage = _uploadFailureMessage(error);
@@ -329,11 +372,12 @@ final class AgentVoiceController extends ChangeNotifier
 
   Future<_RealtimeDraftResult> _collectRealtimeDraft(
     _WorkflowFence fence,
-    Stream<AgentVoiceTranscriptionEvent> events,
+    StreamIterator<AgentVoiceTranscriptionEvent> events,
   ) async {
     AgentVoiceDraft? completed;
     try {
-      await for (final event in events) {
+      while (await events.moveNext()) {
+        final event = events.current;
         if (!_isWorkflowCurrent(fence)) {
           if (event case AgentVoiceDraftCompleted(:final draft)) {
             await _deleteDraftBestEffort(draft.id);
@@ -355,24 +399,29 @@ final class AgentVoiceController extends ChangeNotifier
   }
 
   Future<void> cancel() async {
+    final existingCleanup = _workflowCleanup;
+    if (existingCleanup != null) {
+      await existingCleanup;
+      return;
+    }
     final staleRecording = _recording;
     final staleDraft = _draft;
+    final staleRealtime = _realtimeSession;
+    final staleOperation = _workflowOperation;
     _workflowGeneration++;
     _draftPlaybackGeneration++;
     _cancelRecordingTimers();
     _resetWorkflowPresentation();
-    _realtimeDraft = null;
     _resetDraftPlayback();
     if (!_disposed) {
       notifyListeners();
     }
-    await Future.wait<void>([
-      _discardCurrentBestEffort(),
-      if (staleRecording != null) _discardRecordingBestEffort(staleRecording),
-      Future<void>.sync(audioPlayer.stop),
-      if (staleDraft != null && !_isConfirmed(staleDraft))
-        _deleteDraftBestEffort(staleDraft.id),
-    ]);
+    await _startWorkflowCleanup(
+      realtime: staleRealtime,
+      operation: staleOperation,
+      recording: staleRecording,
+      draft: staleDraft,
+    );
   }
 
   Future<void> rerecord() async {
@@ -1384,12 +1433,79 @@ final class AgentVoiceController extends ChangeNotifier
     await operation;
   }
 
+  Future<void> _startWorkflowCleanup({
+    required _RealtimeDraftSession? realtime,
+    required Future<void>? operation,
+    required AgentVoiceLocalRecording? recording,
+    required AgentVoiceDraft? draft,
+  }) {
+    final existing = _workflowCleanup;
+    if (existing != null) {
+      return existing;
+    }
+    late final Future<void> cleanup;
+    cleanup =
+        Future<void>.sync(() async {
+          await _cancelRealtimeBestEffort(realtime);
+          await _awaitOperationBestEffort(operation);
+          await Future.wait<void>([
+            _discardCurrentBestEffort(),
+            if (recording != null) _discardRecordingBestEffort(recording),
+            Future<void>.sync(audioPlayer.stop),
+            if (draft != null && !_isConfirmed(draft))
+              _deleteDraftBestEffort(draft.id),
+          ]);
+        }).whenComplete(() {
+          if (identical(_workflowCleanup, cleanup)) {
+            _workflowCleanup = null;
+            if (!_disposed) {
+              notifyListeners();
+            }
+          }
+        });
+    _workflowCleanup = cleanup;
+    if (!_disposed) {
+      notifyListeners();
+    }
+    return cleanup;
+  }
+
+  Future<void> _cancelRealtimeBestEffort(
+    _RealtimeDraftSession? realtime,
+  ) async {
+    if (realtime == null) {
+      return;
+    }
+    try {
+      await realtime.cancel().timeout(workflowCleanupTimeout);
+    } catch (_) {
+      // The workflow fence and recorder cleanup still isolate stale input.
+    }
+  }
+
+  Future<void> _awaitOperationBestEffort(Future<void>? operation) async {
+    if (operation == null) {
+      return;
+    }
+    try {
+      await operation.timeout(workflowCleanupTimeout);
+    } catch (_) {
+      // The generation fence prevents the stale operation from publishing.
+      // Keeping `_workflowOperation` set until its source actually completes
+      // also prevents a new recording from running concurrently with it.
+    }
+  }
+
   Future<void> clearPrivateState({bool clearClient = true}) async {
     final existing = _cleanupFuture;
     if (existing != null) {
       await existing;
       return;
     }
+    final staleRecording = _recording;
+    final staleDraft = _draft;
+    final staleRealtime = _realtimeSession;
+    final staleOperation = _workflowOperation;
     _accountEpoch++;
     _workflowGeneration++;
     _draftPlaybackGeneration++;
@@ -1402,17 +1518,22 @@ final class AgentVoiceController extends ChangeNotifier
     if (!_disposed) {
       notifyListeners();
     }
-    final cleanup = Future.wait<void>([
-      Future<void>.sync(recorder.clearAccountState),
-      Future<void>.sync(audioPlayer.clearAccountState),
-      if (clearClient) Future<void>.sync(client.clearAccountState),
-    ]);
+    final cleanup = Future<void>.sync(() async {
+      await _startWorkflowCleanup(
+        realtime: staleRealtime,
+        operation: staleOperation,
+        recording: staleRecording,
+        draft: staleDraft,
+      );
+      await Future.wait<void>([
+        Future<void>.sync(recorder.clearAccountState),
+        Future<void>.sync(audioPlayer.clearAccountState),
+        if (clearClient) Future<void>.sync(client.clearAccountState),
+      ]);
+    });
     _cleanupFuture = cleanup;
     try {
       await cleanup;
-      await _workflowOperation;
-      await recorder.clearAccountState();
-      await audioPlayer.clearAccountState();
     } finally {
       if (identical(_cleanupFuture, cleanup)) {
         _cleanupFuture = null;
@@ -1528,6 +1649,8 @@ final class AgentVoiceController extends ChangeNotifier
     if (_disposed) {
       return;
     }
+    final staleRealtime = _realtimeSession;
+    final staleOperation = _workflowOperation;
     _disposed = true;
     WidgetsBinding.instance.removeObserver(this);
     _accountEpoch++;
@@ -1536,10 +1659,21 @@ final class AgentVoiceController extends ChangeNotifier
     _lifecycleGeneration++;
     _cancelRecordingTimers();
     unawaited(_completionSubscription?.cancel());
-    unawaited(recorder.discardCurrent());
-    unawaited(audioPlayer.dispose());
-    unawaited(client.dispose());
+    unawaited(_disposeResources(staleRealtime, staleOperation));
     super.dispose();
+  }
+
+  Future<void> _disposeResources(
+    _RealtimeDraftSession? realtime,
+    Future<void>? operation,
+  ) async {
+    await _cancelRealtimeBestEffort(realtime);
+    await _awaitOperationBestEffort(operation);
+    await Future.wait<void>([
+      Future<void>.sync(recorder.discardCurrent),
+      Future<void>.sync(audioPlayer.dispose),
+      Future<void>.sync(client.dispose),
+    ]);
   }
 
   void _startRecordingTimers(_WorkflowFence fence) {
@@ -1601,7 +1735,7 @@ final class AgentVoiceController extends ChangeNotifier
     _confirmationCommand = null;
     _runRetrySourceRunId = null;
     _runRetryId = null;
-    _realtimeDraft = null;
+    _realtimeSession = null;
     _recordingElapsed = Duration.zero;
   }
 
@@ -1962,6 +2096,34 @@ final class _RealtimeDraftResult {
 
   final AgentVoiceDraft? draft;
   final Object? error;
+}
+
+final class _RealtimeDraftSession {
+  _RealtimeDraftSession({
+    required Stream<AgentVoiceTranscriptionEvent> events,
+    required Future<_RealtimeDraftResult> Function(
+      StreamIterator<AgentVoiceTranscriptionEvent> events,
+    )
+    collect,
+  }) {
+    final iterator = StreamIterator<AgentVoiceTranscriptionEvent>(events);
+    _events = iterator;
+    result = collect(iterator);
+  }
+
+  late final StreamIterator<AgentVoiceTranscriptionEvent> _events;
+  late final Future<_RealtimeDraftResult> result;
+  Future<void>? _cancellation;
+
+  Future<void> cancel() {
+    final existing = _cancellation;
+    if (existing != null) {
+      return existing;
+    }
+    final cancellation = Future<void>.sync(_events.cancel);
+    _cancellation = cancellation;
+    return cancellation;
+  }
 }
 
 final class _AsrRetryCommand {

--- a/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
+++ b/mobile/lib/features/agent/composer/voice/agent_voice_recording.dart
@@ -121,6 +121,7 @@ final class IosAgentVoiceRecorder
   static const _minimumWavBytes = 45;
   static const _maximumWavBytes = 7400000;
   static const _maximumPCMBytes = 16000 * 2 * 60;
+  static const _nativeCleanupTimeout = Duration(seconds: 2);
 
   final NativeAgentVoiceRecorder _recorder;
   final Future<Directory> Function() _temporaryDirectory;
@@ -130,68 +131,126 @@ final class IosAgentVoiceRecorder
   String? _activePath;
   DateTime? _startedAt;
   Pcm16StreamCapture? _streamCapture;
+  int _startGeneration = 0;
+  bool _startPending = false;
+  Future<String?>? _nativeStop;
 
   @override
   Future<void> start() async {
-    if (_activePath != null) {
-      throw const AgentVoiceRecordingException(
-        AgentVoiceRecordingFailureKind.alreadyRecording,
-      );
-    }
-    await _retryPendingDeletions();
-    if (!await _recorder.hasPermission()) {
-      throw const AgentVoiceRecordingException(
-        AgentVoiceRecordingFailureKind.permissionDenied,
-      );
-    }
-    final directory = await _managedDirectory();
-    final path = '${directory.path}/${_newFileName()}';
-    _activePath = path;
-    _startedAt = _clock();
+    final generation = _beginStart();
+    String? path;
+    var started = false;
     try {
+      await _retryPendingDeletions();
+      _requireStartCurrent(generation);
+      final hasPermission = await _recorder.hasPermission();
+      _requireStartCurrent(generation);
+      if (!hasPermission) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.permissionDenied,
+        );
+      }
+      final directory = await _managedDirectory();
+      _requireStartCurrent(generation);
+      path = '${directory.path}/${_newFileName()}';
+      _activePath = path;
+      _startedAt = _clock();
       await _recorder.startWav(path);
+      _requireStartCurrent(generation);
+      if (_activePath != path) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.unavailable,
+        );
+      }
+      started = true;
+    } on AgentVoiceRecordingException {
+      rethrow;
     } catch (_) {
-      _activePath = null;
-      _startedAt = null;
-      await _deletePath(path);
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.unavailable,
       );
+    } finally {
+      try {
+        if (!started) {
+          if (path != null) {
+            await _stopNativeBestEffort(forceAfterCurrent: true);
+          }
+          if (_activePath == path) {
+            _activePath = null;
+            _startedAt = null;
+          }
+          if (path != null) {
+            await _deletePath(path);
+          }
+        }
+      } finally {
+        _startPending = false;
+      }
     }
   }
 
   @override
   Future<Stream<Uint8List>> startAudioStream() async {
-    if (_activePath != null) {
-      throw const AgentVoiceRecordingException(
-        AgentVoiceRecordingFailureKind.alreadyRecording,
-      );
-    }
-    await _retryPendingDeletions();
-    if (!await _recorder.hasPermission()) {
-      throw const AgentVoiceRecordingException(
-        AgentVoiceRecordingFailureKind.permissionDenied,
-      );
-    }
-    final directory = await _managedDirectory();
-    final path = '${directory.path}/${_newFileName()}';
-    _activePath = path;
-    _startedAt = _clock();
+    final generation = _beginStart();
+    String? path;
+    Pcm16StreamCapture? capture;
+    var started = false;
     try {
+      await _retryPendingDeletions();
+      _requireStartCurrent(generation);
+      final hasPermission = await _recorder.hasPermission();
+      _requireStartCurrent(generation);
+      if (!hasPermission) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.permissionDenied,
+        );
+      }
+      final directory = await _managedDirectory();
+      _requireStartCurrent(generation);
+      path = '${directory.path}/${_newFileName()}';
+      _activePath = path;
+      _startedAt = _clock();
       final input = await _recorder.startPcm16Stream();
-      final capture = Pcm16StreamCapture(
+      capture = Pcm16StreamCapture(
         input: input,
         maximumPcmBytes: _maximumPCMBytes,
       );
+      _requireStartCurrent(generation);
+      if (_activePath != path) {
+        throw const AgentVoiceRecordingException(
+          AgentVoiceRecordingFailureKind.unavailable,
+        );
+      }
       _streamCapture = capture;
+      started = true;
       return capture.stream;
+    } on AgentVoiceRecordingException {
+      rethrow;
     } catch (_) {
-      _clearStreamingState();
-      _activePath = null;
-      _startedAt = null;
       throw const AgentVoiceRecordingException(
         AgentVoiceRecordingFailureKind.unavailable,
       );
+    } finally {
+      try {
+        if (!started) {
+          await Future.wait<void>([
+            _cancelCaptureBestEffort(capture),
+            if (path != null) _stopNativeBestEffort(forceAfterCurrent: true),
+          ]);
+          if (identical(_streamCapture, capture)) {
+            _clearStreamingState();
+          }
+          if (_activePath == path) {
+            _activePath = null;
+            _startedAt = null;
+          }
+          if (path != null) {
+            await _deletePath(path);
+          }
+        }
+      } finally {
+        _startPending = false;
+      }
     }
   }
 
@@ -208,7 +267,7 @@ final class IosAgentVoiceRecorder
     _startedAt = null;
     String? stoppedPath;
     try {
-      stoppedPath = await _recorder.stop();
+      stoppedPath = await _stopNative();
     } catch (_) {
       await _deletePath(expectedPath);
       throw const AgentVoiceRecordingException(
@@ -273,7 +332,7 @@ final class IosAgentVoiceRecorder
     _activePath = null;
     _startedAt = null;
     try {
-      await _recorder.stop();
+      await _stopNative();
       final wav = await capture.finish();
       await File(path).writeAsBytes(wav, flush: true);
       final elapsed = _boundedRecordingDuration(startedAt);
@@ -315,7 +374,7 @@ final class IosAgentVoiceRecorder
     _activePath = null;
     _startedAt = null;
     try {
-      await _recorder.stop();
+      await _stopNative();
       await capture.finishAndDiscard();
     } on Pcm16StreamCaptureException catch (error) {
       await capture.cancel();
@@ -336,22 +395,84 @@ final class IosAgentVoiceRecorder
 
   @override
   Future<void> discardCurrent() async {
+    _startGeneration++;
     final path = _activePath;
     final capture = _streamCapture;
+    final shouldStopNative = path != null || capture != null || _startPending;
     _activePath = null;
     _startedAt = null;
+    _clearStreamingState();
+    await Future.wait<void>([
+      _cancelCaptureBestEffort(capture),
+      if (shouldStopNative) _stopNativeBestEffort(),
+    ]);
     if (path == null) {
       await _retryPendingDeletions();
       return;
     }
-    await capture?.cancel();
-    try {
-      await _recorder.stop();
-    } catch (_) {
-      // The owned path is still removed below.
-    }
-    _clearStreamingState();
     await _deletePath(path);
+  }
+
+  int _beginStart() {
+    if (_activePath != null ||
+        _streamCapture != null ||
+        _startPending ||
+        _nativeStop != null) {
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.alreadyRecording,
+      );
+    }
+    _startPending = true;
+    return ++_startGeneration;
+  }
+
+  void _requireStartCurrent(int generation) {
+    if (generation != _startGeneration) {
+      throw const AgentVoiceRecordingException(
+        AgentVoiceRecordingFailureKind.unavailable,
+      );
+    }
+  }
+
+  Future<String?> _stopNative({bool forceAfterCurrent = false}) {
+    final existing = _nativeStop;
+    if (existing != null && !forceAfterCurrent) {
+      return existing;
+    }
+    // Cleanup callers share one stop. A fenced late start queues one successor
+    // because an earlier stop may have run before native capture became active.
+    final predecessor = existing == null
+        ? Future<void>.value()
+        : existing.then<void>((_) {}, onError: (Object _, StackTrace _) {});
+    late final Future<String?> stop;
+    stop = predecessor.then((_) => _recorder.stop()).whenComplete(() {
+      if (identical(_nativeStop, stop)) {
+        _nativeStop = null;
+      }
+    });
+    _nativeStop = stop;
+    return stop;
+  }
+
+  Future<void> _stopNativeBestEffort({bool forceAfterCurrent = false}) async {
+    try {
+      await _stopNative(
+        forceAfterCurrent: forceAfterCurrent,
+      ).timeout(_nativeCleanupTimeout);
+    } catch (_) {
+      // The owned local state is still cleared by the caller.
+    }
+  }
+
+  Future<void> _cancelCaptureBestEffort(Pcm16StreamCapture? capture) async {
+    if (capture == null) {
+      return;
+    }
+    try {
+      await capture.cancel().timeout(_nativeCleanupTimeout);
+    } catch (_) {
+      // The paired native stop still releases the microphone at the fence.
+    }
   }
 
   Duration _boundedRecordingDuration(DateTime startedAt) {

--- a/mobile/lib/platform/audio/realtime_voice_input.dart
+++ b/mobile/lib/platform/audio/realtime_voice_input.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:speakup/identity/network/authenticated_web_socket.dart';
@@ -26,9 +27,19 @@ final class RealtimeVoiceInputEnvelope {
 }
 
 final class RealtimeVoiceInputTransport {
-  const RealtimeVoiceInputTransport({required this.connector});
+  RealtimeVoiceInputTransport({
+    required this.connector,
+    this.connectionTimeout = const Duration(seconds: 15),
+    this.pingInterval = const Duration(seconds: 10),
+  }) {
+    if (connectionTimeout <= Duration.zero || pingInterval <= Duration.zero) {
+      throw ArgumentError('Realtime voice input timing is invalid.');
+    }
+  }
 
   final SessionAuthenticatedWebSocketConnector connector;
+  final Duration connectionTimeout;
+  final Duration pingInterval;
 
   Stream<RealtimeVoiceInputEnvelope> stream({
     required Uri uri,
@@ -54,8 +65,9 @@ final class RealtimeVoiceInputTransport {
     final senderControl = _RealtimeVoiceInputSenderControl();
     var receivedTerminalEvent = false;
     try {
-      connection = await connector.connect(uri: uri);
+      connection = await _connect(uri);
       ensureCurrent();
+      connection.socket.pingInterval = pingInterval;
       connection.socket.add(
         jsonEncode(<String, Object>{
           'type': 'start',
@@ -70,6 +82,16 @@ final class RealtimeVoiceInputTransport {
         ensureCurrent: ensureCurrent,
         maximumChunkBytes: maximumChunkBytes,
         control: senderControl,
+        onAudioFinished: () {
+          // The server stops reading after `finish` while it waits for the
+          // provider terminal result. Bound that phase at the controller
+          // instead of treating a missing control-frame pong as a disconnect.
+          try {
+            connection?.socket.pingInterval = null;
+          } catch (_) {
+            // The socket may already have closed because the sender failed.
+          }
+        },
       );
       await for (final message in connection.socket) {
         ensureCurrent();
@@ -122,7 +144,42 @@ final class RealtimeVoiceInputTransport {
           // cancelled consumer only needs its socket and microphone released.
         }
       }
-      await connection?.socket.close();
+      if (connection != null) {
+        await _closeBestEffort(connection.socket);
+      }
+    }
+  }
+
+  Future<SessionAuthenticatedWebSocketConnection> _connect(Uri uri) async {
+    final pending = connector.connect(uri: uri);
+    try {
+      return await pending.timeout(connectionTimeout);
+    } on TimeoutException {
+      unawaited(_closeLateConnection(pending));
+      throw const RealtimeVoiceInputException(
+        RealtimeVoiceInputFailureKind.network,
+      );
+    }
+  }
+
+  Future<void> _closeLateConnection(
+    Future<SessionAuthenticatedWebSocketConnection> pending,
+  ) async {
+    try {
+      final connection = await pending;
+      await _closeBestEffort(connection.socket);
+    } catch (_) {
+      // The timed-out dial either failed independently or was closed here.
+    }
+  }
+
+  Future<void> _closeBestEffort(WebSocket socket) async {
+    socket.pingInterval = null;
+    try {
+      await socket.close().timeout(connectionTimeout);
+    } catch (_) {
+      // Closing is terminal cleanup. The active stream already exposes the
+      // protocol, network, or cancellation result that selected this path.
     }
   }
 }
@@ -133,6 +190,7 @@ Future<void> _sendAudio({
   required void Function() ensureCurrent,
   required int maximumChunkBytes,
   required _RealtimeVoiceInputSenderControl control,
+  required void Function() onAudioFinished,
 }) async {
   try {
     while (await chunks.moveNext()) {
@@ -162,6 +220,8 @@ Future<void> _sendAudio({
       // Preserve the capture or account-fence failure that ended the stream.
     }
     Error.throwWithStackTrace(error, stackTrace);
+  } finally {
+    onAudioFinished();
   }
 }
 

--- a/mobile/lib/providers/agent/wire_agent_voice_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_voice_client.dart
@@ -90,13 +90,13 @@ final class WireAgentVoiceClient
     AuthenticatedWebSocketConnector? assistantSpeechConnector,
     AgentVoiceNow? now,
     Duration requestTimeout = const Duration(seconds: 75),
+    Duration realtimeConnectionTimeout = const Duration(seconds: 15),
+    Duration realtimePingInterval = const Duration(seconds: 10),
   }) {
-    if (requestTimeout <= Duration.zero) {
-      throw ArgumentError.value(
-        requestTimeout,
-        'requestTimeout',
-        'must be positive',
-      );
+    if (requestTimeout <= Duration.zero ||
+        realtimeConnectionTimeout <= Duration.zero ||
+        realtimePingInterval <= Duration.zero) {
+      throw ArgumentError('Agent voice client timing must be positive.');
     }
     final createTransport =
         transportFactory ??
@@ -132,6 +132,8 @@ final class WireAgentVoiceClient
         trustedBaseUri: _webSocketBaseUri(baseUri),
       ),
       requestTimeout,
+      realtimeConnectionTimeout,
+      realtimePingInterval,
       now ?? _utcNow,
     );
   }
@@ -149,6 +151,8 @@ final class WireAgentVoiceClient
     this._realtimeConnector,
     this._assistantSpeechConnector,
     this._requestTimeout,
+    this._realtimeConnectionTimeout,
+    this._realtimePingInterval,
     this._now,
   );
 
@@ -171,6 +175,8 @@ final class WireAgentVoiceClient
   final SessionAuthenticatedWebSocketConnector _realtimeConnector;
   final SessionAuthenticatedWebSocketConnector _assistantSpeechConnector;
   final Duration _requestTimeout;
+  final Duration _realtimeConnectionTimeout;
+  final Duration _realtimePingInterval;
   final AgentVoiceNow _now;
 
   int _accountGeneration = 0;
@@ -304,6 +310,8 @@ final class WireAgentVoiceClient
     try {
       final transport = RealtimeVoiceInputTransport(
         connector: _realtimeConnector,
+        connectionTimeout: _realtimeConnectionTimeout,
+        pingInterval: _realtimePingInterval,
       );
       await for (final envelope in transport.stream(
         uri: uri,
@@ -357,6 +365,8 @@ final class WireAgentVoiceClient
     try {
       final transport = RealtimeVoiceInputTransport(
         connector: _realtimeConnector,
+        connectionTimeout: _realtimeConnectionTimeout,
+        pingInterval: _realtimePingInterval,
       );
       await for (final envelope in transport.stream(
         uri: uri,

--- a/mobile/test/agent/agent_voice_fence_test.dart
+++ b/mobile/test/agent/agent_voice_fence_test.dart
@@ -37,6 +37,203 @@ void main() {
     expect(controller.state, AgentVoiceComposerState.awaitingConfirmation);
     expect(controller.editedTranscript, 'Draft text');
   });
+
+  test(
+    'stuck realtime cancellation gates cleanup and permits a second recording',
+    () async {
+      final cancelGate = Completer<void>();
+      final client = _StallingRealtimeVoiceClient(cancelGate: cancelGate);
+      final recorder = _StreamingVoiceRecorder();
+      final controller = _controller(
+        client,
+        <AgentMessage>[],
+        recorder: recorder,
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-a');
+
+      await controller.startRecording();
+      await client.sessions.single.listened.future.timeout(
+        const Duration(seconds: 1),
+      );
+      final stopping = controller.stopRecording();
+      await _waitUntil(
+        () => controller.state == AgentVoiceComposerState.transcribing,
+      );
+
+      final cancelling = controller.cancel();
+      await client.sessions.single.cancelRequested.future.timeout(
+        const Duration(seconds: 1),
+      );
+      expect(controller.state, AgentVoiceComposerState.idle);
+      expect(controller.canStartRecording, isFalse);
+      await controller.startRecording();
+      expect(client.realtimeCalls, 1);
+
+      cancelGate.complete();
+      await cancelling.timeout(const Duration(seconds: 1));
+      await stopping.timeout(const Duration(seconds: 1));
+      expect(controller.canStartRecording, isTrue);
+
+      await controller.startRecording();
+      await client.sessions[1].listened.future.timeout(
+        const Duration(seconds: 1),
+      );
+      expect(controller.state, AgentVoiceComposerState.recording);
+      expect(client.realtimeCalls, 2);
+      await controller.cancel();
+    },
+  );
+
+  test('cancelling while capture starts gates the next recording', () async {
+    final startGate = Completer<void>();
+    final recorder = _StreamingVoiceRecorder(firstStartGate: startGate);
+    final client = _StallingRealtimeVoiceClient();
+    final controller = _controller(
+      client,
+      <AgentMessage>[],
+      recorder: recorder,
+    );
+    addTearDown(controller.dispose);
+    await controller.bindThread('thread-a');
+
+    final starting = controller.startRecording();
+    await recorder.firstStartRequested.future.timeout(
+      const Duration(seconds: 1),
+    );
+    final cancelling = controller.cancel();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.state, AgentVoiceComposerState.idle);
+    expect(controller.canStartRecording, isFalse);
+    await controller.startRecording();
+    expect(recorder.startCalls, 1);
+
+    startGate.complete();
+    await Future.wait<void>([
+      starting,
+      cancelling,
+    ]).timeout(const Duration(seconds: 1));
+    expect(controller.canStartRecording, isTrue);
+
+    await controller.startRecording();
+    await client.sessions.single.listened.future.timeout(
+      const Duration(seconds: 1),
+    );
+    expect(controller.state, AgentVoiceComposerState.recording);
+    expect(recorder.startCalls, 2);
+    expect(client.realtimeCalls, 1);
+    await controller.cancel();
+  });
+
+  test('terminal timeout retains WAV and retries with one identity', () async {
+    final client = _StallingRealtimeVoiceClient();
+    final recorder = _StreamingVoiceRecorder();
+    final controller = _controller(
+      client,
+      <AgentMessage>[],
+      recorder: recorder,
+      realtimeCompletionTimeout: const Duration(milliseconds: 10),
+    );
+    addTearDown(controller.dispose);
+    await controller.bindThread('thread-a');
+
+    await controller.startRecording();
+    await client.sessions.single.listened.future.timeout(
+      const Duration(seconds: 1),
+    );
+    await controller.stopRecording().timeout(const Duration(seconds: 1));
+
+    expect(controller.state, AgentVoiceComposerState.failed);
+    expect(controller.canRetry, isTrue);
+    expect(controller.recording?.path, '/tmp/realtime.wav');
+    expect(controller.errorMessage, contains('检查网络'));
+    expect(client.sessions.single.cancelRequested.isCompleted, isTrue);
+
+    await controller.retry();
+
+    expect(controller.state, AgentVoiceComposerState.awaitingConfirmation);
+    expect(controller.recording, isNull);
+    expect(client.fileUploadCalls, 1);
+    expect(client.fileUploadKeys, client.realtimeKeys);
+  });
+
+  test(
+    'Thread switch cancels stuck realtime input and fences late work',
+    () async {
+      final client = _StallingRealtimeVoiceClient();
+      final controller = _controller(
+        client,
+        <AgentMessage>[],
+        recorder: _StreamingVoiceRecorder(),
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-a');
+      await controller.startRecording();
+      final session = client.sessions.single;
+      await session.listened.future.timeout(const Duration(seconds: 1));
+
+      await controller
+          .bindThread('thread-b')
+          .timeout(const Duration(seconds: 1));
+
+      expect(session.cancelRequested.isCompleted, isTrue);
+      expect(controller.threadId, 'thread-b');
+      expect(controller.state, AgentVoiceComposerState.idle);
+      expect(controller.liveTranscript, isEmpty);
+      expect(controller.canStartRecording, isTrue);
+    },
+  );
+
+  test(
+    'account cleanup cancels stuck realtime input without hanging',
+    () async {
+      final client = _StallingRealtimeVoiceClient();
+      final recorder = _StreamingVoiceRecorder();
+      final controller = _controller(
+        client,
+        <AgentMessage>[],
+        recorder: recorder,
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-a');
+      await controller.startRecording();
+      final session = client.sessions.single;
+      await session.listened.future.timeout(const Duration(seconds: 1));
+
+      await controller.clearPrivateState().timeout(const Duration(seconds: 1));
+
+      expect(session.cancelRequested.isCompleted, isTrue);
+      expect(controller.threadId, isNull);
+      expect(controller.state, AgentVoiceComposerState.idle);
+      expect(controller.liveTranscript, isEmpty);
+      expect(recorder.clearAccountCalls, 1);
+    },
+  );
+
+  test(
+    'dispose cancels stuck realtime input without waiting on a terminal',
+    () async {
+      final client = _StallingRealtimeVoiceClient();
+      final controller = _controller(
+        client,
+        <AgentMessage>[],
+        recorder: _StreamingVoiceRecorder(),
+      );
+      await controller.bindThread('thread-a');
+      await controller.startRecording();
+      final session = client.sessions.single;
+      await session.listened.future.timeout(const Duration(seconds: 1));
+
+      controller.dispose();
+
+      await session.cancelRequested.future.timeout(const Duration(seconds: 1));
+      await session.cancelled.future.timeout(const Duration(seconds: 1));
+      await _waitUntil(() => client.disposeCalls == 1);
+      expect(client.disposeCalls, 1);
+    },
+  );
+
   test('late upload result cannot cross the Thread fence', () async {
     final client = _ControlledVoiceClient();
     final committed = <AgentMessage>[];
@@ -899,12 +1096,32 @@ Future<void> _pumpVoiceOperation(WidgetTester tester) async {
   await tester.pump(const Duration(milliseconds: 50));
 }
 
+Future<void> _waitUntil(bool Function() condition) async {
+  for (var attempt = 0; attempt < 100 && !condition(); attempt++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+  if (!condition()) {
+    throw TimeoutException('Timed out waiting for the voice controller state.');
+  }
+}
+
 final class _StreamingVoiceRecorder
     implements AgentVoiceRecorder, AgentVoiceStreamingRecorder {
+  _StreamingVoiceRecorder({this.firstStartGate});
+
+  final Completer<void>? firstStartGate;
+  final Completer<void> firstStartRequested = Completer<void>();
   StreamController<Uint8List>? _stream;
+  int startCalls = 0;
+  int clearAccountCalls = 0;
 
   @override
   Future<Stream<Uint8List>> startAudioStream() async {
+    startCalls++;
+    if (startCalls == 1) {
+      firstStartRequested.complete();
+      await firstStartGate?.future;
+    }
     final stream = StreamController<Uint8List>();
     _stream = stream;
     stream.add(Uint8List.fromList(<int>[1, 2, 3, 4]));
@@ -931,15 +1148,26 @@ final class _StreamingVoiceRecorder
 
   @override
   Future<void> discardCurrent() async {
-    await _stream?.close();
+    final stream = _stream;
     _stream = null;
+    if (stream == null) {
+      return;
+    }
+    if (stream.hasListener) {
+      await stream.close();
+    } else {
+      unawaited(stream.close());
+    }
   }
 
   @override
   Future<void> discard(AgentVoiceLocalRecording recording) async {}
 
   @override
-  Future<void> clearAccountState() => discardCurrent();
+  Future<void> clearAccountState() async {
+    clearAccountCalls++;
+    await discardCurrent();
+  }
 }
 
 AgentVoiceController _controller(
@@ -949,6 +1177,7 @@ AgentVoiceController _controller(
   AgentVoiceRecorder? recorder,
   AgentVoiceControllerClock? clock,
   Duration recordingLimit = const Duration(seconds: 58),
+  Duration realtimeCompletionTimeout = const Duration(seconds: 75),
   AgentVoiceAssistantStreamStarted? onAssistantStreamStarted,
   AgentVoiceAssistantStreamDelta? onAssistantStreamDelta,
   AgentVoiceAssistantStreamCompleted? onAssistantStreamCompleted,
@@ -969,6 +1198,7 @@ AgentVoiceController _controller(
     idFactory: (scope) => '${scope}_${++sequence}'.replaceAll('-', '_'),
     clock: clock ?? DateTime.now,
     recordingLimit: recordingLimit,
+    realtimeCompletionTimeout: realtimeCompletionTimeout,
     pollInterval: Duration.zero,
     maximumDraftPolls: 2,
     maximumRunPolls: 2,
@@ -1205,8 +1435,11 @@ class _ControlledVoiceClient
   final List<String> getRunCalls = <String>[];
   final List<String> getMessageCalls = <String>[];
   final List<String> deletedDraftIds = <String>[];
+  final List<String> realtimeKeys = <String>[];
+  final List<String> fileUploadKeys = <String>[];
   int realtimeCalls = 0;
   int fileUploadCalls = 0;
+  int disposeCalls = 0;
 
   @override
   Stream<AgentVoiceTranscriptionEvent> createDraftStream({
@@ -1215,6 +1448,7 @@ class _ControlledVoiceClient
     required String idempotencyKey,
   }) async* {
     fileUploadCalls++;
+    fileUploadKeys.add(idempotencyKey);
     final draft = await createDraft(
       threadId: threadId,
       recording: recording,
@@ -1230,6 +1464,7 @@ class _ControlledVoiceClient
     required String idempotencyKey,
   }) async* {
     realtimeCalls++;
+    realtimeKeys.add(idempotencyKey);
     await for (final _ in audioChunks) {}
     yield const AgentVoiceTranscriptUpdated(
       text: 'Realtime draft text.',
@@ -1371,7 +1606,59 @@ class _ControlledVoiceClient
   Future<void> clearAccountState() async {}
 
   @override
-  Future<void> dispose() async {}
+  Future<void> dispose() async {
+    disposeCalls++;
+  }
+}
+
+final class _StallingRealtimeVoiceClient extends _ControlledVoiceClient {
+  _StallingRealtimeVoiceClient({this.cancelGate});
+
+  final Completer<void>? cancelGate;
+  final List<_StallingRealtimeSession> sessions = <_StallingRealtimeSession>[];
+
+  @override
+  Stream<AgentVoiceTranscriptionEvent> createDraftRealtime({
+    required String threadId,
+    required Stream<Uint8List> audioChunks,
+    required String idempotencyKey,
+  }) {
+    realtimeCalls++;
+    realtimeKeys.add(idempotencyKey);
+    StreamSubscription<Uint8List>? audioSubscription;
+    late final _StallingRealtimeSession session;
+    late final StreamController<AgentVoiceTranscriptionEvent> events;
+    events = StreamController<AgentVoiceTranscriptionEvent>(
+      onListen: () {
+        audioSubscription = audioChunks.listen((_) {});
+        if (!session.listened.isCompleted) {
+          session.listened.complete();
+        }
+      },
+      onCancel: () async {
+        if (!session.cancelRequested.isCompleted) {
+          session.cancelRequested.complete();
+        }
+        await cancelGate?.future;
+        await audioSubscription?.cancel();
+        if (!session.cancelled.isCompleted) {
+          session.cancelled.complete();
+        }
+      },
+    );
+    session = _StallingRealtimeSession(events);
+    sessions.add(session);
+    return events.stream;
+  }
+}
+
+final class _StallingRealtimeSession {
+  _StallingRealtimeSession(this.events);
+
+  final StreamController<AgentVoiceTranscriptionEvent> events;
+  final Completer<void> listened = Completer<void>();
+  final Completer<void> cancelRequested = Completer<void>();
+  final Completer<void> cancelled = Completer<void>();
 }
 
 final class _StreamingControlledVoiceClient extends _ControlledVoiceClient

--- a/mobile/test/agent/agent_voice_fence_test.dart
+++ b/mobile/test/agent/agent_voice_fence_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -207,7 +208,90 @@ void main() {
       expect(controller.threadId, isNull);
       expect(controller.state, AgentVoiceComposerState.idle);
       expect(controller.liveTranscript, isEmpty);
-      expect(recorder.clearAccountCalls, 1);
+      expect(recorder.clearAccountCalls, 2);
+    },
+  );
+
+  test(
+    'account cleanup serializes native stop across a late recorder start',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'agent-voice-controller-late-start-',
+      );
+      final native = _GatedNativeVoiceRecorder();
+      addTearDown(() async {
+        native.releaseFirstStart();
+        native.releaseStop(1);
+        native.releaseStop(2);
+        await native.dispose();
+        await directory.delete(recursive: true);
+      });
+      final recorder = IosAgentVoiceRecorder(
+        recorder: native,
+        temporaryDirectory: () async => directory,
+      );
+      final controller = _controller(
+        _StallingRealtimeVoiceClient(),
+        <AgentMessage>[],
+        recorder: recorder,
+        workflowCleanupTimeout: const Duration(milliseconds: 10),
+      );
+      addTearDown(controller.dispose);
+      await controller.bindThread('thread-account-a');
+
+      final starting = controller.startRecording();
+      await native.firstStartRequested.future.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () =>
+            throw StateError('first native start was not requested'),
+      );
+      final cleanup = controller.clearPrivateState();
+      await native.firstStopRequested.future.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () =>
+            throw StateError('first native stop was not requested'),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      expect(native.stopCalls, 1);
+      expect(native.maximumConcurrentStops, 1);
+      await expectLater(
+        recorder.startAudioStream(),
+        throwsA(
+          isA<AgentVoiceRecordingException>().having(
+            (error) => error.kind,
+            'kind',
+            AgentVoiceRecordingFailureKind.alreadyRecording,
+          ),
+        ),
+      );
+
+      final bindingAccountB = controller.bindThread('thread-account-b');
+      native.releaseFirstStart();
+      native.releaseStop(1);
+      await native.secondStopRequested.future.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () =>
+            throw StateError('second native stop was not requested'),
+      );
+      expect(native.maximumConcurrentStops, 1);
+
+      await controller.startRecording();
+      expect(native.startCalls, 1);
+
+      native.releaseStop(2);
+      await Future.wait<void>([starting, cleanup, bindingAccountB]).timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => throw StateError('late start cleanup stayed blocked'),
+      );
+      expect(native.maximumConcurrentStops, 1);
+      expect(controller.threadId, 'thread-account-b');
+      expect(controller.canStartRecording, isTrue);
+
+      await controller.startRecording();
+      expect(native.startCalls, 2);
+      expect(controller.state, AgentVoiceComposerState.recording);
+      await controller.cancel();
     },
   );
 
@@ -1170,6 +1254,84 @@ final class _StreamingVoiceRecorder
   }
 }
 
+final class _GatedNativeVoiceRecorder implements NativeAgentVoiceRecorder {
+  final Completer<void> firstStartRequested = Completer<void>();
+  final Completer<void> _firstStartGate = Completer<void>();
+  final Completer<void> firstStopRequested = Completer<void>();
+  final Completer<void> secondStopRequested = Completer<void>();
+  final List<Completer<void>> _stopGates = <Completer<void>>[
+    Completer<void>(),
+    Completer<void>(),
+  ];
+  final List<StreamController<Uint8List>> _streams =
+      <StreamController<Uint8List>>[];
+  int startCalls = 0;
+  int stopCalls = 0;
+  int maximumConcurrentStops = 0;
+  int _concurrentStops = 0;
+
+  void releaseFirstStart() {
+    if (!_firstStartGate.isCompleted) {
+      _firstStartGate.complete();
+    }
+  }
+
+  void releaseStop(int ordinal) {
+    final index = ordinal - 1;
+    if (index >= 0 &&
+        index < _stopGates.length &&
+        !_stopGates[index].isCompleted) {
+      _stopGates[index].complete();
+    }
+  }
+
+  Future<void> dispose() async {
+    for (final stream in _streams) {
+      await stream.close();
+    }
+  }
+
+  @override
+  Future<bool> hasPermission() async => true;
+
+  @override
+  Future<void> startWav(String path) => throw UnimplementedError();
+
+  @override
+  Future<Stream<Uint8List>> startPcm16Stream() async {
+    startCalls++;
+    final stream = StreamController<Uint8List>();
+    _streams.add(stream);
+    if (startCalls == 1) {
+      firstStartRequested.complete();
+      await _firstStartGate.future;
+    }
+    return stream.stream;
+  }
+
+  @override
+  Future<String?> stop() async {
+    final ordinal = ++stopCalls;
+    _concurrentStops++;
+    if (_concurrentStops > maximumConcurrentStops) {
+      maximumConcurrentStops = _concurrentStops;
+    }
+    if (ordinal == 1) {
+      firstStopRequested.complete();
+    } else if (ordinal == 2) {
+      secondStopRequested.complete();
+    }
+    try {
+      if (ordinal <= _stopGates.length) {
+        await _stopGates[ordinal - 1].future;
+      }
+      return null;
+    } finally {
+      _concurrentStops--;
+    }
+  }
+}
+
 AgentVoiceController _controller(
   _ControlledVoiceClient client,
   List<AgentMessage> committed, {
@@ -1178,6 +1340,7 @@ AgentVoiceController _controller(
   AgentVoiceControllerClock? clock,
   Duration recordingLimit = const Duration(seconds: 58),
   Duration realtimeCompletionTimeout = const Duration(seconds: 75),
+  Duration workflowCleanupTimeout = const Duration(seconds: 2),
   AgentVoiceAssistantStreamStarted? onAssistantStreamStarted,
   AgentVoiceAssistantStreamDelta? onAssistantStreamDelta,
   AgentVoiceAssistantStreamCompleted? onAssistantStreamCompleted,
@@ -1199,6 +1362,7 @@ AgentVoiceController _controller(
     clock: clock ?? DateTime.now,
     recordingLimit: recordingLimit,
     realtimeCompletionTimeout: realtimeCompletionTimeout,
+    workflowCleanupTimeout: workflowCleanupTimeout,
     pollInterval: Duration.zero,
     maximumDraftPolls: 2,
     maximumRunPolls: 2,

--- a/mobile/test/agent/agent_voice_recording_stream_test.dart
+++ b/mobile/test/agent/agent_voice_recording_stream_test.dart
@@ -98,6 +98,125 @@ void main() {
     expect(pcm, <int>[0, 0, 0, 0]);
     await subscription.cancel();
   });
+
+  test(
+    'account clear cancels a native stream that finishes starting late',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'agent-voice-late-stream-recorder-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final native = _DelayedStartNativeRecorder();
+      addTearDown(native.dispose);
+      final recorder = IosAgentVoiceRecorder(
+        recorder: native,
+        temporaryDirectory: () async => directory,
+      );
+
+      final starting = recorder.startAudioStream();
+      await native.firstStartRequested.future.timeout(
+        const Duration(seconds: 1),
+      );
+
+      await recorder.clearAccountState().timeout(const Duration(seconds: 1));
+      await expectLater(
+        recorder.startAudioStream(),
+        throwsA(
+          isA<AgentVoiceRecordingException>().having(
+            (error) => error.kind,
+            'kind',
+            AgentVoiceRecordingFailureKind.alreadyRecording,
+          ),
+        ),
+      );
+
+      final lateStartFailure = expectLater(
+        starting,
+        throwsA(
+          isA<AgentVoiceRecordingException>().having(
+            (error) => error.kind,
+            'kind',
+            AgentVoiceRecordingFailureKind.unavailable,
+          ),
+        ),
+      );
+      native.releaseFirstStart();
+      await lateStartFailure;
+
+      expect(native.cancelCount, 1);
+      expect(native.stopCount, 2);
+      expect(
+        await directory
+            .list(recursive: true, followLinks: false)
+            .where((entity) => entity is File)
+            .toList(),
+        isEmpty,
+      );
+
+      final next = await recorder.startAudioStream();
+      final nextSubscription = next.listen((_) {});
+      await recorder.discardCurrent();
+      await nextSubscription.cancel();
+      expect(native.startCount, 2);
+    },
+  );
+
+  test(
+    'account clear is bounded while native stop remains in flight',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'agent-voice-bounded-recorder-clear-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final native = _DelayedStartNativeRecorder(gateFirstStop: true);
+      addTearDown(() async {
+        native.releaseFirstStart();
+        native.releaseFirstStop();
+        await native.dispose();
+      });
+      final recorder = IosAgentVoiceRecorder(
+        recorder: native,
+        temporaryDirectory: () async => directory,
+      );
+
+      final starting = recorder.startAudioStream();
+      await native.firstStartRequested.future.timeout(
+        const Duration(seconds: 1),
+      );
+      native.releaseFirstStart();
+      final stream = await starting;
+      final subscription = stream.listen((_) {});
+
+      final clear = recorder.clearAccountState();
+      await native.firstStopRequested.future.timeout(
+        const Duration(seconds: 1),
+      );
+      await clear.timeout(const Duration(seconds: 3));
+      await expectLater(
+        recorder.startAudioStream(),
+        throwsA(
+          isA<AgentVoiceRecordingException>().having(
+            (error) => error.kind,
+            'kind',
+            AgentVoiceRecordingFailureKind.alreadyRecording,
+          ),
+        ),
+      );
+
+      native.releaseFirstStop();
+      await native.firstStopCompleted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final next = await recorder.startAudioStream();
+      final nextSubscription = next.listen((_) {});
+      await recorder.discardCurrent();
+      await Future.wait<void>([
+        subscription.cancel(),
+        nextSubscription.cancel(),
+      ]);
+    },
+  );
 }
 
 final class _StreamingNativeRecorder implements NativeAgentVoiceRecorder {
@@ -126,6 +245,71 @@ final class _StreamingNativeRecorder implements NativeAgentVoiceRecorder {
       throw error;
     }
     await _chunks.close();
+    return null;
+  }
+}
+
+final class _DelayedStartNativeRecorder implements NativeAgentVoiceRecorder {
+  _DelayedStartNativeRecorder({this.gateFirstStop = false});
+
+  final bool gateFirstStop;
+  final Completer<void> firstStartRequested = Completer<void>();
+  final Completer<void> _firstStartGate = Completer<void>();
+  final Completer<void> firstStopRequested = Completer<void>();
+  final Completer<void> firstStopCompleted = Completer<void>();
+  final Completer<void> _firstStopGate = Completer<void>();
+  final List<StreamController<Uint8List>> _streams =
+      <StreamController<Uint8List>>[];
+  int startCount = 0;
+  int stopCount = 0;
+  int cancelCount = 0;
+
+  void releaseFirstStart() {
+    if (!_firstStartGate.isCompleted) {
+      _firstStartGate.complete();
+    }
+  }
+
+  void releaseFirstStop() {
+    if (!_firstStopGate.isCompleted) {
+      _firstStopGate.complete();
+    }
+  }
+
+  Future<void> dispose() async {
+    for (final stream in _streams) {
+      await stream.close();
+    }
+  }
+
+  @override
+  Future<bool> hasPermission() async => true;
+
+  @override
+  Future<void> startWav(String path) => throw UnimplementedError();
+
+  @override
+  Future<Stream<Uint8List>> startPcm16Stream() async {
+    startCount++;
+    final stream = StreamController<Uint8List>(onCancel: () => cancelCount++);
+    _streams.add(stream);
+    if (startCount == 1) {
+      firstStartRequested.complete();
+      await _firstStartGate.future;
+    }
+    return stream.stream;
+  }
+
+  @override
+  Future<String?> stop() async {
+    stopCount++;
+    if (stopCount == 1) {
+      firstStopRequested.complete();
+      if (gateFirstStop) {
+        await _firstStopGate.future;
+      }
+      firstStopCompleted.complete();
+    }
     return null;
   }
 }

--- a/mobile/test/agent/wire_agent_voice_client_test.dart
+++ b/mobile/test/agent/wire_agent_voice_client_test.dart
@@ -13,6 +13,7 @@ import 'package:speakup/features/agent/composer/voice/agent_voice_models.dart';
 import 'package:speakup/providers/agent/wire_agent_voice_client.dart';
 import 'package:speakup/features/coaching/preparation/practice_plan_client_action.dart';
 import 'package:speakup/identity/auth_state.dart';
+import 'package:speakup/identity/network/authenticated_web_socket.dart';
 
 void main() {
   test('receives assistant PCM before text input stream completes', () async {
@@ -162,6 +163,195 @@ void main() {
     expect(jsonDecode(received.last as String), <String, Object?>{
       'type': 'finish',
     });
+  });
+
+  test(
+    'realtime connection timeout is retryable and closes a late socket',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final connected = Completer<void>();
+      final disconnected = Completer<void>();
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(
+          request,
+          protocolSelector: (_) => 'speakup.voice-input.v1',
+        );
+        connected.complete();
+        await for (final _ in socket) {}
+        disconnected.complete();
+      });
+      final gate = Completer<void>();
+      final client = WireAgentVoiceClient(
+        baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+        credentialProvider: () => _credential,
+        invalidateSession: _ignoreInvalidation,
+        apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+        signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+        realtimeConnector: _DelayedRealtimeConnector(gate.future),
+        realtimeConnectionTimeout: const Duration(milliseconds: 10),
+      );
+      addTearDown(client.dispose);
+
+      await expectLater(
+        client
+            .createDraftRealtime(
+              threadId: _threadId,
+              audioChunks: Stream<Uint8List>.value(
+                Uint8List.fromList(const <int>[1, 0]),
+              ),
+              idempotencyKey: 'voice_connect_timeout_001',
+            )
+            .toList(),
+        throwsA(
+          isA<AgentClientException>()
+              .having(
+                (error) => error.kind,
+                'kind',
+                AgentClientFailureKind.network,
+              )
+              .having((error) => error.retryable, 'retryable', isTrue),
+        ),
+      );
+
+      gate.complete();
+      await connected.future.timeout(const Duration(seconds: 2));
+      await disconnected.future.timeout(const Duration(seconds: 2));
+    },
+  );
+
+  test(
+    'cancelling durable realtime input sends cancel without finish',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final receivedTypes = <String>[];
+      final started = Completer<void>();
+      final cancelled = Completer<void>();
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(
+          request,
+          protocolSelector: (_) => 'speakup.voice-input.v1',
+        );
+        await for (final message in socket) {
+          if (message is! String) {
+            continue;
+          }
+          final type = (jsonDecode(message) as Map<String, dynamic>)['type'];
+          if (type is! String) {
+            continue;
+          }
+          receivedTypes.add(type);
+          if (type == 'start') {
+            socket.add(
+              jsonEncode(const <String, Object>{
+                'type': 'transcription.updated',
+                'data': <String, Object>{
+                  'transcript': 'Partial transcript',
+                  'final': false,
+                },
+              }),
+            );
+          } else if (type == 'cancel') {
+            cancelled.complete();
+            await socket.close();
+            break;
+          }
+        }
+      });
+      final client = WireAgentVoiceClient(
+        baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+        credentialProvider: () => _credential,
+        invalidateSession: _ignoreInvalidation,
+        apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+        signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+      );
+      addTearDown(client.dispose);
+      final audio = StreamController<Uint8List>();
+      addTearDown(audio.close);
+      final subscription = client
+          .createDraftRealtime(
+            threadId: _threadId,
+            audioChunks: audio.stream,
+            idempotencyKey: 'voice_cancel_001',
+          )
+          .listen((event) {
+            if (event is AgentVoiceTranscriptUpdated && !started.isCompleted) {
+              started.complete();
+            }
+          });
+
+      await started.future.timeout(const Duration(seconds: 2));
+      final cancellation = subscription.cancel();
+      await cancelled.future.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => throw TimeoutException(
+          'Server did not receive the realtime cancellation.',
+        ),
+      );
+      await cancellation.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => throw TimeoutException(
+          'Realtime cancellation did not finish local cleanup.',
+        ),
+      );
+
+      expect(
+        receivedTypes,
+        containsAllInOrder(const <String>['start', 'cancel']),
+      );
+      expect(receivedTypes, isNot(contains('finish')));
+    },
+  );
+
+  test('peer disconnect before a terminal event is retryable', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    final disconnected = Completer<void>();
+    server.listen((request) async {
+      final socket = await WebSocketTransformer.upgrade(
+        request,
+        protocolSelector: (_) => 'speakup.voice-input.v1',
+      );
+      await for (final message in socket) {
+        if (message is String &&
+            (jsonDecode(message) as Map<String, dynamic>)['type'] == 'start') {
+          await socket.close(WebSocketStatus.goingAway, 'network_lost');
+          disconnected.complete();
+          break;
+        }
+      }
+    });
+    final client = WireAgentVoiceClient(
+      baseUri: Uri.parse('http://${server.address.address}:${server.port}'),
+      credentialProvider: () => _credential,
+      invalidateSession: _ignoreInvalidation,
+      apiTransport: _ScriptedVoiceTransport(const <_Step>[]),
+      signedAudioTransport: _ScriptedVoiceTransport(const <_Step>[]),
+    );
+    addTearDown(client.dispose);
+
+    await expectLater(
+      client
+          .createDraftRealtime(
+            threadId: _threadId,
+            audioChunks: Stream<Uint8List>.value(
+              Uint8List.fromList(const <int>[1, 0]),
+            ),
+            idempotencyKey: 'voice_disconnect_001',
+          )
+          .toList(),
+      throwsA(
+        isA<AgentClientException>()
+            .having(
+              (error) => error.kind,
+              'kind',
+              AgentClientFailureKind.network,
+            )
+            .having((error) => error.retryable, 'retryable', isTrue),
+      ),
+    );
+    await disconnected.future.timeout(const Duration(seconds: 2));
   });
 
   test(
@@ -1060,6 +1250,28 @@ const _credential = AuthSessionCredential(
   sessionToken: 'sess_voice',
   generation: 1,
 );
+
+final class _DelayedRealtimeConnector
+    implements AuthenticatedWebSocketConnector {
+  const _DelayedRealtimeConnector(this.gate);
+
+  final Future<void> gate;
+
+  @override
+  Future<WebSocket> connect({
+    required Uri uri,
+    required String sessionToken,
+  }) async {
+    await gate;
+    return WebSocket.connect(
+      uri.toString(),
+      protocols: const <String>['speakup.voice-input.v1'],
+      headers: <String, String>{
+        HttpHeaders.authorizationHeader: 'Bearer $sessionToken',
+      },
+    );
+  }
+}
 
 final class _ScriptedVoiceTransport implements AgentVoiceWireTransport {
   _ScriptedVoiceTransport(Iterable<_Step> steps)


### PR DESCRIPTION
## 功能描述

- 修复 Android 实时语音在断网、WebSocket 无终态或取消卡住后无法再次录音的问题。
- 实时失败时保留已完成的本地 WAV，并进入现有上传重试路径。
- 修复账号切换遇到迟到的原生录音启动时，多个清理流程可能并发调用 `stop`、旧录音可能越过账号边界的问题。

## 实现思路

- 用可取消的 realtime session 管理转写事件，不再只持有不可取消的 Future。
- `cancel`、Thread 切换、账号清理和 dispose 共用有界清理流程；清理或旧 operation 未结束时禁止启动新录音。
- 录音阶段启用 WebSocket ping 检测失联；发送 `finish` 后关闭 ping，由 75 秒终态上限负责收口。
- 建连超时后主动关闭迟到连接；取消发送 `cancel`，不发送 `finish`。
- 终态超时时保留 WAV 与原幂等键，联网后可转为文件上传重试。
- 原生录音 `stop` 由单一 in-flight gate 串行化；迟到启动只在现有清理结束后追加一次清理。清理超时后仍保持启动闸门，直到原生清理真正结束。

## 可复现测试

- `make check-flutter-coverage`
  - Dart format：通过
  - Flutter analyze：通过
  - Android signing fixture：通过
  - Flutter 全量测试：832 项通过
  - Flutter coverage gate：通过
- `git diff --check upstream/dev...HEAD`

新增回归覆盖：断网恢复、无终态超时、迟到连接、WAV 保留上传重试、账号清理并发、迟到原生录音启动、悬挂 `stop` 的有界清理，以及账号 A → B 隔离。

已 rebase 至包含 #982/#983 的最新 `upstream/dev` (`2cd18939`)，两个 #975 提交的 range-diff 补丁保持等价。

Android 真机飞行模式和弱网恢复保留为 Staging 发布前验收项；在该验收完成前保持 Issue 打开。

Related #975
