### PR TITLE
feat(portal): 提供生产版本更新日志

### DIFF
--- a/portal/README.md
+++ b/portal/README.md
@@ -15,7 +15,8 @@ npm install
 npm run dev
 ```
 
-默认首页为 `/`，Android 发布页为 `/download/android`，运营后台为 `/admin`。
+默认首页为 `/`，Android 发布页为 `/download/android`，面向用户的更新日志为
+`/changelog`，运营后台为 `/admin`。
 
 Android 发布页只从同源 `/downloads/android/release.json` 读取当前正式版本。
 `404` 显示“准备中”；网络、HTTP、JSON 或严格协议校验失败时显示“暂不可用”；只有
@@ -23,6 +24,16 @@ Android 发布页只从同源 `/downloads/android/release.json` 读取当前正�
 SHA-256。页面不会猜测下载地址，也不使用 `latest.apk`。APK 与发布元数据由宿主机
 Nginx 提供，不放入 Portal Docker 镜像；发布操作见
 [`deploy/android-download/README.md`](../deploy/android-download/README.md)。
+
+更新日志同样先以 `/downloads/android/release.json` 为当前正式版本的唯一依据，再读取
+`/release-notes/android/v<version>.zh-CN.json`。版本化说明中的首个版本和发布时间必须
+与当前正式版本完全一致；文件缺失、协议无效或信息不匹配时，页面会明确显示暂不可用，
+不会回退到其他版本的内容。
+
+每次准备正式版本时，新增一份只描述该版本的中文说明文件。内容只写用户可以感知的
+变化：新功能、体验优化、问题修复、兼容性变化和确实需要告知的已知限制。不要写提交
+记录、重构、依赖升级、测试或部署过程；小修复也应说明解决了什么用户问题，不使用
+“修复已知 bug”这类无法判断影响的占位文案。
 
 如需在本地持久化报名和事件数据：
 

--- a/portal/app/changelog/ChangelogContent.tsx
+++ b/portal/app/changelog/ChangelogContent.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { loadAndroidRelease } from "../../lib/android-release-metadata.mjs";
+import { loadAndroidReleaseNotes } from "../../lib/android-release-notes.mjs";
+
+type AndroidReleaseMetadata = {
+  version: string;
+  published_at: string;
+};
+
+type ChangeType =
+  | "feature"
+  | "improvement"
+  | "fix"
+  | "compatibility"
+  | "known_limitation";
+
+type ReleaseChange = {
+  type: ChangeType;
+  text: string;
+};
+
+type ReleaseNotes = {
+  version: string;
+  published_at: string;
+  changes: ReleaseChange[];
+};
+
+type ChangelogState =
+  | { status: "loading" }
+  | { status: "preparing" }
+  | { status: "unavailable" }
+  | { status: "ready"; notes: ReleaseNotes };
+
+const changeSections: Array<{ type: ChangeType; title: string }> = [
+  { type: "feature", title: "新功能" },
+  { type: "improvement", title: "体验优化" },
+  { type: "fix", title: "问题修复" },
+  { type: "compatibility", title: "兼容性" },
+  { type: "known_limitation", title: "已知限制" },
+];
+
+function formatReleaseDate(value: string) {
+  return new Intl.DateTimeFormat("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(value));
+}
+
+export default function ChangelogContent() {
+  const [state, setState] = useState<ChangelogState>({ status: "loading" });
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      const releaseState = await loadAndroidRelease();
+      if (!active) return;
+      if (releaseState.status !== "ready") {
+        setState({ status: releaseState.status });
+        return;
+      }
+
+      const release = releaseState.release as AndroidReleaseMetadata;
+      const notesState = await loadAndroidReleaseNotes(release);
+      if (!active) return;
+      if (notesState.status !== "ready") {
+        setState({ status: "unavailable" });
+        return;
+      }
+      setState({
+        status: "ready",
+        notes: notesState.notes as ReleaseNotes,
+      });
+    }
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (state.status !== "ready") {
+    const copy =
+      state.status === "loading"
+        ? {
+            title: "正在确认当前正式版本…",
+            detail: "确认完成后，只展示已经正式发布的更新内容。",
+          }
+        : state.status === "preparing"
+          ? {
+              title: "暂无正式版本更新",
+              detail: "首个正式版本发布后，这里会同步记录用户可以感知的变化。",
+            }
+          : {
+              title: "更新日志暂不可用",
+              detail:
+                "暂时无法验证当前正式版本，因此不会展示可能过期的更新内容。",
+            };
+
+    return (
+      <section className="changelog-list changelog-status" aria-live="polite">
+        <h2>{copy.title}</h2>
+        <p>{copy.detail}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="changelog-list" aria-label="Android 正式版本更新">
+      <article
+        className="changelog-release"
+        aria-labelledby={`release-v${state.notes.version.replaceAll(".", "-")}`}
+      >
+        <div className="changelog-release-meta">
+          <p>当前正式版本</p>
+          <time dateTime={state.notes.published_at}>
+            {formatReleaseDate(state.notes.published_at)}
+          </time>
+        </div>
+        <div className="changelog-release-body">
+          <h2 id={`release-v${state.notes.version.replaceAll(".", "-")}`}>
+            v{state.notes.version}
+          </h2>
+          {changeSections.map((section) => {
+            const changes = state.notes.changes.filter(
+              (change) => change.type === section.type,
+            );
+            if (changes.length === 0) return null;
+            return (
+              <div className="changelog-change-group" key={section.type}>
+                <h3>{section.title}</h3>
+                <ul>
+                  {changes.map((change) => (
+                    <li key={change.text}>{change.text}</li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/portal/app/changelog/page.tsx
+++ b/portal/app/changelog/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import BrandMark from "../BrandMark";
+import BrandWordmark from "../BrandWordmark";
+import ChangelogContent from "./ChangelogContent";
+
+export const metadata: Metadata = {
+  title: "更新日志 · SpeakUp",
+  description: "查看 SpeakUp 已正式发布的功能、体验优化与问题修复。",
+};
+
+export default function ChangelogPage() {
+  return (
+    <main className="release-site release-home changelog-page" id="top">
+      <nav className="site-nav release-nav release-nav-simple" aria-label="主导航">
+        <Link className="brand" href="/" aria-label="SpeakUp 首页">
+          <BrandMark />
+          <BrandWordmark />
+        </Link>
+        <div className="nav-links">
+          <Link href="/">产品首页</Link>
+          <Link href="/changelog" aria-current="page">
+            更新日志
+          </Link>
+        </div>
+      </nav>
+
+      <header className="changelog-hero">
+        <Link className="changelog-back" href="/">
+          ← 返回产品首页
+        </Link>
+        <p className="eyebrow">产品更新</p>
+        <h1>更新日志</h1>
+        <p className="changelog-intro">
+          记录 SpeakUp 已正式发布的功能、体验优化与问题修复。
+        </p>
+      </header>
+
+      <ChangelogContent />
+
+      <footer>
+        <Link className="brand" href="/" aria-label="SpeakUp 首页">
+          <BrandMark />
+          <BrandWordmark />
+        </Link>
+        <p>只记录已经正式上线、与你使用直接相关的变化。</p>
+        <span className="release-footer-meta">
+          <Link href="/changelog" aria-current="page">
+            更新日志
+          </Link>
+          <i aria-hidden="true">·</i>© 2026 SpeakUp
+        </span>
+      </footer>
+    </main>
+  );
+}

--- a/portal/app/download/android/page.tsx
+++ b/portal/app/download/android/page.tsx
@@ -24,11 +24,15 @@ type ReleaseState =
   | { status: "unavailable" }
   | { status: "ready"; release: AndroidReleaseMetadata };
 
-const supportFields = [
-  ["更新状态", "当前下载状态与版本信息以本页为准"],
-  ["更新日志", "独立更新日志尚未提供"],
-  ["隐私与权限", "正式隐私说明与权限清单尚未提供"],
-  ["问题反馈", "正式反馈入口尚未提供"],
+const supportFields: Array<{ label: string; value: string; href?: string }> = [
+  { label: "更新状态", value: "当前下载状态与版本信息以本页为准" },
+  {
+    label: "更新日志",
+    value: "查看正式版本更新记录 →",
+    href: "/changelog",
+  },
+  { label: "隐私与权限", value: "正式隐私说明与权限清单尚未提供" },
+  { label: "问题反馈", value: "正式反馈入口尚未提供" },
 ];
 
 function formatBytes(bytes: number) {
@@ -113,6 +117,7 @@ export default function AndroidDownloadPage() {
         </Link>
         <div className="nav-links">
           <Link href="/">产品首页</Link>
+          <Link href="/changelog">更新日志</Link>
           <a href="#verify">验证信息</a>
         </div>
         <Link className="button button-small" href="/">
@@ -212,10 +217,18 @@ export default function AndroidDownloadPage() {
           <h2 id="support-title">已提供与待补充的信息，都明确说明。</h2>
         </div>
         <dl className="download-facts">
-          {supportFields.map(([label, value]) => (
-            <div key={label}>
-              <dt>{label}</dt>
-              <dd>{value}</dd>
+          {supportFields.map((field) => (
+            <div key={field.label}>
+              <dt>{field.label}</dt>
+              <dd>
+                {field.href ? (
+                  <Link className="download-inline-link" href={field.href}>
+                    {field.value}
+                  </Link>
+                ) : (
+                  field.value
+                )}
+              </dd>
             </div>
           ))}
         </dl>

--- a/portal/app/marketing.css
+++ b/portal/app/marketing.css
@@ -349,6 +349,149 @@
   color: #111;
 }
 
+.release-footer-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.release-footer-meta i {
+  color: var(--muted);
+  font-style: normal;
+}
+
+.release-footer-meta a,
+.download-page .download-inline-link {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.release-footer-meta a:focus-visible,
+.download-page .download-inline-link:focus-visible,
+.changelog-page .changelog-back:focus-visible {
+  outline: 3px solid #2d62ff;
+  outline-offset: 3px;
+}
+
+/* User-facing production release notes. */
+.changelog-page .nav-links a[aria-current="page"] {
+  border-color: #111;
+}
+
+.changelog-page .changelog-hero,
+.changelog-page .changelog-list {
+  width: min(960px, calc(100% - var(--page-gutter) * 2));
+  margin-inline: auto;
+}
+
+.changelog-page .changelog-hero {
+  padding: clamp(72px, 8vw, 108px) 0 clamp(68px, 7vw, 96px);
+}
+
+.changelog-page .changelog-back {
+  display: inline-block;
+  margin-bottom: clamp(58px, 6vw, 82px);
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.changelog-page .changelog-hero h1 {
+  max-width: 760px;
+  font-size: clamp(52px, 7vw, 88px);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.changelog-page .changelog-intro {
+  max-width: 660px;
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: clamp(17px, 1.7vw, 20px);
+  line-height: 1.7;
+}
+
+.changelog-page .changelog-list {
+  margin-bottom: clamp(92px, 10vw, 140px);
+}
+
+.changelog-page .changelog-release {
+  padding: clamp(44px, 5vw, 64px) 0;
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
+  gap: clamp(48px, 7vw, 80px);
+  border-top: 1px solid var(--line);
+}
+
+.changelog-page .changelog-release:last-child {
+  border-bottom: 1px solid var(--line);
+}
+
+.changelog-page .changelog-release-meta {
+  padding-top: 7px;
+}
+
+.changelog-page .changelog-release-meta p {
+  margin-bottom: 8px;
+  font-size: 14px;
+  font-weight: 680;
+}
+
+.changelog-page .changelog-release-meta time {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.changelog-page .changelog-release-body h2 {
+  font-size: clamp(32px, 3.6vw, 42px);
+  font-weight: 680;
+  line-height: 1.1;
+}
+
+.changelog-page .changelog-change-group {
+  margin-top: 34px;
+}
+
+.changelog-page .changelog-change-group h3 {
+  margin: 0 0 14px;
+  font-size: 18px;
+  font-weight: 680;
+  letter-spacing: -0.025em;
+}
+
+.changelog-page .changelog-change-group ul {
+  margin: 0;
+  padding-left: 1.15em;
+}
+
+.changelog-page .changelog-change-group li {
+  padding-left: 6px;
+  color: #333;
+  font-size: 17px;
+  line-height: 1.75;
+}
+
+.changelog-page .changelog-status {
+  min-height: 220px;
+  padding: clamp(44px, 5vw, 64px) 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.changelog-page .changelog-status h2 {
+  font-size: clamp(30px, 3.6vw, 40px);
+  font-weight: 680;
+}
+
+.changelog-page .changelog-status p {
+  max-width: 620px;
+  margin-top: 16px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
 /* Detailed Android release and verification page. */
 .download-page .download-hero,
 .download-page .download-section,
@@ -610,6 +753,11 @@
   .download-page .download-section {
     grid-template-columns: 1fr;
   }
+
+  .changelog-page .changelog-release {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
 }
 
 @media (max-width: 640px) {
@@ -708,6 +856,22 @@
     font-size: 44px;
   }
 
+  .changelog-page .changelog-hero {
+    padding: 58px 0 64px;
+  }
+
+  .changelog-page .changelog-back {
+    margin-bottom: 56px;
+  }
+
+  .changelog-page .changelog-hero h1 {
+    font-size: clamp(46px, 13vw, 54px);
+  }
+
+  .changelog-page .changelog-release {
+    padding: 40px 0 44px;
+  }
+
   .download-page .download-hero {
     padding: 58px 0 86px;
     gap: 50px;
@@ -764,12 +928,25 @@
   }
 
   .release-site footer {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr;
+    gap: 10px;
     padding: 28px 20px;
   }
 
   .release-site footer p {
     display: none;
+  }
+
+  .release-site footer > .release-footer-meta {
+    justify-self: start;
+    flex-wrap: wrap;
+    white-space: normal;
+  }
+
+  .release-footer-meta a {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
   }
 }
 

--- a/portal/app/page.tsx
+++ b/portal/app/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import BrandMark from "./BrandMark";
 import BrandWordmark from "./BrandWordmark";
 import { HomeAndroidDownloadAction } from "./HomeAndroidRelease";
@@ -39,6 +40,7 @@ export default function Home() {
           <a href="#top">产品介绍</a>
           <a href="#method">怎么练</a>
           <a href="#memory">长期记忆</a>
+          <Link href="/changelog">更新日志</Link>
         </div>
       </nav>
 
@@ -111,7 +113,10 @@ export default function Home() {
           <BrandWordmark />
         </a>
         <p>为真实世界准备英文表达。</p>
-        <span>© 2026 SpeakUp</span>
+        <span className="release-footer-meta">
+          <Link href="/changelog">更新日志</Link>
+          <i aria-hidden="true">·</i>© 2026 SpeakUp
+        </span>
       </footer>
     </main>
   );

--- a/portal/design-qa.md
+++ b/portal/design-qa.md
@@ -32,6 +32,19 @@
   for the brand, navigation links, and action.
 - Runtime: no application console errors were observed during the desktop and
   mobile checks.
+- Changelog: checked `/changelog` at 1280 × 720, 390 × 844, and 320 × 800.
+  The page uses the homepage's restrained black-and-white editorial language,
+  one flat release list, clear version/date/category hierarchy, and no cards,
+  gradients, glow, or horizontal overflow.
+- Changelog release state: the browser rendered v0.1.4 only after the active
+  Android metadata matched the versioned Chinese notes, including the
+  Asia/Shanghai date `2026年8月24日` and the verified user-facing fix copy.
+- Changelog discovery: both the homepage navigation and the Android detail
+  page's “查看正式版本更新记录” link navigated to `/changelog`. The mobile
+  navigation collapses at narrow widths; the footer becomes one-column at
+  320 px, keeps the entry visible, and provides a 44 px-high touch target.
+- Changelog runtime: no application console warnings, errors, or Vinext error
+  overlays were observed during the desktop and mobile checks.
 - Automated verification: lint, unit tests, rendered HTML checks, production
   build, and `git diff --check` must pass on the final clean worktree.
 

--- a/portal/lib/android-release-notes.mjs
+++ b/portal/lib/android-release-notes.mjs
@@ -1,0 +1,109 @@
+const documentKeys = [
+  "changes",
+  "locale",
+  "published_at",
+  "release_notes_version",
+  "version",
+];
+const changeKeys = ["text", "type"];
+const changeTypes = new Set([
+  "feature",
+  "improvement",
+  "fix",
+  "compatibility",
+  "known_limitation",
+]);
+const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const canonicalUtcPattern =
+  /^\d{4}-(0[1-9]|1[0-2])-([012]\d|3[01])T([01]\d|2[0-3]):[0-5]\d:[0-5]\dZ$/;
+
+function invalid() {
+  throw new Error("Android release notes are invalid");
+}
+
+function exactObject(value, keys) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    JSON.stringify(Object.keys(value).sort()) === JSON.stringify(keys)
+  );
+}
+
+function canonicalPublishedAt(value) {
+  if (typeof value !== "string" || !canonicalUtcPattern.test(value)) return false;
+  const parsed = new Date(value);
+  return (
+    !Number.isNaN(parsed.valueOf()) &&
+    parsed.toISOString().replace(".000Z", "Z") === value
+  );
+}
+
+export function parseAndroidReleaseNotes(value) {
+  if (
+    !exactObject(value, documentKeys) ||
+    value.release_notes_version !== 1 ||
+    value.locale !== "zh-CN" ||
+    typeof value.version !== "string" ||
+    !versionPattern.test(value.version) ||
+    !canonicalPublishedAt(value.published_at) ||
+    !Array.isArray(value.changes) ||
+    value.changes.length < 1 ||
+    value.changes.length > 20
+  ) {
+    invalid();
+  }
+
+  const changeTexts = new Set();
+  for (const change of value.changes) {
+    if (
+      !exactObject(change, changeKeys) ||
+      !changeTypes.has(change.type) ||
+      typeof change.text !== "string" ||
+      change.text.length < 1 ||
+      change.text.length > 160 ||
+      change.text.trim() !== change.text ||
+      /[\r\n]/.test(change.text) ||
+      changeTexts.has(change.text)
+    ) {
+      invalid();
+    }
+    changeTexts.add(change.text);
+  }
+
+  return value;
+}
+
+export function androidReleaseNotesPath(version) {
+  if (typeof version !== "string" || !versionPattern.test(version)) invalid();
+  return `/release-notes/android/v${version}.zh-CN.json`;
+}
+
+export function matchAndroidReleaseNotes(release, notes) {
+  const parsed = parseAndroidReleaseNotes(notes);
+  if (
+    release === null ||
+    typeof release !== "object" ||
+    parsed.version !== release.version ||
+    parsed.published_at !== release.published_at
+  ) {
+    invalid();
+  }
+  return parsed;
+}
+
+export async function loadAndroidReleaseNotes(release, fetcher = fetch) {
+  try {
+    const response = await fetcher(androidReleaseNotesPath(release.version), {
+      cache: "force-cache",
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) return { status: "unavailable" };
+    return {
+      status: "ready",
+      notes: matchAndroidReleaseNotes(release, await response.json()),
+    };
+  } catch {
+    return { status: "unavailable" };
+  }
+}

--- a/portal/public/release-notes/android/v0.1.4.zh-CN.json
+++ b/portal/public/release-notes/android/v0.1.4.zh-CN.json
@@ -1,0 +1,12 @@
+{
+  "release_notes_version": 1,
+  "locale": "zh-CN",
+  "version": "0.1.4",
+  "published_at": "2026-08-23T20:16:29Z",
+  "changes": [
+    {
+      "type": "fix",
+      "text": "修复部分情况下实时语音识别无法返回文字结果的问题。"
+    }
+  ]
+}

--- a/portal/tests/android-release-notes.test.mjs
+++ b/portal/tests/android-release-notes.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  androidReleaseNotesPath,
+  loadAndroidReleaseNotes,
+  matchAndroidReleaseNotes,
+  parseAndroidReleaseNotes,
+} from "../lib/android-release-notes.mjs";
+
+const release = {
+  version: "0.1.4",
+  published_at: "2026-08-23T20:16:29Z",
+};
+
+function validNotes() {
+  return {
+    release_notes_version: 1,
+    locale: "zh-CN",
+    version: "0.1.4",
+    published_at: "2026-08-23T20:16:29Z",
+    changes: [
+      {
+        type: "fix",
+        text: "修复部分情况下实时语音识别无法返回文字结果的问题。",
+      },
+    ],
+  };
+}
+
+test("publishes an honest v0.1.4 user-facing release note", () => {
+  const notes = JSON.parse(
+    readFileSync(
+      new URL(
+        "../public/release-notes/android/v0.1.4.zh-CN.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+
+  assert.equal(matchAndroidReleaseNotes(release, notes), notes);
+  assert.deepEqual(notes.changes, [
+    {
+      type: "fix",
+      text: "修复部分情况下实时语音识别无法返回文字结果的问题。",
+    },
+  ]);
+});
+
+test("parses strict, single-version Android release notes", () => {
+  const notes = validNotes();
+
+  assert.equal(parseAndroidReleaseNotes(notes), notes);
+  assert.equal(
+    androidReleaseNotesPath("0.1.4"),
+    "/release-notes/android/v0.1.4.zh-CN.json",
+  );
+  assert.equal(matchAndroidReleaseNotes(release, notes), notes);
+});
+
+test("rejects malformed Android release notes", () => {
+  const invalidCases = [
+    { ...validNotes(), unexpected: true },
+    { ...validNotes(), locale: "en-US" },
+    { ...validNotes(), published_at: "2026-02-30T10:00:00Z" },
+    {
+      ...validNotes(),
+      changes: [{ type: "internal", text: "重构内部模块。" }],
+    },
+    {
+      ...validNotes(),
+      changes: [{ type: "fix", text: " 修复问题。" }],
+    },
+    {
+      ...validNotes(),
+      changes: [
+        ...validNotes().changes,
+        {
+          type: "improvement",
+          text: "修复部分情况下实时语音识别无法返回文字结果的问题。",
+        },
+      ],
+    },
+  ];
+
+  for (const notes of invalidCases) {
+    assert.throws(
+      () => parseAndroidReleaseNotes(notes),
+      /Android release notes are invalid/,
+    );
+  }
+});
+
+test("requires current notes to match production version and publication time", () => {
+  assert.throws(
+    () => matchAndroidReleaseNotes({ ...release, version: "0.1.5" }, validNotes()),
+    /Android release notes are invalid/,
+  );
+  assert.throws(
+    () =>
+      matchAndroidReleaseNotes(
+        { ...release, published_at: "2026-08-23T20:17:00Z" },
+        validNotes(),
+      ),
+    /Android release notes are invalid/,
+  );
+});
+
+test("loads only the versioned notes for the active production release", async () => {
+  const requests = [];
+  const ready = await loadAndroidReleaseNotes(release, async (url, options) => {
+    requests.push({ url, options });
+    return new Response(JSON.stringify(validNotes()), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  assert.equal(ready.status, "ready");
+  assert.deepEqual(requests, [
+    {
+      url: "/release-notes/android/v0.1.4.zh-CN.json",
+      options: {
+        cache: "force-cache",
+        headers: { accept: "application/json" },
+      },
+    },
+  ]);
+
+  const unavailable = await loadAndroidReleaseNotes(release, async () =>
+    new Response("Not found", { status: 404 }),
+  );
+  assert.deepEqual(unavailable, { status: "unavailable" });
+});

--- a/portal/tests/rendered-html.test.mjs
+++ b/portal/tests/rendered-html.test.mjs
@@ -40,6 +40,7 @@ test("renders the standalone SpeakUp portal", async () => {
   assert.match(html, /speak-up-wordmark-black\.png/);
   assert.match(html, /speakup-mark\.svg/);
   assert.doesNotMatch(html, /speakup-mascot-blue/);
+  assert.match(html, /href="\/changelog"[^>]*>更新日志<\/a>/);
   assert.doesNotMatch(html, /href="\/download\/android"/);
   assert.doesNotMatch(html, /常见问题|唯一官方下载|制品信息完整/);
   assert.doesNotMatch(html, /SHA-256|签名证书|ABI/);
@@ -58,7 +59,7 @@ test("renders an honest Android download preparing state", async () => {
   assert.match(html, /更新日志/);
   assert.match(html, /隐私与权限/);
   assert.match(html, /问题反馈/);
-  assert.match(html, /独立更新日志尚未提供/);
+  assert.match(html, /href="\/changelog"[^>]*>查看正式版本更新记录/);
   assert.match(html, /正式隐私说明与权限清单尚未提供/);
   assert.match(html, /正式反馈入口尚未提供/);
   assert.doesNotMatch(html, /开放下载前公开/);
@@ -66,6 +67,20 @@ test("renders an honest Android download preparing state", async () => {
   assert.match(html, /安装未知应用/);
   assert.doesNotMatch(html, /\.apk(?:"|\?)/);
   assert.doesNotMatch(html, /versionName:\s*\d/);
+});
+
+test("renders the user-facing changelog without guessing a release", async () => {
+  const response = await render("/changelog");
+  assert.equal(response.status, 200);
+
+  const html = await response.text();
+  assert.match(html, /<title>更新日志 · SpeakUp<\/title>/);
+  assert.match(html, /<h1>更新日志<\/h1>/);
+  assert.match(html, /记录 SpeakUp 已正式发布的功能、体验优化与问题修复/);
+  assert.match(html, /正在确认当前正式版本/);
+  assert.match(html, /href="\/changelog"[^>]*aria-current="page"/);
+  assert.doesNotMatch(html, /v0\.1\.4/);
+  assert.doesNotMatch(html, /实时语音识别无法返回文字结果/);
 });
 
 test("renders the password-gated portal admin page", async () => {


### PR DESCRIPTION
## 功能描述

- 新增 `/changelog`，展示生产当前 Android 版本、发布时间与用户可感知的更新条目。
- 首页和 Android 下载页增加稳定可发现的更新日志入口。
- 首次仅发布可由生产状态核验的 `v0.1.4` 更新说明；缺失、无效或版本不匹配时明确显示不可用。

## 实现思路

- 保持现有 `release.json` v1 严格契约不变，新增独立的版本化资源 `/release-notes/android/v<version>.zh-CN.json`。
- 先读取生产下载元数据中的当前版本，再只加载同版本更新日志；严格校验字段、版本与发布时间，禁止猜测或模板兜底。
- 复用 Portal 现有黑白视觉体系并补齐桌面、移动端响应式样式及渲染断言。

## 可复现测试

- `cd portal && npm test`：25/25 通过（包含生产构建、数据契约、页面渲染、下载元数据回归）。
- `cd portal && npm run lint`：通过。
- `docker build -f portal/Dockerfile -t speakup-portal:issue-969 portal`：通过。
- 本地桌面、390×844 与 320×800 视口完成真实页面检查：无控制台错误、无横向溢出，首页返回与更新日志入口可用；视觉结果已人工确认。

## 关联 Issue

Related #969