### PR TITLE
fix(agent): 恢复 Thread 时禁止隐藏触发 Run

### DIFF
--- a/api/modules/agent.yaml
+++ b/api/modules/agent.yaml
@@ -788,6 +788,32 @@ paths:
           $ref: ../common/errors.yaml#/components/responses/Conflict
         default:
           $ref: ../common/errors.yaml#/components/responses/DefaultError
+  /v1/agent-threads/{thread_id}/runs/latest:
+    parameters:
+      - $ref: '#/components/parameters/AgentThreadId'
+    get:
+      tags:
+        - Agent
+      summary: Read the latest durable AgentRun for one owned Thread
+      description: |
+        This safe read never creates, claims, retries, or resumes a Run. The
+        `run` property is absent when the owned Thread has no Run. Latest means
+        the Run for the highest input Message sequence, with the highest attempt
+        number breaking ties.
+      operationId: getLatestAgentRunForThread
+      responses:
+        '200':
+          description: The latest durable Run state, if one exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LatestAgentRun'
+        '401':
+          $ref: ../common/errors.yaml#/components/responses/Unauthorized
+        '404':
+          $ref: ../common/errors.yaml#/components/responses/NotFound
+        default:
+          $ref: ../common/errors.yaml#/components/responses/DefaultError
   /v1/agent-threads/{thread_id}/runs/stream:
     parameters:
       - $ref: '#/components/parameters/AgentThreadId'
@@ -1703,6 +1729,12 @@ components:
           type: string
           format: date-time
           readOnly: true
+    LatestAgentRun:
+      type: object
+      additionalProperties: false
+      properties:
+        run:
+          $ref: '#/components/schemas/AgentRun'
     AgentMessageList:
       type: object
       additionalProperties: false

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -127,6 +127,8 @@ paths:
     $ref: ./modules/agent.yaml#/paths/~1v1~1agent-messages~1{message_id}~1translation
   /v1/agent-threads/{thread_id}/runs:
     $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1runs
+  /v1/agent-threads/{thread_id}/runs/latest:
+    $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1runs~1latest
   /v1/agent-threads/{thread_id}/runs/stream:
     $ref: ./modules/agent.yaml#/paths/~1v1~1agent-threads~1{thread_id}~1runs~1stream
   /v1/agent-runs/{run_id}:
@@ -276,6 +278,8 @@ components:
       $ref: ./modules/agent.yaml#/components/schemas/AgentMessageTranslation
     AgentRun:
       $ref: ./modules/agent.yaml#/components/schemas/AgentRun
+    LatestAgentRun:
+      $ref: ./modules/agent.yaml#/components/schemas/LatestAgentRun
     SceneDefinition:
       $ref: ./modules/scene.yaml#/components/schemas/SceneDefinition
     SceneDefinitionList:

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -720,6 +720,9 @@ class _SpeakUpShellState extends State<SpeakUpShell>
         errorMessage:
             widget.conversationController.errorMessage ??
             widget.conversationController.threadHistoryErrorMessage,
+        retryOperationLabel: widget.conversationController.canRetry
+            ? widget.conversationController.retryActionLabel
+            : '重试',
         onSubmitText: widget.composerController.sendText,
         onRetryOperation: widget.conversationController.canRetry
             ? widget.conversationController.retryLastOperation

--- a/mobile/lib/features/agent/conversation/agent_models.dart
+++ b/mobile/lib/features/agent/conversation/agent_models.dart
@@ -330,7 +330,7 @@ final class AgentThreadSnapshot {
   final String? nextMessageCursor;
 }
 
-/// A server-restored failed text operation that keeps its idempotency identity.
+/// A server-restored incomplete text operation and its latest durable evidence.
 ///
 /// This is a transient presentation projection. The durable Message and Run
 /// remain authoritative on the server.
@@ -338,16 +338,20 @@ final class AgentTextRecovery {
   const AgentTextRecovery({
     required this.text,
     required this.clientMessageId,
-    required this.failureKind,
-    required this.retryable,
+    required this.latestRun,
     this.imageAssetIds = const <String>[],
   });
 
   final String text;
   final String clientMessageId;
-  final String failureKind;
-  final bool retryable;
+  final AgentRun? latestRun;
   final List<String> imageAssetIds;
+
+  bool get canContinue => switch (latestRun?.status) {
+    AgentRunStatus.pending || AgentRunStatus.running => true,
+    AgentRunStatus.failed => latestRun!.failureRetryable,
+    AgentRunStatus.completed || null => false,
+  };
 }
 
 final class AgentExchange {

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -68,6 +68,7 @@ class ConversationPage extends StatefulWidget {
     this.isReplyPending = false,
     this.isComposerBlocked = false,
     this.errorMessage,
+    this.retryOperationLabel = '重试',
     this.onSubmitText,
     this.onRetryOperation,
     this.onLoadEarlierMessages,
@@ -111,6 +112,7 @@ class ConversationPage extends StatefulWidget {
   final bool isReplyPending;
   final bool isComposerBlocked;
   final String? errorMessage;
+  final String retryOperationLabel;
   final Future<bool> Function(String)? onSubmitText;
   final VoidCallback? onRetryOperation;
   final VoidCallback? onLoadEarlierMessages;
@@ -325,6 +327,7 @@ class ConversationPage extends StatefulWidget {
                             _InlineError(
                               message: message,
                               onRetry: onRetryOperation,
+                              retryLabel: retryOperationLabel,
                             ),
                           ],
                         ],
@@ -1032,10 +1035,15 @@ class _MessageList extends StatelessWidget {
 }
 
 class _InlineError extends StatelessWidget {
-  const _InlineError({required this.message, required this.onRetry});
+  const _InlineError({
+    required this.message,
+    required this.onRetry,
+    required this.retryLabel,
+  });
 
   final String message;
   final VoidCallback? onRetry;
+  final String retryLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -1057,7 +1065,7 @@ class _InlineError extends StatelessWidget {
               TextButton(
                 key: const Key('agent-retry-operation-button'),
                 onPressed: onRetry,
-                child: const Text('重试'),
+                child: Text(retryLabel),
               ),
           ],
         ),

--- a/mobile/lib/features/agent/conversation/conversation_controller.dart
+++ b/mobile/lib/features/agent/conversation/conversation_controller.dart
@@ -85,6 +85,10 @@ final class ConversationController extends ChangeNotifier {
   bool get isComposerBlocked =>
       _replyPending || _threadTransitionInFlight || (_busy && !isRestoring);
   bool get canRetry => _retry != null;
+  String get retryActionLabel => switch (_retry) {
+    _TextRetry(restored: true) => '继续',
+    _ => '重试',
+  };
 
   Future<void> initialize() async {
     if (_initialized || _disposed) {
@@ -185,16 +189,26 @@ final class ConversationController extends ChangeNotifier {
   void _applyRestoredTextState(AgentThreadSnapshot thread) {
     final textRecovery = thread.textRecovery;
     if (textRecovery != null) {
-      _retry = textRecovery.retryable
+      final latestRun = textRecovery.latestRun;
+      final inputMessageID =
+          latestRun?.inputMessageId ?? thread.messages.last.id;
+      _retry = textRecovery.canContinue
           ? _TextRetry(
               text: textRecovery.text,
               clientMessageId: textRecovery.clientMessageId,
               imageAssetIds: textRecovery.imageAssetIds,
+              committedUserMessageID: inputMessageID,
+              restored: true,
             )
           : null;
-      _errorMessage = textRecovery.retryable
-          ? '上次 Agent 运行未能完成，可以继续重试。'
-          : '上次 Agent 运行未能完成，服务端不允许重试。';
+      _errorMessage = switch (latestRun?.status) {
+        AgentRunStatus.pending || AgentRunStatus.running => '上次回复未完成，点击“继续”恢复。',
+        AgentRunStatus.failed when latestRun!.failureRetryable =>
+          '上次回复未完成，可以继续。',
+        AgentRunStatus.failed => '上次回复未完成，服务端不允许继续。',
+        AgentRunStatus.completed => null,
+        null => '上次回复未完成，但没有可恢复的运行记录。',
+      };
     }
   }
 
@@ -642,6 +656,7 @@ final class ConversationController extends ChangeNotifier {
     final retry = _retry;
     final operation =
         retry is _TextRetry &&
+            !retry.restored &&
             retry.text == text &&
             listEquals(retry.imageAssetIds, imageAssetIds)
         ? retry
@@ -662,7 +677,9 @@ final class ConversationController extends ChangeNotifier {
     _retry = null;
     _errorMessage = null;
     _setReplyPending(true);
-    if (operation.imageAssetIds.isEmpty && client is AgentStreamingTextClient) {
+    if (!operation.restored &&
+        operation.imageAssetIds.isEmpty &&
+        client is AgentStreamingTextClient) {
       final streamingClient = client as AgentStreamingTextClient;
       final committedUserMessageID = operation.committedUserMessageID;
       final reuseCommittedUser =
@@ -1441,12 +1458,28 @@ final class ConversationController extends ChangeNotifier {
         (snapshot.nextMessageCursor != null &&
             (snapshot.nextMessageCursor!.isEmpty ||
                 snapshot.nextMessageCursor!.runes.length > 1024)) ||
-        (recovery != null &&
-            (recovery.text.trim().isEmpty ||
-                recovery.clientMessageId.trim().isEmpty ||
-                recovery.failureKind.trim().isEmpty))) {
+        (recovery != null && !_validTextRecovery(snapshot, recovery))) {
       throw StateError('Invalid Agent Thread snapshot.');
     }
+  }
+
+  bool _validTextRecovery(
+    AgentThreadSnapshot snapshot,
+    AgentTextRecovery recovery,
+  ) {
+    final message = snapshot.messages.lastOrNull;
+    final run = recovery.latestRun;
+    return recovery.text.trim().isNotEmpty &&
+        recovery.clientMessageId.trim().isNotEmpty &&
+        message != null &&
+        message.role == AgentMessageRole.user &&
+        message.modality != AgentMessageModality.voice &&
+        message.text == recovery.text &&
+        message.clientMessageId == recovery.clientMessageId &&
+        (run == null ||
+            (run.threadId == snapshot.threadId &&
+                run.inputMessageId == message.id &&
+                run.status != AgentRunStatus.completed));
   }
 
   void _validateThreadSummary(AgentThreadSummary summary) {
@@ -1561,12 +1594,15 @@ final class _TextRetry extends _ConversationRetry {
     required this.text,
     required this.clientMessageId,
     this.imageAssetIds = const <String>[],
+    this.committedUserMessageID,
+    this.restored = false,
   });
 
   final String text;
   final String clientMessageId;
   final List<String> imageAssetIds;
   String? committedUserMessageID;
+  final bool restored;
 }
 
 final Random _clientIdRandom = Random.secure();

--- a/mobile/lib/providers/agent/wire_agent_client.dart
+++ b/mobile/lib/providers/agent/wire_agent_client.dart
@@ -75,6 +75,7 @@ final class WireAgentClient
   int _accountGeneration = 0;
   final Set<Future<void>> _inFlightOperations = <Future<void>>{};
   final Map<String, _FailedRun> _failedRuns = <String, _FailedRun>{};
+  final Map<String, AgentRun> _restoredRuns = <String, AgentRun>{};
   final Set<String> _ambiguousSubmissions = <String>{};
   _AmbiguousThreadCreation? _ambiguousThreadCreation;
   Future<void>? _cleanupFuture;
@@ -97,6 +98,7 @@ final class WireAgentClient
   Future<void> _performAccountCleanup() async {
     _accountGeneration++;
     _failedRuns.clear();
+    _restoredRuns.clear();
     _ambiguousSubmissions.clear();
     _ambiguousThreadCreation = null;
     final staleOperations = List<Future<void>>.of(_inFlightOperations);
@@ -230,7 +232,7 @@ final class WireAgentClient
       threadId: thread.id,
     );
     _requireCurrentGeneration(generation);
-    final recovery = await _restoreLastTextRun(
+    final recovery = await _readLastTextRun(
       generation: generation,
       threadId: thread.id,
       messages: messagePage.messages,
@@ -238,7 +240,7 @@ final class WireAgentClient
     return AgentThreadSnapshot(
       threadId: thread.id,
       title: thread.title,
-      textRecovery: recovery.failure,
+      textRecovery: recovery.recovery,
       messages: <AgentMessage>[
         for (final message in messagePage.messages) message.presentation,
         ?recovery.completedAssistant,
@@ -249,7 +251,7 @@ final class WireAgentClient
     );
   }
 
-  Future<_RestoredTextRun> _restoreLastTextRun({
+  Future<_RestoredTextRun> _readLastTextRun({
     required int generation,
     required String threadId,
     required List<AgentWireMessage> messages,
@@ -272,28 +274,29 @@ final class WireAgentClient
       );
     }
     final operationKey = '$threadId\u{0}$clientMessageId';
-    final terminalRun = await _pollUntilTerminal(
+    final latestRun = await _getLatestThreadRun(
       generation: generation,
-      initialRun: await _submitRun(
-        generation: generation,
-        threadId: threadId,
-        text: userMessage.content,
-        clientMessageId: clientMessageId,
-        imageAssetIds: imageAssetIds,
-      ),
+      threadId: threadId,
     );
     _requireCurrentGeneration(generation);
-    if (terminalRun.inputMessageId != userMessage.id) {
-      throw const AgentClientException(
-        kind: AgentClientFailureKind.invalidResponse,
-        retryable: true,
+    if (latestRun == null || latestRun.inputMessageId != userMessage.id) {
+      _failedRuns.remove(operationKey);
+      _restoredRuns.remove(operationKey);
+      return _RestoredTextRun(
+        recovery: AgentTextRecovery(
+          text: userMessage.content,
+          clientMessageId: clientMessageId,
+          latestRun: null,
+          imageAssetIds: imageAssetIds,
+        ),
       );
     }
-    if (terminalRun.status == AgentRunStatus.completed) {
+    if (latestRun.status == AgentRunStatus.completed) {
       _failedRuns.remove(operationKey);
+      _restoredRuns.remove(operationKey);
       final exchange = await _loadCompletedExchange(
         generation: generation,
-        run: terminalRun,
+        run: latestRun,
         expectedUserContent: userMessage.content,
         expectedClientMessageId: clientMessageId,
         expectedImageAssetIds: imageAssetIds,
@@ -308,32 +311,50 @@ final class WireAgentClient
       return _RestoredTextRun(completedAssistant: exchange.assistantMessage);
     }
 
-    final failureKind = terminalRun.failureKind;
-    if (failureKind == null) {
+    if (latestRun.status == AgentRunStatus.failed) {
+      _restoredRuns.remove(operationKey);
+      if (latestRun.failureRetryable) {
+        _failedRuns[operationKey] = _FailedRun(
+          run: latestRun,
+          clientMessageId: clientMessageId,
+          content: userMessage.content,
+          imageAssetIds: imageAssetIds,
+        );
+      } else {
+        _failedRuns.remove(operationKey);
+      }
+    } else {
+      _failedRuns.remove(operationKey);
+      _restoredRuns[operationKey] = latestRun;
+    }
+    return _RestoredTextRun(
+      recovery: AgentTextRecovery(
+        text: userMessage.content,
+        clientMessageId: clientMessageId,
+        latestRun: latestRun,
+        imageAssetIds: imageAssetIds,
+      ),
+    );
+  }
+
+  Future<AgentRun?> _getLatestThreadRun({
+    required int generation,
+    required String threadId,
+  }) async {
+    final response = await _send(
+      generation: generation,
+      method: 'GET',
+      path: '/v1/agent-threads/$threadId/runs/latest',
+    );
+    _requireStatus(response, const <int>{HttpStatus.ok});
+    final run = _decodeLatestRun(response.body);
+    if (run != null && run.threadId != threadId) {
       throw const AgentClientException(
         kind: AgentClientFailureKind.invalidResponse,
         retryable: true,
       );
     }
-    if (terminalRun.failureRetryable) {
-      _failedRuns[operationKey] = _FailedRun(
-        run: terminalRun,
-        clientMessageId: clientMessageId,
-        content: userMessage.content,
-        imageAssetIds: imageAssetIds,
-      );
-    } else {
-      _failedRuns.remove(operationKey);
-    }
-    return _RestoredTextRun(
-      failure: AgentTextRecovery(
-        text: userMessage.content,
-        clientMessageId: clientMessageId,
-        failureKind: failureKind,
-        retryable: terminalRun.failureRetryable,
-        imageAssetIds: imageAssetIds,
-      ),
-    );
+    return run;
   }
 
   Future<_WireThread> _createWireThread(int generation) async {
@@ -437,7 +458,16 @@ final class WireAgentClient
       _requireContent(text);
       _requireImageAssetIds(imageAssetIds);
       final operationKey = '$threadId\u{0}$clientMessageId';
+      final restoredRun = _restoredRuns[operationKey];
       var failedRun = _failedRuns[operationKey];
+      if (restoredRun != null &&
+          (restoredRun.threadId != threadId ||
+              restoredRun.inputMessageId.trim().isEmpty)) {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.invalidResponse,
+          retryable: true,
+        );
+      }
       if (failedRun != null &&
           (failedRun.threadId != threadId ||
               failedRun.clientMessageId != clientMessageId ||
@@ -484,7 +514,16 @@ final class WireAgentClient
       }
 
       late AgentRun initialRun;
-      if (failedRun != null) {
+      if (restoredRun != null) {
+        initialRun = await _resumeRestoredRun(
+          generation: generation,
+          restoredRun: restoredRun,
+          threadId: threadId,
+          text: text,
+          clientMessageId: clientMessageId,
+          imageAssetIds: imageAssetIds,
+        );
+      } else if (failedRun != null) {
         initialRun = await _retryRun(
           generation: generation,
           failedRun: failedRun,
@@ -553,6 +592,7 @@ final class WireAgentClient
       _ambiguousSubmissions.remove(operationKey);
 
       if (resolvedRun.status == AgentRunStatus.failed) {
+        _restoredRuns.remove(operationKey);
         if (resolvedRun.failureRetryable) {
           _failedRuns[operationKey] = _FailedRun(
             run: resolvedRun,
@@ -571,13 +611,15 @@ final class WireAgentClient
       }
 
       _failedRuns.remove(operationKey);
-      return _loadCompletedExchange(
+      final exchange = await _loadCompletedExchange(
         generation: generation,
         run: resolvedRun,
         expectedUserContent: text,
         expectedClientMessageId: clientMessageId,
         expectedImageAssetIds: imageAssetIds,
       );
+      _restoredRuns.remove(operationKey);
+      return exchange;
     });
   }
 
@@ -1197,6 +1239,54 @@ final class WireAgentClient
     return run;
   }
 
+  Future<AgentRun> _resumeRestoredRun({
+    required int generation,
+    required AgentRun restoredRun,
+    required String threadId,
+    required String text,
+    required String clientMessageId,
+    required List<String> imageAssetIds,
+  }) async {
+    late final AgentRun current;
+    if (restoredRun.attempt == 1) {
+      current = await _submitRun(
+        generation: generation,
+        threadId: threadId,
+        text: text,
+        clientMessageId: clientMessageId,
+        imageAssetIds: imageAssetIds,
+      );
+    } else {
+      final sourceRunId = restoredRun.retryOfRunId;
+      final retryClientId = restoredRun.clientRetryId;
+      if (sourceRunId == null || retryClientId == null) {
+        throw const AgentClientException(
+          kind: AgentClientFailureKind.invalidResponse,
+          retryable: true,
+        );
+      }
+      final response = await _send(
+        generation: generation,
+        method: 'POST',
+        path: '/v1/agent-runs/$sourceRunId/retries',
+        body: <String, Object?>{'client_retry_id': retryClientId},
+      );
+      _requireStatus(response, const <int>{
+        HttpStatus.created,
+        HttpStatus.accepted,
+      });
+      current = _decodeRun(response.body);
+      _validateRunWriteStatus(response.statusCode, current);
+    }
+    if (!sameAgentRunIdentity(current, restoredRun)) {
+      throw const AgentClientException(
+        kind: AgentClientFailureKind.invalidResponse,
+        retryable: true,
+      );
+    }
+    return current;
+  }
+
   Future<AgentRun> _retryRun({
     required int generation,
     required _FailedRun failedRun,
@@ -1664,9 +1754,9 @@ final class _WireThreadPage {
 }
 
 final class _RestoredTextRun {
-  const _RestoredTextRun({this.failure, this.completedAssistant});
+  const _RestoredTextRun({this.recovery, this.completedAssistant});
 
-  final AgentTextRecovery? failure;
+  final AgentTextRecovery? recovery;
   final AgentMessage? completedAssistant;
 }
 
@@ -1784,6 +1874,17 @@ AgentWireMessage _decodeMessageObject(
 
 AgentRun _decodeRun(String body) {
   return _decodeBody(body, decodeAgentWireRun);
+}
+
+AgentRun? _decodeLatestRun(String body) {
+  return _decodeBody(body, (value) {
+    final object = _strictObject(
+      value,
+      allowed: const <String>{'run'},
+      required: const <String>{},
+    );
+    return _absentOnlyOptional(object, 'run', decodeAgentWireRun);
+  });
 }
 
 void _validateRunWriteStatus(int statusCode, AgentRun run) {

--- a/mobile/test/agent/conversation_controller_test.dart
+++ b/mobile/test/agent/conversation_controller_test.dart
@@ -119,21 +119,90 @@ void main() {
     expect(controller.canRetry, isFalse);
   });
 
-  test('restores a failed text operation with its server identity', () async {
+  test(
+    'restores an incomplete text operation with its server identity',
+    () async {
+      final client = _SnapshotAgentClient(
+        AgentThreadSnapshot(
+          threadId: 'thread_restored_text',
+          textRecovery: AgentTextRecovery(
+            text: 'retry the restored text',
+            clientMessageId: 'message_restored_stable',
+            latestRun: _recoveryRun(),
+          ),
+          messages: const <AgentMessage>[
+            AgentMessage(
+              id: 'message_restored_user',
+              role: AgentMessageRole.user,
+              text: 'retry the restored text',
+              clientMessageId: 'message_restored_stable',
+            ),
+          ],
+        ),
+      );
+      final controller = ConversationController(client: client);
+
+      await controller.initialize();
+
+      expect(controller.canRetry, isTrue);
+      expect(controller.messages, hasLength(1));
+      expect(controller.errorMessage, contains('上次回复未完成'));
+      expect(controller.retryActionLabel, '继续');
+
+      final first = controller.retryLastOperation();
+      final duplicate = controller.retryLastOperation();
+      await Future.wait(<Future<void>>[first, duplicate]);
+
+      expect(client.messageClientIds, <String>['message_restored_stable']);
+      expect(controller.messages, hasLength(2));
+      expect(controller.canRetry, isFalse);
+    },
+  );
+
+  test('composer sends matching restored text as a new operation', () async {
     final client = _SnapshotAgentClient(
-      const AgentThreadSnapshot(
+      AgentThreadSnapshot(
         threadId: 'thread_restored_text',
         textRecovery: AgentTextRecovery(
           text: 'retry the restored text',
           clientMessageId: 'message_restored_stable',
-          failureKind: 'timeout',
-          retryable: true,
+          latestRun: _recoveryRun(),
         ),
-        messages: <AgentMessage>[
+        messages: const <AgentMessage>[
           AgentMessage(
             id: 'message_restored_user',
             role: AgentMessageRole.user,
             text: 'retry the restored text',
+            clientMessageId: 'message_restored_stable',
+          ),
+        ],
+      ),
+    );
+    final controller = ConversationController(client: client);
+
+    await controller.initialize();
+    expect(await controller.sendText('retry the restored text'), isTrue);
+
+    expect(client.messageClientIds, hasLength(1));
+    expect(client.messageClientIds.single, isNot('message_restored_stable'));
+    expect(controller.canRetry, isFalse);
+  });
+
+  test('renders missing Run evidence without offering continuation', () async {
+    final client = _SnapshotAgentClient(
+      const AgentThreadSnapshot(
+        threadId: 'thread_missing_run',
+        textRecovery: AgentTextRecovery(
+          text: 'input without a Run',
+          clientMessageId: 'message_missing_run',
+          latestRun: null,
+        ),
+        messages: <AgentMessage>[
+          AgentMessage(
+            id: 'message_missing_run_id',
+            role: AgentMessageRole.user,
+            text: 'input without a Run',
+            clientMessageId: 'message_missing_run',
           ),
         ],
       ),
@@ -142,15 +211,9 @@ void main() {
 
     await controller.initialize();
 
-    expect(controller.canRetry, isTrue);
-    expect(controller.messages, hasLength(1));
-    expect(controller.errorMessage, contains('继续重试'));
-
-    await controller.retryLastOperation();
-
-    expect(client.messageClientIds, <String>['message_restored_stable']);
-    expect(controller.messages, hasLength(2));
+    expect(controller.errorMessage, contains('没有可恢复的运行记录'));
     expect(controller.canRetry, isFalse);
+    expect(client.messageClientIds, isEmpty);
   });
 
   test('restore exposes an executable operation-specific retry', () async {
@@ -792,6 +855,25 @@ void main() {
       controller.dispose();
     }
   });
+}
+
+AgentRun _recoveryRun() {
+  final createdAt = DateTime.utc(2026, 8, 25, 8);
+  return AgentRun(
+    id: 'run_restored_failed',
+    threadId: 'thread_restored_text',
+    inputMessageId: 'message_restored_user',
+    attempt: 1,
+    status: AgentRunStatus.failed,
+    requestedProvider: 'fake',
+    requestedModel: 'fake-model',
+    maxOutputTokens: 256,
+    failure: const AgentRunFailure(kind: 'timeout', retryable: true),
+    createdAt: createdAt,
+    startedAt: createdAt.add(const Duration(seconds: 1)),
+    completedAt: createdAt.add(const Duration(seconds: 2)),
+    updatedAt: createdAt.add(const Duration(seconds: 2)),
+  );
 }
 
 class _DelegatingAgentClient implements AgentClient {

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -282,7 +282,7 @@ void main() {
       },
     );
 
-    test('restores a failed Run and its stable retry identity', () async {
+    test('reads a failed Run without POST and keeps its retry identity', () async {
       const text = 'Restore this failed request.';
       const clientMessageId = 'message_cold_restore';
       final transport = _ScriptedTransport([
@@ -307,21 +307,17 @@ void main() {
           }),
         ),
         _Step(
-          method: 'POST',
-          path: '/v1/agent-threads/$_threadId/runs',
-          verify: (call) {
-            expect(jsonDecode(call.body!), {
-              'client_message_id': clientMessageId,
-              'content': text,
-            });
-          },
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/runs/latest',
           response: _jsonResponse(
-            HttpStatus.created,
-            _runJson(
-              status: 'failed',
-              failureKind: 'timeout',
-              failureRetryable: true,
-            ),
+            HttpStatus.ok,
+            {
+              'run': _runJson(
+                status: 'failed',
+                failureKind: 'timeout',
+                failureRetryable: true,
+              ),
+            },
           ),
         ),
         _Step(
@@ -349,7 +345,9 @@ void main() {
 
       expect(snapshot.messages, hasLength(1));
       expect(snapshot.textRecovery?.clientMessageId, clientMessageId);
-      expect(snapshot.textRecovery?.retryable, isTrue);
+      expect(snapshot.textRecovery?.latestRun?.status, AgentRunStatus.failed);
+      expect(snapshot.textRecovery?.canContinue, isTrue);
+      expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
 
       final exchange = await harness.client.sendText(
         threadId: _threadId,
@@ -359,16 +357,14 @@ void main() {
 
       expect(exchange.assistantMessage, isNotNull);
       expect(
-        transport.calls
-            .where((call) => call.path == '/v1/agent-threads/$_threadId/runs')
-            .length,
+        transport.calls.where((call) => call.method == 'POST').length,
         1,
       );
       transport.expectDone();
     });
 
     test(
-      'finishes a restored pending Message without duplicating it',
+      'only resumes a pending Message after one explicit POST',
       () async {
         const text = 'Finish this restored request.';
         final transport = _ScriptedTransport([
@@ -393,8 +389,22 @@ void main() {
             }),
           ),
           _Step(
+            method: 'GET',
+            path: '/v1/agent-threads/$_threadId/runs/latest',
+            response: _jsonResponse(
+              HttpStatus.ok,
+              {'run': _runJson(status: 'pending')},
+            ),
+          ),
+          _Step(
             method: 'POST',
             path: '/v1/agent-threads/$_threadId/runs',
+            verify: (call) {
+              expect(jsonDecode(call.body!), {
+                'client_message_id': 'message_pending_restore',
+                'content': text,
+              });
+            },
             response: _jsonResponse(
               HttpStatus.accepted,
               _runJson(status: 'pending'),
@@ -417,13 +427,194 @@ void main() {
 
         final snapshot = await harness.client.getThread(threadId: _threadId);
 
-        expect(snapshot.textRecovery, isNull);
-        expect(snapshot.messages, hasLength(2));
-        expect(snapshot.messages.first.id, _userMessageId);
-        expect(snapshot.messages.last.id, _assistantMessageId);
+        expect(snapshot.textRecovery?.latestRun?.status, AgentRunStatus.pending);
+        expect(snapshot.textRecovery?.canContinue, isTrue);
+        expect(snapshot.messages, hasLength(1));
+        expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
+
+        final exchange = await harness.client.sendText(
+          threadId: _threadId,
+          text: text,
+          clientMessageId: 'message_pending_restore',
+        );
+
+        expect(exchange.userMessage.id, _userMessageId);
+        expect(exchange.assistantMessage?.id, _assistantMessageId);
+        expect(transport.calls.where((call) => call.method == 'POST'), hasLength(1));
         transport.expectDone();
       },
     );
+
+    test('renders missing Run evidence without attempting a write', () async {
+      const text = 'This input has no durable Run.';
+      const clientMessageId = 'message_without_run';
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId',
+          response: _jsonResponse(HttpStatus.ok, _threadJson()),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/messages',
+          response: _jsonResponse(HttpStatus.ok, {
+            'messages': [
+              _messageJson(
+                id: _userMessageId,
+                sequence: 1,
+                role: 'user',
+                content: text,
+                clientMessageId: clientMessageId,
+              ),
+            ],
+          }),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/runs/latest',
+          response: _jsonResponse(HttpStatus.ok, <String, Object?>{}),
+        ),
+      ]);
+      final harness = _Harness(transport);
+
+      final snapshot = await harness.client.getThread(threadId: _threadId);
+
+      expect(snapshot.textRecovery, isNotNull);
+      expect(snapshot.textRecovery?.latestRun, isNull);
+      expect(snapshot.textRecovery?.canContinue, isFalse);
+      expect(transport.calls.every((call) => call.method == 'GET'), isTrue);
+      transport.expectDone();
+    });
+
+    test('replays one in-flight retry only after explicit continuation', () async {
+      const text = 'Continue the existing retry.';
+      const clientMessageId = 'message_retry_restore';
+      final retryRun = _runJson(
+        id: _retryRunId,
+        status: 'running',
+        attempt: 2,
+        retryOfRunId: _runId,
+        clientRetryId: 'retry:$_runId',
+      );
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId',
+          response: _jsonResponse(HttpStatus.ok, _threadJson()),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/messages',
+          response: _jsonResponse(HttpStatus.ok, {
+            'messages': [
+              _messageJson(
+                id: _userMessageId,
+                sequence: 1,
+                role: 'user',
+                content: text,
+                clientMessageId: clientMessageId,
+              ),
+            ],
+          }),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/runs/latest',
+          response: _jsonResponse(HttpStatus.ok, {'run': retryRun}),
+        ),
+        _Step(
+          method: 'POST',
+          path: '/v1/agent-runs/$_runId/retries',
+          verify: (call) {
+            expect(jsonDecode(call.body!), {'client_retry_id': 'retry:$_runId'});
+          },
+          response: _jsonResponse(HttpStatus.accepted, retryRun),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-runs/$_retryRunId',
+          response: _jsonResponse(
+            HttpStatus.ok,
+            _runJson(
+              id: _retryRunId,
+              status: 'completed',
+              attempt: 2,
+              retryOfRunId: _runId,
+              clientRetryId: 'retry:$_runId',
+            ),
+          ),
+        ),
+        _messagesStep(
+          userContent: text,
+          clientMessageId: clientMessageId,
+          assistantRunId: _retryRunId,
+        ),
+      ]);
+      final harness = _Harness(transport, maxRunPollAttempts: 2);
+
+      final snapshot = await harness.client.getThread(threadId: _threadId);
+
+      expect(snapshot.textRecovery?.latestRun?.attempt, 2);
+      expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
+
+      final exchange = await harness.client.sendText(
+        threadId: _threadId,
+        text: text,
+        clientMessageId: clientMessageId,
+      );
+
+      expect(exchange.assistantMessage?.producedByRunId, _retryRunId);
+      expect(transport.calls.where((call) => call.method == 'POST'), hasLength(1));
+      transport.expectDone();
+    });
+
+    test('hydrates a just-completed Run using GET requests only', () async {
+      const text = 'The response completed during restoration.';
+      const clientMessageId = 'message_completed_restore';
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId',
+          response: _jsonResponse(HttpStatus.ok, _threadJson()),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/messages',
+          response: _jsonResponse(HttpStatus.ok, {
+            'messages': [
+              _messageJson(
+                id: _userMessageId,
+                sequence: 1,
+                role: 'user',
+                content: text,
+                clientMessageId: clientMessageId,
+              ),
+            ],
+          }),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/runs/latest',
+          response: _jsonResponse(
+            HttpStatus.ok,
+            {'run': _runJson(status: 'completed')},
+          ),
+        ),
+        _messagesStep(
+          userContent: text,
+          clientMessageId: clientMessageId,
+        ),
+      ]);
+      final harness = _Harness(transport);
+
+      final snapshot = await harness.client.getThread(threadId: _threadId);
+
+      expect(snapshot.textRecovery, isNull);
+      expect(snapshot.messages, hasLength(2));
+      expect(snapshot.messages.last.id, _assistantMessageId);
+      expect(transport.calls.every((call) => call.method == 'GET'), isTrue);
+      transport.expectDone();
+    });
 
     test('rejects unknown response fields and unsafe ordering', () async {
       final malformedThread = _threadJson()..['unexpected'] = true;

--- a/mobile/test/agent/wire_agent_client_test.dart
+++ b/mobile/test/agent/wire_agent_client_test.dart
@@ -282,91 +282,11 @@ void main() {
       },
     );
 
-    test('reads a failed Run without POST and keeps its retry identity', () async {
-      const text = 'Restore this failed request.';
-      const clientMessageId = 'message_cold_restore';
-      final transport = _ScriptedTransport([
-        _Step(
-          method: 'GET',
-          path: '/v1/agent-threads/$_threadId',
-          response: _jsonResponse(HttpStatus.ok, _threadJson()),
-        ),
-        _Step(
-          method: 'GET',
-          path: '/v1/agent-threads/$_threadId/messages',
-          response: _jsonResponse(HttpStatus.ok, {
-            'messages': [
-              _messageJson(
-                id: _userMessageId,
-                sequence: 1,
-                role: 'user',
-                content: text,
-                clientMessageId: clientMessageId,
-              ),
-            ],
-          }),
-        ),
-        _Step(
-          method: 'GET',
-          path: '/v1/agent-threads/$_threadId/runs/latest',
-          response: _jsonResponse(
-            HttpStatus.ok,
-            {
-              'run': _runJson(
-                status: 'failed',
-                failureKind: 'timeout',
-                failureRetryable: true,
-              ),
-            },
-          ),
-        ),
-        _Step(
-          method: 'POST',
-          path: '/v1/agent-runs/$_runId/retries',
-          response: _jsonResponse(
-            HttpStatus.created,
-            _runJson(
-              id: _retryRunId,
-              status: 'completed',
-              retryOfRunId: _runId,
-              clientRetryId: 'retry:$_runId',
-            ),
-          ),
-        ),
-        _messagesStep(
-          userContent: text,
-          clientMessageId: clientMessageId,
-          assistantRunId: _retryRunId,
-        ),
-      ]);
-      final harness = _Harness(transport);
-
-      final snapshot = await harness.client.getThread(threadId: _threadId);
-
-      expect(snapshot.messages, hasLength(1));
-      expect(snapshot.textRecovery?.clientMessageId, clientMessageId);
-      expect(snapshot.textRecovery?.latestRun?.status, AgentRunStatus.failed);
-      expect(snapshot.textRecovery?.canContinue, isTrue);
-      expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
-
-      final exchange = await harness.client.sendText(
-        threadId: _threadId,
-        text: text,
-        clientMessageId: clientMessageId,
-      );
-
-      expect(exchange.assistantMessage, isNotNull);
-      expect(
-        transport.calls.where((call) => call.method == 'POST').length,
-        1,
-      );
-      transport.expectDone();
-    });
-
     test(
-      'only resumes a pending Message after one explicit POST',
+      'reads a failed Run without POST and keeps its retry identity',
       () async {
-        const text = 'Finish this restored request.';
+        const text = 'Restore this failed request.';
+        const clientMessageId = 'message_cold_restore';
         final transport = _ScriptedTransport([
           _Step(
             method: 'GET',
@@ -383,7 +303,7 @@ void main() {
                   sequence: 1,
                   role: 'user',
                   content: text,
-                  clientMessageId: 'message_pending_restore',
+                  clientMessageId: clientMessageId,
                 ),
               ],
             }),
@@ -391,59 +311,135 @@ void main() {
           _Step(
             method: 'GET',
             path: '/v1/agent-threads/$_threadId/runs/latest',
-            response: _jsonResponse(
-              HttpStatus.ok,
-              {'run': _runJson(status: 'pending')},
-            ),
+            response: _jsonResponse(HttpStatus.ok, {
+              'run': _runJson(
+                status: 'failed',
+                failureKind: 'timeout',
+                failureRetryable: true,
+              ),
+            }),
           ),
           _Step(
             method: 'POST',
-            path: '/v1/agent-threads/$_threadId/runs',
-            verify: (call) {
-              expect(jsonDecode(call.body!), {
-                'client_message_id': 'message_pending_restore',
-                'content': text,
-              });
-            },
+            path: '/v1/agent-runs/$_runId/retries',
             response: _jsonResponse(
-              HttpStatus.accepted,
-              _runJson(status: 'pending'),
-            ),
-          ),
-          _Step(
-            method: 'GET',
-            path: '/v1/agent-runs/$_runId',
-            response: _jsonResponse(
-              HttpStatus.ok,
-              _runJson(status: 'completed'),
+              HttpStatus.created,
+              _runJson(
+                id: _retryRunId,
+                status: 'completed',
+                retryOfRunId: _runId,
+                clientRetryId: 'retry:$_runId',
+              ),
             ),
           ),
           _messagesStep(
             userContent: text,
-            clientMessageId: 'message_pending_restore',
+            clientMessageId: clientMessageId,
+            assistantRunId: _retryRunId,
           ),
         ]);
-        final harness = _Harness(transport, maxRunPollAttempts: 2);
+        final harness = _Harness(transport);
 
         final snapshot = await harness.client.getThread(threadId: _threadId);
 
-        expect(snapshot.textRecovery?.latestRun?.status, AgentRunStatus.pending);
-        expect(snapshot.textRecovery?.canContinue, isTrue);
         expect(snapshot.messages, hasLength(1));
+        expect(snapshot.textRecovery?.clientMessageId, clientMessageId);
+        expect(snapshot.textRecovery?.latestRun?.status, AgentRunStatus.failed);
+        expect(snapshot.textRecovery?.canContinue, isTrue);
         expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
 
         final exchange = await harness.client.sendText(
           threadId: _threadId,
           text: text,
-          clientMessageId: 'message_pending_restore',
+          clientMessageId: clientMessageId,
         );
 
-        expect(exchange.userMessage.id, _userMessageId);
-        expect(exchange.assistantMessage?.id, _assistantMessageId);
-        expect(transport.calls.where((call) => call.method == 'POST'), hasLength(1));
+        expect(exchange.assistantMessage, isNotNull);
+        expect(
+          transport.calls.where((call) => call.method == 'POST').length,
+          1,
+        );
         transport.expectDone();
       },
     );
+
+    test('only resumes a pending Message after one explicit POST', () async {
+      const text = 'Finish this restored request.';
+      final transport = _ScriptedTransport([
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId',
+          response: _jsonResponse(HttpStatus.ok, _threadJson()),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/messages',
+          response: _jsonResponse(HttpStatus.ok, {
+            'messages': [
+              _messageJson(
+                id: _userMessageId,
+                sequence: 1,
+                role: 'user',
+                content: text,
+                clientMessageId: 'message_pending_restore',
+              ),
+            ],
+          }),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-threads/$_threadId/runs/latest',
+          response: _jsonResponse(HttpStatus.ok, {
+            'run': _runJson(status: 'pending'),
+          }),
+        ),
+        _Step(
+          method: 'POST',
+          path: '/v1/agent-threads/$_threadId/runs',
+          verify: (call) {
+            expect(jsonDecode(call.body!), {
+              'client_message_id': 'message_pending_restore',
+              'content': text,
+            });
+          },
+          response: _jsonResponse(
+            HttpStatus.accepted,
+            _runJson(status: 'pending'),
+          ),
+        ),
+        _Step(
+          method: 'GET',
+          path: '/v1/agent-runs/$_runId',
+          response: _jsonResponse(HttpStatus.ok, _runJson(status: 'completed')),
+        ),
+        _messagesStep(
+          userContent: text,
+          clientMessageId: 'message_pending_restore',
+        ),
+      ]);
+      final harness = _Harness(transport, maxRunPollAttempts: 2);
+
+      final snapshot = await harness.client.getThread(threadId: _threadId);
+
+      expect(snapshot.textRecovery?.latestRun?.status, AgentRunStatus.pending);
+      expect(snapshot.textRecovery?.canContinue, isTrue);
+      expect(snapshot.messages, hasLength(1));
+      expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
+
+      final exchange = await harness.client.sendText(
+        threadId: _threadId,
+        text: text,
+        clientMessageId: 'message_pending_restore',
+      );
+
+      expect(exchange.userMessage.id, _userMessageId);
+      expect(exchange.assistantMessage?.id, _assistantMessageId);
+      expect(
+        transport.calls.where((call) => call.method == 'POST'),
+        hasLength(1),
+      );
+      transport.expectDone();
+    });
 
     test('renders missing Run evidence without attempting a write', () async {
       const text = 'This input has no durable Run.';
@@ -486,87 +482,95 @@ void main() {
       transport.expectDone();
     });
 
-    test('replays one in-flight retry only after explicit continuation', () async {
-      const text = 'Continue the existing retry.';
-      const clientMessageId = 'message_retry_restore';
-      final retryRun = _runJson(
-        id: _retryRunId,
-        status: 'running',
-        attempt: 2,
-        retryOfRunId: _runId,
-        clientRetryId: 'retry:$_runId',
-      );
-      final transport = _ScriptedTransport([
-        _Step(
-          method: 'GET',
-          path: '/v1/agent-threads/$_threadId',
-          response: _jsonResponse(HttpStatus.ok, _threadJson()),
-        ),
-        _Step(
-          method: 'GET',
-          path: '/v1/agent-threads/$_threadId/messages',
-          response: _jsonResponse(HttpStatus.ok, {
-            'messages': [
-              _messageJson(
-                id: _userMessageId,
-                sequence: 1,
-                role: 'user',
-                content: text,
-                clientMessageId: clientMessageId,
+    test(
+      'replays one in-flight retry only after explicit continuation',
+      () async {
+        const text = 'Continue the existing retry.';
+        const clientMessageId = 'message_retry_restore';
+        final retryRun = _runJson(
+          id: _retryRunId,
+          status: 'running',
+          attempt: 2,
+          retryOfRunId: _runId,
+          clientRetryId: 'retry:$_runId',
+        );
+        final transport = _ScriptedTransport([
+          _Step(
+            method: 'GET',
+            path: '/v1/agent-threads/$_threadId',
+            response: _jsonResponse(HttpStatus.ok, _threadJson()),
+          ),
+          _Step(
+            method: 'GET',
+            path: '/v1/agent-threads/$_threadId/messages',
+            response: _jsonResponse(HttpStatus.ok, {
+              'messages': [
+                _messageJson(
+                  id: _userMessageId,
+                  sequence: 1,
+                  role: 'user',
+                  content: text,
+                  clientMessageId: clientMessageId,
+                ),
+              ],
+            }),
+          ),
+          _Step(
+            method: 'GET',
+            path: '/v1/agent-threads/$_threadId/runs/latest',
+            response: _jsonResponse(HttpStatus.ok, {'run': retryRun}),
+          ),
+          _Step(
+            method: 'POST',
+            path: '/v1/agent-runs/$_runId/retries',
+            verify: (call) {
+              expect(jsonDecode(call.body!), {
+                'client_retry_id': 'retry:$_runId',
+              });
+            },
+            response: _jsonResponse(HttpStatus.accepted, retryRun),
+          ),
+          _Step(
+            method: 'GET',
+            path: '/v1/agent-runs/$_retryRunId',
+            response: _jsonResponse(
+              HttpStatus.ok,
+              _runJson(
+                id: _retryRunId,
+                status: 'completed',
+                attempt: 2,
+                retryOfRunId: _runId,
+                clientRetryId: 'retry:$_runId',
               ),
-            ],
-          }),
-        ),
-        _Step(
-          method: 'GET',
-          path: '/v1/agent-threads/$_threadId/runs/latest',
-          response: _jsonResponse(HttpStatus.ok, {'run': retryRun}),
-        ),
-        _Step(
-          method: 'POST',
-          path: '/v1/agent-runs/$_runId/retries',
-          verify: (call) {
-            expect(jsonDecode(call.body!), {'client_retry_id': 'retry:$_runId'});
-          },
-          response: _jsonResponse(HttpStatus.accepted, retryRun),
-        ),
-        _Step(
-          method: 'GET',
-          path: '/v1/agent-runs/$_retryRunId',
-          response: _jsonResponse(
-            HttpStatus.ok,
-            _runJson(
-              id: _retryRunId,
-              status: 'completed',
-              attempt: 2,
-              retryOfRunId: _runId,
-              clientRetryId: 'retry:$_runId',
             ),
           ),
-        ),
-        _messagesStep(
-          userContent: text,
+          _messagesStep(
+            userContent: text,
+            clientMessageId: clientMessageId,
+            assistantRunId: _retryRunId,
+          ),
+        ]);
+        final harness = _Harness(transport, maxRunPollAttempts: 2);
+
+        final snapshot = await harness.client.getThread(threadId: _threadId);
+
+        expect(snapshot.textRecovery?.latestRun?.attempt, 2);
+        expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
+
+        final exchange = await harness.client.sendText(
+          threadId: _threadId,
+          text: text,
           clientMessageId: clientMessageId,
-          assistantRunId: _retryRunId,
-        ),
-      ]);
-      final harness = _Harness(transport, maxRunPollAttempts: 2);
+        );
 
-      final snapshot = await harness.client.getThread(threadId: _threadId);
-
-      expect(snapshot.textRecovery?.latestRun?.attempt, 2);
-      expect(transport.calls.where((call) => call.method == 'POST'), isEmpty);
-
-      final exchange = await harness.client.sendText(
-        threadId: _threadId,
-        text: text,
-        clientMessageId: clientMessageId,
-      );
-
-      expect(exchange.assistantMessage?.producedByRunId, _retryRunId);
-      expect(transport.calls.where((call) => call.method == 'POST'), hasLength(1));
-      transport.expectDone();
-    });
+        expect(exchange.assistantMessage?.producedByRunId, _retryRunId);
+        expect(
+          transport.calls.where((call) => call.method == 'POST'),
+          hasLength(1),
+        );
+        transport.expectDone();
+      },
+    );
 
     test('hydrates a just-completed Run using GET requests only', () async {
       const text = 'The response completed during restoration.';
@@ -595,15 +599,11 @@ void main() {
         _Step(
           method: 'GET',
           path: '/v1/agent-threads/$_threadId/runs/latest',
-          response: _jsonResponse(
-            HttpStatus.ok,
-            {'run': _runJson(status: 'completed')},
-          ),
+          response: _jsonResponse(HttpStatus.ok, {
+            'run': _runJson(status: 'completed'),
+          }),
         ),
-        _messagesStep(
-          userContent: text,
-          clientMessageId: clientMessageId,
-        ),
+        _messagesStep(userContent: text, clientMessageId: clientMessageId),
       ]);
       final harness = _Harness(transport);
 

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -609,6 +609,33 @@ void main() {
     );
   });
 
+  testWidgets(
+    'an incomplete restored reply exposes an explicit continue action',
+    (tester) async {
+      var continueCalls = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ConversationPage(
+            errorMessage: '上次回复未完成，点击“继续”恢复。',
+            retryOperationLabel: '继续',
+            onRetryOperation: () => continueCalls++,
+          ),
+        ),
+      );
+
+      expect(find.text('上次回复未完成，点击“继续”恢复。'), findsOneWidget);
+      expect(find.text('继续'), findsOneWidget);
+      expect(find.text('SpeakUp 正在回复…'), findsNothing);
+
+      tester
+          .widget<TextButton>(
+            find.byKey(const Key('agent-retry-operation-button')),
+          )
+          .onPressed!();
+      expect(continueCalls, 1);
+    },
+  );
+
   testWidgets('older Message pagination is visible and accessible', (
     tester,
   ) async {

--- a/server/internal/agent/run/http/handler.go
+++ b/server/internal/agent/run/http/handler.go
@@ -38,6 +38,7 @@ func NewHandler(
 func (handler *Handler) RegisterRoutes(routes gin.IRoutes) {
 	routes.POST("/v1/agent-threads/:thread_id/runs", handler.submit)
 	routes.POST("/v1/agent-threads/:thread_id/runs/stream", handler.submitStream)
+	routes.GET("/v1/agent-threads/:thread_id/runs/latest", handler.getLatest)
 	routes.GET("/v1/agent-runs/:run_id", handler.get)
 	routes.POST("/v1/agent-runs/:run_id/retries", handler.retry)
 	routes.POST("/v1/agent-runs/:run_id/retries/stream", handler.retryStream)
@@ -194,6 +195,26 @@ func (handler *Handler) get(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, RunResponse(run))
+}
+
+func (handler *Handler) getLatest(c *gin.Context) {
+	actor, ok := requestcontext.ActorFromContext(c.Request.Context())
+	if !ok {
+		handler.write(c, authenticationRequired())
+		return
+	}
+	run, found, err := handler.application.GetLatestRun(
+		c.Request.Context(), actor, c.Param("thread_id"),
+	)
+	if err != nil {
+		handler.write(c, mapError(err))
+		return
+	}
+	response := gin.H{}
+	if found {
+		response["run"] = RunResponse(run)
+	}
+	c.JSON(http.StatusOK, response)
 }
 
 func (handler *Handler) finishStream(

--- a/server/internal/agent/run/http/image_submission_test.go
+++ b/server/internal/agent/run/http/image_submission_test.go
@@ -3,6 +3,7 @@ package runhttp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,6 +79,55 @@ func TestSubmitRunTreatsEmptyImageAssetIDsAsText(t *testing.T) {
 	}
 }
 
+func TestGetLatestRunReadsWithoutSubmitting(t *testing.T) {
+	runs := &imageRunHTTPApplication{latestRun: imageRunHTTPSubmission(
+		"20000000-0000-4000-8000-000000000001",
+	).Run, latestFound: true}
+	router := newImageRunHTTPRouter(t, runs)
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/v1/agent-threads/20000000-0000-4000-8000-000000000001/runs/latest",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	var body struct {
+		Run map[string]any `json:"run"`
+	}
+	if response.Code != http.StatusOK || json.Unmarshal(response.Body.Bytes(), &body) != nil {
+		t.Fatalf("latest Run response = %d %s", response.Code, response.Body.String())
+	}
+	if body.Run["run_id"] != runs.latestRun.ID ||
+		runs.latestReads != 1 || runs.textCalls != 0 || len(runs.imageAssetIDs) != 0 {
+		t.Fatalf(
+			"latest response = %#v, reads = %d, text calls = %d, image IDs = %#v",
+			body.Run,
+			runs.latestReads,
+			runs.textCalls,
+			runs.imageAssetIDs,
+		)
+	}
+}
+
+func TestGetLatestRunReturnsEmptyEvidenceWhenThreadHasNoRun(t *testing.T) {
+	runs := &imageRunHTTPApplication{}
+	router := newImageRunHTTPRouter(t, runs)
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"/v1/agent-threads/20000000-0000-4000-8000-000000000001/runs/latest",
+		nil,
+	)
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK || response.Body.String() != "{}" {
+		t.Fatalf("empty latest Run response = %d %s", response.Code, response.Body.String())
+	}
+}
+
 func newImageRunHTTPRouter(
 	t *testing.T,
 	application agentrun.Application,
@@ -113,6 +163,9 @@ type imageRunHTTPApplication struct {
 	threadID      string
 	imageAssetIDs []string
 	textCalls     int
+	latestRun     agentrun.Run
+	latestFound   bool
+	latestReads   int
 }
 
 func (application *imageRunHTTPApplication) SubmitText(
@@ -139,6 +192,17 @@ func (application *imageRunHTTPApplication) SubmitWithImages(
 	application.threadID = threadID
 	application.imageAssetIDs = append([]string(nil), imageAssetIDs...)
 	return imageRunHTTPSubmission(threadID), nil
+}
+
+func (application *imageRunHTTPApplication) GetLatestRun(
+	_ context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+) (agentrun.Run, bool, error) {
+	application.actor = actor
+	application.threadID = threadID
+	application.latestReads++
+	return application.latestRun, application.latestFound, nil
 }
 
 func imageRunHTTPSubmission(threadID string) agentrun.Submission {

--- a/server/internal/agent/run/loop_test.go
+++ b/server/internal/agent/run/loop_test.go
@@ -1890,6 +1890,14 @@ func (loopRepository) Find(context.Context, string, string) (Run, error) {
 	panic("unexpected Find")
 }
 
+func (loopRepository) FindLatestForThread(
+	context.Context,
+	string,
+	string,
+) (Run, bool, error) {
+	panic("unexpected FindLatestForThread")
+}
+
 func (loopRepository) SaveContextSnapshot(
 	context.Context,
 	string,

--- a/server/internal/agent/run/postgres/repository_impl.go
+++ b/server/internal/agent/run/postgres/repository_impl.go
@@ -307,6 +307,44 @@ func (r *Repository) Find(
 	return findRun(ctx, r.database, ownerID, runID)
 }
 
+func (r *Repository) FindLatestForThread(
+	ctx context.Context,
+	ownerID string,
+	threadID string,
+) (agentrun.Run, bool, error) {
+	run, err := scanRun(r.database.QueryRow(ctx, `
+SELECT `+runSelectColumns+`
+FROM agent_runs AS runs
+INNER JOIN agent_threads AS threads ON threads.id = runs.thread_id
+INNER JOIN agent_messages AS input_messages
+    ON input_messages.id = runs.input_message_id
+    AND input_messages.thread_id = runs.thread_id
+WHERE runs.thread_id = $1
+    AND threads.user_id = $2
+    AND threads.deleted_at IS NULL
+ORDER BY input_messages.sequence_no DESC, runs.attempt_no DESC
+LIMIT 1`, threadID, ownerID))
+	if err == nil {
+		return run, true, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return agentrun.Run{}, false, mapRunPostgresError(err)
+	}
+	var owned bool
+	if err := r.database.QueryRow(ctx, `
+SELECT EXISTS (
+    SELECT 1
+    FROM agent_threads
+    WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL
+)`, threadID, ownerID).Scan(&owned); err != nil {
+		return agentrun.Run{}, false, agentrun.ErrRepository
+	}
+	if !owned {
+		return agentrun.Run{}, false, agentrun.ErrNotFound
+	}
+	return agentrun.Run{}, false, nil
+}
+
 func (r *Repository) SaveContextSnapshot(
 	ctx context.Context,
 	ownerID string,

--- a/server/internal/agent/run/repository.go
+++ b/server/internal/agent/run/repository.go
@@ -21,6 +21,7 @@ type Repository interface {
 	CreateRetry(stdcontext.Context, string, string, string, Configuration) (Retry, error)
 	Claim(stdcontext.Context, string, string) (Run, bool, error)
 	Find(stdcontext.Context, string, string) (Run, error)
+	FindLatestForThread(stdcontext.Context, string, string) (Run, bool, error)
 	SaveContextSnapshot(
 		stdcontext.Context,
 		string,
@@ -115,5 +116,10 @@ type Application interface {
 		StreamObserver,
 	) (Retry, error)
 	GetRun(stdcontext.Context, requestcontext.Actor, string) (Run, error)
+	GetLatestRun(
+		stdcontext.Context,
+		requestcontext.Actor,
+		string,
+	) (Run, bool, error)
 	ProcessPending(stdcontext.Context, requestcontext.Actor, Run) (Run, error)
 }

--- a/server/internal/agent/run/service.go
+++ b/server/internal/agent/run/service.go
@@ -411,6 +411,17 @@ func (service *Service) GetRun(
 	return service.repository.Find(ctx, actor.UserID, runID)
 }
 
+func (service *Service) GetLatestRun(
+	ctx context.Context,
+	actor requestcontext.Actor,
+	threadID string,
+) (Run, bool, error) {
+	if !actor.Valid() || !ValidUUID(threadID) {
+		return Run{}, false, ErrNotFound
+	}
+	return service.repository.FindLatestForThread(ctx, actor.UserID, threadID)
+}
+
 func (service *Service) GetClientActions(
 	ctx context.Context,
 	actor requestcontext.Actor,

--- a/server/internal/agent/run/service_test.go
+++ b/server/internal/agent/run/service_test.go
@@ -27,6 +27,31 @@ func TestSubmitWithImagesRequiresImageInputCapability(t *testing.T) {
 	}
 }
 
+func TestGetLatestRunUsesOwnedThreadRead(t *testing.T) {
+	actor := requestcontext.Actor{
+		UserID:    "10000000-0000-4000-8000-000000000001",
+		SessionID: "20000000-0000-4000-8000-000000000001",
+	}
+	threadID := "30000000-0000-4000-8000-000000000001"
+	want := Run{ID: "40000000-0000-4000-8000-000000000001"}
+	repository := &latestRunRepository{run: want, found: true}
+	service := &Service{repository: repository}
+
+	got, found, err := service.GetLatestRun(context.Background(), actor, threadID)
+
+	if err != nil || !found || got != want ||
+		repository.ownerID != actor.UserID || repository.threadID != threadID {
+		t.Fatalf(
+			"GetLatestRun = (%#v, %t, %v), read owner = %q thread = %q",
+			got,
+			found,
+			err,
+			repository.ownerID,
+			repository.threadID,
+		)
+	}
+}
+
 func TestClassifyRunFailureRecognizesContextTermination(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -198,6 +223,24 @@ func TestRunConfigurationMatchesPersistedProviderModelAndBudget(t *testing.T) {
 type completedRetryRepository struct {
 	loopRepository
 	retry Retry
+}
+
+type latestRunRepository struct {
+	loopRepository
+	run      Run
+	found    bool
+	ownerID  string
+	threadID string
+}
+
+func (repository *latestRunRepository) FindLatestForThread(
+	_ context.Context,
+	ownerID string,
+	threadID string,
+) (Run, bool, error) {
+	repository.ownerID = ownerID
+	repository.threadID = threadID
+	return repository.run, repository.found, nil
 }
 
 func (repository completedRetryRepository) CreateRetry(

--- a/server/test/agent/postgres/run_core_integration_test.go
+++ b/server/test/agent/postgres/run_core_integration_test.go
@@ -3,6 +3,7 @@ package postgres_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -75,6 +76,76 @@ SELECT id FROM users WHERE id = $1 FOR UPDATE`, actor.UserID); err != nil {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run claim did not resume after owner unlock")
+	}
+}
+
+func TestLatestAgentRunReadDistinguishesEmptyAndOwnedThread(t *testing.T) {
+	database := newAgentTestDatabase(t)
+	conversationService, runService, _ := newAgentRunServices(
+		t,
+		database.pool,
+		newFixedTextGenerator(successfulTextResult()),
+		testRunConfiguration,
+	)
+	ctx := context.Background()
+	actor := testActorA()
+	thread, err := conversationService.CreateThread(ctx, actor)
+	if err != nil {
+		t.Fatalf("create Thread: %v", err)
+	}
+
+	if run, found, err := runService.GetLatestRun(ctx, actor, thread.ID); err != nil || found || run != (agentrun.Run{}) {
+		t.Fatalf("empty latest Run = (%#v, %t, %v)", run, found, err)
+	}
+	first, err := runService.SubmitText(
+		ctx,
+		actor,
+		thread.ID,
+		"latest-run-first",
+		"Create the first durable Run.",
+	)
+	if err != nil {
+		t.Fatalf("submit first Run: %v", err)
+	}
+	second, err := runService.SubmitText(
+		ctx,
+		actor,
+		thread.ID,
+		"latest-run-second",
+		"Create the second durable Run.",
+	)
+	if err != nil {
+		t.Fatalf("submit second Run: %v", err)
+	}
+	latest, found, err := runService.GetLatestRun(ctx, actor, thread.ID)
+	if err != nil || !found || latest.ID != second.Run.ID || latest.ID == first.Run.ID {
+		t.Fatalf(
+			"latest Run = (%#v, %t, %v), want second %q",
+			latest,
+			found,
+			err,
+			second.Run.ID,
+		)
+	}
+	if _, _, err := runService.GetLatestRun(ctx, testActorB(), thread.ID); !errors.Is(err, agentrun.ErrNotFound) {
+		t.Fatalf("cross-owner latest Run error = %v, want not found", err)
+	}
+	if err := conversationService.DeleteThread(ctx, actor, thread.ID); err != nil {
+		t.Fatalf("delete Thread with Runs: %v", err)
+	}
+	if _, _, err := runService.GetLatestRun(ctx, actor, thread.ID); !errors.Is(err, agentrun.ErrNotFound) {
+		t.Fatalf("deleted Thread latest Run error = %v, want not found", err)
+	}
+
+	emptyThread, err := conversationService.CreateThread(ctx, actor)
+	if err != nil {
+		t.Fatalf("create empty Thread: %v", err)
+	}
+	if err := conversationService.DeleteThread(ctx, actor, emptyThread.ID); err != nil {
+		t.Fatalf("delete empty Thread: %v", err)
+	}
+	if _, _, err := runService.GetLatestRun(ctx, actor, emptyThread.ID); !errors.Is(err, agentrun.ErrNotFound) {
+		t.Fatalf("deleted empty Thread latest Run error = %v, want not found", err)
 	}
 }
 


### PR DESCRIPTION
## 功能描述

- 将 Thread 恢复改为纯读取：冷启动、选择会话和底部 Tab 返回不再通过 POST 猜测或恢复 Run。
- 新增 `GET /v1/agent-threads/{thread_id}/runs/latest`，返回最新输入消息的最高 attempt；已删除或非本人 Thread 返回 404，无 Run 的本人 Thread 返回空对象。
- 对未完成文字回复显示明确的“继续”入口，只有用户点击后才复用原始幂等标识恢复；普通输入框发送不会误用恢复身份。
- 保留语音消息原有 durable Run 恢复路径。

## 实现思路

- 服务端以只读查询返回 durable Run 状态，不创建、claim、retry 或 resume Run。
- 客户端严格解码 Run 状态并映射 completed、pending/running、retryable failed、non-retryable failed 与 no-run。
- 显式继续复用原 `client_message_id` / retry identity，并由服务端原子 claim 防止重复生成。
- 查询同时限定 owner、未软删除 Thread，并按 input Message sequence、attempt number 确定最新 Run。

## 可复现测试

- `make check-api`
- `cd server && go test ./internal/agent/run/... -count=1`
- `cd mobile && flutter test --no-pub test/agent/conversation_controller_test.dart`
- 修改前的完整分支验证：Flutter 818/818、Agent 177/177、语音专项 53/53；最终审核修正后定向恢复用例 27/27。

## 验收说明

- 已覆盖纯 GET、空 Run、跨账号、软删除 Thread、状态恢复、连续点击和普通输入框旁路。
- Android 真机的“进入首页 Run POST=0”与界面验收将在 Staging 完成，因此本 PR 不自动关闭 Issue。

Related #977
