### PR TITLE
fix(evaluation): 保留 repair 瞬时故障重试

### DIFF
--- a/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
+++ b/server/internal/coaching/evaluation/postgres/speech_feedback_retry_integration_test.go
@@ -58,6 +58,52 @@ func TestSpeechFeedbackPart1InvalidThenValidReusesAcoustics(t *testing.T) {
 	}
 }
 
+func TestSpeechFeedbackRepairProviderFailureUsesWorkerRetryBudget(t *testing.T) {
+	pool := evaluationTestDatabase(t)
+	insertEvaluationTestUser(t, pool, speechRetryUserID, "speech-repair-retry@example.com")
+	generator := &speechRetryGenerator{
+		contents: []string{
+			`{"items":[{"kind":"CORRECTION","explanation":"动词形式需要修改。","source_text":"missing excerpt","source_occurrence":1,"suggested_text":"read"}]}`,
+			"",
+			`{"items":[{"kind":"RECOMMENDED_EXPRESSION","explanation":"这是更自然的表达。","source_text":"read","source_occurrence":1,"suggested_text":"do some reading"}]}`,
+		},
+		errors: map[int]error{2: speechRetryTextFailure{}},
+	}
+	acoustics := &speechRetryAcoustics{}
+	store, worker := speechRetryWorker(t, pool, generator, acoustics)
+	queueSpeechRetry(t, store, "I usually read before work.")
+
+	processed, err := worker.ProcessSpeech(context.Background())
+	if !processed || err == nil {
+		t.Fatalf("first ProcessSpeech = (%t, %v)", processed, err)
+	}
+	queued, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || queued.Status != evaluation.JobQueued ||
+		queued.AttemptCount != 1 || queued.Error != nil {
+		t.Fatalf("queued retry = %#v, %v", queued, err)
+	}
+
+	processed, err = worker.ProcessSpeech(context.Background())
+	if err != nil || !processed {
+		t.Fatalf("second ProcessSpeech = (%t, %v)", processed, err)
+	}
+	ready, err := store.GetRecordBySource(
+		context.Background(), speechRetryUserID,
+		evaluation.KindPracticeTurnFeedback, speechRetryTurnID,
+	)
+	if err != nil || ready.Status != evaluation.JobReady ||
+		ready.AttemptCount != 2 || ready.Error != nil ||
+		acoustics.calls != 1 || generator.calls != 3 {
+		t.Fatalf(
+			"ready=%#v err=%v acoustic=%d text=%d",
+			ready, err, acoustics.calls, generator.calls,
+		)
+	}
+}
+
 func TestSpeechFeedbackAcousticAndTextRetriesHaveIndependentBudgets(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -462,6 +508,7 @@ func queueSpeechRetry(t *testing.T, store *Store, transcript string) {
 
 type speechRetryGenerator struct {
 	contents []string
+	errors   map[int]error
 	calls    int
 }
 
@@ -470,6 +517,9 @@ func (generator *speechRetryGenerator) Generate(
 	speechfeedback.TextGenerationRequest,
 ) (speechfeedback.TextGenerationResult, error) {
 	generator.calls++
+	if err := generator.errors[generator.calls]; err != nil {
+		return speechfeedback.TextGenerationResult{}, err
+	}
 	if generator.calls > len(generator.contents) {
 		return speechfeedback.TextGenerationResult{}, errors.New("unexpected generation")
 	}
@@ -510,6 +560,12 @@ type speechRetryAcousticFailure struct{}
 func (speechRetryAcousticFailure) Error() string          { return "acoustic unavailable" }
 func (speechRetryAcousticFailure) StableCategory() string { return "PROVIDER_UNAVAILABLE" }
 func (speechRetryAcousticFailure) Retryable() bool        { return true }
+
+type speechRetryTextFailure struct{}
+
+func (speechRetryTextFailure) Error() string          { return "text provider unavailable" }
+func (speechRetryTextFailure) StableCategory() string { return "PROVIDER_UNAVAILABLE" }
+func (speechRetryTextFailure) Retryable() bool        { return true }
 
 type speechRetrySessions struct{}
 

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2.go
@@ -128,7 +128,7 @@ func (evaluator *CompactEvaluator) evaluate(
 			UserPrompt:   string(repairPayload),
 		})
 		if repairErr != nil {
-			return nil, nil, compactRepairFailure{cause: repairErr}
+			return nil, nil, repairErr
 		}
 		items, repairErr = compactFeedbackItemsWithProjection(
 			repaired,

--- a/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
+++ b/server/internal/coaching/evaluation/speechfeedback/evaluator_v2_test.go
@@ -327,14 +327,6 @@ func TestCompactEvaluatorRepairIsBoundedAndDirectFailuresAreNotRetried(t *testin
 			},
 			wantCalls: 2,
 		},
-		{
-			name: "repair generation failure is terminal", transcript: "I has a plan.",
-			steps: []compactGenerationStep{
-				{result: compactResult(invalidEvidence)},
-				{err: errors.New("provider unavailable")},
-			},
-			wantCalls: 2,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -369,6 +361,41 @@ func TestCompactEvaluatorRepairIsBoundedAndDirectFailuresAreNotRetried(t *testin
 				t.Fatalf("public failure = %#v", public)
 			}
 		})
+	}
+}
+
+func TestCompactEvaluatorPreservesRepairGenerationFailure(t *testing.T) {
+	lineage, err := Lineage("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerFailure := retryableCompactGenerationFailure{}
+	generator := &sequenceCompactGenerator{steps: []compactGenerationStep{
+		{result: compactResult(`{"items":[{"kind":"CORRECTION","explanation":"需要修改。","source_text":"missing excerpt","source_occurrence":1,"suggested_text":"have"}]}`)},
+		{err: providerFailure},
+	}}
+	evaluator, err := NewCompactEvaluator(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = evaluator.EvaluatePracticeTurn(
+		context.Background(),
+		evaluation.SpeechInputSnapshot{
+			SchemaVersion: evaluation.SpeechInputSchemaVersion,
+			Transcript:    "I has a plan.",
+			EvidenceRefID: "30000000-0000-4000-8000-000000000023",
+			QuestionID:    "40000000-0000-4000-8000-000000000023",
+			Acoustic: &evaluation.AcousticCheckpoint{
+				Status: evaluation.AcousticNotAssessed,
+				Reason: "TEST_ACOUSTICS_NOT_ASSESSED",
+			},
+		},
+		lineage,
+	)
+	var failure retryableCompactGenerationFailure
+	if !errors.As(err, &failure) || len(generator.requests) != 2 ||
+		failure.StableCategory() != "PROVIDER_UNAVAILABLE" || !failure.Retryable() {
+		t.Fatalf("repair failure=%#v calls=%d", err, len(generator.requests))
 	}
 }
 
@@ -552,6 +579,18 @@ func (generator *sequenceCompactGenerator) Generate(
 }
 
 var _ TextGenerator = (*sequenceCompactGenerator)(nil)
+
+type retryableCompactGenerationFailure struct{}
+
+func (retryableCompactGenerationFailure) Error() string {
+	return "provider unavailable"
+}
+func (retryableCompactGenerationFailure) StableCategory() string {
+	return "PROVIDER_UNAVAILABLE"
+}
+func (retryableCompactGenerationFailure) Retryable() bool { return true }
+
+var _ GenerationFailure = retryableCompactGenerationFailure{}
 
 func TestCompactFeedbackItemsEnforcesClassificationContract(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## 功能说明

- 修复 PR #981 合入后 AI Review 指出的 repair 瞬时供应商故障被错误终止问题。
- repair 输出再次 strict normalize 失败时仍保持终态，不扩大重试范围。

## 实现思路

- repair 的 `Generate` 错误原样返回，保留底层 `GenerationFailure` 的分类和重试语义。
- 只有生成成功但第二次规范化仍失败时，继续使用现有 `compactRepairFailure` 阻止循环重排队。
- 不修改可 repair 原因、模型、供应商、重试次数或 evidence 约束。

## 可复现测试

- `go test -count=1 ./internal/coaching/evaluation/speechfeedback ./internal/coaching/evaluation/postgres -run 'CompactEvaluator|SpeechFeedback'`
- `go test -count=1 ./internal/coaching/evaluation/...`
- `go vet ./internal/coaching/evaluation/...`
- `git diff --check`

测试证明：repair 瞬时供应商失败会进入既有 Worker 重试并复用声学检查点；repair 输出再次非法仍不会循环。

Closes #985
