### PR TITLE
chore(release): 准备 v0.1.7 候选版本

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.6+7
+version: 0.1.7+8
 
 environment:
   sdk: ^3.12.2

--- a/portal/public/release-notes/android/v0.1.7.zh-CN.json
+++ b/portal/public/release-notes/android/v0.1.7.zh-CN.json
@@ -1,0 +1,24 @@
+{
+  "release_notes_version": 1,
+  "locale": "zh-CN",
+  "version": "0.1.7",
+  "published_at": "2026-08-25T14:05:30Z",
+  "changes": [
+    {
+      "type": "fix",
+      "text": "修复断网后实时语音无法再次录音的问题。"
+    },
+    {
+      "type": "fix",
+      "text": "修复语音反馈结果异常时可能重复失败的问题。"
+    },
+    {
+      "type": "improvement",
+      "text": "优化语音评测与文字反馈的重试等待，减少报告长时间卡住。"
+    },
+    {
+      "type": "fix",
+      "text": "修复进入历史练习时可能自动触发新回复的问题。"
+    }
+  ]
+}

--- a/portal/tests/android-release-notes.test.mjs
+++ b/portal/tests/android-release-notes.test.mjs
@@ -10,30 +10,42 @@ import {
 } from "../lib/android-release-notes.mjs";
 
 const release = {
-  version: "0.1.4",
-  published_at: "2026-08-23T20:16:29Z",
+  version: "0.1.7",
+  published_at: "2026-08-25T14:05:30Z",
 };
 
 function validNotes() {
   return {
     release_notes_version: 1,
     locale: "zh-CN",
-    version: "0.1.4",
-    published_at: "2026-08-23T20:16:29Z",
+    version: "0.1.7",
+    published_at: "2026-08-25T14:05:30Z",
     changes: [
       {
         type: "fix",
-        text: "修复部分情况下实时语音识别无法返回文字结果的问题。",
+        text: "修复断网后实时语音无法再次录音的问题。",
+      },
+      {
+        type: "fix",
+        text: "修复语音反馈结果异常时可能重复失败的问题。",
+      },
+      {
+        type: "improvement",
+        text: "优化语音评测与文字反馈的重试等待，减少报告长时间卡住。",
+      },
+      {
+        type: "fix",
+        text: "修复进入历史练习时可能自动触发新回复的问题。",
       },
     ],
   };
 }
 
-test("publishes an honest v0.1.4 user-facing release note", () => {
+test("publishes an honest v0.1.7 user-facing release note", () => {
   const notes = JSON.parse(
     readFileSync(
       new URL(
-        "../public/release-notes/android/v0.1.4.zh-CN.json",
+        "../public/release-notes/android/v0.1.7.zh-CN.json",
         import.meta.url,
       ),
       "utf8",
@@ -44,7 +56,19 @@ test("publishes an honest v0.1.4 user-facing release note", () => {
   assert.deepEqual(notes.changes, [
     {
       type: "fix",
-      text: "修复部分情况下实时语音识别无法返回文字结果的问题。",
+      text: "修复断网后实时语音无法再次录音的问题。",
+    },
+    {
+      type: "fix",
+      text: "修复语音反馈结果异常时可能重复失败的问题。",
+    },
+    {
+      type: "improvement",
+      text: "优化语音评测与文字反馈的重试等待，减少报告长时间卡住。",
+    },
+    {
+      type: "fix",
+      text: "修复进入历史练习时可能自动触发新回复的问题。",
     },
   ]);
 });
@@ -54,8 +78,8 @@ test("parses strict, single-version Android release notes", () => {
 
   assert.equal(parseAndroidReleaseNotes(notes), notes);
   assert.equal(
-    androidReleaseNotesPath("0.1.4"),
-    "/release-notes/android/v0.1.4.zh-CN.json",
+    androidReleaseNotesPath("0.1.7"),
+    "/release-notes/android/v0.1.7.zh-CN.json",
   );
   assert.equal(matchAndroidReleaseNotes(release, notes), notes);
 });
@@ -79,7 +103,7 @@ test("rejects malformed Android release notes", () => {
         ...validNotes().changes,
         {
           type: "improvement",
-          text: "修复部分情况下实时语音识别无法返回文字结果的问题。",
+          text: "修复断网后实时语音无法再次录音的问题。",
         },
       ],
     },
@@ -95,13 +119,13 @@ test("rejects malformed Android release notes", () => {
 
 test("requires current notes to match production version and publication time", () => {
   assert.throws(
-    () => matchAndroidReleaseNotes({ ...release, version: "0.1.5" }, validNotes()),
+    () => matchAndroidReleaseNotes({ ...release, version: "0.1.6" }, validNotes()),
     /Android release notes are invalid/,
   );
   assert.throws(
     () =>
       matchAndroidReleaseNotes(
-        { ...release, published_at: "2026-08-23T20:17:00Z" },
+        { ...release, published_at: "2026-08-25T14:06:00Z" },
         validNotes(),
       ),
     /Android release notes are invalid/,
@@ -121,7 +145,7 @@ test("loads only the versioned notes for the active production release", async (
   assert.equal(ready.status, "ready");
   assert.deepEqual(requests, [
     {
-      url: "/release-notes/android/v0.1.4.zh-CN.json",
+      url: "/release-notes/android/v0.1.7.zh-CN.json",
       options: {
         cache: "force-cache",
         headers: { accept: "application/json" },


### PR DESCRIPTION
## 功能说明

- 将 Android 版本从 `0.1.6+7` 提升到 `0.1.7+8`。
- 新增独立的 `v0.1.7` 中文生产更新日志，并让 Portal 测试校验真实版本文件。
- 冻结本批次 `published_at=2026-08-25T14:05:30Z`，后续 Staging/Production 下载 bundle 必须使用同一值。

## 发布范围

- 断网后实时语音恢复再次录音。
- 语音反馈非法响应的单次有界修复，以及 repair 瞬时供应商故障的既有重试。
- 语音声学评测与文字反馈重试预算隔离。
- 进入历史练习时不隐藏触发新的 Run。

## 可复现测试

- `cd portal && npm test`：25/25 通过，包含生产构建。
- `cd portal && npm run lint`
- `make check-release-candidate`：31/31 发布元数据、签名和 manifest 契约测试通过。
- `git diff --check`

## 后续受控步骤

本 PR 只准备版本源和更新日志。合入 dev 后再创建 dev→main 发布 PR；main 合并提交上的不可变 `v0.1.7` Tag 才会触发签名 APK、镜像和 manifest 构建。Staging 验收完成前不部署 Production。

Closes #984
Related #975
Related #976
Related #985
