### PR TITLE
refactor(release): 将 Candidate 与稳定 Tag 解耦

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,16 +1,14 @@
 name: Release Candidate
 
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
 
 permissions:
   actions: read
   contents: read
 
 concurrency:
-  group: release-candidate-${{ github.ref }}
+  group: release-candidate
   cancel-in-progress: false
 
 env:
@@ -31,6 +29,7 @@ jobs:
       - name: Check out complete release history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -39,27 +38,46 @@ jobs:
         with:
           node-version: "24.18.0"
 
-      - name: Reject moved or deleted Tag events
+      - name: Require an official main Candidate
         env:
-          TAG_CREATED: ${{ github.event.created }}
-          TAG_DELETED: ${{ github.event.deleted }}
-          TAG_FORCED: ${{ github.event.forced }}
+          CANDIDATE_EVENT: ${{ github.event_name }}
+          CANDIDATE_REPOSITORY: ${{ github.repository }}
+          CANDIDATE_REF: ${{ github.ref }}
+          CANDIDATE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REF_TYPE" != "tag" ||
-                "$TAG_CREATED" != "true" ||
-                "$TAG_DELETED" == "true" ||
-                "$TAG_FORCED" == "true" ]]; then
-            echo "Release Candidate requires a newly created immutable Tag." >&2
+          if [[ "$CANDIDATE_EVENT" != "workflow_dispatch" ||
+                "$CANDIDATE_REPOSITORY" != "1024XEngineer/XE3-ESL" ||
+                "$CANDIDATE_REF" != "refs/heads/main" ]]; then
+            echo "Release Candidate must be dispatched from official main." >&2
+            exit 1
+          fi
+          if [[ ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Release Candidate requires a full lowercase commit SHA." >&2
             exit 1
           fi
 
-      - name: Validate Tag, version, commit, and database schema
+      - name: Validate Candidate, version, commit, and database schema
         id: release
         run: >-
           node tools/release-candidate/metadata.mjs
-          --tag "$GITHUB_REF_NAME"
+          --candidate-sha "$GITHUB_SHA"
           --main-ref refs/remotes/origin/main
+
+      - name: Record Candidate identity
+        env:
+          CANDIDATE_VERSION: ${{ steps.release.outputs.version }}
+          CANDIDATE_VERSION_CODE: ${{ steps.release.outputs.version_code }}
+          CANDIDATE_SHA: ${{ steps.release.outputs.git_sha }}
+          CANDIDATE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            printf '## Release Candidate\n\n'
+            printf -- '- Version: `%s`\n' "$CANDIDATE_VERSION"
+            printf -- '- Version code: `%s`\n' "$CANDIDATE_VERSION_CODE"
+            printf -- '- Commit: `%s`\n' "$CANDIDATE_SHA"
+            printf -- '- Run: %s\n' "$CANDIDATE_RUN_URL"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   quality:
     name: Full quality checks
@@ -94,6 +112,7 @@ jobs:
       - name: Check out release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Sign in to GHCR
@@ -165,6 +184,7 @@ jobs:
       - name: Check out release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Set up Flutter
@@ -304,6 +324,7 @@ jobs:
       - name: Check out complete release history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -387,7 +408,7 @@ jobs:
           APK_CERTIFICATE_SHA256="$(tr -d '[:space:]' < "$APK_CERTIFICATE_FILE")"
           export APK_CERTIFICATE_SHA256
           node tools/release-candidate/manifest.mjs \
-            --tag "$GITHUB_REF_NAME" \
+            --candidate-sha "$GITHUB_SHA" \
             --main-ref refs/remotes/origin/main \
             --staging-apk \
               "$RUNNER_TEMP/release-apks/speakup-v$VERSION-staging-arm64.apk" \

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -98,12 +98,18 @@
 | 名称 | 含义 |
 | --- | --- |
 | PR Gate | 决定代码是否允许合入的自动化测试与审核门禁 |
-| Release Candidate | 从确定 commit 构建、等待验收的候选版本 |
+| Release Candidate | 从官方 `main` 精确 commit 构建、等待验收的内部 Candidate；不等于正式发布 |
+| Stable Tag | Candidate 通过验收后才创建的不可变 `vX.Y.Z` Git 引用 |
+| GitHub Release | 基于 Stable Tag 发布用户制品和更新说明的正式发布记录 |
 | Artifact | APK、Portal 镜像、后端镜像、校验和与发布清单 |
-| Staging | 与生产隔离、供团队验证的真实测试环境 |
-| Production | 普通用户访问的正式环境 |
+| Staging | 部署 Candidate 制品、与生产隔离并供团队验证的真实测试环境 |
+| Production | 已批准正式版本面向普通用户运行的环境 |
 | Deploy | 把已经构建好的指定版本放到目标环境运行 |
 | Promote | 将已经验证的候选版本批准进入生产 |
+
+Release Candidate、Stable Tag、GitHub Release、Staging 部署和 Production 部署是
+五种不同状态。Candidate 构建成功不表示已经部署 Staging；创建 Stable Tag 不表示
+GitHub Release 已发布；发布 GitHub Release 也不表示 Production 已完成部署或切换。
 
 测试环境不等于 Mock，也不要求购买第二台服务器。首版可以在同一物理服务器上
 使用不同的容器、端口、域名和数据库建立隔离环境，并通过密码或 IP 白名单只向
@@ -115,8 +121,10 @@
 
 - `dev` 是日常集成分支，功能 PR 合入 `dev`。
 - `main` 是发布分支，只通过 `dev -> main` 的 Release PR 接收候选版本。
-- Release PR 合并后，给 `main` 上新产生的 merge commit 创建 `vX.Y.Z` Tag；
-  Tag 触发制品构建。不存在“合入 main 后再把全部代码额外推送一次”。
+- Release PR 合并后，从官方仓库 `main` 的精确 commit 手动触发内部 Candidate
+  构建，不提前创建 `vX.Y.Z` Tag。不存在“合入 main 后再把全部代码额外推送
+  一次”。
+- Stable Tag 只留给通过验收、准备进入正式发布流程的同一 commit 和制品。
 - `main` 上的 Release merge commit 不会自动回到 `dev`，因此 GitHub 可能显示
   `dev` 落后若干 merge commit。这是历史拓扑差异，不等于 `dev` 缺少代码。
 - 判断是否需要同步时，必须检查 `main` 独有的非 merge commit 和实际 tree diff，
@@ -134,10 +142,12 @@
   -> PR Gate 与 Review
   -> 合入 dev
   -> Release PR: dev -> main
-  -> 创建不可变 vX.Y.Z Tag
-  -> 全量测试并构建 Release Candidate
-  -> 自动部署 Staging
+  -> 从官方 main 精确 SHA 手动触发内部 Release Candidate
+  -> 全量测试并构建完整、可追溯制品
+  -> 后续独立流程部署同一 Candidate 到 Staging
   -> 自动冒烟 + 真人验收
+  -> 批准正式发布并创建不可变 vX.Y.Z Stable Tag
+  -> 基于同一制品创建 GitHub Release 草稿
   -> 等待 Production 人工批准
   -> 生产数据备份与 migration
   -> 部署同一版本的 Portal/后端制品
@@ -186,12 +196,24 @@ Check 严格模式已暂缓，不在本阶段擅自重新启用。
 
 ### 7.2 Release Candidate
 
-不可变 `vX.Y.Z` Tag 触发 Release Workflow。Workflow 必须先验证：
+Release Candidate Workflow 仅允许在官方仓库对 `refs/heads/main` 手动执行，并将
+GitHub Actions 事件提供的精确 `github.sha` 作为 Candidate commit。Workflow 必须
+先验证：
 
-- Tag commit 位于 `main`。
-- Flutter versionName 与 Tag 一致。
-- Android versionCode 高于上一发布版本。
+- 事件为 `workflow_dispatch`，仓库为 `1024XEngineer/XE3-ESL`，ref 为官方
+  `main`。
+- checkout HEAD 与完整小写 Candidate SHA 一致，且 commit 位于 `main` 的
+  first-parent 历史。
+- Candidate 的 versionName 或 commit 尚未被 Stable Tag 使用。
+- Flutter versionName 使用 `X.Y.Z`，且版本与 Android versionCode 均高于上一
+  稳定发布版本。
+- 现有 Stable Tag 集合与运行时远端精确一致，且全部位于 `main` first-parent；
+  Tag、versionName 和 versionCode 继续保持单调。
 - 全量测试通过。
+
+Candidate 身份由 `version`、`versionCode`、`git_sha` 和 GitHub Actions run ID
+共同组成。run ID 由 Actions 运行及 manifest 的 `quality_run_url` 保留；内部
+Candidate 不创建、模拟或要求 `vX.Y.Z` Stable Tag。
 
 一次构建产生：
 
@@ -224,6 +246,10 @@ Check 严格模式已暂缓，不在本阶段擅自重新启用。
 镜像可使用语义版本标签方便识别，但部署必须引用 digest，不能引用可变
 `latest`。
 
+当前 #999 对应 PR 只构建并上传上述制品，不创建 Stable Tag 或 GitHub Release，
+不部署 Staging 或 Production，也不更新公开 changelog 或 Production 当前版本
+指针。Staging 验收、正式发布和 Production 提升属于后续独立任务。
+
 Android 正式签名采用以下已确认边界：
 
 - GitHub Environment 固定为 `android-release-signing`。
@@ -236,8 +262,9 @@ Android 正式签名采用以下已确认边界：
   Runner；构建结束后删除，不进入 Artifact、日志或仓库。
 
 首次运行前，管理员必须先创建该 Environment，将 Deployment branches and tags
-设为 Selected branches and tags、Tag pattern 设为 `v*.*.*`，并配置 Required
-reviewer；随后才能添加以下 Environment Secrets：
+设为 Selected branches and tags，并至少允许 Branch pattern `main`，同时配置
+Required reviewer；随后才能添加以下 Environment Secrets。后续正式 Tag 流程仍可
+保留 Tag pattern `v*.*.*`：
 
 - `SPEAKUP_ANDROID_KEYSTORE_BASE64`
 - `SPEAKUP_ANDROID_KEY_ALIAS`
@@ -245,10 +272,20 @@ reviewer；随后才能添加以下 Environment Secrets：
 - `SPEAKUP_ANDROID_KEY_PASSWORD`
 - `SPEAKUP_ANDROID_CERT_SHA256`
 
-正式 Tag 还需要单独的 Tag ruleset 禁止更新和删除。Workflow 会严格校验 Tag
-格式及其 commit 是否位于 `main`，但 Workflow 本身不能阻止有权限的人移动 Tag。
+如果 `android-release-signing` 仍只允许 Tag pattern `v*.*.*`，从 `main` 手动触发
+的 Candidate 将无法进入签名 job 或取得 Environment Secrets。本 PR 不修改
+Environment 保护规则；实际运行前必须由管理员确认 `main` 已获准，不能通过移出
+Environment 或复制 Secrets 绕过该门禁。
+
+正式 Tag 还需要单独的 Tag ruleset 禁止更新和删除。Candidate Workflow 不创建
+Tag；保留的 Stable Tag 校验会继续检查运行时本地/远端集合、Tag 格式、commit、
+`main` 历史和版本单调性，但单次 Workflow 无法重建运行前已经被移动或删除的历史，
+因此不能替代平台 Tag ruleset。
 
 ### 7.3 Staging 与 Production Deploy
+
+本节描述后续独立阶段；当前 Release Candidate Workflow 不调用 Staging 或
+Production 部署入口。
 
 Deploy Workflow 接收确定的 `version` 和 `environment`，读取 Release manifest
 后部署现有制品，不重新构建。
@@ -486,7 +523,9 @@ Portal 报名和访问事件继续使用独立 SQLite。它与产品核心业务
 ### 14.1 自动门禁
 
 - [ ] PR Gate 全绿。
-- [ ] Release Tag、commit 和版本一致。
+- [ ] Candidate 来自官方 `main` 精确 SHA，version、versionCode、SHA 和 run ID
+      已记录。
+- [ ] 进入正式发布阶段后，Stable Tag、commit 和版本一致。
 - [ ] Portal/后端镜像 digest 已记录。
 - [ ] APK 签名、版本、架构和 SHA-256 正确。
 - [ ] Staging migration、健康检查和真实供应商冒烟通过。
@@ -531,7 +570,8 @@ Portal 报名和访问事件继续使用独立 SQLite。它与产品核心业务
 
 7. 为 Go 后端增加最小生产多阶段 Dockerfile 和健康检查。
 8. 建立 Android 正式签名、版本规则、Staging/Production API 配置和 APK 校验。
-9. 建立 Release Candidate Workflow、OCI 镜像、APK、SHA-256 与 manifest。
+9. 建立不依赖 Stable Tag 的内部 Release Candidate Workflow、OCI 镜像、APK、
+   SHA-256 与 manifest。
 10. 为 Portal 增加版本化 APK 下载展示，但在生产验证前不公开新版本。
 
 ### Phase 3：测试环境与生产部署

--- a/tools/release-candidate/manifest.mjs
+++ b/tools/release-candidate/manifest.mjs
@@ -17,7 +17,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { readArguments } from "./cli.mjs";
-import { collectReleaseMetadata } from "./metadata.mjs";
+import {
+  collectCandidateMetadata,
+  collectReleaseMetadata,
+} from "./metadata.mjs";
 
 const sha256Pattern = /^[0-9a-f]{64}$/;
 const imageDigestPattern = /^sha256:[0-9a-f]{64}$/;
@@ -415,13 +418,15 @@ export function writeReleaseManifest(outputInput, manifest) {
 
 function main() {
   const usage =
-    "Usage: manifest.mjs --tag <vX.Y.Z> --main-ref <ref> " +
+    "Usage: manifest.mjs (--tag <vX.Y.Z> | --candidate-sha <sha>) " +
+    "--main-ref <ref> " +
     "--staging-apk <file> --production-apk <file> --output <file> " +
     "[--repo <path>] [--tag-remote <name>]";
   const arguments_ = readArguments(
     process.argv.slice(2),
     [
       "tag",
+      "candidate-sha",
       "main-ref",
       "staging-apk",
       "production-apk",
@@ -431,16 +436,24 @@ function main() {
     ],
     usage,
   );
-  for (const name of ["tag", "main-ref", "staging-apk", "production-apk", "output"]) {
+  for (const name of ["main-ref", "staging-apk", "production-apk", "output"]) {
     if (!arguments_[name]) throw new Error(`--${name} is required`);
   }
+  if (Boolean(arguments_.tag) === Boolean(arguments_["candidate-sha"])) {
+    throw new Error("Exactly one of --tag or --candidate-sha is required");
+  }
   const repoDir = path.resolve(arguments_.repo ?? ".");
-  const metadata = collectReleaseMetadata({
+  const common = {
     repoDir,
-    tag: arguments_.tag,
     mainRef: arguments_["main-ref"],
     tagRemote: arguments_["tag-remote"] ?? "origin",
-  });
+  };
+  const metadata = arguments_.tag
+    ? collectReleaseMetadata({ ...common, tag: arguments_.tag })
+    : collectCandidateMetadata({
+        ...common,
+        candidateSha: arguments_["candidate-sha"],
+      });
   const manifest = createReleaseManifest(
     {
       ...process.env,

--- a/tools/release-candidate/metadata.mjs
+++ b/tools/release-candidate/metadata.mjs
@@ -11,6 +11,7 @@ const stableTagPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const pubspecVersionPattern = /^version:\s*["']?([^+\s"']+)\+(\d+)["']?\s*$/gm;
 const migrationPattern = /^server\/migrations\/(\d{6})_[^/]+\.up\.sql$/;
 const tagRemotePattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const gitShaPattern = /^[0-9a-f]{40}$/;
 const officialUpstreamUrl = "https://github.com/1024XEngineer/XE3-ESL.git";
 
 export function parseStableTag(tag) {
@@ -182,12 +183,7 @@ function officialUpstreamMain(repoDir) {
   return commit;
 }
 
-export function collectReleaseMetadata({
-  repoDir,
-  tag,
-  mainRef,
-  tagRemote = "origin",
-}) {
+function releaseHistory(repoDir, mainRef, tagRemote) {
   if (
     typeof tagRemote !== "string" ||
     !tagRemotePattern.test(tagRemote) ||
@@ -199,22 +195,9 @@ export function collectReleaseMetadata({
   if (git(repoDir, ["rev-parse", "--is-shallow-repository"]) === "true") {
     throw new Error("Release validation requires the complete Git history");
   }
-  parseStableTag(tag);
-  const tagCommit = git(repoDir, [
-    "rev-parse",
-    "--verify",
-    `refs/tags/${tag}^{commit}`,
-  ]);
-  const headCommit = git(repoDir, ["rev-parse", "--verify", "HEAD^{commit}"]);
-  if (headCommit !== tagCommit) {
-    throw new Error(`HEAD ${headCommit} does not match release tag ${tag}`);
-  }
   const mainCommit = git(repoDir, ["rev-parse", "--verify", `${mainRef}^{commit}`]);
   if (tagRemote === "upstream" && mainCommit !== officialUpstreamMain(repoDir)) {
     throw new Error(`${mainRef} does not match live upstream main`);
-  }
-  if (!isAncestor(repoDir, tagCommit, mainCommit)) {
-    throw new Error(`Release tag ${tag} is not contained in ${mainRef}`);
   }
   const mainHistory = git(repoDir, [
     "rev-list",
@@ -223,58 +206,58 @@ export function collectReleaseMetadata({
     mainCommit,
   ]).split("\n");
   const firstParentCommits = new Set(mainHistory);
-  if (!firstParentCommits.has(tagCommit)) {
-    throw new Error(`Release tag ${tag} is not on the first-parent history of ${mainRef}`);
-  }
   const allStableTags = stableTagRefs(repoDir, tagRemote);
-
-  const pubspec = git(repoDir, ["show", `${tagCommit}:mobile/pubspec.yaml`]);
-  const current = parsePubspecVersion(pubspec);
-  if (`v${current.version}` !== tag) {
-    throw new Error(`Release tag ${tag} does not match versionName ${current.version}`);
+  const releasesOnMain = allStableTags.map((tag) => ({
+    tag,
+    commit: git(repoDir, [
+      "rev-parse",
+      "--verify",
+      `refs/tags/${tag}^{commit}`,
+    ]),
+    version: parseStableTag(tag),
+  }));
+  const offMainTag = releasesOnMain.find(
+    (release) => !isAncestor(repoDir, release.commit, mainCommit),
+  );
+  if (offMainTag) {
+    throw new Error(
+      `Previous release tag ${offMainTag.tag} is not contained in ${mainRef}`,
+    );
   }
-  validateVersionCode(current.versionCode, "Current release");
-
-  const releasesOnMain = allStableTags
-    .map((candidate) => ({
-      tag: candidate,
-      commit: git(repoDir, [
-        "rev-parse",
-        "--verify",
-        `refs/tags/${candidate}^{commit}`,
-      ]),
-      version: parseStableTag(candidate),
-    }))
-    .filter((candidate) => isAncestor(repoDir, candidate.commit, mainCommit));
-
   const sideHistoryTag = releasesOnMain.find(
-    (candidate) => !firstParentCommits.has(candidate.commit),
+    (release) => !firstParentCommits.has(release.commit),
   );
   if (sideHistoryTag) {
     throw new Error(
       `Previous release tag ${sideHistoryTag.tag} is not on the first-parent history of ${mainRef}`,
     );
   }
-  const historyOrder = new Map(
-    mainHistory.map((commit, index) => [commit, index]),
-  );
-  const releases = releasesOnMain.map((candidate) => {
-    let version = current;
-    if (candidate.tag !== tag) {
-      version = parsePubspecVersion(
-        git(repoDir, [
-          "show",
-          `refs/tags/${candidate.tag}^{commit}:mobile/pubspec.yaml`,
-        ]),
-      );
-    }
-    if (`v${version.version}` !== candidate.tag) {
+  return {
+    allStableTags,
+    firstParentCommits,
+    historyOrder: new Map(mainHistory.map((commit, index) => [commit, index])),
+    mainCommit,
+    releasesOnMain,
+  };
+}
+
+function validateReleaseSequence(repoDir, releasesOnMain, historyOrder, current) {
+  const releases = releasesOnMain.map((release) => {
+    const version = release.tag === current.tag && release.commit === current.commit
+      ? current.version
+      : parsePubspecVersion(
+          git(repoDir, [
+            "show",
+            `refs/tags/${release.tag}^{commit}:mobile/pubspec.yaml`,
+          ]),
+        );
+    if (`v${version.version}` !== release.tag) {
       throw new Error(
-        `Previous release tag ${candidate.tag} does not match versionName ${version.version}`,
+        `Previous release tag ${release.tag} does not match versionName ${version.version}`,
       );
     }
-    validateVersionCode(version.versionCode, candidate.tag);
-    return { ...candidate, versionCode: version.versionCode };
+    validateVersionCode(version.versionCode, release.tag);
+    return { ...release, versionCode: version.versionCode };
   }).sort(
     (left, right) => historyOrder.get(left.commit) - historyOrder.get(right.commit),
   );
@@ -294,43 +277,143 @@ export function collectReleaseMetadata({
       );
     }
   }
+}
 
+function metadataForCommit(repoDir, commit, current, extra = {}) {
   const migrationFiles = git(repoDir, [
     "ls-tree",
     "-r",
     "--name-only",
-    tagCommit,
+    commit,
     "--",
     "server/migrations",
   ]).split("\n");
-
   return {
-    tag,
+    ...extra,
     version: current.version,
     version_code: String(current.versionCode),
-    git_sha: tagCommit,
+    git_sha: commit,
     database_schema_version: String(databaseSchemaVersion(migrationFiles)),
   };
 }
 
+export function collectReleaseMetadata({
+  repoDir,
+  tag,
+  mainRef,
+  tagRemote = "origin",
+}) {
+  parseStableTag(tag);
+  const tagCommit = git(repoDir, [
+    "rev-parse",
+    "--verify",
+    `refs/tags/${tag}^{commit}`,
+  ]);
+  const headCommit = git(repoDir, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (headCommit !== tagCommit) {
+    throw new Error(`HEAD ${headCommit} does not match release tag ${tag}`);
+  }
+  const history = releaseHistory(repoDir, mainRef, tagRemote);
+  const { mainCommit } = history;
+  if (!isAncestor(repoDir, tagCommit, mainCommit)) {
+    throw new Error(`Release tag ${tag} is not contained in ${mainRef}`);
+  }
+  if (!history.firstParentCommits.has(tagCommit)) {
+    throw new Error(`Release tag ${tag} is not on the first-parent history of ${mainRef}`);
+  }
+
+  const pubspec = git(repoDir, ["show", `${tagCommit}:mobile/pubspec.yaml`]);
+  const current = parsePubspecVersion(pubspec);
+  if (`v${current.version}` !== tag) {
+    throw new Error(`Release tag ${tag} does not match versionName ${current.version}`);
+  }
+  validateVersionCode(current.versionCode, "Current release");
+  validateReleaseSequence(repoDir, history.releasesOnMain, history.historyOrder, {
+    tag,
+    commit: tagCommit,
+    version: current,
+  });
+  return metadataForCommit(repoDir, tagCommit, current, { tag });
+}
+
+export function collectCandidateMetadata({
+  repoDir,
+  candidateSha,
+  mainRef,
+  tagRemote = "origin",
+}) {
+  if (!gitShaPattern.test(candidateSha)) {
+    throw new Error("candidateSha must be a full lowercase Git commit SHA");
+  }
+  const headCommit = git(repoDir, ["rev-parse", "--verify", "HEAD^{commit}"]);
+  if (headCommit !== candidateSha) {
+    throw new Error(`HEAD ${headCommit} does not match Candidate ${candidateSha}`);
+  }
+  const history = releaseHistory(repoDir, mainRef, tagRemote);
+  if (!isAncestor(repoDir, candidateSha, history.mainCommit)) {
+    throw new Error(`Candidate ${candidateSha} is not contained in ${mainRef}`);
+  }
+  if (!history.firstParentCommits.has(candidateSha)) {
+    throw new Error(
+      `Candidate ${candidateSha} is not on the first-parent history of ${mainRef}`,
+    );
+  }
+  const current = parsePubspecVersion(
+    git(repoDir, ["show", `${candidateSha}:mobile/pubspec.yaml`]),
+  );
+  const expectedTag = `v${current.version}`;
+  const parsedVersion = parseStableTag(expectedTag);
+  validateVersionCode(current.versionCode, "Candidate");
+  if (history.allStableTags.includes(expectedTag)) {
+    throw new Error(`Candidate stable Tag already exists: ${expectedTag}`);
+  }
+  const tagOnCandidate = history.releasesOnMain.find(
+    (release) => release.commit === candidateSha,
+  );
+  if (tagOnCandidate) {
+    throw new Error(
+      `Candidate commit is already used by stable release Tag ${tagOnCandidate.tag}`,
+    );
+  }
+  validateReleaseSequence(
+    repoDir,
+    [
+      ...history.releasesOnMain,
+      { tag: expectedTag, commit: candidateSha, version: parsedVersion },
+    ],
+    history.historyOrder,
+    { tag: expectedTag, commit: candidateSha, version: current },
+  );
+  return metadataForCommit(repoDir, candidateSha, current);
+}
+
 function main() {
   const usage =
-    "Usage: metadata.mjs --tag <vX.Y.Z> --main-ref <ref> " +
+    "Usage: metadata.mjs (--tag <vX.Y.Z> | --candidate-sha <sha>) " +
+    "--main-ref <ref> " +
     "[--repo <path>] [--tag-remote <name>]";
   const arguments_ = readArguments(
     process.argv.slice(2),
-    ["tag", "main-ref", "repo", "tag-remote"],
+    ["tag", "candidate-sha", "main-ref", "repo", "tag-remote"],
     usage,
   );
-  if (!arguments_.tag || !arguments_["main-ref"]) {
-    throw new Error("Both --tag and --main-ref are required");
+  if (!arguments_["main-ref"]) {
+    throw new Error("--main-ref is required");
   }
-  const metadata = collectReleaseMetadata({
+  if (Boolean(arguments_.tag) === Boolean(arguments_["candidate-sha"])) {
+    throw new Error("Exactly one of --tag or --candidate-sha is required");
+  }
+  const common = {
     repoDir: path.resolve(arguments_.repo ?? "."),
-    tag: arguments_.tag,
     mainRef: arguments_["main-ref"],
     tagRemote: arguments_["tag-remote"] ?? "origin",
-  });
+  };
+  const metadata = arguments_.tag
+    ? collectReleaseMetadata({ ...common, tag: arguments_.tag })
+    : collectCandidateMetadata({
+        ...common,
+        candidateSha: arguments_["candidate-sha"],
+      });
   const output = Object.entries(metadata)
     .map(([key, value]) => `${key}=${value}`)
     .join("\n");

--- a/tools/release-candidate/release-candidate.test.mjs
+++ b/tools/release-candidate/release-candidate.test.mjs
@@ -27,6 +27,7 @@ import {
   validateQualityRun,
 } from "./offline-manifest.mjs";
 import {
+  collectCandidateMetadata,
   collectReleaseMetadata,
   databaseSchemaVersion,
   parseStableTag,
@@ -36,6 +37,9 @@ const manifestScript = fileURLToPath(new URL("./manifest.mjs", import.meta.url))
 const metadataScript = fileURLToPath(new URL("./metadata.mjs", import.meta.url));
 const offlineManifestScript = fileURLToPath(
   new URL("./offline-manifest.mjs", import.meta.url),
+);
+const releaseCandidateWorkflow = fileURLToPath(
+  new URL("../../.github/workflows/release-candidate.yml", import.meta.url),
 );
 const officialUpstreamUrl = "https://github.com/1024XEngineer/XE3-ESL.git";
 const officialRepository = "1024XEngineer/XE3-ESL";
@@ -72,6 +76,13 @@ function createRepository(version = "0.1.0+1") {
   git(repo, "commit", "-m", "initial release");
   git(repo, "remote", "add", "origin", repo);
   return repo;
+}
+
+function commitVersion(repo, version, message = `prepare ${version}`) {
+  writeReleaseFiles(repo, version);
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", message);
+  return git(repo, "rev-parse", "HEAD");
 }
 
 function configureOfficialUpstream(repo) {
@@ -351,6 +362,24 @@ function manifestArguments(repo, input, output) {
   ];
 }
 
+function candidateManifestArguments(repo, input, output) {
+  return [
+    manifestScript,
+    "--candidate-sha",
+    git(repo, "rev-parse", "HEAD"),
+    "--main-ref",
+    "main",
+    "--staging-apk",
+    input.STAGING_APK_PATH,
+    "--production-apk",
+    input.PRODUCTION_APK_PATH,
+    "--output",
+    output,
+    "--repo",
+    repo,
+  ];
+}
+
 function offlineManifestArguments(
   repo,
   input,
@@ -401,6 +430,158 @@ test("accepts the first stable release and ignores prerelease tags", () => {
       git_sha: git(repo, "rev-parse", "HEAD"),
       database_schema_version: "7",
     },
+  );
+});
+
+test("accepts an untagged Candidate from the exact main checkout", () => {
+  const repo = createRepository();
+  const candidateSha = git(repo, "rev-parse", "HEAD");
+  const tagsBefore = git(repo, "tag", "--list");
+
+  assert.deepEqual(
+    collectCandidateMetadata({
+      repoDir: repo,
+      candidateSha,
+      mainRef: "main",
+    }),
+    {
+      version: "0.1.0",
+      version_code: "1",
+      git_sha: candidateSha,
+      database_schema_version: "7",
+    },
+  );
+  assert.equal(git(repo, "tag", "--list"), tagsBefore);
+});
+
+test("accepts a Candidate newer than the complete stable release history", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  const candidateSha = commitVersion(repo, "0.1.1+2");
+
+  assert.equal(
+    collectCandidateMetadata({ repoDir: repo, candidateSha, mainRef: "main" })
+      .version,
+    "0.1.1",
+  );
+});
+
+test("rejects Candidate checkout drift, side history, and reused stable identity", () => {
+  const drifted = createRepository();
+  const oldSha = git(drifted, "rev-parse", "HEAD");
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: drifted,
+      candidateSha: "not-a-full-sha",
+      mainRef: "main",
+    }),
+    /full lowercase Git commit SHA/,
+  );
+  commitVersion(drifted, "0.1.1+2");
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: drifted,
+      candidateSha: oldSha,
+      mainRef: "main",
+    }),
+    /does not match Candidate/,
+  );
+
+  const sideHistory = createRepository();
+  git(sideHistory, "checkout", "-b", "feature");
+  const sideSha = commitVersion(sideHistory, "0.1.1+2");
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: sideHistory,
+      candidateSha: sideSha,
+      mainRef: "main",
+    }),
+    /not contained in main/,
+  );
+
+  const tagged = createRepository();
+  const taggedSha = git(tagged, "rev-parse", "HEAD");
+  git(tagged, "tag", "v0.1.0");
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: tagged,
+      candidateSha: taggedSha,
+      mainRef: "main",
+    }),
+    /stable Tag already exists: v0\.1\.0/,
+  );
+});
+
+test("rejects Candidate version and versionCode regressions", () => {
+  const versionRegression = createRepository("0.2.0+2");
+  git(versionRegression, "tag", "v0.2.0");
+  const lowerVersionSha = commitVersion(versionRegression, "0.1.9+3");
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: versionRegression,
+      candidateSha: lowerVersionSha,
+      mainRef: "main",
+    }),
+    /Release version v0\.1\.9 must be newer than v0\.2\.0/,
+  );
+
+  const codeRegression = createRepository("0.1.0+2");
+  git(codeRegression, "tag", "v0.1.0");
+  const lowerCodeSha = commitVersion(codeRegression, "0.1.1+2");
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: codeRegression,
+      candidateSha: lowerCodeSha,
+      mainRef: "main",
+    }),
+    /versionCode 2 must be greater than 2/,
+  );
+});
+
+test("rejects malformed Candidate versions and incomplete Tag history", () => {
+  const prerelease = createRepository("0.1.0-rc.1+1");
+  const prereleaseSha = git(prerelease, "rev-parse", "HEAD");
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: prerelease,
+      candidateSha: prereleaseSha,
+      mainRef: "main",
+    }),
+    /must use vX\.Y\.Z/,
+  );
+
+  const source = createRepository();
+  git(source, "tag", "v0.1.0");
+  const candidateSha = commitVersion(source, "0.1.1+2");
+  const cloneParent = mkdtempSync(path.join(tmpdir(), "speakup-candidate-no-tags-"));
+  const clone = path.join(cloneParent, "repo");
+  execFileSync("git", ["clone", "--no-tags", source, clone], { stdio: "ignore" });
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: clone,
+      candidateSha,
+      mainRef: "main",
+    }),
+    /stable release tags do not match origin/,
+  );
+});
+
+test("rejects an existing stable Tag outside main history", () => {
+  const repo = createRepository();
+  git(repo, "tag", "v0.1.0");
+  git(repo, "checkout", "-b", "orphaned-release");
+  commitVersion(repo, "9.0.0+9");
+  git(repo, "tag", "v9.0.0");
+  git(repo, "checkout", "main");
+  const candidateSha = commitVersion(repo, "0.1.1+2");
+
+  assert.throws(
+    () => collectCandidateMetadata({
+      repoDir: repo,
+      candidateSha,
+      mainRef: "main",
+    }),
+    /Previous release tag v9\.0\.0 is not contained in main/,
   );
 });
 
@@ -570,6 +751,79 @@ test("metadata and manifest CLIs reject unknown and duplicate options", () => {
       },
     );
   }
+});
+
+test("metadata and manifest CLIs require exactly one release identity", () => {
+  const sharedManifestArguments = [
+    "--main-ref",
+    "main",
+    "--staging-apk",
+    "staging.apk",
+    "--production-apk",
+    "production.apk",
+    "--output",
+    "release-manifest.json",
+  ];
+  const cases = [
+    {
+      script: metadataScript,
+      arguments_: ["--main-ref", "main"],
+    },
+    {
+      script: metadataScript,
+      arguments_: [
+        "--tag",
+        "v0.1.0",
+        "--candidate-sha",
+        "a".repeat(40),
+        "--main-ref",
+        "main",
+      ],
+    },
+    {
+      script: manifestScript,
+      arguments_: sharedManifestArguments,
+    },
+    {
+      script: manifestScript,
+      arguments_: [
+        "--tag",
+        "v0.1.0",
+        "--candidate-sha",
+        "a".repeat(40),
+        ...sharedManifestArguments,
+      ],
+    },
+  ];
+
+  for (const scenario of cases) {
+    assert.throws(
+      () => execFileSync(
+        process.execPath,
+        [scenario.script, ...scenario.arguments_],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      ),
+      (error) => {
+        assert.match(error.stderr, /Exactly one of --tag or --candidate-sha is required/);
+        return true;
+      },
+    );
+  }
+});
+
+test("Release Candidate workflow is manual, official-main-only, and Tag-free", () => {
+  const workflow = readFileSync(releaseCandidateWorkflow, "utf8");
+  assert.match(workflow, /on:\n  workflow_dispatch:/);
+  assert.match(workflow, /CANDIDATE_REPOSITORY.*github\.repository/);
+  assert.match(workflow, /1024XEngineer\/XE3-ESL/);
+  assert.match(workflow, /CANDIDATE_REF.*github\.ref/);
+  assert.match(workflow, /refs\/heads\/main/);
+  assert.match(workflow, /--candidate-sha "\$GITHUB_SHA"/);
+  assert.doesNotMatch(workflow, /push:\n\s+tags:/);
+  assert.doesNotMatch(workflow, /GITHUB_REF_NAME/);
+  assert.doesNotMatch(workflow, /--tag "\$GITHUB_REF_NAME"/);
+  assert.doesNotMatch(workflow, /contents:\s*write/);
+  assert.doesNotMatch(workflow, /deploy\/(staging|production)\/manage\.sh/);
 });
 
 test("rejects a release tag that is not contained in main", () => {
@@ -825,6 +1079,26 @@ test("writes the validated manifest atomically through the CLI", () => {
     ),
   );
   assert.equal(existsSync(rejectedOutput), false);
+});
+
+test("writes the unchanged v1 manifest for an untagged Candidate", () => {
+  const repo = createRepository();
+  const { input } = validManifestFixture();
+  const output = path.join(repo, "candidate-release-manifest.json");
+  const tagsBefore = git(repo, "tag", "--list");
+
+  execFileSync(
+    process.execPath,
+    candidateManifestArguments(repo, input, output),
+    { env: { ...process.env, ...input }, stdio: "pipe" },
+  );
+
+  const manifest = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(manifest.manifest_version, 1);
+  assert.equal(manifest.version, "0.1.0");
+  assert.equal(manifest.git_sha, git(repo, "rev-parse", "HEAD"));
+  assert.equal(Object.hasOwn(manifest, "tag"), false);
+  assert.equal(git(repo, "tag", "--list"), tagsBefore);
 });
 
 test("refuses to replace an existing manifest file, directory, or symbolic link", () => {


### PR DESCRIPTION
## 功能描述

- 将内部 Release Candidate 从稳定 `vX.Y.Z` Tag 触发改为官方仓库 `main` 的精确 SHA 手动触发。
- Candidate 不创建或占用 Stable Tag，同时继续构建 Portal/Server OCI 镜像、正式签名的 Staging/Production APK 与 manifest v1。
- 保留稳定 Tag 模式，供后续正式发布阶段复验同一版本历史。

## 实现思路

- Release Candidate Workflow 只接受 `workflow_dispatch`、官方仓库和 `refs/heads/main`，所有构建 job 显式 checkout 同一个 `github.sha`。
- `metadata.mjs` 新增独立 Candidate 模式：校验完整 SHA、HEAD、`main` first-parent、Stable Tag 完整历史、版本和 versionCode 单调性及数据库 schema。
- `manifest.mjs` 要求 `--tag` 与 `--candidate-sha` 恰好选择一个，Candidate 继续生成字段不变的 manifest v1。
- 所有既有 Stable Tag 都必须位于 `main` first-parent；异常、孤立或 side-history Stable Tag fail closed。
- 文档明确 Candidate、Stable Tag、GitHub Release、Staging 和 Production 是不同状态。

## 可复现测试

- `make check-release-candidate`：40/40 通过。
- `node --check tools/release-candidate/metadata.mjs`：通过。
- `node --check tools/release-candidate/manifest.mjs`：通过。
- Release Candidate Workflow YAML 解析：通过。
- `git diff --check`：通过。

## 外部配置前置

首次实际运行前，`android-release-signing` GitHub Environment 需要在保留现有 Tag policy、Required reviewer 和 Secrets 的前提下，额外允许 Branch pattern `main`。本 PR 不绕过或复制签名 Secrets。

## 范围边界

- 不创建正式 Tag 或 GitHub Release。
- 不部署 Staging 或 Production。
- 不连接共享生产服务器。
- 不更新公开 APK 指针或 changelog。

Closes #999
