### PR TITLE
feat(mobile): 为全产品接入淡蓝 Ambient 渐变背景

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -12,6 +12,7 @@ import 'package:speakup/features/agent/conversation/agent_message_image_client.d
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/speak_up_shell.dart';
+import 'package:speakup/design/speak_up_components.dart';
 import 'package:speakup/design/speak_up_theme.dart';
 import 'package:speakup/features/coaching/preparation/practice_plan_client_action_controller.dart';
 import 'package:speakup/features/coaching/scenario/scenario_practice.dart';
@@ -109,6 +110,10 @@ class SpeakUpApp extends StatelessWidget {
       title: 'SpeakUp',
       debugShowCheckedModeBanner: false,
       theme: SpeakUpTheme.light,
+      builder: (context, child) => Stack(
+        fit: StackFit.expand,
+        children: [const SpeakUpAmbientBackground(), ?child],
+      ),
       home: controller == null
           ? _AuthenticatedNavigator(
               conversationController: conversationController,

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -788,9 +788,7 @@ class _SpeakUpShellState extends State<SpeakUpShell>
           key: _scaffoldKey,
           extendBody: !practiceSelected,
           resizeToAvoidBottomInset: false,
-          backgroundColor: practiceSelected
-              ? SpeakUpDesign.canvas
-              : Colors.transparent,
+          backgroundColor: Colors.transparent,
           drawer: _ConversationDrawer(
             controller: widget.conversationController,
             avatarBytes: widget.authController?.avatarBytes,

--- a/mobile/lib/design/speak_up_components.dart
+++ b/mobile/lib/design/speak_up_components.dart
@@ -1,6 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
 
+class SpeakUpAmbientBackground extends StatelessWidget {
+  const SpeakUpAmbientBackground({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ExcludeSemantics(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              SpeakUpDesign.ambientTop,
+              SpeakUpDesign.ambientBase,
+              SpeakUpDesign.ambientBase,
+            ],
+            stops: [0, 0.42, 1],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class SpeakUpWordmark extends StatelessWidget {
   const SpeakUpWordmark({this.height = 28, super.key});
 

--- a/mobile/lib/design/speak_up_design.dart
+++ b/mobile/lib/design/speak_up_design.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 /// The single visual source of truth for SpeakUp's mobile surfaces.
 abstract final class SpeakUpDesign {
+  static const ambientTop = Color(0xFFEEF7FA);
+  static const ambientBase = Color(0xFFF7F8FC);
   static const canvas = Color(0xFFFFFFFF);
   static const surface = Color(0xFFFFFFFF);
   static const surfaceMuted = Color(0xFFF5F5F5);

--- a/mobile/lib/design/speak_up_theme.dart
+++ b/mobile/lib/design/speak_up_theme.dart
@@ -22,7 +22,7 @@ abstract final class SpeakUpTheme {
     return ThemeData(
       useMaterial3: true,
       colorScheme: scheme,
-      scaffoldBackgroundColor: SpeakUpDesign.canvas,
+      scaffoldBackgroundColor: Colors.transparent,
       canvasColor: SpeakUpDesign.canvas,
       dividerColor: SpeakUpDesign.border,
       disabledColor: SpeakUpDesign.tertiary,
@@ -39,7 +39,7 @@ abstract final class SpeakUpTheme {
         labelMedium: SpeakUpDesign.meta,
       ),
       appBarTheme: const AppBarTheme(
-        backgroundColor: SpeakUpDesign.canvas,
+        backgroundColor: Colors.transparent,
         foregroundColor: SpeakUpDesign.ink,
         surfaceTintColor: Colors.transparent,
         elevation: 0,

--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -347,9 +347,9 @@ class ConversationPage extends StatefulWidget {
                             begin: Alignment.topCenter,
                             end: Alignment.bottomCenter,
                             colors: [
-                              SpeakUpDesign.canvas,
-                              SpeakUpDesign.canvas.withValues(alpha: 0.94),
-                              SpeakUpDesign.canvas.withValues(alpha: 0),
+                              SpeakUpDesign.ambientTop,
+                              SpeakUpDesign.ambientTop.withValues(alpha: 0.94),
+                              SpeakUpDesign.ambientTop.withValues(alpha: 0),
                             ],
                             stops: const [0, 0.7, 1],
                           ),
@@ -371,9 +371,11 @@ class ConversationPage extends StatefulWidget {
                               begin: Alignment.topCenter,
                               end: Alignment.bottomCenter,
                               colors: [
-                                SpeakUpDesign.canvas.withValues(alpha: 0),
-                                SpeakUpDesign.canvas.withValues(alpha: 0.94),
-                                SpeakUpDesign.canvas,
+                                SpeakUpDesign.ambientBase.withValues(alpha: 0),
+                                SpeakUpDesign.ambientBase.withValues(
+                                  alpha: 0.94,
+                                ),
+                                SpeakUpDesign.ambientBase,
                               ],
                               stops: const [0, 0.38, 1],
                             ),
@@ -763,9 +765,7 @@ class _AgentBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const ExcludeSemantics(
-      child: ColoredBox(color: SpeakUpDesign.canvas),
-    );
+    return const SpeakUpAmbientBackground();
   }
 }
 

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -1584,7 +1584,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       },
       child: Scaffold(
         key: const Key('ielts-mock-page'),
-        backgroundColor: SpeakUpDesign.surface,
+        backgroundColor: Colors.transparent,
         appBar: showCompletionPage ? _buildAppBar(progress.phase) : null,
         body: SafeArea(
           top: !showCompletionPage,
@@ -1912,7 +1912,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _ => 'IELTS Speaking',
     };
     return AppBar(
-      backgroundColor: SpeakUpDesign.surface,
+      backgroundColor: Colors.transparent,
       surfaceTintColor: Colors.transparent,
       centerTitle: true,
       leading: IconButton(

--- a/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_set_detail.dart
@@ -265,9 +265,9 @@ class _IeltsSetDetailPageState extends State<IeltsSetDetailPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('ielts-set-detail'),
-      backgroundColor: PreparationDesign.canvas,
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
-        backgroundColor: PreparationDesign.canvas,
+        backgroundColor: Colors.transparent,
         surfaceTintColor: Colors.transparent,
         leading: IconButton(
           key: const Key('ielts-set-detail-back'),

--- a/mobile/lib/features/coaching/preparation/preparation.dart
+++ b/mobile/lib/features/coaching/preparation/preparation.dart
@@ -531,10 +531,10 @@ class _PreparationPageState extends State<PreparationPage> {
       },
       child: Scaffold(
         key: const Key('scenes-page'),
-        backgroundColor: PreparationDesign.canvas,
+        backgroundColor: Colors.transparent,
         appBar: widget.showBackButton
             ? AppBar(
-                backgroundColor: PreparationDesign.canvas,
+                backgroundColor: Colors.transparent,
                 surfaceTintColor: Colors.transparent,
                 elevation: 0,
                 scrolledUnderElevation: 0,

--- a/mobile/lib/features/coaching/review/review.dart
+++ b/mobile/lib/features/coaching/review/review.dart
@@ -114,9 +114,9 @@ class CurrentIeltsAbilityPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('current-ielts-ability-page'),
-      backgroundColor: SpeakUpDesign.surfaceMuted,
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
-        backgroundColor: SpeakUpDesign.surfaceMuted,
+        backgroundColor: Colors.transparent,
         leading: IconButton(
           key: const Key('current-ielts-ability-back-button'),
           tooltip: '返回',

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -629,7 +629,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       },
       child: Scaffold(
         key: const Key('scenario-practice-page'),
-        backgroundColor: SpeakUpDesign.canvas,
+        backgroundColor: Colors.transparent,
         body: SafeArea(
           child: scene == null
               ? const Center(child: Text('请先选择一个情景开始对话。'))

--- a/mobile/lib/features/profile/profile_page.dart
+++ b/mobile/lib/features/profile/profile_page.dart
@@ -57,10 +57,10 @@ class ProfilePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       key: const Key('profile-page'),
-      backgroundColor: SpeakUpDesign.surfaceMuted,
+      backgroundColor: Colors.transparent,
       appBar: showBackButton
           ? AppBar(
-              backgroundColor: SpeakUpDesign.surfaceMuted,
+              backgroundColor: Colors.transparent,
               leading: IconButton(
                 key: const Key('profile-route-back-button'),
                 tooltip: '返回',

--- a/mobile/lib/identity/login_page.dart
+++ b/mobile/lib/identity/login_page.dart
@@ -105,7 +105,7 @@ class AuthFormScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AuthPalette.background,
+      backgroundColor: Colors.transparent,
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, constraints) {
@@ -212,7 +212,6 @@ class AuthSwitchPrompt extends StatelessWidget {
 }
 
 abstract final class AuthPalette {
-  static const background = SpeakUpDesign.canvas;
   static const field = SpeakUpDesign.surface;
   static const ink = SpeakUpDesign.ink;
   static const muted = SpeakUpDesign.secondary;

--- a/mobile/test/design/speak_up_design_test.dart
+++ b/mobile/test/design/speak_up_design_test.dart
@@ -8,7 +8,8 @@ void main() {
   test('theme exposes the shared semantic visual tokens', () {
     final theme = SpeakUpTheme.light;
 
-    expect(theme.scaffoldBackgroundColor, SpeakUpDesign.canvas);
+    expect(theme.scaffoldBackgroundColor, Colors.transparent);
+    expect(theme.appBarTheme.backgroundColor, Colors.transparent);
     expect(theme.colorScheme.primary, SpeakUpDesign.primary);
     expect(SpeakUpDesign.primary, SpeakUpDesign.ink);
     expect(theme.progressIndicatorTheme.color, SpeakUpDesign.primary);
@@ -27,6 +28,30 @@ void main() {
     );
     expect(theme.inputDecorationTheme.fillColor, SpeakUpDesign.surface);
     expect(theme.bottomSheetTheme.showDragHandle, isTrue);
+  });
+
+  testWidgets('ambient background matches the approved product gradient', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: SizedBox.expand(child: SpeakUpAmbientBackground()),
+      ),
+    );
+
+    final box = tester.widget<DecoratedBox>(find.byType(DecoratedBox));
+    final decoration = box.decoration as BoxDecoration;
+    final gradient = decoration.gradient! as LinearGradient;
+
+    expect(gradient.begin, Alignment.topCenter);
+    expect(gradient.end, Alignment.bottomCenter);
+    expect(gradient.colors, const [
+      SpeakUpDesign.ambientTop,
+      SpeakUpDesign.ambientBase,
+      SpeakUpDesign.ambientBase,
+    ]);
+    expect(gradient.stops, const [0, 0.42, 1]);
   });
 
   testWidgets(

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -12,6 +12,7 @@ import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/platform_navigation_bar.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/app/speak_up_shell.dart';
+import 'package:speakup/design/speak_up_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/agent/client_action/agent_client_action.dart';
 import 'package:speakup/features/agent/conversation/conversation.dart';
@@ -213,6 +214,8 @@ void main() {
     await tester.pumpWidget(const SpeakUpApp.preview());
     final semantics = tester.ensureSemantics();
 
+    expect(find.byType(SpeakUpAmbientBackground), findsWidgets);
+
     await _tapPrimaryDestination(
       tester,
       key: 'primary-tab-scenes',
@@ -234,6 +237,13 @@ void main() {
       ),
     );
     expect(shellScaffold.extendBody, isFalse);
+    expect(shellScaffold.backgroundColor, Colors.transparent);
+    expect(
+      tester
+          .widget<Scaffold>(find.byKey(const Key('scenes-page')))
+          .backgroundColor,
+      Colors.transparent,
+    );
     await _tapPrimaryDestination(
       tester,
       key: 'primary-tab-review',
@@ -249,6 +259,12 @@ void main() {
     );
     expect(find.byKey(const Key('profile-avatar')), findsOneWidget);
     expect(find.byKey(const Key('profile-display-name')), findsOneWidget);
+    expect(
+      tester
+          .widget<Scaffold>(find.byKey(const Key('profile-page')))
+          .backgroundColor,
+      Colors.transparent,
+    );
     expect(
       find.byKey(const Key('profile-ielts-ability-button')),
       findsOneWidget,


### PR DESCRIPTION
## 功能描述

- 为 SpeakUp 移动端全产品接入统一的淡蓝 Ambient 渐变背景
- 覆盖登录、SpeakUp、训练、复盘、我的及练习/详情路由
- 仅参考 #839 的背景实现，不引入其配色、排版、圆角、玻璃态、导航或动效改动

## 实现思路

- 新增全局 `SpeakUpAmbientBackground`，使用 `#EEF7FA → #F7F8FC` 的纵向渐变，停靠点为 `[0, 0.42, 1]`
- 在 `MaterialApp.builder` 根层统一挂载背景，保证所有产品路由共享同一视觉底层
- 将 Scaffold 与 AppBar 的页面底色改为透明，同时保留卡片、输入框、Drawer 和导航等前景表面原有白色
- 调整会话页顶部和底部遮罩，使其与全局渐变连续，不再被纯白遮挡

## 测试

- `cd mobile && dart format --output=none --set-exit-if-changed lib test`
- `cd mobile && dart analyze lib test`
- `cd mobile && flutter test --no-pub`（833 项通过）
- `cd mobile && flutter test --no-pub test/design/speak_up_design_test.dart test/speak_up_app_test.dart`（42 项通过）
- 使用真实后端在 iPhone 17 iOS Simulator 完成启动验证；最终视觉效果待人工体验确认

Closes #1002