### PR TITLE
refactor(staging): 拆分运行时部署与边缘密钥输入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ help:
 		'  make check-observability  Validate monitoring, alert, and log rotation contracts' \
 		'  make check-production-deploy  Validate the immutable Production contract' \
 		'  make check-production-nginx  Run nginx -t against the Production template' \
-		'  make check-staging-deploy  Validate Staging runtime, schema, lock, and receipt contracts' \
-		'  make check-staging-nginx  Run nginx -t against the rendered Staging template' \
+		'  make check-staging-deploy  Validate Staging runtime-env, schema, lock, and receipt contracts' \
+		'  make check-staging-nginx  Validate the Staging edge-env and rendered Nginx contract' \
 		'  make dev-android    Start the backend and run the App on an Android device' \
 		'  make dev-ios-simulator  Start the backend on an iOS Simulator' \
 		'  make build-android-release-staging  Build the signed staging arm64 APK' \

--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -4,6 +4,11 @@ This directory is the host-side contract for running a Release Candidate in an
 isolated Staging environment. It does not connect to a server, install Nginx,
 issue a certificate, or change Production by itself.
 
+Runtime deployment and edge rendering deliberately use separate configuration
+files and commands. This removes the runtime command's need to read TLS,
+htpasswd, ACME, or public-root inputs; it is a functional dependency boundary,
+not host-enforced privilege isolation.
+
 ## Verified inputs and design choices
 
 The Release Candidate workflow emits `release-manifest.json` with the exact
@@ -21,25 +26,30 @@ This Staging contract deliberately uses:
 - separate Portal, Server-egress, and internal database networks;
 - image references of the form `repository@sha256:digest`, with no `build`;
 - a one-shot migration before either application container is updated;
+- a runtime-only configuration for PostgreSQL, Portal, and Server containers;
+- an edge-only configuration for TLS, Basic Auth, ACME, and public downloads;
 - HTTP Basic Authentication on the Staging Portal only;
 - TLS plus the application's Bearer authentication on the Staging API, so the
   mobile client's `Authorization` header is never consumed by Nginx;
 - an exact public `/metrics` denial, while internal metrics work remains in
   its own Issue.
 
-The selected hostnames are `staging.speak-up.top` for Portal and
-`staging-api.speak-up.top` for API; the latter matches the Staging APK's fixed
-API base URL. Their DNS targets, TLS paths, htpasswd path, provider credentials,
-and server environment are externally injected and are not committed.
+The hostnames `staging.speak-up.top` for Portal and
+`staging-api.speak-up.top` for API are fixed repository contracts; the latter
+matches the Staging APK's fixed API base URL. They are not repeated in either
+environment file. DNS targets, TLS paths, htpasswd path, provider credentials,
+and server environment remain externally injected and are not committed.
 
 ## Prerequisites
 
 - Bash, `jq`, `curl`, Docker Engine, and Docker Compose with `up --wait` support.
 - `flock`, plus either `sha256sum` or `shasum`, on the deployment host.
-- Nginx with the HTTP SSL, proxy, and Basic Auth modules.
+- Nginx with the HTTP SSL, proxy, and Basic Auth modules for edge rendering and
+  installation.
 - A certificate whose SANs are exactly both Staging hostnames, issued and
   verified through [`deploy/tls/`](../tls/README.md).
-- A populated htpasswd file and a real Staging Server environment file.
+- Populated runtime and edge environment files, a populated htpasswd file, and
+  a real Staging Server environment file.
 - Registry credentials with read access to the two GHCR images.
 - A real, current-UID-owned `STAGING_PUBLIC_ROOT` that is not group- or
   world-writable.
@@ -50,7 +60,7 @@ only as a key reference; do not copy local defaults as deployment values and do
 not disable OSS or OCR to bypass missing configuration. It must not define
 `DATABASE_URL`, `SERVER_HOST`, or `SERVER_PORT`; Compose owns those three values.
 
-## 1. Acquire a manifest and configuration
+## 1. Acquire a manifest and split configuration
 
 Download the manifest artifact from the selected, successful Release Candidate
 run. For example:
@@ -62,30 +72,33 @@ gh run download RUN_ID \
   --dir /opt/speakup/releases/v0.1.1
 ```
 
-Copy `staging.env.example` to a location outside the repository, populate every
-blank value, and restrict both environment files:
+Copy the two examples to locations outside the repository, populate every blank
+value, and restrict both files plus the Server environment:
 
 ```sh
 install -d -m 0750 /etc/speakup
-install -m 0600 staging.env.example /etc/speakup/staging.env
+install -m 0600 deploy/staging/staging-runtime.env.example \
+  /etc/speakup/staging-runtime.env
+install -m 0600 deploy/staging/staging-edge.env.example \
+  /etc/speakup/staging-edge.env
 install -m 0600 /secure/source/staging-server.env \
   /etc/speakup/staging-server.env
 install -d -m 0755 /var/www/speakup-staging-public
 install -d -o root -g root -m 0700 /run/lock/xe3-speakup-staging
 ```
 
-Run the contract as the same UID that owns all deployment inputs (normally
-`root` on the server). `staging.env`, the Server environment, and htpasswd file
-must be regular, non-symlink files owned by that UID with mode `0400` or
+Each command must run as the same UID that owns the private inputs it reads.
+`staging-runtime.env`, `staging-edge.env`, the Server environment, and htpasswd
+file must be regular, non-symlink files owned by that UID with mode `0400` or
 `0600`. The TLS private key may be a regular file or Certbot's stable
 `live/.../privkey.pem` symlink; its resolved target must be regular, non-empty,
 owned by that UID, and mode `0400` or `0600`. The public certificate must be
 non-empty, owned by that UID, and not group- or world-writable. The ACME webroot
 must be a non-symlink directory owned by that UID with mode `0700`, `0750`, or
-`0755`. Validation checks these properties before a Docker pull, migration,
-container update, or shutdown. Keep the stable `live/` paths so Certbot renewal
-can advance their archive targets; never pin an `archive/.../privkeyN.pem`
-generation.
+`0755`. Runtime validation finishes before a Docker pull, migration, container
+update, or shutdown; edge validation finishes before a rendered output is
+written. Keep the stable `live/` paths so Certbot renewal can advance their
+archive targets; never pin an `archive/.../privkeyN.pem` generation.
 
 Every ancestor of these paths must be a real directory owned by `root` or the
 execution UID and must not be group- or world-writable. A sticky directory
@@ -94,6 +107,19 @@ exception. Only the final TLS certificate and private-key components may be
 Certbot `live/*.pem` symlinks; their resolved `archive/` targets and target
 ancestors are checked under the same boundary. Any other symbolic-link path
 component fails closed.
+
+The two configuration contracts are exact and non-overlapping:
+
+| File | Exact keys and responsibility | Commands | Required access |
+| --- | --- | --- | --- |
+| `staging-runtime.env` | `STAGING_POSTGRES_DB`, `STAGING_POSTGRES_USER`, `STAGING_POSTGRES_PASSWORD`, `PORTAL_ADMIN_PASSWORD`, `STAGING_SERVER_ENV_FILE`; Compose, migration, loopback health, runtime verification, and receipt inputs | `validate`, `deploy`, `verify`, `status`, `down` with `--runtime-env-file` | Read the manifest, runtime env, and referenced Server env; use the Staging Docker/Compose runtime; use the private deployment lock and write a new receipt where applicable. No edge file or edge Secret access is required. |
+| `staging-edge.env` | `STAGING_TLS_CERTIFICATE`, `STAGING_TLS_CERTIFICATE_KEY`, `STAGING_HTPASSWD_FILE`, `STAGING_ACME_ROOT`, `STAGING_PUBLIC_ROOT`; strict Nginx template rendering only | `render-nginx` with `--edge-env-file` and `--output` | Read the edge env and referenced TLS/htpasswd inputs, traverse the ACME/public roots, and create the requested output. No manifest, runtime/Server env, receipt, Docker, or Compose access is required. |
+
+Unknown, duplicate, or cross-contract keys fail closed. Values are read only
+from the selected file; exported ambient variables do not fill missing keys.
+Error output identifies the key or line but never prints a Secret value. The
+fixed Portal and API hostnames are injected by the repository contract and must
+not be added to either file.
 
 The dedicated lock directory is mandatory and must be recreated at boot when
 `/run` is volatile. The deployment script never creates this directory and
@@ -118,33 +144,55 @@ tool; neither plaintext credentials nor the generated file belong in the
 repository. Do not add HTTP Basic Auth to the API host: the Staging APK uses its
 `Authorization: Bearer` header for application identity.
 
+### Migrate from the legacy combined environment
+
+The old `staging.env` and `--env-file` interface have no compatibility fallback.
+Migrate explicitly:
+
+1. create `/etc/speakup/staging-runtime.env` and
+   `/etc/speakup/staging-edge.env` from the committed examples;
+2. copy only the five allowlisted runtime keys and five allowlisted edge keys
+   from the old file; remove `STAGING_PORTAL_HOST` and `STAGING_API_HOST` because
+   both hostnames are now fixed repository contracts;
+3. keep both new files owned by their executing UID with mode `0400` or `0600`,
+   and preserve the existing ownership, mode, and ancestor checks for every
+   referenced path;
+4. replace runtime invocations with `--runtime-env-file` and the Nginx renderer
+   with `--edge-env-file`;
+5. run runtime `validate` and edge `render-nginx` independently before removing
+   the old combined file.
+
+Passing `--env-file` fails with the appropriate migration flag. Do not export
+the old values into the process environment as a workaround.
+
 ## 2. Validate without changing containers
 
 ```sh
 ./deploy/staging/manage.sh validate \
   --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
-  --env-file /etc/speakup/staging.env
+  --runtime-env-file /etc/speakup/staging-runtime.env
 ```
 
 Validation accepts only the canonical v1 Release Candidate manifest with its
 exact key set; missing, unknown, or multiple JSON documents fail closed. It
 also fails on a malformed manifest, mutable or placeholder image reference,
-missing configuration value, invalid private input, or invalid Compose model.
-It does not pull images or contact the application providers.
+missing runtime value, invalid runtime or Server input, or invalid Compose
+model. It does not read the edge env, validate edge files, render Nginx, pull
+images, or contact the application providers.
 
 ## 3. Deploy the immutable Staging images
 
 ```sh
 ./deploy/staging/manage.sh deploy \
   --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
-  --env-file /etc/speakup/staging.env \
+  --runtime-env-file /etc/speakup/staging-runtime.env \
   --receipt /opt/speakup/releases/v0.1.1/staging-deployment-receipt.json
 ```
 
 The command performs the following fail-closed sequence:
 
-1. validate the manifest, external configuration, Compose model, and Nginx
-   template, and require a new receipt path;
+1. validate the manifest, runtime configuration, Server env, and Compose model,
+   and require a new receipt path without reading edge inputs;
 2. acquire the exclusive
    `/run/lock/xe3-speakup-staging/deploy.lock` lock shared by `deploy` and
    `down` (the test harness alone overrides this path);
@@ -180,9 +228,15 @@ Rendering writes only the requested output file. It never reloads Nginx:
 
 ```sh
 ./deploy/staging/manage.sh render-nginx \
-  --env-file /etc/speakup/staging.env \
+  --edge-env-file /etc/speakup/staging-edge.env \
   --output /opt/speakup/releases/v0.1.1/staging-nginx.conf
 ```
+
+`render-nginx` validates only the exact edge allowlist and its referenced
+certificate, private key, htpasswd, ACME root, and public root. It uses the two
+fixed repository hostnames, requires no manifest or runtime/Server env, and
+does not invoke Docker Compose. Runtime flags, `--manifest`, and `--receipt`
+fail before an output is written.
 
 Review the rendered file, install it at the host's configured include path,
 then test and reload Nginx using the paths appropriate to that host. The
@@ -204,11 +258,11 @@ the separate [Android publication contract](../android-download/README.md).
 ```sh
 ./deploy/staging/manage.sh status \
   --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
-  --env-file /etc/speakup/staging.env
+  --runtime-env-file /etc/speakup/staging-runtime.env
 
 ./deploy/staging/manage.sh verify \
   --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
-  --env-file /etc/speakup/staging.env
+  --runtime-env-file /etc/speakup/staging-runtime.env
 
 curl --fail --user staging-user https://staging.speak-up.top/
 curl --fail --user staging-user \
@@ -267,7 +321,7 @@ mode `0700`, and resolve without symbolic-link ancestors.
 ```sh
 ./deploy/staging/manage.sh down \
   --manifest /opt/speakup/releases/v0.1.1/release-manifest.json \
-  --env-file /etc/speakup/staging.env
+  --runtime-env-file /etc/speakup/staging-runtime.env
 ```
 
 `down` removes only the `xe3-speakup-staging` containers and networks and keeps
@@ -280,28 +334,57 @@ Staging-scoped volumes before deleting them by name.
 `down` uses the same exclusive lock as `deploy` and fails rather than running
 unlocked or concurrently with a release.
 
+## Security boundary and future CI
+
+This split removes the runtime command's functional dependency on edge Secrets;
+it does not create a restricted host identity, syscall or filesystem sandbox,
+independent Docker daemon, SSH forced command, or privilege boundary. The
+current runtime path still invokes Docker Compose. Access to a rootful Docker
+socket, whether directly, through the `docker` group, through unrestricted
+`sudo`, or through arbitrary root SSH, provides root-level influence over the
+host and is not an acceptable CI capability.
+
+A future CI-to-Staging task must therefore expose only a reviewed,
+Staging-scoped broker or forced command and must not give the job root, the raw
+Docker socket, Docker-group membership, or an arbitrary remote shell. A
+separate Staging daemon or stronger host/VM boundary and the broker's exact
+verbs, inputs, receipts, and resource limits belong to that later task. Edge
+rendering and Nginx installation remain a trusted host-operator responsibility;
+runtime automation must not receive the edge env, TLS private key, or htpasswd.
+
+This PR creates no workflow, host user, ACL, sudoers entry, systemd service,
+broker, or socket configuration and does not authorize CI to run `manage.sh` on
+a server.
+
 ## Reproducible contract checks
 
 ```sh
 make check-android-download
 make check-staging-deploy
 make check-staging-nginx
+make check-tls-lifecycle
 ```
 
-The first command checks private input ownership/modes and symlink rejection,
-lock conflicts, manifest and configuration failures, the resolved Compose
-isolation model, strict schema parsing, runtime identity and resources,
-no-pull verification, endpoint checks, and atomic no-clobber receipts. The
-second renders a temporary TLS config and runs `nginx -t` in a pinned Docker
-Official Nginx image.
+`check-staging-deploy` covers the runtime allowlist, private input
+ownership/modes and symlink rejection, lock conflicts, manifest failures,
+Compose model, schema parsing, runtime identity, no-pull verification, endpoint
+checks, and atomic no-clobber receipts without edge inputs.
+`check-staging-nginx` covers the edge allowlist and private-path validation,
+renders without runtime inputs or Compose, and runs `nginx -t` in a pinned
+Docker Official Nginx image. The other two commands retain the adjacent Android
+publication and TLS lifecycle contracts; their edge paths and behavior are
+unchanged.
 
 ## Official references
 
 - [Docker Compose image and healthcheck reference](https://docs.docker.com/reference/compose-file/services/)
 - [Docker Compose startup order](https://docs.docker.com/compose/how-tos/startup-order/)
 - [Docker Compose project isolation](https://docs.docker.com/compose/how-tos/project-name/)
+- [Docker Engine security and daemon attack surface](https://docs.docker.com/engine/security/)
+- [Docker group root-level privileges](https://docs.docker.com/engine/install/linux-postinstall/)
 - [Docker Official PostgreSQL image storage contract](https://github.com/docker-library/docs/blob/master/postgres/content.md)
 - [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)
 - [Nginx TLS module](https://nginx.org/en/docs/http/ngx_http_ssl_module.html)
 - [Nginx Basic Auth module](https://nginx.org/en/docs/http/ngx_http_auth_basic_module.html)
 - [GitHub Actions artifact download](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/download-workflow-artifacts)
+- [GitHub secure use of self-hosted runners](https://docs.github.com/en/actions/reference/security/secure-use)

--- a/deploy/staging/compose.yaml
+++ b/deploy/staging/compose.yaml
@@ -97,7 +97,7 @@ services:
     environment:
       PORTAL_ADMIN_PASSWORD: ${PORTAL_ADMIN_PASSWORD:?PORTAL_ADMIN_PASSWORD is required}
       PORTAL_SQLITE_PATH: /app/.wrangler/portal.sqlite
-      VINEXT_TRUSTED_HOSTS: ${STAGING_PORTAL_HOST:?STAGING_PORTAL_HOST is required}
+      VINEXT_TRUSTED_HOSTS: staging.speak-up.top
     ports:
       - "127.0.0.1:28082:3000"
     volumes:

--- a/deploy/staging/manage.sh
+++ b/deploy/staging/manage.sh
@@ -11,6 +11,8 @@ readonly server_image_repository="ghcr.io/1024xengineer/xe3-esl-server"
 readonly postgres_image="postgres:18-bookworm@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
 readonly portal_data_volume="${compose_project}_portal_data"
 readonly postgres_data_volume="${compose_project}_postgres_data"
+readonly staging_portal_host="staging.speak-up.top"
+readonly staging_api_host="staging-api.speak-up.top"
 readonly staging_lock_file="${SPEAKUP_STAGING_LOCK_FILE:-/run/lock/xe3-speakup-staging/deploy.lock}"
 readonly portal_health_url="http://127.0.0.1:28082/"
 readonly server_health_url="http://127.0.0.1:28083/health"
@@ -19,12 +21,12 @@ readonly server_readiness_url="http://127.0.0.1:28083/readyz"
 usage() {
   cat >&2 <<'EOF'
 Usage:
-  manage.sh validate --manifest FILE --env-file FILE
-  manage.sh deploy --manifest FILE --env-file FILE --receipt FILE
-  manage.sh verify --manifest FILE --env-file FILE
-  manage.sh status --manifest FILE --env-file FILE
-  manage.sh down --manifest FILE --env-file FILE
-  manage.sh render-nginx --env-file FILE --output FILE
+  manage.sh validate --manifest FILE --runtime-env-file FILE
+  manage.sh deploy --manifest FILE --runtime-env-file FILE --receipt FILE
+  manage.sh verify --manifest FILE --runtime-env-file FILE
+  manage.sh status --manifest FILE --runtime-env-file FILE
+  manage.sh down --manifest FILE --runtime-env-file FILE
+  manage.sh render-nginx --edge-env-file FILE --output FILE
 EOF
 }
 
@@ -375,16 +377,24 @@ require_owned_public_directory() {
     fail "$description cannot be group or world writable: $directory"
 }
 
-allowed_configuration_key() {
+allowed_runtime_configuration_key() {
   case "$1" in
     STAGING_POSTGRES_DB | \
       STAGING_POSTGRES_USER | \
       STAGING_POSTGRES_PASSWORD | \
       PORTAL_ADMIN_PASSWORD | \
-      STAGING_SERVER_ENV_FILE | \
-      STAGING_PORTAL_HOST | \
-      STAGING_API_HOST | \
-      STAGING_TLS_CERTIFICATE | \
+      STAGING_SERVER_ENV_FILE)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+allowed_edge_configuration_key() {
+  case "$1" in
+    STAGING_TLS_CERTIFICATE | \
       STAGING_TLS_CERTIFICATE_KEY | \
       STAGING_HTPASSWD_FILE | \
       STAGING_ACME_ROOT | \
@@ -397,25 +407,28 @@ allowed_configuration_key() {
   esac
 }
 
-load_configuration() {
-  local file=$1
-  local line name value line_number=0
-
-  require_private_file "environment file" "$file"
-
+unset_configuration() {
   unset \
     STAGING_POSTGRES_DB \
     STAGING_POSTGRES_USER \
     STAGING_POSTGRES_PASSWORD \
     PORTAL_ADMIN_PASSWORD \
     STAGING_SERVER_ENV_FILE \
-    STAGING_PORTAL_HOST \
-    STAGING_API_HOST \
     STAGING_TLS_CERTIFICATE \
     STAGING_TLS_CERTIFICATE_KEY \
     STAGING_HTPASSWD_FILE \
     STAGING_ACME_ROOT \
     STAGING_PUBLIC_ROOT
+}
+
+load_configuration() {
+  local file=$1
+  local kind=$2
+  local allowed_key="allowed_${kind}_configuration_key"
+  local line name value line_number=0 seen_keys="|"
+
+  require_private_file "$kind environment file" "$file"
+  unset_configuration
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     line_number=$((line_number + 1))
@@ -431,30 +444,30 @@ load_configuration() {
     value=${line#*=}
     [[ "$name" =~ ^[A-Z][A-Z0-9_]*$ ]] ||
       fail "invalid environment key at line $line_number"
-    allowed_configuration_key "$name" ||
-      fail "unsupported environment key at line $line_number"
+    "$allowed_key" "$name" ||
+      fail "unsupported $kind environment key at line $line_number"
+    case "$seen_keys" in
+      *"|$name|"*)
+        fail "duplicate $kind environment key at line $line_number"
+        ;;
+    esac
+    seen_keys="${seen_keys}${name}|"
     printf -v "$name" '%s' "$value"
     export "$name"
   done <"$file"
 }
 
+load_runtime_configuration() {
+  load_configuration "$1" runtime
+}
+
+load_edge_configuration() {
+  load_configuration "$1" edge
+}
+
 require_value() {
   local name=$1
   [[ -n "${!name:-}" ]] || fail "$name is required"
-}
-
-valid_hostname() {
-  local value=$1
-  local label
-  local -a labels
-
-  [[ ${#value} -le 253 ]] || return 1
-  [[ "$value" != *..* ]] || return 1
-  IFS='.' read -r -a labels <<<"$value"
-  ((${#labels[@]} >= 2)) || return 1
-  for label in "${labels[@]}"; do
-    [[ "$label" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]] || return 1
-  done
 }
 
 valid_absolute_path() {
@@ -467,7 +480,7 @@ valid_absolute_path() {
     [[ "$value" != */. ]]
 }
 
-validate_configuration() {
+validate_runtime_configuration() {
   local name
   local required=(
     STAGING_POSTGRES_DB
@@ -475,13 +488,6 @@ validate_configuration() {
     STAGING_POSTGRES_PASSWORD
     PORTAL_ADMIN_PASSWORD
     STAGING_SERVER_ENV_FILE
-    STAGING_PORTAL_HOST
-    STAGING_API_HOST
-    STAGING_TLS_CERTIFICATE
-    STAGING_TLS_CERTIFICATE_KEY
-    STAGING_HTPASSWD_FILE
-    STAGING_ACME_ROOT
-    STAGING_PUBLIC_ROOT
   )
   for name in "${required[@]}"; do
     require_value "$name"
@@ -495,16 +501,24 @@ validate_configuration() {
     fail "STAGING_POSTGRES_PASSWORD must be at least 24 URL-safe characters"
   [[ ${#PORTAL_ADMIN_PASSWORD} -ge 16 ]] ||
     fail "PORTAL_ADMIN_PASSWORD must be at least 16 characters"
+  valid_absolute_path "$STAGING_SERVER_ENV_FILE" ||
+    fail "STAGING_SERVER_ENV_FILE must be a safe absolute path"
+  require_private_file "server environment file" "$STAGING_SERVER_ENV_FILE"
+}
 
-  valid_hostname "$STAGING_PORTAL_HOST" ||
-    fail "STAGING_PORTAL_HOST must be a lowercase DNS hostname"
-  valid_hostname "$STAGING_API_HOST" ||
-    fail "STAGING_API_HOST must be a lowercase DNS hostname"
-  [[ "$STAGING_PORTAL_HOST" != "$STAGING_API_HOST" ]] ||
-    fail "Staging Portal and API hostnames must be different"
-
+validate_edge_configuration() {
+  local name
+  local required=(
+    STAGING_TLS_CERTIFICATE
+    STAGING_TLS_CERTIFICATE_KEY
+    STAGING_HTPASSWD_FILE
+    STAGING_ACME_ROOT
+    STAGING_PUBLIC_ROOT
+  )
+  for name in "${required[@]}"; do
+    require_value "$name"
+  done
   for name in \
-    STAGING_SERVER_ENV_FILE \
     STAGING_TLS_CERTIFICATE \
     STAGING_TLS_CERTIFICATE_KEY \
     STAGING_HTPASSWD_FILE \
@@ -513,7 +527,6 @@ validate_configuration() {
     valid_absolute_path "${!name}" || fail "$name must be a safe absolute path"
   done
 
-  require_private_file "server environment file" "$STAGING_SERVER_ENV_FILE"
   require_public_certificate "$STAGING_TLS_CERTIFICATE"
   require_private_key_file "TLS certificate key" "$STAGING_TLS_CERTIFICATE_KEY"
   require_private_file "htpasswd file" "$STAGING_HTPASSWD_FILE"
@@ -694,8 +707,8 @@ render_nginx() {
   [[ -d "$(dirname "$output")" ]] || fail "Nginx output directory does not exist"
   temporary=$(mktemp "${output}.tmp.XXXXXX")
   if ! sed \
-    -e "s|__STAGING_PORTAL_HOST__|$STAGING_PORTAL_HOST|g" \
-    -e "s|__STAGING_API_HOST__|$STAGING_API_HOST|g" \
+    -e "s|__STAGING_PORTAL_HOST__|$staging_portal_host|g" \
+    -e "s|__STAGING_API_HOST__|$staging_api_host|g" \
     -e "s|__STAGING_TLS_CERTIFICATE__|$STAGING_TLS_CERTIFICATE|g" \
     -e "s|__STAGING_TLS_CERTIFICATE_KEY__|$STAGING_TLS_CERTIFICATE_KEY|g" \
     -e "s|__STAGING_HTPASSWD_FILE__|$STAGING_HTPASSWD_FILE|g" \
@@ -908,14 +921,16 @@ verify_runtime() {
 
   portal=$(inspect_runtime_service \
     portal "$portal_image_repository@$PORTAL_IMAGE_DIGEST" true)
-  jq --exit-status --arg network "${compose_project}_portal_edge" '
+  jq --exit-status \
+    --arg network "${compose_project}_portal_edge" \
+    --arg portal_host "$staging_portal_host" '
     def exact_env($key; $value):
       [.Config.Env[]? | select(startswith($key + "="))] ==
         [($key + "=" + $value)];
     .[0] |
     exact_env("PORTAL_ADMIN_PASSWORD"; env.PORTAL_ADMIN_PASSWORD) and
     exact_env("PORTAL_SQLITE_PATH"; "/app/.wrangler/portal.sqlite") and
-    exact_env("VINEXT_TRUSTED_HOSTS"; env.STAGING_PORTAL_HOST) and
+    exact_env("VINEXT_TRUSTED_HOSTS"; $portal_host) and
     (.Mounts | length == 1) and
     .Mounts[0].Type == "volume" and
     .Mounts[0].Name == "xe3-speakup-staging_portal_data" and
@@ -1031,24 +1046,26 @@ write_deployment_receipt() {
   rm -f "$temporary"
 }
 
-validate_all() {
+validate_runtime_all() {
   local manifest=$1
-  local rendered
 
-  validate_configuration
+  validate_runtime_configuration
   validate_manifest "$manifest"
   validate_compose
-  rendered=$(mktemp)
-  render_nginx "$rendered"
-  rm -f "$rendered"
 }
 
 main() {
   local command=${1:-}
+  local edge_environment_file=""
+  local edge_environment_file_seen=false
   local manifest=""
-  local environment_file=""
+  local manifest_seen=false
   local output=""
+  local output_seen=false
   local receipt=""
+  local receipt_seen=false
+  local runtime_environment_file=""
+  local runtime_environment_file_seen=false
 
   [[ -n "$command" ]] || {
     usage
@@ -1058,22 +1075,42 @@ main() {
   while (($# > 0)); do
     case "$1" in
       --manifest)
+        ! $manifest_seen || fail "--manifest may only be provided once"
         (($# >= 2)) || fail "--manifest requires a value"
+        manifest_seen=true
         manifest=$2
         shift 2
         ;;
-      --env-file)
-        (($# >= 2)) || fail "--env-file requires a value"
-        environment_file=$2
+      --runtime-env-file)
+        ! $runtime_environment_file_seen ||
+          fail "--runtime-env-file may only be provided once"
+        (($# >= 2)) || fail "--runtime-env-file requires a value"
+        runtime_environment_file_seen=true
+        runtime_environment_file=$2
         shift 2
         ;;
+      --edge-env-file)
+        ! $edge_environment_file_seen ||
+          fail "--edge-env-file may only be provided once"
+        (($# >= 2)) || fail "--edge-env-file requires a value"
+        edge_environment_file_seen=true
+        edge_environment_file=$2
+        shift 2
+        ;;
+      --env-file)
+        fail "--env-file was removed; use --runtime-env-file or --edge-env-file"
+        ;;
       --output)
+        ! $output_seen || fail "--output may only be provided once"
         (($# >= 2)) || fail "--output requires a value"
+        output_seen=true
         output=$2
         shift 2
         ;;
       --receipt)
+        ! $receipt_seen || fail "--receipt may only be provided once"
         (($# >= 2)) || fail "--receipt requires a value"
+        receipt_seen=true
         receipt=$2
         shift 2
         ;;
@@ -1083,27 +1120,41 @@ main() {
     esac
   done
 
-  [[ -n "$environment_file" ]] || fail "--env-file is required"
-  load_configuration "$environment_file"
-
   case "$command" in
     render-nginx)
-      [[ -z "$manifest" ]] || fail "render-nginx does not accept --manifest"
-      [[ -z "$receipt" ]] || fail "render-nginx does not accept --receipt"
+      $edge_environment_file_seen ||
+        fail "render-nginx requires --edge-env-file"
+      [[ -n "$edge_environment_file" ]] ||
+        fail "render-nginx requires --edge-env-file"
+      ! $runtime_environment_file_seen ||
+        fail "render-nginx does not accept --runtime-env-file"
+      ! $manifest_seen || fail "render-nginx does not accept --manifest"
+      ! $receipt_seen || fail "render-nginx does not accept --receipt"
+      $output_seen || fail "render-nginx requires --output"
       [[ -n "$output" ]] || fail "render-nginx requires --output"
-      validate_configuration
+      load_edge_configuration "$edge_environment_file"
+      validate_edge_configuration
       render_nginx "$output"
       printf 'rendered=%s\n' "$output"
       ;;
     validate | deploy | verify | status | down)
+      $runtime_environment_file_seen ||
+        fail "$command requires --runtime-env-file"
+      [[ -n "$runtime_environment_file" ]] ||
+        fail "$command requires --runtime-env-file"
+      ! $edge_environment_file_seen ||
+        fail "$command does not accept --edge-env-file"
+      $manifest_seen || fail "$command requires --manifest"
       [[ -n "$manifest" ]] || fail "$command requires --manifest"
-      [[ -z "$output" ]] || fail "$command does not accept --output"
+      ! $output_seen || fail "$command does not accept --output"
       if [[ "$command" == deploy ]]; then
+        $receipt_seen || fail "deploy requires --receipt"
         [[ -n "$receipt" ]] || fail "deploy requires --receipt"
       else
-        [[ -z "$receipt" ]] || fail "$command does not accept --receipt"
+        ! $receipt_seen || fail "$command does not accept --receipt"
       fi
-      validate_all "$manifest"
+      load_runtime_configuration "$runtime_environment_file"
+      validate_runtime_all "$manifest"
       case "$command" in
         validate)
           printf 'version=%s git_sha=%s schema=%s validated=true\n' \
@@ -1112,7 +1163,7 @@ main() {
         deploy)
           validate_receipt_target "$receipt"
           acquire_deployment_lock
-          validate_all "$manifest"
+          validate_runtime_all "$manifest"
           validate_receipt_target "$receipt"
           compose pull postgres migrate server portal
           compose up --pull never --detach --no-build --wait --wait-timeout 90 \
@@ -1135,7 +1186,7 @@ main() {
           ;;
         down)
           acquire_deployment_lock
-          validate_all "$manifest"
+          validate_runtime_all "$manifest"
           compose down --remove-orphans
           ;;
       esac

--- a/deploy/staging/staging-edge.env.example
+++ b/deploy/staging/staging-edge.env.example
@@ -1,14 +1,5 @@
-# Raw KEY=value configuration. Do not use shell expressions or quote values.
+# Raw KEY=value edge configuration. Do not use shell expressions or quote values.
 # Copy this file outside the repository and keep the populated copy mode 0600.
-STAGING_POSTGRES_DB=speakup_staging
-STAGING_POSTGRES_USER=speakup_staging
-STAGING_POSTGRES_PASSWORD=
-PORTAL_ADMIN_PASSWORD=
-STAGING_SERVER_ENV_FILE=/etc/speakup/staging-server.env
-
-# DNS, certificate, and access-control choices are injected by the operator.
-STAGING_PORTAL_HOST=staging.speak-up.top
-STAGING_API_HOST=staging-api.speak-up.top
 STAGING_TLS_CERTIFICATE=/opt/xe3-speakup-portal/certbot/conf/live/staging.speak-up.top/fullchain.pem
 STAGING_TLS_CERTIFICATE_KEY=/opt/xe3-speakup-portal/certbot/conf/live/staging.speak-up.top/privkey.pem
 STAGING_HTPASSWD_FILE=/etc/nginx/staging.htpasswd

--- a/deploy/staging/staging-runtime.env.example
+++ b/deploy/staging/staging-runtime.env.example
@@ -1,0 +1,7 @@
+# Raw KEY=value runtime configuration. Do not use shell expressions or quote values.
+# Copy this file outside the repository and keep the populated copy mode 0600.
+STAGING_POSTGRES_DB=speakup_staging
+STAGING_POSTGRES_USER=speakup_staging
+STAGING_POSTGRES_PASSWORD=
+PORTAL_ADMIN_PASSWORD=
+STAGING_SERVER_ENV_FILE=/etc/speakup/staging-server.env

--- a/deploy/staging/test-nginx.sh
+++ b/deploy/staging/test-nginx.sh
@@ -7,9 +7,79 @@ readonly manage="$staging_directory/manage.sh"
 readonly nginx_image="nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de"
 readonly runtime_container="xe3-staging-nginx-test-${PPID}-$$"
 
+fail() {
+  printf 'staging Nginx test: %s\n' "$*" >&2
+  exit 1
+}
+
 cleanup() {
   docker rm --force "$runtime_container" >/dev/null 2>&1 || true
   rm -rf "$temporary_directory"
+}
+
+write_edge_environment() {
+  local destination=$1
+  local certificate=${2:-$temporary_directory/fullchain.pem}
+  local certificate_key=${3:-$temporary_directory/privkey.pem}
+  local htpasswd=${4:-$temporary_directory/staging.htpasswd}
+  local acme_root=${5:-$temporary_directory/acme}
+  local public_root=${6:-$temporary_directory/public}
+
+  printf '%s\n' \
+    "STAGING_TLS_CERTIFICATE=$certificate" \
+    "STAGING_TLS_CERTIFICATE_KEY=$certificate_key" \
+    "STAGING_HTPASSWD_FILE=$htpasswd" \
+    "STAGING_ACME_ROOT=$acme_root" \
+    "STAGING_PUBLIC_ROOT=$public_root" \
+    >"$destination"
+  chmod 0600 "$destination"
+}
+
+failure_index=0
+LAST_FAILURE_OUTPUT=
+
+expect_failure_without_compose() {
+  local name=$1
+  shift
+
+  failure_index=$((failure_index + 1))
+  LAST_FAILURE_OUTPUT="$temporary_directory/failure-$failure_index.out"
+  rm -f "$compose_marker"
+  if env \
+    TEST_COMPOSE_MARKER="$compose_marker" \
+    PATH="$temporary_directory/fake-bin:$PATH" \
+    "$@" >"$LAST_FAILURE_OUTPUT" 2>&1; then
+    fail "$name unexpectedly succeeded"
+  fi
+  [[ ! -e "$compose_marker" ]] ||
+    fail "$name invoked Docker Compose before failing"
+}
+
+expect_edge_failure() {
+  local name=$1
+  local environment_file=$2
+  local output="$temporary_directory/rejected-$failure_index.conf"
+
+  expect_failure_without_compose "$name" \
+    "$manage" render-nginx \
+      --edge-env-file "$environment_file" \
+      --output "$output"
+  [[ ! -e "$output" ]] || fail "$name wrote a rejected Nginx configuration"
+}
+
+render_edge_without_compose() {
+  local environment_file=$1
+  local output=$2
+
+  rm -f "$compose_marker"
+  env \
+    TEST_COMPOSE_MARKER="$compose_marker" \
+    PATH="$temporary_directory/fake-bin:$PATH" \
+    "$manage" render-nginx \
+      --edge-env-file "$environment_file" \
+      --output "$output" \
+      >/dev/null
+  [[ ! -e "$compose_marker" ]] || fail 'render-nginx invoked Docker Compose'
 }
 
 assert_contains() {
@@ -53,12 +123,10 @@ assert_curl_succeeds() {
 }
 
 command -v docker >/dev/null 2>&1 || {
-  printf '%s\n' 'docker is required for the Nginx configuration check' >&2
-  exit 1
+  fail 'docker is required for the Nginx configuration check'
 }
 command -v openssl >/dev/null 2>&1 || {
-  printf '%s\n' 'openssl is required for the Nginx configuration check' >&2
-  exit 1
+  fail 'openssl is required for the Nginx configuration check'
 }
 
 temporary_directory=$(mktemp -d)
@@ -67,9 +135,9 @@ readonly temporary_directory
 trap cleanup EXIT
 
 mkdir -p "$temporary_directory/acme" \
+  "$temporary_directory/fake-bin" \
   "$temporary_directory/logs" \
   "$temporary_directory/public/downloads/android/v0.1.0"
-printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
 password_hash=$(openssl passwd -apr1 'test-password')
 printf 'staging:%s\n' "$password_hash" >"$temporary_directory/staging.htpasswd"
 chmod 0644 "$temporary_directory/staging.htpasswd"
@@ -116,30 +184,465 @@ openssl req \
   -out "$temporary_directory/fullchain.pem" \
   >/dev/null 2>&1
 chmod 0600 \
-  "$temporary_directory/server.env" \
   "$temporary_directory/staging.htpasswd" \
   "$temporary_directory/privkey.pem"
 
 printf '%s\n' \
-  'STAGING_POSTGRES_DB=speakup_staging' \
-  'STAGING_POSTGRES_USER=speakup_staging' \
-  'STAGING_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef' \
-  'PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests' \
-  "STAGING_SERVER_ENV_FILE=$temporary_directory/server.env" \
-  'STAGING_PORTAL_HOST=staging.speak-up.top' \
-  'STAGING_API_HOST=staging-api.speak-up.top' \
-  "STAGING_TLS_CERTIFICATE=$temporary_directory/fullchain.pem" \
-  "STAGING_TLS_CERTIFICATE_KEY=$temporary_directory/privkey.pem" \
-  "STAGING_HTPASSWD_FILE=$temporary_directory/staging.htpasswd" \
-  "STAGING_ACME_ROOT=$temporary_directory/acme" \
-  "STAGING_PUBLIC_ROOT=$temporary_directory/public" \
-  >"$temporary_directory/staging.env"
-chmod 0600 "$temporary_directory/staging.env"
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  ': > "$TEST_COMPOSE_MARKER"' \
+  'exit 97' \
+  >"$temporary_directory/fake-bin/docker"
+chmod 0700 "$temporary_directory/fake-bin/docker"
+readonly compose_marker="$temporary_directory/compose-called"
 
-"$manage" render-nginx \
-  --env-file "$temporary_directory/staging.env" \
-  --output "$temporary_directory/default.conf" \
-  >/dev/null
+readonly edge_environment="$temporary_directory/staging-edge.env"
+write_edge_environment "$edge_environment"
+
+for forbidden_input in \
+  "$temporary_directory/staging-runtime.env" \
+  "$temporary_directory/server.env" \
+  "$temporary_directory/release-manifest.json"; do
+  [[ ! -e "$forbidden_input" && ! -L "$forbidden_input" ]] ||
+    fail "edge fixture unexpectedly created runtime input: $forbidden_input"
+done
+
+cross_secret='runtime-secret-must-not-leak'
+printf '%s\n%s\n' \
+  "$(<"$edge_environment")" \
+  "STAGING_POSTGRES_PASSWORD=$cross_secret" \
+  >"$temporary_directory/cross-runtime-key.env"
+chmod 0600 "$temporary_directory/cross-runtime-key.env"
+expect_edge_failure \
+  'edge environment containing a runtime key' \
+  "$temporary_directory/cross-runtime-key.env"
+if grep -Fq "$cross_secret" "$LAST_FAILURE_OUTPUT"; then
+  fail 'rejected runtime key leaked its Secret value'
+fi
+
+legacy_output="$temporary_directory/legacy.conf"
+expect_failure_without_compose 'legacy --env-file' \
+  "$manage" render-nginx \
+    --env-file "$edge_environment" \
+    --output "$legacy_output"
+[[ ! -e "$legacy_output" ]] || fail 'legacy --env-file wrote Nginx configuration'
+grep -Fq -- '--edge-env-file' "$LAST_FAILURE_OUTPUT" ||
+  fail 'legacy --env-file rejection did not provide the edge migration flag'
+
+runtime_argument_index=0
+for runtime_argument in --runtime-env-file --manifest --receipt; do
+  runtime_argument_index=$((runtime_argument_index + 1))
+  runtime_argument_output="$temporary_directory/runtime-argument-$runtime_argument_index.conf"
+  expect_failure_without_compose "render-nginx with $runtime_argument" \
+    "$manage" render-nginx \
+      --edge-env-file "$edge_environment" \
+      "$runtime_argument" "$temporary_directory/does-not-exist" \
+      --output "$runtime_argument_output"
+  [[ ! -e "$runtime_argument_output" ]] ||
+    fail "render-nginx with $runtime_argument wrote Nginx configuration"
+done
+
+empty_runtime_output="$temporary_directory/empty-runtime-argument.conf"
+expect_failure_without_compose 'render-nginx with empty runtime argument' \
+  "$manage" render-nginx \
+    --edge-env-file "$edge_environment" \
+    --runtime-env-file '' \
+    --output "$empty_runtime_output"
+[[ ! -e "$empty_runtime_output" ]] ||
+  fail 'render-nginx with empty runtime argument wrote Nginx configuration'
+
+for empty_edge_argument in --edge-env-file --output; do
+  empty_edge_argument_output="$temporary_directory/empty-${empty_edge_argument#--}.conf"
+  case "$empty_edge_argument" in
+    --edge-env-file)
+      expect_failure_without_compose 'render-nginx with empty edge env argument' \
+        "$manage" render-nginx \
+          --edge-env-file '' \
+          --output "$empty_edge_argument_output"
+      ;;
+    --output)
+      expect_failure_without_compose 'render-nginx with empty output argument' \
+        "$manage" render-nginx \
+          --edge-env-file "$edge_environment" \
+          --output ''
+      ;;
+  esac
+  [[ ! -e "$empty_edge_argument_output" ]] ||
+    fail "empty required edge argument wrote Nginx configuration: $empty_edge_argument"
+done
+
+duplicate_edge_argument_index=0
+for duplicate_edge_argument in --edge-env-file --output; do
+  duplicate_edge_argument_index=$((duplicate_edge_argument_index + 1))
+  duplicate_edge_argument_output="$temporary_directory/duplicate-edge-argument-$duplicate_edge_argument_index.conf"
+  case "$duplicate_edge_argument" in
+    --edge-env-file)
+      duplicate_edge_argument_value="$edge_environment"
+      ;;
+    --output)
+      duplicate_edge_argument_value="$temporary_directory/other-edge-output.conf"
+      ;;
+  esac
+  expect_failure_without_compose \
+    "render-nginx with duplicate $duplicate_edge_argument" \
+    "$manage" render-nginx \
+      --edge-env-file "$edge_environment" \
+      --output "$duplicate_edge_argument_output" \
+      "$duplicate_edge_argument" "$duplicate_edge_argument_value"
+  [[ ! -e "$duplicate_edge_argument_output" ]] ||
+    fail "duplicate edge argument wrote Nginx configuration: $duplicate_edge_argument"
+done
+
+edge_keys=$(sed -n 's/=.*//p' "$edge_environment" | LC_ALL=C sort)
+[[ "$edge_keys" == $'STAGING_ACME_ROOT\nSTAGING_HTPASSWD_FILE\nSTAGING_PUBLIC_ROOT\nSTAGING_TLS_CERTIFICATE\nSTAGING_TLS_CERTIFICATE_KEY' ]] ||
+  fail 'edge fixture does not contain the exact edge key set'
+
+grep -v '^STAGING_HTPASSWD_FILE=' \
+  "$edge_environment" >"$temporary_directory/missing-edge-key.env"
+chmod 0600 "$temporary_directory/missing-edge-key.env"
+missing_edge_output="$temporary_directory/missing-edge-key.conf"
+expect_failure_without_compose 'ambient edge value replacing a missing key' \
+  env STAGING_HTPASSWD_FILE="$temporary_directory/staging.htpasswd" \
+  "$manage" render-nginx \
+    --edge-env-file "$temporary_directory/missing-edge-key.env" \
+    --output "$missing_edge_output"
+[[ ! -e "$missing_edge_output" ]] ||
+  fail 'ambient edge value wrote Nginx configuration'
+
+printf '%s\n%s\n' \
+  "$(<"$edge_environment")" \
+  "STAGING_ACME_ROOT=$temporary_directory/acme" \
+  >"$temporary_directory/duplicate-edge-key.env"
+chmod 0600 "$temporary_directory/duplicate-edge-key.env"
+expect_edge_failure \
+  'duplicate edge key' \
+  "$temporary_directory/duplicate-edge-key.env"
+
+edge_secret_sentinel='edge-secret-must-not-leak'
+printf '%s\n%s\n' \
+  "$(<"$edge_environment")" \
+  "INVALID-KEY=$edge_secret_sentinel" \
+  >"$temporary_directory/malformed-edge.env"
+chmod 0600 "$temporary_directory/malformed-edge.env"
+expect_edge_failure \
+  'malformed edge key' \
+  "$temporary_directory/malformed-edge.env"
+if grep -Fq "$edge_secret_sentinel" "$LAST_FAILURE_OUTPUT"; then
+  fail 'malformed edge entry leaked its raw content'
+fi
+grep -Eq 'at line [1-9][0-9]*' "$LAST_FAILURE_OUTPUT" ||
+  fail 'malformed edge entry did not report a safe line number'
+
+cp "$edge_environment" "$temporary_directory/insecure-edge.env"
+chmod 0640 "$temporary_directory/insecure-edge.env"
+expect_edge_failure \
+  'group-readable edge environment' \
+  "$temporary_directory/insecure-edge.env"
+
+ln -s "$edge_environment" "$temporary_directory/edge-link.env"
+expect_edge_failure \
+  'symbolic-link edge environment' \
+  "$temporary_directory/edge-link.env"
+
+mkdir "$temporary_directory/edge-env-ancestor-target"
+cp "$edge_environment" \
+  "$temporary_directory/edge-env-ancestor-target/staging-edge.env"
+chmod 0600 "$temporary_directory/edge-env-ancestor-target/staging-edge.env"
+ln -s "$temporary_directory/edge-env-ancestor-target" \
+  "$temporary_directory/edge-env-ancestor-link"
+expect_edge_failure \
+  'edge environment with a symbolic-link ancestor' \
+  "$temporary_directory/edge-env-ancestor-link/staging-edge.env"
+
+mkdir -p \
+  "$temporary_directory/input-ancestor-target/nested/acme" \
+  "$temporary_directory/input-ancestor-target/nested/public" \
+  "$temporary_directory/unsafe-input-ancestor/nested"
+cp \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/input-ancestor-target/nested/"
+chmod 0600 \
+  "$temporary_directory/input-ancestor-target/nested/privkey.pem" \
+  "$temporary_directory/input-ancestor-target/nested/staging.htpasswd"
+ln -s "$temporary_directory/input-ancestor-target" \
+  "$temporary_directory/input-ancestor-link"
+
+write_edge_environment \
+  "$temporary_directory/certificate-ancestor-link.env" \
+  "$temporary_directory/input-ancestor-link/nested/fullchain.pem"
+expect_edge_failure \
+  'TLS certificate with a symbolic-link ancestor' \
+  "$temporary_directory/certificate-ancestor-link.env"
+
+write_edge_environment \
+  "$temporary_directory/key-ancestor-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/input-ancestor-link/nested/privkey.pem"
+expect_edge_failure \
+  'TLS private key with a symbolic-link ancestor' \
+  "$temporary_directory/key-ancestor-link.env"
+
+write_edge_environment \
+  "$temporary_directory/htpasswd-ancestor-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/input-ancestor-link/nested/staging.htpasswd"
+expect_edge_failure \
+  'htpasswd with a symbolic-link ancestor' \
+  "$temporary_directory/htpasswd-ancestor-link.env"
+
+write_edge_environment \
+  "$temporary_directory/acme-ancestor-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/input-ancestor-link/nested/acme"
+expect_edge_failure \
+  'ACME root with a symbolic-link ancestor' \
+  "$temporary_directory/acme-ancestor-link.env"
+
+write_edge_environment \
+  "$temporary_directory/public-ancestor-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/acme" \
+  "$temporary_directory/input-ancestor-link/nested/public"
+expect_edge_failure \
+  'public root with a symbolic-link ancestor' \
+  "$temporary_directory/public-ancestor-link.env"
+
+chmod 0777 "$temporary_directory/unsafe-input-ancestor"
+cp "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/unsafe-input-ancestor/nested/fullchain.pem"
+write_edge_environment \
+  "$temporary_directory/unsafe-certificate-ancestor.env" \
+  "$temporary_directory/unsafe-input-ancestor/nested/fullchain.pem"
+expect_edge_failure \
+  'TLS certificate with an unsafe writable ancestor' \
+  "$temporary_directory/unsafe-certificate-ancestor.env"
+
+cp "$temporary_directory/privkey.pem" "$temporary_directory/insecure-key.pem"
+chmod 0644 "$temporary_directory/insecure-key.pem"
+write_edge_environment \
+  "$temporary_directory/insecure-key.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/insecure-key.pem"
+expect_edge_failure \
+  'world-readable TLS private key' \
+  "$temporary_directory/insecure-key.env"
+
+ln -s "$temporary_directory/privkey.pem" "$temporary_directory/key-link.pem"
+write_edge_environment \
+  "$temporary_directory/key-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/key-link.pem"
+render_edge_without_compose \
+  "$temporary_directory/key-link.env" \
+  "$temporary_directory/key-link.conf"
+
+mkdir -p \
+  "$temporary_directory/certbot/live/staging.speak-up.top" \
+  "$temporary_directory/certbot/archive/staging.speak-up.top"
+cp "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/certbot/archive/staging.speak-up.top/fullchain1.pem"
+cp "$temporary_directory/privkey.pem" \
+  "$temporary_directory/certbot/archive/staging.speak-up.top/privkey1.pem"
+chmod 0600 \
+  "$temporary_directory/certbot/archive/staging.speak-up.top/privkey1.pem"
+ln -s ../../archive/staging.speak-up.top/fullchain1.pem \
+  "$temporary_directory/certbot/live/staging.speak-up.top/fullchain.pem"
+ln -s ../../archive/staging.speak-up.top/privkey1.pem \
+  "$temporary_directory/certbot/live/staging.speak-up.top/privkey.pem"
+write_edge_environment \
+  "$temporary_directory/certbot-links.env" \
+  "$temporary_directory/certbot/live/staging.speak-up.top/fullchain.pem" \
+  "$temporary_directory/certbot/live/staging.speak-up.top/privkey.pem"
+render_edge_without_compose \
+  "$temporary_directory/certbot-links.env" \
+  "$temporary_directory/certbot-links.conf"
+
+ln -s "$temporary_directory/not-there-key.pem" \
+  "$temporary_directory/broken-key-link.pem"
+write_edge_environment \
+  "$temporary_directory/broken-key-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/broken-key-link.pem"
+expect_edge_failure \
+  'broken TLS private-key symlink' \
+  "$temporary_directory/broken-key-link.env"
+
+ln -s "$temporary_directory/insecure-key.pem" \
+  "$temporary_directory/insecure-key-link.pem"
+write_edge_environment \
+  "$temporary_directory/insecure-key-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/insecure-key-link.pem"
+expect_edge_failure \
+  'TLS private-key symlink with an insecure target' \
+  "$temporary_directory/insecure-key-link.env"
+
+cp "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/insecure.htpasswd"
+chmod 0644 "$temporary_directory/insecure.htpasswd"
+write_edge_environment \
+  "$temporary_directory/insecure-htpasswd.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/insecure.htpasswd"
+expect_edge_failure \
+  'world-readable htpasswd' \
+  "$temporary_directory/insecure-htpasswd.env"
+
+ln -s "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/htpasswd-link"
+write_edge_environment \
+  "$temporary_directory/htpasswd-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/htpasswd-link"
+expect_edge_failure \
+  'symbolic-link htpasswd' \
+  "$temporary_directory/htpasswd-link.env"
+
+cp "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/insecure-certificate.pem"
+chmod 0664 "$temporary_directory/insecure-certificate.pem"
+write_edge_environment \
+  "$temporary_directory/insecure-certificate.env" \
+  "$temporary_directory/insecure-certificate.pem"
+expect_edge_failure \
+  'group-writable public certificate' \
+  "$temporary_directory/insecure-certificate.env"
+
+mkdir "$temporary_directory/insecure-acme"
+chmod 0777 "$temporary_directory/insecure-acme"
+write_edge_environment \
+  "$temporary_directory/insecure-acme.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/insecure-acme"
+expect_edge_failure \
+  'world-writable ACME root' \
+  "$temporary_directory/insecure-acme.env"
+
+mkdir "$temporary_directory/acme-target"
+ln -s "$temporary_directory/acme-target" "$temporary_directory/acme-link"
+write_edge_environment \
+  "$temporary_directory/acme-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/acme-link"
+expect_edge_failure \
+  'symbolic-link ACME root' \
+  "$temporary_directory/acme-link.env"
+
+chmod 0777 "$temporary_directory/public"
+expect_edge_failure \
+  'world-writable public root' \
+  "$edge_environment"
+chmod 0755 "$temporary_directory/public"
+
+chmod 0777 "$temporary_directory/public/downloads/android"
+expect_edge_failure \
+  'world-writable Android public directory' \
+  "$edge_environment"
+chmod 0755 "$temporary_directory/public/downloads/android"
+
+mkdir "$temporary_directory/public-target"
+ln -s "$temporary_directory/public-target" "$temporary_directory/public-link"
+write_edge_environment \
+  "$temporary_directory/public-link.env" \
+  "$temporary_directory/fullchain.pem" \
+  "$temporary_directory/privkey.pem" \
+  "$temporary_directory/staging.htpasswd" \
+  "$temporary_directory/acme" \
+  "$temporary_directory/public-link"
+expect_edge_failure \
+  'symbolic-link public root' \
+  "$temporary_directory/public-link.env"
+
+real_id=$(command -v id)
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [[ "${1:-}" == -u ]]; then' \
+  '  printf "%s\\n" 999999' \
+  '  exit' \
+  'fi' \
+  'exec "$TEST_REAL_ID" "$@"' \
+  >"$temporary_directory/fake-bin/id"
+chmod 0700 "$temporary_directory/fake-bin/id"
+wrong_edge_owner_output="$temporary_directory/wrong-edge-owner.conf"
+expect_failure_without_compose 'edge environment owned by another UID' \
+  env \
+    TEST_REAL_ID="$real_id" \
+    PATH="$temporary_directory/fake-bin:$PATH" \
+  "$manage" render-nginx \
+    --edge-env-file "$edge_environment" \
+    --output "$wrong_edge_owner_output"
+[[ ! -e "$wrong_edge_owner_output" ]] ||
+  fail 'wrongly owned edge environment wrote Nginx configuration'
+rm "$temporary_directory/fake-bin/id"
+
+mkdir "$temporary_directory/fake-owner-bin"
+real_stat=$(command -v stat)
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'path=${!#}' \
+  'if [[ "$path" == "${TEST_WRONG_OWNER_PATH:-}" ]]; then' \
+  '  for argument in "$@"; do' \
+  '    if [[ "$argument" == "%u" ]]; then' \
+  '      printf "%s\\n" 999999' \
+  '      exit' \
+  '    fi' \
+  '  done' \
+  'fi' \
+  'exec "$TEST_REAL_STAT" "$@"' \
+  >"$temporary_directory/fake-owner-bin/stat"
+chmod 0700 "$temporary_directory/fake-owner-bin/stat"
+owner_case_index=0
+for owner_case in \
+  "$temporary_directory/fullchain.pem|public certificate" \
+  "$temporary_directory/staging.htpasswd|htpasswd" \
+  "$temporary_directory/acme|ACME root" \
+  "$temporary_directory/public|public root"; do
+  owner_case_index=$((owner_case_index + 1))
+  owner_path=${owner_case%%|*}
+  owner_description=${owner_case#*|}
+  owner_output="$temporary_directory/wrong-edge-owner-$owner_case_index.conf"
+  expect_failure_without_compose "$owner_description owned by another UID" \
+    env \
+      TEST_REAL_STAT="$real_stat" \
+      TEST_WRONG_OWNER_PATH="$owner_path" \
+      PATH="$temporary_directory/fake-owner-bin:$temporary_directory/fake-bin:$PATH" \
+    "$manage" render-nginx \
+      --edge-env-file "$edge_environment" \
+      --output "$owner_output"
+  [[ ! -e "$owner_output" ]] ||
+    fail "$owner_description owned by another UID wrote Nginx configuration"
+done
+
+wrong_key_owner_output="$temporary_directory/wrong-key-owner.conf"
+expect_failure_without_compose \
+  'TLS private-key symlink target owned by another UID' \
+  env \
+    TEST_REAL_STAT="$real_stat" \
+    TEST_WRONG_OWNER_PATH="$temporary_directory/privkey.pem" \
+    PATH="$temporary_directory/fake-owner-bin:$temporary_directory/fake-bin:$PATH" \
+  "$manage" render-nginx \
+    --edge-env-file "$temporary_directory/key-link.env" \
+    --output "$wrong_key_owner_output"
+[[ ! -e "$wrong_key_owner_output" ]] ||
+  fail 'wrongly owned TLS private-key target wrote Nginx configuration'
+
+render_edge_without_compose \
+  "$edge_environment" \
+  "$temporary_directory/default.conf"
 
 for expected in \
   'access_log logs/xe3-speakup-staging-portal.access.log;' \

--- a/deploy/staging/test.sh
+++ b/deploy/staging/test.sh
@@ -25,27 +25,16 @@ expect_failure() {
   fi
 }
 
-write_environment() {
+write_runtime_environment() {
   local destination=$1
   local server_environment=$2
-  local certificate=${3:-$temporary_directory/fullchain.pem}
-  local certificate_key=${4:-$temporary_directory/privkey.pem}
-  local htpasswd=${5:-$temporary_directory/staging.htpasswd}
-  local acme_root=${6:-$temporary_directory/acme}
 
   printf '%s\n' \
     'STAGING_POSTGRES_DB=speakup_staging' \
     'STAGING_POSTGRES_USER=speakup_staging' \
     'STAGING_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef' \
     'PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests' \
-    "STAGING_SERVER_ENV_FILE=$server_environment" \
-    'STAGING_PORTAL_HOST=staging.speak-up.top' \
-    'STAGING_API_HOST=staging-api.speak-up.top' \
-    "STAGING_TLS_CERTIFICATE=$certificate" \
-    "STAGING_TLS_CERTIFICATE_KEY=$certificate_key" \
-    "STAGING_HTPASSWD_FILE=$htpasswd" \
-    "STAGING_ACME_ROOT=$acme_root" \
-    "STAGING_PUBLIC_ROOT=$temporary_directory/public" >"$destination"
+    "STAGING_SERVER_ENV_FILE=$server_environment" >"$destination"
   chmod 0600 "$destination"
 }
 
@@ -82,53 +71,136 @@ temporary_directory=$(cd "$temporary_directory" && pwd -P)
 readonly temporary_directory
 trap 'rm -rf "$temporary_directory"' EXIT
 
-mkdir -p \
-  "$temporary_directory/acme" \
-  "$temporary_directory/fake-bin" \
-  "$temporary_directory/public"
+mkdir -p "$temporary_directory/fake-bin"
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$temporary_directory/server.env"
-printf '%s\n' 'test-user:test-password-hash' >"$temporary_directory/staging.htpasswd"
-printf '%s\n' 'test-certificate-placeholder' >"$temporary_directory/fullchain.pem"
-printf '%s\n' 'test-key-placeholder' >"$temporary_directory/privkey.pem"
-chmod 0600 \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/staging.htpasswd" \
-  "$temporary_directory/privkey.pem"
-write_environment "$temporary_directory/staging.env" "$temporary_directory/server.env"
+chmod 0600 "$temporary_directory/server.env"
+write_runtime_environment \
+  "$temporary_directory/staging-runtime.env" \
+  "$temporary_directory/server.env"
 write_manifest "$temporary_directory/release-manifest.json"
 
 bash -n "$manage" "$0"
 
 "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/staging.env" \
+  --runtime-env-file "$temporary_directory/staging-runtime.env" \
   >"$temporary_directory/validate.out"
 grep -Fq 'validated=true' "$temporary_directory/validate.out" ||
   fail "valid deployment contract was not accepted"
 
-chmod 0777 "$temporary_directory/public"
-expect_failure "world-writable public root" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
-chmod 0700 "$temporary_directory/public"
+mkdir "$temporary_directory/reject-bin"
+cat >"$temporary_directory/reject-bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${COMMAND_LOG:-}" ]] || printf 'docker %s\n' "$*" >>"$COMMAND_LOG"
+exit 99
+EOF
+chmod +x "$temporary_directory/reject-bin/docker"
+readonly reject_path="$temporary_directory/reject-bin:$PATH"
 
-mkdir -p "$temporary_directory/public/downloads/android"
-chmod 0777 "$temporary_directory/public/downloads/android"
-expect_failure "world-writable Android public directory" \
+legacy_argument_log="$temporary_directory/legacy-argument.log"
+: >"$legacy_argument_log"
+expect_failure "legacy runtime --env-file argument" \
+  env COMMAND_LOG="$legacy_argument_log" PATH="$reject_path" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
-chmod 0700 "$temporary_directory/public/downloads/android"
-rmdir \
-  "$temporary_directory/public/downloads/android" \
-  "$temporary_directory/public/downloads"
+    --env-file "$temporary_directory/staging-runtime.env"
+grep -Fq -- '--runtime-env-file' "$temporary_directory/failure.out" ||
+  fail "legacy --env-file rejection did not identify --runtime-env-file"
+[[ ! -s "$legacy_argument_log" ]] ||
+  fail "legacy --env-file rejection invoked Docker"
+
+empty_edge_log="$temporary_directory/empty-edge.log"
+: >"$empty_edge_log"
+expect_failure "empty edge argument on runtime command" \
+  env COMMAND_LOG="$empty_edge_log" PATH="$reject_path" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --runtime-env-file "$temporary_directory/staging-runtime.env" \
+    --edge-env-file ''
+[[ ! -s "$empty_edge_log" ]] ||
+  fail "empty forbidden edge argument invoked Docker"
+
+empty_required_argument_index=0
+for empty_required_argument in --manifest --runtime-env-file --receipt; do
+  empty_required_argument_index=$((empty_required_argument_index + 1))
+  empty_required_argument_log="$temporary_directory/empty-required-argument-$empty_required_argument_index.log"
+  : >"$empty_required_argument_log"
+  case "$empty_required_argument" in
+    --manifest)
+      expect_failure "empty required runtime argument $empty_required_argument" \
+        env COMMAND_LOG="$empty_required_argument_log" PATH="$reject_path" \
+        "$manage" validate \
+          --manifest '' \
+          --runtime-env-file "$temporary_directory/staging-runtime.env"
+      ;;
+    --runtime-env-file)
+      expect_failure "empty required runtime argument $empty_required_argument" \
+        env COMMAND_LOG="$empty_required_argument_log" PATH="$reject_path" \
+        "$manage" validate \
+          --manifest "$temporary_directory/release-manifest.json" \
+          --runtime-env-file ''
+      ;;
+    --receipt)
+      expect_failure "empty required runtime argument $empty_required_argument" \
+        env COMMAND_LOG="$empty_required_argument_log" PATH="$reject_path" \
+        "$manage" deploy \
+          --manifest "$temporary_directory/release-manifest.json" \
+          --runtime-env-file "$temporary_directory/staging-runtime.env" \
+          --receipt ''
+      ;;
+  esac
+  [[ ! -s "$empty_required_argument_log" ]] ||
+    fail "empty required runtime argument invoked Docker: $empty_required_argument"
+done
+
+duplicate_runtime_argument_index=0
+for duplicate_runtime_argument in --manifest --runtime-env-file --receipt; do
+  duplicate_runtime_argument_index=$((duplicate_runtime_argument_index + 1))
+  duplicate_runtime_argument_log="$temporary_directory/duplicate-runtime-argument-$duplicate_runtime_argument_index.log"
+  : >"$duplicate_runtime_argument_log"
+  case "$duplicate_runtime_argument" in
+    --manifest)
+      duplicate_runtime_argument_value="$temporary_directory/release-manifest.json"
+      ;;
+    --runtime-env-file)
+      duplicate_runtime_argument_value="$temporary_directory/staging-runtime.env"
+      ;;
+    --receipt)
+      duplicate_runtime_argument_value="$temporary_directory/other-receipt.json"
+      ;;
+  esac
+  expect_failure "duplicate runtime argument $duplicate_runtime_argument" \
+    env COMMAND_LOG="$duplicate_runtime_argument_log" PATH="$reject_path" \
+    "$manage" deploy \
+      --manifest "$temporary_directory/release-manifest.json" \
+      --runtime-env-file "$temporary_directory/staging-runtime.env" \
+      --receipt "$temporary_directory/receipt.json" \
+      "$duplicate_runtime_argument" "$duplicate_runtime_argument_value"
+  [[ ! -s "$duplicate_runtime_argument_log" ]] ||
+    fail "duplicate runtime argument invoked Docker: $duplicate_runtime_argument"
+done
+
+printf '%s\n%s\n' \
+  "$(<"$temporary_directory/staging-runtime.env")" \
+  'STAGING_TLS_CERTIFICATE=/edge-only/fullchain.pem' \
+  >"$temporary_directory/cross-edge.env"
+chmod 0600 "$temporary_directory/cross-edge.env"
+cross_edge_log="$temporary_directory/cross-edge.log"
+: >"$cross_edge_log"
+expect_failure "edge key in runtime environment" \
+  env COMMAND_LOG="$cross_edge_log" PATH="$reject_path" \
+  "$manage" validate \
+    --manifest "$temporary_directory/release-manifest.json" \
+    --runtime-env-file "$temporary_directory/cross-edge.env"
+[[ ! -s "$cross_edge_log" ]] ||
+  fail "cross-scope runtime environment invoked Docker"
 
 write_manifest "$temporary_directory/invalid-manifest.json" 'latest'
 expect_failure "mutable Portal image reference" \
   "$manage" validate \
   --manifest "$temporary_directory/invalid-manifest.json" \
-  --env-file "$temporary_directory/staging.env"
+  --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 write_manifest \
   "$temporary_directory/zero-digest-manifest.json" \
@@ -136,7 +208,7 @@ write_manifest \
 expect_failure "placeholder Portal digest" \
   "$manage" validate \
   --manifest "$temporary_directory/zero-digest-manifest.json" \
-  --env-file "$temporary_directory/staging.env"
+  --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 jq 'del(.quality_run_url)' \
   "$temporary_directory/release-manifest.json" \
@@ -144,7 +216,7 @@ jq 'del(.quality_run_url)' \
 expect_failure "incomplete release manifest" \
   "$manage" validate \
     --manifest "$temporary_directory/incomplete-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 jq '.unexpected = true' \
   "$temporary_directory/release-manifest.json" \
@@ -152,7 +224,7 @@ jq '.unexpected = true' \
 expect_failure "release manifest with an unknown field" \
   "$manage" validate \
     --manifest "$temporary_directory/extended-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 printf '%s\n%s\n' \
   "$(< "$temporary_directory/release-manifest.json")" \
@@ -161,43 +233,52 @@ printf '%s\n%s\n' \
 expect_failure "multiple release manifest documents" \
   "$manage" validate \
     --manifest "$temporary_directory/multiple-manifests.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 expect_failure "missing release manifest" \
   "$manage" validate \
   --manifest "$temporary_directory/missing.json" \
-  --env-file "$temporary_directory/staging.env"
+  --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 expect_failure "missing environment file" \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/not-there.env"
+  --runtime-env-file "$temporary_directory/not-there.env"
 
 sed 's/^PORTAL_ADMIN_PASSWORD=.*/PORTAL_ADMIN_PASSWORD=/' \
-  "$temporary_directory/staging.env" >"$temporary_directory/missing-value.env"
+  "$temporary_directory/staging-runtime.env" >"$temporary_directory/missing-value.env"
 chmod 0600 "$temporary_directory/missing-value.env"
 expect_failure "missing required environment value" \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/missing-value.env"
+  --runtime-env-file "$temporary_directory/missing-value.env"
 
 sed '/^PORTAL_ADMIN_PASSWORD=/d' \
-  "$temporary_directory/staging.env" >"$temporary_directory/missing-key.env"
+  "$temporary_directory/staging-runtime.env" >"$temporary_directory/missing-key.env"
 chmod 0600 "$temporary_directory/missing-key.env"
 expect_failure "ambient value replacing a missing environment key" \
-  env PORTAL_ADMIN_PASSWORD=ambient-password-must-not-be-used \
+  env \
+    COMMAND_LOG="$temporary_directory/ambient-fallback.log" \
+    PATH="$reject_path" \
+    PORTAL_ADMIN_PASSWORD=ambient-password-must-not-be-used \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/missing-key.env"
+  --runtime-env-file "$temporary_directory/missing-key.env"
+[[ ! -s "$temporary_directory/ambient-fallback.log" ]] ||
+  fail "ambient runtime fallback invoked Docker"
+if grep -Fq 'ambient-password-must-not-be-used' \
+  "$temporary_directory/failure.out"; then
+  fail "ambient runtime value was exposed in the rejection output"
+fi
 
 printf '%s\n' \
-  "$(<"$temporary_directory/staging.env")" \
+  "$(<"$temporary_directory/staging-runtime.env")" \
   'UNKNOWN_SETTING=typo' >"$temporary_directory/unknown.env"
 chmod 0600 "$temporary_directory/unknown.env"
 expect_failure "unknown environment setting" \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/unknown.env"
+  --runtime-env-file "$temporary_directory/unknown.env"
 
 readonly secret_sentinel='must-not-leak-environment-secret-sentinel'
 environment_leak_index=0
@@ -209,12 +290,12 @@ for unsafe_environment_line in \
   leak_environment="$temporary_directory/leak-$environment_leak_index.env"
   leak_output="$temporary_directory/leak-$environment_leak_index.out"
   printf '%s\n%s\n' \
-    "$(< "$temporary_directory/staging.env")" \
+    "$(< "$temporary_directory/staging-runtime.env")" \
     "$unsafe_environment_line" > "$leak_environment"
   chmod 0600 "$leak_environment"
   if "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$leak_environment" > "$leak_output" 2>&1; then
+    --runtime-env-file "$leak_environment" > "$leak_output" 2>&1; then
     fail "invalid environment entry unexpectedly succeeded"
   fi
   if grep -Fq "$secret_sentinel" "$leak_output"; then
@@ -224,254 +305,79 @@ for unsafe_environment_line in \
     fail "invalid environment entry did not report a safe line number"
 done
 
-write_environment "$temporary_directory/missing-server.env" "$temporary_directory/not-there.env"
+write_runtime_environment "$temporary_directory/missing-server.env" "$temporary_directory/not-there.env"
 expect_failure "missing Server environment file" \
   "$manage" validate \
   --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/missing-server.env"
+    --runtime-env-file "$temporary_directory/missing-server.env"
 
-cp "$temporary_directory/staging.env" "$temporary_directory/insecure-staging.env"
-chmod 0640 "$temporary_directory/insecure-staging.env"
-expect_failure "group-readable Staging environment" \
+cp "$temporary_directory/staging-runtime.env" "$temporary_directory/insecure-runtime.env"
+chmod 0640 "$temporary_directory/insecure-runtime.env"
+expect_failure "group-readable runtime environment" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/insecure-staging.env"
+    --runtime-env-file "$temporary_directory/insecure-runtime.env"
 
-ln -s "$temporary_directory/staging.env" "$temporary_directory/symlink-staging.env"
-expect_failure "symbolic-link Staging environment" \
+ln -s "$temporary_directory/staging-runtime.env" "$temporary_directory/symlink-runtime.env"
+expect_failure "symbolic-link runtime environment" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/symlink-staging.env"
+    --runtime-env-file "$temporary_directory/symlink-runtime.env"
 
-mkdir "$temporary_directory/staging-env-ancestor-target"
-cp "$temporary_directory/staging.env" \
-  "$temporary_directory/staging-env-ancestor-target/staging.env"
-chmod 0600 "$temporary_directory/staging-env-ancestor-target/staging.env"
-ln -s "$temporary_directory/staging-env-ancestor-target" \
-  "$temporary_directory/staging-env-ancestor-link"
-expect_failure "Staging environment with a symbolic-link ancestor" \
+mkdir "$temporary_directory/runtime-env-ancestor-target"
+cp "$temporary_directory/staging-runtime.env" \
+  "$temporary_directory/runtime-env-ancestor-target/runtime.env"
+chmod 0600 "$temporary_directory/runtime-env-ancestor-target/runtime.env"
+ln -s "$temporary_directory/runtime-env-ancestor-target" \
+  "$temporary_directory/runtime-env-ancestor-link"
+expect_failure "runtime environment with a symbolic-link ancestor" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging-env-ancestor-link/staging.env"
+    --runtime-env-file "$temporary_directory/runtime-env-ancestor-link/runtime.env"
 
 cp "$temporary_directory/server.env" "$temporary_directory/insecure-server.env"
 chmod 0644 "$temporary_directory/insecure-server.env"
-write_environment "$temporary_directory/insecure-server-config.env" \
+write_runtime_environment "$temporary_directory/insecure-server-config.env" \
   "$temporary_directory/insecure-server.env"
 expect_failure "world-readable Server environment" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/insecure-server-config.env"
+    --runtime-env-file "$temporary_directory/insecure-server-config.env"
 
 ln -s "$temporary_directory/server.env" "$temporary_directory/server-link.env"
-write_environment "$temporary_directory/server-link-config.env" \
+write_runtime_environment "$temporary_directory/server-link-config.env" \
   "$temporary_directory/server-link.env"
 expect_failure "symbolic-link Server environment" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/server-link-config.env"
+    --runtime-env-file "$temporary_directory/server-link-config.env"
 
 mkdir -p \
-  "$temporary_directory/input-ancestor-target/nested/acme" \
+  "$temporary_directory/input-ancestor-target/nested" \
   "$temporary_directory/unsafe-input-ancestor/nested"
 cp "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/privkey.pem" \
-  "$temporary_directory/staging.htpasswd" \
   "$temporary_directory/input-ancestor-target/nested/"
-chmod 0600 \
-  "$temporary_directory/input-ancestor-target/nested/server.env" \
-  "$temporary_directory/input-ancestor-target/nested/privkey.pem" \
-  "$temporary_directory/input-ancestor-target/nested/staging.htpasswd"
+chmod 0600 "$temporary_directory/input-ancestor-target/nested/server.env"
 ln -s "$temporary_directory/input-ancestor-target" \
   "$temporary_directory/input-ancestor-link"
 
-write_environment "$temporary_directory/server-ancestor-link.env" \
+write_runtime_environment "$temporary_directory/server-ancestor-link.env" \
   "$temporary_directory/input-ancestor-link/nested/server.env"
 expect_failure "Server environment with a symbolic-link ancestor" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/server-ancestor-link.env"
-
-write_environment "$temporary_directory/certificate-ancestor-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/input-ancestor-link/nested/fullchain.pem"
-expect_failure "TLS certificate with a symbolic-link ancestor" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/certificate-ancestor-link.env"
-
-write_environment "$temporary_directory/key-ancestor-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/input-ancestor-link/nested/privkey.pem"
-expect_failure "TLS private key with a symbolic-link ancestor" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/key-ancestor-link.env"
-
-write_environment "$temporary_directory/htpasswd-ancestor-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/privkey.pem" \
-  "$temporary_directory/input-ancestor-link/nested/staging.htpasswd"
-expect_failure "htpasswd with a symbolic-link ancestor" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/htpasswd-ancestor-link.env"
-
-write_environment "$temporary_directory/acme-ancestor-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/privkey.pem" \
-  "$temporary_directory/staging.htpasswd" \
-  "$temporary_directory/input-ancestor-link/nested/acme"
-expect_failure "ACME root with a symbolic-link ancestor" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/acme-ancestor-link.env"
+    --runtime-env-file "$temporary_directory/server-ancestor-link.env"
 
 chmod 0777 "$temporary_directory/unsafe-input-ancestor"
 cp "$temporary_directory/server.env" \
   "$temporary_directory/unsafe-input-ancestor/nested/server.env"
 chmod 0600 "$temporary_directory/unsafe-input-ancestor/nested/server.env"
-write_environment "$temporary_directory/unsafe-server-ancestor.env" \
+write_runtime_environment "$temporary_directory/unsafe-server-ancestor.env" \
   "$temporary_directory/unsafe-input-ancestor/nested/server.env"
 expect_failure "Server environment with an unsafe writable ancestor" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/unsafe-server-ancestor.env"
-
-cp "$temporary_directory/privkey.pem" "$temporary_directory/insecure-key.pem"
-chmod 0644 "$temporary_directory/insecure-key.pem"
-write_environment "$temporary_directory/insecure-key.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/insecure-key.pem"
-expect_failure "world-readable TLS private key" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/insecure-key.env"
-
-ln -s "$temporary_directory/privkey.pem" "$temporary_directory/key-link.pem"
-write_environment "$temporary_directory/key-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/key-link.pem"
-"$manage" validate \
-  --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/key-link.env" \
-  > "$temporary_directory/key-link-validate.out"
-grep -Fq 'validated=true' "$temporary_directory/key-link-validate.out" ||
-  fail "valid Certbot-style TLS private-key symlink was rejected"
-
-mkdir -p \
-  "$temporary_directory/certbot/live/staging.speak-up.top" \
-  "$temporary_directory/certbot/archive/staging.speak-up.top"
-cp "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/certbot/archive/staging.speak-up.top/fullchain1.pem"
-cp "$temporary_directory/privkey.pem" \
-  "$temporary_directory/certbot/archive/staging.speak-up.top/privkey1.pem"
-chmod 0600 \
-  "$temporary_directory/certbot/archive/staging.speak-up.top/privkey1.pem"
-ln -s ../../archive/staging.speak-up.top/fullchain1.pem \
-  "$temporary_directory/certbot/live/staging.speak-up.top/fullchain.pem"
-ln -s ../../archive/staging.speak-up.top/privkey1.pem \
-  "$temporary_directory/certbot/live/staging.speak-up.top/privkey.pem"
-write_environment "$temporary_directory/certbot-links.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/certbot/live/staging.speak-up.top/fullchain.pem" \
-  "$temporary_directory/certbot/live/staging.speak-up.top/privkey.pem"
-"$manage" validate \
-  --manifest "$temporary_directory/release-manifest.json" \
-  --env-file "$temporary_directory/certbot-links.env" \
-  > "$temporary_directory/certbot-links.out"
-grep -Fq 'validated=true' "$temporary_directory/certbot-links.out" ||
-  fail "valid Certbot live/archive links were rejected"
-
-ln -s "$temporary_directory/not-there-key.pem" \
-  "$temporary_directory/broken-key-link.pem"
-write_environment "$temporary_directory/broken-key-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/broken-key-link.pem"
-expect_failure "broken TLS private-key symlink" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/broken-key-link.env"
-
-ln -s "$temporary_directory/insecure-key.pem" \
-  "$temporary_directory/insecure-key-link.pem"
-write_environment "$temporary_directory/insecure-key-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/insecure-key-link.pem"
-expect_failure "TLS private-key symlink with an insecure target" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/insecure-key-link.env"
-
-cp "$temporary_directory/staging.htpasswd" \
-  "$temporary_directory/insecure.htpasswd"
-chmod 0644 "$temporary_directory/insecure.htpasswd"
-write_environment "$temporary_directory/insecure-htpasswd.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/privkey.pem" \
-  "$temporary_directory/insecure.htpasswd"
-expect_failure "world-readable htpasswd" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/insecure-htpasswd.env"
-
-ln -s "$temporary_directory/staging.htpasswd" \
-  "$temporary_directory/htpasswd-link"
-write_environment "$temporary_directory/htpasswd-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/privkey.pem" \
-  "$temporary_directory/htpasswd-link"
-expect_failure "symbolic-link htpasswd" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/htpasswd-link.env"
-
-cp "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/insecure-certificate.pem"
-chmod 0664 "$temporary_directory/insecure-certificate.pem"
-write_environment "$temporary_directory/insecure-certificate.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/insecure-certificate.pem"
-expect_failure "group-writable public certificate" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/insecure-certificate.env"
-
-mkdir "$temporary_directory/insecure-acme"
-chmod 0777 "$temporary_directory/insecure-acme"
-write_environment "$temporary_directory/insecure-acme.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/privkey.pem" \
-  "$temporary_directory/staging.htpasswd" \
-  "$temporary_directory/insecure-acme"
-expect_failure "world-writable ACME root" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/insecure-acme.env"
-
-mkdir "$temporary_directory/acme-target"
-ln -s "$temporary_directory/acme-target" "$temporary_directory/acme-link"
-write_environment "$temporary_directory/acme-link.env" \
-  "$temporary_directory/server.env" \
-  "$temporary_directory/fullchain.pem" \
-  "$temporary_directory/privkey.pem" \
-  "$temporary_directory/staging.htpasswd" \
-  "$temporary_directory/acme-link"
-expect_failure "symbolic-link ACME root" \
-  "$manage" validate \
-    --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/acme-link.env"
+    --runtime-env-file "$temporary_directory/unsafe-server-ancestor.env"
 
 real_id=$(command -v id)
 printf '%s\n' \
@@ -482,11 +388,11 @@ printf '%s\n' \
   'fi' \
   'exec "$TEST_REAL_ID" "$@"' > "$temporary_directory/fake-bin/id"
 chmod +x "$temporary_directory/fake-bin/id"
-expect_failure "Staging environment owned by another UID" \
+expect_failure "runtime environment owned by another UID" \
   env TEST_REAL_ID="$real_id" PATH="$temporary_directory/fake-bin:$PATH" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 rm "$temporary_directory/fake-bin/id"
 
 mkdir "$temporary_directory/fake-owner-bin"
@@ -506,60 +412,20 @@ fi
 exec "$TEST_REAL_STAT" "$@"
 EOF
 chmod +x "$temporary_directory/fake-owner-bin/stat"
-for owner_case in \
-  "$temporary_directory/server.env|Server environment" \
-  "$temporary_directory/fullchain.pem|public certificate" \
-  "$temporary_directory/acme|ACME root"; do
-  owner_path=${owner_case%%|*}
-  owner_description=${owner_case#*|}
-  expect_failure "$owner_description owned by another UID" \
-    env \
-      TEST_REAL_STAT="$real_stat" \
-      TEST_WRONG_OWNER_PATH="$owner_path" \
-      PATH="$temporary_directory/fake-owner-bin:$PATH" \
-    "$manage" validate \
-      --manifest "$temporary_directory/release-manifest.json" \
-      --env-file "$temporary_directory/staging.env"
-done
-expect_failure "TLS private-key symlink target owned by another UID" \
+expect_failure "Server environment owned by another UID" \
   env \
     TEST_REAL_STAT="$real_stat" \
-    TEST_WRONG_OWNER_PATH="$temporary_directory/privkey.pem" \
+    TEST_WRONG_OWNER_PATH="$temporary_directory/server.env" \
     PATH="$temporary_directory/fake-owner-bin:$PATH" \
   "$manage" validate \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/key-link.env"
-
-"$manage" render-nginx \
-  --env-file "$temporary_directory/staging.env" \
-  --output "$temporary_directory/staging.conf" \
-  >"$temporary_directory/render.out"
-if grep -Eq '__STAGING_[A-Z_]+__' "$temporary_directory/staging.conf"; then
-  fail "rendered Nginx configuration contains a placeholder"
-fi
-[[ $(grep -Fc 'auth_basic "SpeakUp Staging";' "$temporary_directory/staging.conf") -eq 1 ]] ||
-  fail "Nginx Basic Auth must apply only to the Portal host"
-sed -n '/server_name staging-api.speak-up.top;/,$p' \
-  "$temporary_directory/staging.conf" >"$temporary_directory/api-server.conf"
-if grep -Fq 'auth_basic' "$temporary_directory/api-server.conf"; then
-  fail "API host must preserve application Bearer auth without HTTP Basic Auth"
-fi
-grep -Fq 'proxy_set_header Authorization $http_authorization;' \
-  "$temporary_directory/api-server.conf" ||
-  fail "API proxy does not explicitly preserve the Authorization header"
-[[ $(grep -Fc 'location = /metrics {' "$temporary_directory/staging.conf") -eq 2 ]] ||
-  fail "Nginx does not block /metrics on both hosts"
-grep -Fq 'proxy_pass http://127.0.0.1:28082;' "$temporary_directory/staging.conf" ||
-  fail "Portal proxy is not loopback-only"
-grep -Fq 'proxy_pass http://127.0.0.1:28083;' "$temporary_directory/staging.conf" ||
-  fail "Server proxy is not loopback-only"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 STAGING_POSTGRES_DB=speakup_staging \
 STAGING_POSTGRES_USER=speakup_staging \
 STAGING_POSTGRES_PASSWORD=0123456789abcdef0123456789abcdef \
 PORTAL_ADMIN_PASSWORD=portal-admin-password-for-tests \
 STAGING_SERVER_ENV_FILE="$temporary_directory/server.env" \
-STAGING_PORTAL_HOST=staging.speak-up.top \
 PORTAL_IMAGE_DIGEST="$portal_digest" \
 SERVER_IMAGE_DIGEST="$server_digest" \
 COMPOSE_PROJECT_NAME=xe3-speakup-production \
@@ -599,6 +465,8 @@ jq --exit-status \
     (.services.server.networks | keys | sort) == ["database", "server_edge"] and
     .services.server.networks.server_edge.aliases ==
       ["staging-api-metrics"] and
+    .services.portal.environment.VINEXT_TRUSTED_HOSTS ==
+      "staging.speak-up.top" and
     .services.server.environment.METRICS_HOST == "0.0.0.0" and
     (.volumes | keys | sort) == ["portal_data", "postgres_data"]
   ' "$temporary_directory/compose.json" >/dev/null ||
@@ -897,7 +765,7 @@ expect_failure "deploy without a receipt" \
   env PATH="$fake_path" SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 receipt="$temporary_directory/staging-deploy-receipt.json"
 COMMAND_LOG="$temporary_directory/deploy.log" \
@@ -905,7 +773,7 @@ PATH="$fake_path" \
 SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env" \
+    --runtime-env-file "$temporary_directory/staging-runtime.env" \
     --receipt "$receipt" \
     > "$temporary_directory/deploy.out"
 
@@ -984,7 +852,7 @@ expect_failure "existing deployment receipt" \
     SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env" \
+    --runtime-env-file "$temporary_directory/staging-runtime.env" \
     --receipt "$receipt"
 jq --exit-status '.receipt_version == 1' "$receipt" >/dev/null ||
   fail "existing deployment receipt was changed"
@@ -1007,7 +875,7 @@ assert_failed_deploy_before_application() {
     "$@" \
     "$manage" deploy \
       --manifest "$temporary_directory/release-manifest.json" \
-      --env-file "$temporary_directory/staging.env" \
+      --runtime-env-file "$temporary_directory/staging-runtime.env" \
       --receipt "$failed_receipt"
   [[ ! -e "$failed_receipt" && ! -L "$failed_receipt" ]] ||
     fail "$name wrote a deployment receipt"
@@ -1048,7 +916,7 @@ expect_failure "runtime verification failure after update" \
     TEST_BAD_RUNTIME_IMAGE=portal \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env" \
+    --runtime-env-file "$temporary_directory/staging-runtime.env" \
     --receipt "$failed_runtime_receipt"
 [[ ! -e "$failed_runtime_receipt" ]] ||
   fail "runtime verification failure wrote a deployment receipt"
@@ -1062,7 +930,7 @@ expect_failure "loopback verification failure after update" \
     FAIL_HEALTH=1 \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env" \
+    --runtime-env-file "$temporary_directory/staging-runtime.env" \
     --receipt "$failed_health_receipt"
 [[ ! -e "$failed_health_receipt" ]] ||
   fail "loopback verification failure wrote a deployment receipt"
@@ -1071,7 +939,7 @@ COMMAND_LOG="$temporary_directory/verify.log" \
 PATH="$fake_path" \
   "$manage" verify \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env" \
+    --runtime-env-file "$temporary_directory/staging-runtime.env" \
     > "$temporary_directory/verify.out"
 grep -Fq \
   'run --pull never --rm --no-deps migrate /usr/local/bin/speakup-migrate version' \
@@ -1093,7 +961,7 @@ while IFS='|' read -r name variable value; do
     "$variable=$value" \
     "$manage" verify \
       --manifest "$temporary_directory/release-manifest.json" \
-      --env-file "$temporary_directory/staging.env"
+      --runtime-env-file "$temporary_directory/staging-runtime.env"
   if grep -Fq 'curl ' "$runtime_log"; then
     fail "$name reached endpoint checks before runtime identity validation"
   fi
@@ -1118,7 +986,7 @@ expect_failure "verify with wrong live schema" env \
   'SCHEMA_OUTPUT=version=6 dirty=false' \
   "$manage" verify \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 if grep -Fq 'curl ' "$temporary_directory/schema-verify.log"; then
   fail "verify checked endpoints after the schema mismatch"
 fi
@@ -1132,7 +1000,7 @@ expect_failure "concurrent Staging deploy" env \
   TEST_FLOCK_BUSY=1 \
   "$manage" deploy \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env" \
+    --runtime-env-file "$temporary_directory/staging-runtime.env" \
     --receipt "$busy_receipt"
 [[ ! -e "$busy_receipt" ]] || fail "concurrent deploy wrote a receipt"
 if grep -Eq ' compose .* (pull|up|run|down) ' "$temporary_directory/busy.log"; then
@@ -1148,7 +1016,7 @@ expect_failure "insecure deployment lock" env \
   SPEAKUP_STAGING_LOCK_FILE="$insecure_lock" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 lock_target="$temporary_directory/lock-target"
 : > "$lock_target"
@@ -1160,7 +1028,7 @@ expect_failure "symbolic-link deployment lock" env \
   SPEAKUP_STAGING_LOCK_FILE="$temporary_directory/lock-link" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 
 missing_lock_directory="$temporary_directory/missing-lock-directory"
 expect_failure "missing dedicated deployment lock directory" env \
@@ -1169,7 +1037,7 @@ expect_failure "missing dedicated deployment lock directory" env \
   SPEAKUP_STAGING_LOCK_FILE="$missing_lock_directory/deploy.lock" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 [[ ! -e "$missing_lock_directory" ]] ||
   fail "deployment created its missing lock directory"
 
@@ -1182,7 +1050,7 @@ expect_failure "world-writable deployment lock directory" env \
   SPEAKUP_STAGING_LOCK_FILE="$unsafe_lock_directory/deploy.lock" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 [[ ! -e "$unsafe_lock_directory/deploy.lock" ]] ||
   fail "deployment created a lock in a world-writable directory"
 
@@ -1196,7 +1064,7 @@ expect_failure "symbolic-link deployment lock directory" env \
   SPEAKUP_STAGING_LOCK_FILE="$temporary_directory/symlink-lock-directory/deploy.lock" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 [[ ! -e "$temporary_directory/real-lock-directory/deploy.lock" ]] ||
   fail "deployment followed a symbolic-link lock directory"
 
@@ -1212,7 +1080,7 @@ expect_failure "deployment lock with a symbolic-link ancestor" env \
   SPEAKUP_STAGING_LOCK_FILE="$temporary_directory/symlink-lock-ancestor/nested/deploy.lock" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 [[ ! -e "$temporary_directory/real-lock-ancestor/nested/deploy.lock" ]] ||
   fail "deployment followed a symbolic-link lock ancestor"
 
@@ -1232,7 +1100,7 @@ expect_failure "deployment lock replaced during acquisition" env \
   TEST_LOCK_SWAP_TARGET="$race_target" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 [[ -L "$race_lock" ]] || fail "lock replacement boundary was not exercised"
 if grep -Fq ' down ' "$temporary_directory/race-lock.log"; then
   fail "deployment continued after the lock path was replaced"
@@ -1246,7 +1114,7 @@ expect_failure "concurrent Staging down" env \
   TEST_FLOCK_BUSY=1 \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 if grep -Fq ' compose ' "$temporary_directory/down-busy.log" &&
   grep -Fq ' down ' "$temporary_directory/down-busy.log"; then
   fail "concurrent down mutated the Staging project"
@@ -1257,7 +1125,7 @@ PATH="$fake_path" \
 SPEAKUP_STAGING_LOCK_FILE="$lock_file" \
   "$manage" down \
     --manifest "$temporary_directory/release-manifest.json" \
-    --env-file "$temporary_directory/staging.env"
+    --runtime-env-file "$temporary_directory/staging-runtime.env"
 grep -Fq 'flock --nonblock 9' "$temporary_directory/down.log" ||
   fail "down did not acquire the shared Staging lock"
 grep -Fq 'down --remove-orphans' "$temporary_directory/down.log" ||

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -290,6 +290,27 @@ Production 部署入口。
 Deploy Workflow 接收确定的 `version` 和 `environment`，读取 Release manifest
 后部署现有制品，不重新构建。
 
+Staging 主机 contract 先把配置和命令依赖拆成两个互不重叠的接口：
+
+| 输入 | 职责与命令 | 调用身份所需访问 |
+| --- | --- | --- |
+| `staging-runtime.env` | 只包含 PostgreSQL、Portal、Server runtime 输入；`validate`、`deploy`、`verify`、`status`、`down` 只接受 `--runtime-env-file`，负责 manifest、Compose、migration、loopback health、锁和 receipt | 读取 manifest、runtime env 及其引用的 Server env，访问 Staging Docker/Compose runtime，并按命令访问锁和新 receipt；不需要 edge env、TLS key、htpasswd、ACME 或 public root |
+| `staging-edge.env` | 只包含 TLS certificate/key、htpasswd、ACME root 和 public root；`render-nginx` 只接受 `--edge-env-file` 与 `--output` | 读取 edge env 及其引用的边缘文件、遍历边缘目录并创建指定输出；不需要 manifest、runtime/Server env、receipt、Docker 或 Compose |
+
+`staging.speak-up.top` 与 `staging-api.speak-up.top` 固定为仓库 contract，不在两个
+env 中重复配置。两类 env 使用精确 allowlist，未知、重复、交叉 key 或 ambient
+environment 补值均 fail closed，错误不得输出 Secret 值。现有合并式 `staging.env`
+迁移时必须拆出两个 mode `0400`/`0600`、由各自执行 UID 持有的文件，删除两个旧
+hostname key，并分别替换为 `--runtime-env-file` 和 `--edge-env-file`；旧
+`--env-file` 明确失败，不提供兼容 fallback。
+
+这次拆分只消除 runtime 命令读取 edge Secret 的功能依赖，不构成主机级强制隔离。
+当前 runtime 路径仍会调用 Docker Compose；原始 rootful Docker socket、`docker`
+group、无限制 `sudo` 或 root SSH 都具有主机 root 级影响面，未来 CI 不得获得这些
+能力。受限 broker/forced-command、独立 Staging daemon 或更强 VM/主机边界、专用
+身份和资源限制属于后续独立任务。#1001 对应 PR 不创建 Workflow、主机用户、ACL、
+sudoers、systemd service 或 broker，也不授权 CI 连接服务器。
+
 Staging 自动部署并验证：
 
 - Portal、后端和隔离数据库启动成功。
@@ -605,6 +626,9 @@ Workflow 猜测或静默采用默认值。
 
 - [GitHub Deployments and environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)
 - [GitHub Reviewing deployments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/review-deployments)
+- [GitHub secure use of self-hosted runners](https://docs.github.com/en/actions/reference/security/secure-use)
+- [Docker Engine security and daemon attack surface](https://docs.docker.com/engine/security/)
+- [Docker group root-level privileges](https://docs.docker.com/engine/install/linux-postinstall/)
 - [Android Sign your app](https://developer.android.com/studio/publish/app-signing)
 - [Android Version your app](https://developer.android.com/studio/publish/versioning)
 - [Android Release through a website](https://developer.android.com/studio/publish#publishing-website)


### PR DESCRIPTION
## 功能描述

- 将 Staging 的运行时部署输入与 TLS、Basic Auth、ACME、公开下载目录等边缘输入拆成两个精确契约。
- 运行时命令只接受 `--runtime-env-file`，Nginx 渲染只接受 `--edge-env-file`。
- 固定 Staging Portal/API 域名为仓库契约，服务器公网 IP 继续由 DNS 和运维配置管理。

## 实现思路

- 新增 `staging-runtime.env.example` 与 `staging-edge.env.example`，两组 key 互不重叠。
- 加载前清空 ambient 变量；未知、交叉、重复或缺失 key 均 fail closed。
- 重复、空值或跨命令 CLI 参数在读取配置及调用 Docker 前失败。
- 运行时校验不再读取证书、私钥、htpasswd、ACME 或 public root，也不渲染 Nginx。
- Nginx 渲染不读取 manifest、runtime/Server env 或 receipt，也不调用 Compose。
- 文档明确：本次只拆分功能依赖，不把 rootful Docker 权限误称为主机安全隔离；受限 CI 部署入口属于后续 Issue。

## 可复现测试

- `make check-staging-deploy`
- `make check-staging-nginx`
- `make check-tls-lifecycle`
- `make check-android-download`
- `bash -n deploy/staging/manage.sh deploy/staging/test.sh deploy/staging/test-nginx.sh`
- `git diff --check`

## 范围说明

- 不创建或修改 GitHub Workflow。
- 不连接服务器，不创建主机用户、sudoers、systemd 或 Docker 权限。
- 不修改 Production 部署契约。

Closes #1001
