### PR TITLE
fix(agent): anchor home actions above composer

### DIFF
--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:speakup/design/practice_conversation_components.dart';
@@ -146,8 +147,6 @@ class ConversationPage extends StatefulWidget {
     final horizontalPadding = width >= 390 ? 20.0 : 16.0;
     final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     final titleSize = width < 350 ? 27.0 : 30.0;
-    final emptyHomeActionGap = (MediaQuery.sizeOf(context).height * 0.325)
-        .clamp(180.0, 274.0);
     final composerBottom = keyboardVisible ? 10.0 : restingComposerBottom;
     final acceptedUserMessage = _lastUserMessage(messages);
     final canCompose = hasFocusedThread || onCreateConversation != null;
@@ -174,9 +173,10 @@ class ConversationPage extends StatefulWidget {
               child: Stack(
                 children: [
                   Positioned.fill(
-                    child: SingleChildScrollView(
-                      key: const Key('agent-conversation-scroll'),
+                    child: _ConversationScrollView(
+                      scrollKey: const Key('agent-conversation-scroll'),
                       controller: scrollController,
+                      fillViewport: messages.isEmpty,
                       padding: EdgeInsets.fromLTRB(
                         horizontalPadding,
                         topContentInset,
@@ -208,7 +208,7 @@ class ConversationPage extends StatefulWidget {
                                 ),
                               ),
                             ],
-                            SizedBox(height: emptyHomeActionGap),
+                            const Spacer(),
                             if (practiceAvailable)
                               _QuickActions(
                                 onCreatePlan: onCreatePlan,
@@ -451,6 +451,47 @@ class ConversationPage extends StatefulWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _ConversationScrollView extends StatelessWidget {
+  const _ConversationScrollView({
+    required this.scrollKey,
+    required this.controller,
+    required this.fillViewport,
+    required this.padding,
+    required this.child,
+  });
+
+  final Key scrollKey;
+  final ScrollController controller;
+  final bool fillViewport;
+  final EdgeInsets padding;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final content = fillViewport
+            ? ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: math.max(
+                    0,
+                    constraints.maxHeight - padding.vertical,
+                  ),
+                ),
+                child: IntrinsicHeight(child: child),
+              )
+            : child;
+        return SingleChildScrollView(
+          key: scrollKey,
+          controller: controller,
+          padding: padding,
+          child: content,
+        );
+      },
     );
   }
 }

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -945,7 +945,7 @@ void main() {
     );
   });
 
-  testWidgets('keeps available Agent actions above the composer on iPhone', (
+  testWidgets('anchors available Agent actions above the composer', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(402, 874);
@@ -973,7 +973,7 @@ void main() {
     final composerRect = tester.getRect(
       find.byKey(const Key('agent-composer-surface')),
     );
-    expect(composerRect.top - lastActionRect.bottom, greaterThanOrEqualTo(16));
+    expect(composerRect.top - lastActionRect.bottom, closeTo(16, 0.01));
   });
 
   testWidgets('keeps three and four Agent actions on the same bottom edge', (


### PR DESCRIPTION
## 功能描述
- 移除首页快捷入口与输入框之间按屏幕高度计算的固定空白。
- 将可用快捷入口稳定锚定在输入框上方 16pt。
- 小屏幕和大字体内容超出时仍可滚动。

## 实现思路
- 空会话使用视口最小高度约束与 IntrinsicHeight。
- 在欢迎区和快捷入口之间使用 Spacer 消化剩余空间。
- 非空会话沿用原滚动布局。

## 可复现测试
- `cd mobile && flutter test test/speak_up_app_test.dart`（37 项通过）
- `cd mobile && dart analyze lib/features/agent/conversation/conversation.dart test/speak_up_app_test.dart`（无问题）
- Android 真机 2211133C：快捷入口贴近输入框上方，应用正常启动，无崩溃日志。

Closes #996