### PR TITLE
fix(navigation): align Android tab states with iOS

### DIFF
--- a/mobile/lib/app/platform_navigation_bar.dart
+++ b/mobile/lib/app/platform_navigation_bar.dart
@@ -67,12 +67,22 @@ class PlatformNavigationBar extends StatelessWidget {
         indicatorColor: SpeakUpDesign.primaryMuted,
         elevation: 0,
         labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
+        labelTextStyle: WidgetStateProperty.resolveWith((states) {
+          final selected = states.contains(WidgetState.selected);
+          return SpeakUpDesign.label.copyWith(
+            color: selected ? SpeakUpDesign.ink : SpeakUpDesign.secondary,
+            fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
+          );
+        }),
         destinations: [
           for (final destination in destinations)
             NavigationDestination(
               key: destination.key,
-              icon: Icon(destination.icon),
-              selectedIcon: Icon(destination.selectedIcon),
+              icon: Icon(destination.icon, color: SpeakUpDesign.secondary),
+              selectedIcon: Icon(
+                destination.selectedIcon,
+                color: SpeakUpDesign.ink,
+              ),
               label: destination.label,
             ),
         ],

--- a/mobile/lib/app/speak_up_shell.dart
+++ b/mobile/lib/app/speak_up_shell.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:speakup/features/agent/composer/composer_controller.dart';
 import 'package:speakup/features/agent/conversation/agent_message_audio_controller.dart';
@@ -91,32 +92,32 @@ class _SpeakUpShellState extends State<SpeakUpShell>
   static const _destinations = [
     PlatformNavigationDestination(
       label: 'SpeakUp',
-      icon: Icons.mic_none_rounded,
-      selectedIcon: Icons.mic_rounded,
+      icon: CupertinoIcons.waveform_circle,
+      selectedIcon: CupertinoIcons.waveform_circle_fill,
       iosSystemImage: 'waveform.circle',
       iosSelectedSystemImage: 'waveform.circle.fill',
       key: Key('primary-tab-agent'),
     ),
     PlatformNavigationDestination(
       label: '训练',
-      icon: Icons.grid_view_rounded,
-      selectedIcon: Icons.dashboard_rounded,
+      icon: CupertinoIcons.square_grid_2x2,
+      selectedIcon: CupertinoIcons.square_grid_2x2_fill,
       iosSystemImage: 'square.grid.2x2',
       iosSelectedSystemImage: 'square.grid.2x2.fill',
       key: Key('primary-tab-scenes'),
     ),
     PlatformNavigationDestination(
       label: '复盘',
-      icon: Icons.insights_outlined,
-      selectedIcon: Icons.insights_rounded,
+      icon: CupertinoIcons.chart_bar,
+      selectedIcon: CupertinoIcons.chart_bar_fill,
       iosSystemImage: 'chart.bar',
       iosSelectedSystemImage: 'chart.bar.fill',
       key: Key('primary-tab-review'),
     ),
     PlatformNavigationDestination(
       label: '我的',
-      icon: Icons.person_outline_rounded,
-      selectedIcon: Icons.person_rounded,
+      icon: CupertinoIcons.person,
+      selectedIcon: CupertinoIcons.person_fill,
       iosSystemImage: 'person',
       iosSelectedSystemImage: 'person.fill',
       key: Key('primary-tab-profile'),

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -137,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cupertino_icons:
+    dependency: "direct main"
+    description:
+      name: cupertino_icons
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.9"
   dbus:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   avatar_kit: 1.0.0-beta.44
   audioplayers: ^6.8.1
+  cupertino_icons: ^1.0.8
   flutter:
     sdk: flutter
   flutter_markdown_plus: ^1.0.12

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -11,6 +12,7 @@ import 'package:speakup/app/app_routes.dart';
 import 'package:speakup/app/platform_navigation_bar.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/app/speak_up_shell.dart';
+import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/agent/client_action/agent_client_action.dart';
 import 'package:speakup/features/agent/conversation/conversation.dart';
 import 'package:speakup/features/agent/conversation/agent_message_bubble.dart';
@@ -21,22 +23,43 @@ import 'package:speakup/features/coaching/preparation/practice_plan_client_actio
 import 'package:speakup/features/coaching/review/review.dart';
 
 void main() {
-  testWidgets('uses voice and analysis icons for Material navigation', (
+  testWidgets('reuses the iOS icon set for Material navigation', (
     tester,
   ) async {
     await tester.pumpWidget(const SpeakUpApp.preview());
     final navigation = find.byKey(const Key('primary-navigation'));
 
     expect(
-      find.descendant(of: navigation, matching: find.byIcon(Icons.mic_rounded)),
+      find.descendant(
+        of: navigation,
+        matching: find.byIcon(CupertinoIcons.waveform_circle_fill),
+      ),
       findsOneWidget,
     );
     expect(
       find.descendant(
         of: navigation,
-        matching: find.byIcon(Icons.insights_outlined),
+        matching: find.byIcon(CupertinoIcons.chart_bar),
       ),
       findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<Icon>(find.byIcon(CupertinoIcons.waveform_circle_fill))
+          .color,
+      SpeakUpDesign.ink,
+    );
+    expect(
+      tester.widget<Icon>(find.byIcon(CupertinoIcons.square_grid_2x2)).color,
+      SpeakUpDesign.secondary,
+    );
+    expect(
+      tester.widget<Text>(find.text('SpeakUp')).style?.color,
+      SpeakUpDesign.ink,
+    );
+    expect(
+      tester.widget<Text>(find.text('训练')).style?.color,
+      SpeakUpDesign.secondary,
     );
 
     await tester.tap(find.byKey(const Key('primary-tab-review')));
@@ -44,16 +67,32 @@ void main() {
     expect(
       find.descendant(
         of: navigation,
-        matching: find.byIcon(Icons.mic_none_rounded),
+        matching: find.byIcon(CupertinoIcons.waveform_circle),
       ),
       findsOneWidget,
     );
     expect(
       find.descendant(
         of: navigation,
-        matching: find.byIcon(Icons.insights_rounded),
+        matching: find.byIcon(CupertinoIcons.chart_bar_fill),
       ),
       findsOneWidget,
+    );
+    expect(
+      tester.widget<Icon>(find.byIcon(CupertinoIcons.waveform_circle)).color,
+      SpeakUpDesign.secondary,
+    );
+    expect(
+      tester.widget<Icon>(find.byIcon(CupertinoIcons.chart_bar_fill)).color,
+      SpeakUpDesign.ink,
+    );
+    expect(
+      tester.widget<Text>(find.text('SpeakUp')).style?.color,
+      SpeakUpDesign.secondary,
+    );
+    expect(
+      tester.widget<Text>(find.text('复盘')).style?.color,
+      SpeakUpDesign.ink,
     );
   });
 
@@ -134,7 +173,10 @@ void main() {
     final navigation = find.byKey(const Key('primary-navigation'));
     expect(navigation, findsOneWidget);
     expect(
-      find.descendant(of: navigation, matching: find.byIcon(Icons.mic_rounded)),
+      find.descendant(
+        of: navigation,
+        matching: find.byIcon(CupertinoIcons.waveform_circle_fill),
+      ),
       findsOneWidget,
     );
     expect(find.byType(BackdropFilter), findsNothing);
@@ -180,7 +222,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byKey(const Key('primary-navigation')),
-        matching: find.byIcon(Icons.dashboard_rounded),
+        matching: find.byIcon(CupertinoIcons.square_grid_2x2_fill),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
## 功能描述
- 修正 Android 底部导航选中项反而变淡的问题。
- Android 四个导航入口复用与 iOS 对应的 Cupertino 图标及填充态。
- 保持 iOS 原生 UITabBar 实现不变。

## 实现思路
- 显式区分 Material NavigationBar 的选中/未选中图标及文字颜色。
- 使用 waveform.circle、square.grid.2x2、chart.bar、person 对应的 Cupertino 图标。
- 增加 Cupertino Icons 直接依赖与选中态交互测试。

## 可复现测试
- `cd mobile && flutter test test/speak_up_app_test.dart test/app/platform_navigation_bar_ios_test.dart`（38 项通过）
- `cd mobile && dart analyze lib/app/speak_up_shell.dart lib/app/platform_navigation_bar.dart test/speak_up_app_test.dart test/app/platform_navigation_bar_ios_test.dart`（无问题）
- Android 真机 2211133C：APK 安装启动成功，前台 Activity 正常，无崩溃日志。

Closes #997