### PR TITLE
feat(portal): 支持首页产品轮播滚轮切换

### DIFF
--- a/portal/app/HeroProductCarousel.tsx
+++ b/portal/app/HeroProductCarousel.tsx
@@ -12,7 +12,10 @@ import {
 
 const AUTOPLAY_DELAY_MS = 5000;
 const SLIDE_TRANSITION_MS = 620;
+const WHEEL_DELTA_THRESHOLD_PX = 40;
+const WHEEL_GESTURE_IDLE_MS = 180;
 const LOOP_START_INDEX = 1;
+const LOOP_LEADING_CLONE_INDEX = 0;
 
 const productSlides = [
   {
@@ -71,7 +74,19 @@ const loopSlides = [
   })),
 ];
 
-const LOOP_RESET_INDEX = productSlides.length + LOOP_START_INDEX;
+const LOOP_TRAILING_CLONE_INDEX = productSlides.length + LOOP_START_INDEX;
+
+function getLoopResetIndex(trackIndex: number) {
+  if (trackIndex === LOOP_LEADING_CLONE_INDEX) return productSlides.length;
+  if (trackIndex === LOOP_TRAILING_CLONE_INDEX) return LOOP_START_INDEX;
+  return null;
+}
+
+function getWheelDeltaInPixels(event: WheelEvent, pageHeight: number) {
+  if (event.deltaMode === 1) return event.deltaY * 16;
+  if (event.deltaMode === 2) return event.deltaY * pageHeight;
+  return event.deltaY;
+}
 
 function getSlidePosition(index: number, trackIndex: number) {
   return Math.max(-2, Math.min(2, index - trackIndex));
@@ -95,18 +110,32 @@ export default function HeroProductCarousel() {
   const [isInView, setIsInView] = useState(true);
   const [isDocumentVisible, setIsDocumentVisible] = useState(true);
   const rootRef = useRef<HTMLElement>(null);
+  const isSlidingRef = useRef(false);
+  const wheelDeltaRef = useRef(0);
+  const wheelGestureLockedRef = useRef(false);
+  const wheelGestureTimerRef = useRef<number | null>(null);
 
   const activeIndex =
     (trackIndex - LOOP_START_INDEX + productSlides.length) %
     productSlides.length;
 
-  const resetLoop = useCallback(() => {
+  const resetLoop = useCallback((resetIndex: number) => {
     setTransitionsEnabled(false);
-    setTrackIndex(LOOP_START_INDEX);
+    setTrackIndex(resetIndex);
 
     window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => setTransitionsEnabled(true));
+      window.requestAnimationFrame(() => {
+        setTransitionsEnabled(true);
+        isSlidingRef.current = false;
+      });
     });
+  }, []);
+
+  const moveSlides = useCallback((offset: -1 | 1) => {
+    if (isSlidingRef.current) return;
+
+    isSlidingRef.current = true;
+    setTrackIndex((current) => current + offset);
   }, []);
 
   useEffect(() => {
@@ -144,6 +173,63 @@ export default function HeroProductCarousel() {
   }, []);
 
   useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const finishWheelGesture = () => {
+      wheelDeltaRef.current = 0;
+      wheelGestureLockedRef.current = false;
+      wheelGestureTimerRef.current = null;
+    };
+
+    const scheduleWheelGestureEnd = () => {
+      if (wheelGestureTimerRef.current !== null) {
+        window.clearTimeout(wheelGestureTimerRef.current);
+      }
+
+      wheelGestureTimerRef.current = window.setTimeout(
+        finishWheelGesture,
+        WHEEL_GESTURE_IDLE_MS,
+      );
+    };
+
+    const handleWheel = (event: WheelEvent) => {
+      if (event.ctrlKey || event.deltaY === 0) return;
+
+      event.preventDefault();
+      scheduleWheelGestureEnd();
+
+      if (wheelGestureLockedRef.current) return;
+
+      const delta = getWheelDeltaInPixels(event, root.clientHeight);
+      const accumulatedDelta = wheelDeltaRef.current;
+
+      if (
+        accumulatedDelta !== 0 &&
+        Math.sign(accumulatedDelta) !== Math.sign(delta)
+      ) {
+        wheelDeltaRef.current = 0;
+      }
+
+      wheelDeltaRef.current += delta;
+
+      if (Math.abs(wheelDeltaRef.current) < WHEEL_DELTA_THRESHOLD_PX) return;
+
+      wheelGestureLockedRef.current = true;
+      moveSlides(wheelDeltaRef.current > 0 ? 1 : -1);
+    };
+
+    root.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      root.removeEventListener("wheel", handleWheel);
+      if (wheelGestureTimerRef.current !== null) {
+        window.clearTimeout(wheelGestureTimerRef.current);
+      }
+    };
+  }, [moveSlides]);
+
+  useEffect(() => {
     const shouldAutoplay =
       autoplayEnabled &&
       !isHovered &&
@@ -154,7 +240,7 @@ export default function HeroProductCarousel() {
     if (!shouldAutoplay) return;
 
     const timer = window.setTimeout(() => {
-      setTrackIndex((current) => current + 1);
+      moveSlides(1);
     }, AUTOPLAY_DELAY_MS);
 
     return () => window.clearTimeout(timer);
@@ -165,12 +251,20 @@ export default function HeroProductCarousel() {
     isDocumentVisible,
     isHovered,
     isInView,
+    moveSlides,
   ]);
 
   useEffect(() => {
-    if (trackIndex !== LOOP_RESET_INDEX) return;
+    const resetIndex = getLoopResetIndex(trackIndex);
 
-    const fallback = window.setTimeout(resetLoop, SLIDE_TRANSITION_MS + 80);
+    const fallback = window.setTimeout(() => {
+      if (resetIndex === null) {
+        isSlidingRef.current = false;
+        return;
+      }
+
+      resetLoop(resetIndex);
+    }, SLIDE_TRANSITION_MS + 80);
     return () => window.clearTimeout(fallback);
   }, [resetLoop, trackIndex]);
 
@@ -190,12 +284,18 @@ export default function HeroProductCarousel() {
     event: TransitionEvent<HTMLElement>,
   ) => {
     if (
-      event.target === event.currentTarget &&
-      event.propertyName === "transform" &&
-      trackIndex === LOOP_RESET_INDEX
-    ) {
-      resetLoop();
+      event.target !== event.currentTarget ||
+      event.propertyName !== "transform"
+    )
+      return;
+
+    const resetIndex = getLoopResetIndex(trackIndex);
+    if (resetIndex === null) {
+      isSlidingRef.current = false;
+      return;
     }
+
+    resetLoop(resetIndex);
   };
 
   const activeSlide = productSlides[activeIndex];


### PR DESCRIPTION
## 功能描述

为首页右侧产品截图轮播增加鼠标滚轮交互：鼠标位于轮播区域时，向下滚动切换下一张，向上滚动切换上一张。一次连续滚轮手势最多切换一张，避免大幅滚动或触控板惯性连续跳过多张。

## 实现思路

- 在轮播根节点注册非被动 `wheel` 监听器，仅在轮播区域内接管垂直滚动；`Ctrl + 滚轮`保持浏览器默认行为
- 统一处理 pixel、line、page 三种 `deltaMode`，使用 40px 累计阈值过滤轻微误触
- 用 180ms 静默窗口识别一次连续手势，并通过 `ref` 保存高频瞬态状态，避免 wheel 事件触发额外 React 重渲染
- 切换动画进行期间锁定导航，防止快速输入越过多个轨道索引
- 补齐第一张向前滚动时的反向克隆回绕，使首尾两个方向都保持无缝循环
- 保持现有自动播放、悬停暂停、焦点暂停、页面可见性和减少动态效果策略

## 可复现测试

```bash
cd portal
npm ci
npm run lint
npm test
```

结果：

- ESLint 通过
- Portal 生产构建通过
- 28 项测试全部通过

### 真实页面交互验证

本地首页桌面视口验证：

- 大幅向下滚动：索引 `3 → 0`，只切换一张并完成尾到首循环
- 普通向下滚动：索引 `0 → 1`
- 三个快速连续滚轮事件：索引 `1 → 2`，未连续跳图
- 三次独立向上滚动：索引 `2 → 1 → 0 → 3`，反向首尾循环正常
- 轮播区域内页面 `scrollY` 保持不变；轮播区域外同样输入可正常滚动页面
- 390×844 移动视口无布局回归
- 无与本次改动相关的控制台 warning/error；本机沉浸式翻译扩展向 `<html>` 注入属性时会产生与代码无关的 hydration 提示

Closes #1009