### PR TITLE
fix(mobile): 修复空录音重录后无法发送或取消

### DIFF
--- a/mobile/lib/design/voice_capture_control.dart
+++ b/mobile/lib/design/voice_capture_control.dart
@@ -105,10 +105,10 @@ class _VoiceCaptureControlState extends State<VoiceCaptureControl> {
   @override
   void didUpdateWidget(covariant VoiceCaptureControl oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.phase == VoiceCapturePhase.idle &&
-        _isCapturing &&
-        !_pointerActive &&
-        !_startInFlight) {
+    final wasCapturing =
+        oldWidget.phase == VoiceCapturePhase.starting ||
+        oldWidget.phase == VoiceCapturePhase.recording;
+    if (!wasCapturing && _isCapturing && !_pointerActive && !_startInFlight) {
       _tapMode = true;
     }
     if (widget.phase == VoiceCapturePhase.busy ||

--- a/mobile/test/design/voice_capture_control_test.dart
+++ b/mobile/test/design/voice_capture_control_test.dart
@@ -205,6 +205,40 @@ void main() {
     expect(harness.currentState?.sends, 1);
   });
 
+  testWidgets('external restart after busy restores tap send and cancel', (
+    tester,
+  ) async {
+    final harness = GlobalKey<_VoiceCaptureHarnessState>();
+    await tester.pumpWidget(
+      _VoiceCaptureHarness(key: harness, upwardCancelOnly: true),
+    );
+
+    harness.currentState?.setPhase(VoiceCapturePhase.busy);
+    await tester.pump();
+    harness.currentState?.setPhase(VoiceCapturePhase.starting);
+    await tester.pump();
+    harness.currentState?.setPhase(VoiceCapturePhase.recording);
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('voice-capture-target')));
+    await tester.pump();
+    expect(harness.currentState?.sends, 1);
+
+    harness.currentState?.setPhase(VoiceCapturePhase.starting);
+    await tester.pump();
+    harness.currentState?.setPhase(VoiceCapturePhase.recording);
+    await tester.pump();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const Key('voice-capture-target'))),
+    );
+    await gesture.moveBy(const Offset(0, -80));
+    await gesture.up();
+    await tester.pump();
+
+    expect(harness.currentState?.cancels, 1);
+  });
+
   testWidgets('release waits for asynchronous microphone start', (
     tester,
   ) async {
@@ -318,6 +352,7 @@ class _VoiceCaptureHarness extends StatefulWidget {
     this.sendCompleter,
     this.showTapActions = false,
     this.detachTargetWhileRecording = false,
+    this.upwardCancelOnly = false,
   });
 
   final Completer<void>? startCompleter;
@@ -325,6 +360,7 @@ class _VoiceCaptureHarness extends StatefulWidget {
   final Completer<void>? sendCompleter;
   final bool showTapActions;
   final bool detachTargetWhileRecording;
+  final bool upwardCancelOnly;
 
   @override
   State<_VoiceCaptureHarness> createState() => _VoiceCaptureHarnessState();
@@ -373,6 +409,10 @@ class _VoiceCaptureHarnessState extends State<_VoiceCaptureHarness> {
     setState(() => phase = VoiceCapturePhase.idle);
   }
 
+  void setPhase(VoiceCapturePhase value) {
+    setState(() => phase = value);
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -387,6 +427,7 @@ class _VoiceCaptureHarnessState extends State<_VoiceCaptureHarness> {
             onSendVoice: _send,
             onConvertToText: _convert,
             onCancel: _cancel,
+            upwardCancelOnly: widget.upwardCancelOnly,
             builder: (context, capture) {
               if (widget.detachTargetWhileRecording &&
                   phase == VoiceCapturePhase.recording) {


### PR DESCRIPTION
## 功能描述

修复首页语音输入触发“没有录到声音，请重新录音”后，点击重试进入录音态却无法发送或上滑取消的问题。

## 实现思路

`AgentVoiceController.retry()` 的重新录音路径对 UI 表现为 `busy -> starting`，不会渲染中间 `idle`。本 PR 将 `VoiceCaptureControl` 的外部录音同步条件改为“非 capturing -> capturing”，并保留活跃指针及组件自身启动操作的围栏，避免依赖中间帧。

新增回归测试模拟 `busy -> starting -> recording`，分别验证点击发送与上滑取消。录音协议、后端接口和页面视觉均未改变。

## 测试方式

1. `cd mobile && flutter test --no-pub test/design/voice_capture_control_test.dart test/agent/agent_voice_fence_test.dart`
2. `PUB_HOSTED_URL=https://pub.dev make check-flutter-test`
3. `SPEAKUP_DEV_PORT=18082 make dev-ios-simulator`，确认 iPhone 17 启动、Dart VM Service 可用，且 `/health`、`/readyz` 返回健康。
4. 预期：新增重录发送/取消用例通过；完整 834 项 Flutter 测试通过；格式、静态分析、依赖锁与 iOS stub 契约通过。

本地模拟器应用与真实后端已健康启动；因当前 macOS 未授予 System Events 自动点击权限，真实模拟器自动点击链路未执行，交互状态由 widget 回归测试覆盖。

## 相关 Issue / 备注

Closes #1012

## AI 辅助说明

使用 AI 协助定位跨控制器/手势组件状态转换、编写回归测试并执行质量门禁。已人工核对改动仅影响外部启动录音时的 tap 模式同步，不改变现有录音协议与业务状态机。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置