### PR TITLE
fix(staging): 安装 Rootless Docker 固定启用链接

### DIFF
--- a/deploy/staging/host/bootstrap.sh
+++ b/deploy/staging/host/bootstrap.sh
@@ -17,6 +17,8 @@ readonly sudoers_file="/etc/sudoers.d/speakup-staging-ci"
 readonly tmpfiles_file="/etc/tmpfiles.d/xe3-speakup-staging.conf"
 readonly rootless_unit_name="speakup-staging-rootless-docker.service"
 readonly rootless_unit="$runtime_home/.config/systemd/user/$rootless_unit_name"
+readonly rootless_wants_directory="$runtime_home/.config/systemd/user/default.target.wants"
+readonly rootless_wants_link="$rootless_wants_directory/$rootless_unit_name"
 readonly rootless_daemon_config="$runtime_home/.config/docker/daemon.json"
 readonly trusted_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -431,6 +433,7 @@ install_directory "$runtime_home/.config" root "$runtime_user" 750
 install_directory "$runtime_home/.config/docker" root "$runtime_user" 750
 install_directory "$runtime_home/.config/systemd" root "$runtime_user" 750
 install_directory "$runtime_home/.config/systemd/user" root "$runtime_user" 750
+install_directory "$rootless_wants_directory" root "$runtime_user" 750
 install_directory "$runtime_home/.docker" "$runtime_user" "$runtime_user" 700
 install_directory "$runtime_home/docker-data" "$runtime_user" "$runtime_user" 700
 install_directory /var/lib/speakup/staging-broker "$runtime_user" "$runtime_user" 700
@@ -448,8 +451,17 @@ install_directory "$control_root/releases" root root 755
 
 install_file "$script_directory/rootless-docker.service" \
   "$rootless_unit" root "$runtime_user" 440
+rootless_wants_path=$(host_path "$rootless_wants_link")
+if [[ -e "$rootless_wants_path" && ! -L "$rootless_wants_path" ]]; then
+  fail "rootless Docker enablement path must be a symbolic link"
+fi
+ln -sfn "../$rootless_unit_name" "$rootless_wants_path"
+if (( ! test_mode )); then
+  chown -h root:root "$rootless_wants_path"
+fi
 install_file "$script_directory/daemon.json" \
   "$rootless_daemon_config" root "$runtime_user" 440
+install_directory "$rootless_wants_directory" root "$runtime_user" 550
 install_directory "$runtime_home/.config/docker" root "$runtime_user" 550
 install_directory "$runtime_home/.config/systemd/user" root "$runtime_user" 550
 install_directory "$runtime_home/.config/systemd" root "$runtime_user" 550
@@ -510,7 +522,7 @@ if [[ -e "$current_path" && ! -L "$current_path" ]]; then
 fi
 current_link_temporary=$(mktemp "$(host_path "$control_root")/.current.XXXXXX")
 ln -sfn "releases/$contract_revision" "$current_link_temporary"
-mv -f -- "$current_link_temporary" "$current_path"
+mv -Tf -- "$current_link_temporary" "$current_path"
 current_link_temporary=""
 
 systemd-tmpfiles --create "$(host_path "$tmpfiles_file")"
@@ -534,7 +546,8 @@ runtime_systemctl=(
   systemctl --user
 )
 "${runtime_systemctl[@]}" daemon-reload
-"${runtime_systemctl[@]}" enable "$rootless_unit_name"
+"${runtime_systemctl[@]}" is-enabled --quiet "$rootless_unit_name" ||
+  fail "rootless Docker user service is not enabled by the fixed host link"
 "${runtime_systemctl[@]}" restart "$rootless_unit_name"
 
 rootless_socket=$(host_path "/run/user/$runtime_uid/docker.sock")

--- a/deploy/staging/host/validate.sh
+++ b/deploy/staging/host/validate.sh
@@ -18,6 +18,7 @@ readonly sudoers_file="/etc/sudoers.d/speakup-staging-ci"
 readonly tmpfiles_file="/etc/tmpfiles.d/xe3-speakup-staging.conf"
 readonly rootless_unit_name="speakup-staging-rootless-docker.service"
 readonly rootless_unit="$runtime_home/.config/systemd/user/$rootless_unit_name"
+readonly rootless_wants_link="$runtime_home/.config/systemd/user/default.target.wants/$rootless_unit_name"
 readonly rootless_daemon_config="$runtime_home/.config/docker/daemon.json"
 readonly registry_config="$runtime_home/.docker/config.json"
 readonly trusted_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -394,6 +395,15 @@ require_file "rootless Docker unit" "$rootless_unit" \
   "$expected_root_uid" "$runtime_gid" 440
 cmp -s "$script_directory/rootless-docker.service" "$(host_path "$rootless_unit")" ||
   fail "installed rootless Docker unit differs from the contract"
+rootless_wants_path=$(host_path "$rootless_wants_link")
+[[ -L "$rootless_wants_path" ]] ||
+  fail "rootless Docker enablement link is missing"
+[[ "$(readlink "$rootless_wants_path")" == "../$rootless_unit_name" ]] ||
+  fail "rootless Docker enablement link has an unexpected target"
+rootless_wants_owner=$(path_owner "$rootless_wants_path") ||
+  fail "cannot inspect rootless Docker enablement link owner"
+[[ "$rootless_wants_owner" == "$expected_root_uid" ]] ||
+  fail "rootless Docker enablement link must be root-owned"
 require_file "rootless Docker daemon config" "$rootless_daemon_config" \
   "$expected_root_uid" "$runtime_gid" 440
 cmp -s "$script_directory/daemon.json" "$(host_path "$rootless_daemon_config")" ||

--- a/deploy/staging/test-host-access.sh
+++ b/deploy/staging/test-host-access.sh
@@ -254,6 +254,19 @@ set -euo pipefail
 [[ "$1" == --create && -f "$2" ]]
 EOF
 
+cat >"$mock_bin/mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == -Tf && "${2:-}" == -- && $# == 4 ]]; then
+  source=$3
+  destination=$4
+  [[ ! -e "$destination" || -L "$destination" ]]
+  /bin/rm -f -- "$destination"
+  exec /bin/mv -f -- "$source" "$destination"
+fi
+exec /bin/mv "$@"
+EOF
+
 cat >"$mock_bin/docker" <<'EOF'
 #!/usr/bin/env bash
 exit 99
@@ -339,6 +352,15 @@ mv "$temporary_directory/slirp4netns" "$fixture_root/usr/bin/slirp4netns"
 
 "${host_environment[@]}" "${bootstrap_command[@]}" \
   >"$temporary_directory/bootstrap.log"
+
+rootless_enablement_link="$fixture_root/var/lib/speakup/staging-runtime/.config/systemd/user/default.target.wants/speakup-staging-rootless-docker.service"
+[[ -L "$rootless_enablement_link" ]] ||
+  fail "bootstrap did not install the fixed rootless Docker enablement link"
+[[ "$(readlink "$rootless_enablement_link")" == '../speakup-staging-rootless-docker.service' ]] ||
+  fail "rootless Docker enablement link has an unexpected target"
+
+"${host_environment[@]}" "${bootstrap_command[@]}" \
+  >"$temporary_directory/bootstrap-repeat.log"
 
 runtime_env="$fixture_root/etc/speakup/staging-runtime.env"
 server_env="$fixture_root/etc/speakup/staging-server.env"


### PR DESCRIPTION
## 功能描述

- 修复 Staging 主机 bootstrap 无法启用 Rootless Docker user service 的问题。
- 由 root 固定安装 `default.target.wants` 启用链接，避免运行用户因目录权限无法创建链接。
- 修复重复 bootstrap 时更新 `current` 符号链接的幂等性问题。

## 实现思路

- bootstrap 安装并校验 root-owned 的固定 systemd user enablement symlink。
- 运行用户只验证服务已启用并重启，不再自行修改受保护的 unit 目录。
- 使用 `mv -T` 原子替换 `current` 链接，避免把已有目录链接当成目标目录。
- validator 和主机契约测试同步覆盖链接目标、所有者与重复执行。

## 可复现测试

```bash
bash -n deploy/staging/host/bootstrap.sh deploy/staging/host/validate.sh deploy/staging/test-host-access.sh
make check-staging-host-access
git diff --check
```

本地结果：全部通过，且 bootstrap fixture 连续执行两次成功。

Closes #1015

Reviewers: @gangcaiyoule @jyqin0203 @Scorbunny2
