### PR TITLE
style(mobile): 将用户消息气泡调整为淡蓝色

### DIFF
--- a/mobile/lib/design/conversation_bubble_surface.dart
+++ b/mobile/lib/design/conversation_bubble_surface.dart
@@ -33,9 +33,11 @@ class ConversationBubbleSurface extends StatelessWidget {
               ? const EdgeInsets.fromLTRB(14, 11, 12, 11)
               : const EdgeInsets.fromLTRB(2, 7, 12, 9)),
       decoration: BoxDecoration(
-        color: isUser ? SpeakUpDesign.primaryMuted : Colors.transparent,
+        color: isUser ? SpeakUpDesign.userBubble : Colors.transparent,
         borderRadius: BorderRadius.circular(SpeakUpDesign.radiusCard),
-        border: isUser ? Border.all(color: SpeakUpDesign.border) : null,
+        border: isUser
+            ? Border.all(color: SpeakUpDesign.userBubbleBorder)
+            : null,
       ),
       child: child,
     );

--- a/mobile/lib/design/speak_up_design.dart
+++ b/mobile/lib/design/speak_up_design.dart
@@ -13,6 +13,8 @@ abstract final class SpeakUpDesign {
   static const border = Color(0xFFE5E5E5);
   static const primary = ink;
   static const primaryMuted = Color(0xFFF0F0F0);
+  static const userBubble = Color(0xFFE6F2FF);
+  static const userBubbleBorder = Color(0xFFDDE5F0);
   static const success = Color(0xFF285443);
   static const successMuted = Color(0xFFEAF3EF);
   static const warning = Color(0xFFC58000);

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -427,7 +427,7 @@ void main() {
     final userBubble = find.byKey(Key('practice-message-${userMessage.id}'));
     expect(
       (tester.widget<Container>(userBubble).decoration! as BoxDecoration).color,
-      SpeakUpDesign.primaryMuted,
+      SpeakUpDesign.userBubble,
     );
 
     final userTurnsAfterSend = controller.practiceMessages

--- a/mobile/test/design/speak_up_design_test.dart
+++ b/mobile/test/design/speak_up_design_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/conversation_bubble_surface.dart';
 import 'package:speakup/design/speak_up_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/design/speak_up_theme.dart';
@@ -52,6 +53,45 @@ void main() {
       SpeakUpDesign.ambientBase,
     ]);
     expect(gradient.stops, const [0, 0.42, 1]);
+  });
+
+  testWidgets('user conversation bubbles use the dedicated pale blue surface', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Column(
+          children: [
+            ConversationBubbleSurface(
+              bubbleKey: Key('user-bubble'),
+              isUser: true,
+              child: Text('用户消息'),
+            ),
+            ConversationBubbleSurface(
+              bubbleKey: Key('assistant-bubble'),
+              isUser: false,
+              child: Text('AI 消息'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final userDecoration =
+        tester
+                .widget<Container>(find.byKey(const Key('user-bubble')))
+                .decoration!
+            as BoxDecoration;
+    final assistantDecoration =
+        tester
+                .widget<Container>(find.byKey(const Key('assistant-bubble')))
+                .decoration!
+            as BoxDecoration;
+
+    expect(userDecoration.color, SpeakUpDesign.userBubble);
+    expect(userDecoration.border?.top.color, SpeakUpDesign.userBubbleBorder);
+    expect(assistantDecoration.color, Colors.transparent);
+    expect(assistantDecoration.border, isNull);
   });
 
   testWidgets(


### PR DESCRIPTION
## 功能描述

- 为共享设计系统增加用户消息气泡专用淡蓝填充与冷色边框令牌
- 普通聊天、场景练习和面试练习通过 ConversationBubbleSurface 统一应用新样式
- AI 消息、尺寸、圆角、间距、字体和交互保持不变

## 实现思路

- 新增 userBubble（#E6F2FF）与 userBubbleBorder（#DDE5F0）语义令牌
- ConversationBubbleSurface 仅在 isUser=true 时使用专用令牌
- 补充共享组件测试，并更新场景练习的颜色断言

## 可复现测试

1. PUB_HOSTED_URL=https://pub.dev make check-flutter-test
2. SPEAKUP_DEV_PORT=18082 make dev-ios-simulator
3. 打开含用户消息的普通聊天或练习会话
4. 确认用户气泡为淡蓝色，AI 消息与其他表面不变

本地结果：Flutter 格式检查通过，flutter analyze 0 issues，avatar stub 合约通过，835 个 Flutter 测试通过；iPhone 17 模拟器配合真实 18082 后端完成视觉验证。

Closes #1005