### PR TITLE
feat(practice): 在各练习场景复用纠错与润色

### DIFF
--- a/mobile/lib/design/practice_conversation_components.dart
+++ b/mobile/lib/design/practice_conversation_components.dart
@@ -31,6 +31,7 @@ class InlineLanguageFeedback extends StatefulWidget {
     this.onSpeakSuggestion,
     this.suggestionLoading = false,
     this.suggestionPlaying = false,
+    this.feedbackLoading = false,
     this.optimizeIconOnly = false,
     this.onExpandedChanged,
     this.foregroundColor = SpeakUpDesign.primary,
@@ -48,6 +49,7 @@ class InlineLanguageFeedback extends StatefulWidget {
   final ValueChanged<String>? onSpeakSuggestion;
   final bool suggestionLoading;
   final bool suggestionPlaying;
+  final bool feedbackLoading;
   final bool optimizeIconOnly;
   final ValueChanged<bool>? onExpandedChanged;
   final Color foregroundColor;
@@ -97,6 +99,16 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
           selected: _expanded,
           color: widget.foregroundColor,
           onPressed: _toggle,
+        ),
+      if (!hasFeedback && widget.feedbackLoading)
+        _InlineFeedbackAction(
+          key: const Key('inline-language-optimizing'),
+          icon: Icons.auto_awesome_outlined,
+          label: '优化中',
+          loading: true,
+          iconOnly: widget.optimizeIconOnly,
+          color: widget.foregroundColor,
+          onPressed: null,
         ),
     ];
     final actionWrap = Wrap(
@@ -201,6 +213,64 @@ class _InlineLanguageFeedbackState extends State<InlineLanguageFeedback> {
       ],
     );
   }
+}
+
+class InlineVoicePlaybackAction extends StatelessWidget {
+  const InlineVoicePlaybackAction({
+    required this.loading,
+    required this.playing,
+    required this.onPressed,
+    this.duration,
+    super.key,
+  });
+
+  final bool loading;
+  final bool playing;
+  final Duration? duration;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final durationLabel = duration == null
+        ? ''
+        : '，${_formatInlineDuration(duration!)}';
+    return Semantics(
+      button: true,
+      enabled: onPressed != null,
+      label: playing ? '停止播放原声' : '播放原声$durationLabel',
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
+          child: SizedBox.square(
+            dimension: SpeakUpDesign.minTapTarget,
+            child: Center(
+              child: loading
+                  ? const SizedBox.square(
+                      dimension: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(
+                      playing ? Icons.pause_rounded : Icons.graphic_eq_rounded,
+                      size: 24,
+                      color: onPressed == null
+                          ? SpeakUpDesign.tertiary
+                          : SpeakUpDesign.primary,
+                    ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _formatInlineDuration(Duration value) {
+  final totalSeconds = value.inSeconds.clamp(0, 3599);
+  final minutes = totalSeconds ~/ 60;
+  final seconds = totalSeconds % 60;
+  return '$minutes:${seconds.toString().padLeft(2, '0')}';
 }
 
 class _InlineFeedbackHeading extends StatelessWidget {

--- a/mobile/lib/features/agent/conversation/agent_message_bubble.dart
+++ b/mobile/lib/features/agent/conversation/agent_message_bubble.dart
@@ -317,7 +317,7 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
         InlineLanguageFeedback(
           leading: recordingDeleted
               ? null
-              : _VoicePlaybackAction(
+              : InlineVoicePlaybackAction(
                   key: Key('agent-user-voice-play-${message.id}'),
                   loading: loading,
                   playing: playing,
@@ -355,54 +355,6 @@ class _AgentMessageBubbleState extends State<AgentMessageBubble> {
           ),
         ],
       ],
-    );
-  }
-}
-
-class _VoicePlaybackAction extends StatelessWidget {
-  const _VoicePlaybackAction({
-    required this.loading,
-    required this.playing,
-    required this.duration,
-    required this.onPressed,
-    super.key,
-  });
-
-  final bool loading;
-  final bool playing;
-  final Duration duration;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      enabled: onPressed != null,
-      label: playing ? '停止播放原声' : '播放原声，${_formatDuration(duration)}',
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onPressed,
-          borderRadius: BorderRadius.circular(SpeakUpDesign.radiusControl),
-          child: SizedBox.square(
-            dimension: SpeakUpDesign.minTapTarget,
-            child: Center(
-              child: loading
-                  ? const SizedBox.square(
-                      dimension: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : Icon(
-                      playing ? Icons.pause_rounded : Icons.graphic_eq_rounded,
-                      size: 24,
-                      color: onPressed == null
-                          ? SpeakUpDesign.tertiary
-                          : SpeakUpDesign.primary,
-                    ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }
@@ -472,13 +424,6 @@ typedef _AgentMessageAudioSnapshot = ({
   double speechSpeed,
   bool usesPreview,
 });
-
-String _formatDuration(Duration value) {
-  final totalSeconds = value.inSeconds.clamp(0, 3599);
-  final minutes = totalSeconds ~/ 60;
-  final seconds = totalSeconds % 60;
-  return '$minutes:${seconds.toString().padLeft(2, '0')}';
-}
 
 String _formatSpeed(double value) {
   return value == value.roundToDouble()

--- a/mobile/lib/features/coaching/evaluation/inline_speech_feedback.dart
+++ b/mobile/lib/features/coaching/evaluation/inline_speech_feedback.dart
@@ -50,6 +50,8 @@ class InlineSpeechFeedback extends StatelessWidget {
               explanation: polish.explanation,
             ),
       feedbackNotice: strength == null ? null : '表达已经很自然，无需润色',
+      feedbackLoading: projection?.isPolling ?? false,
+      optimizeIconOnly: true,
       correctionFooter: correction == null || onRepractice == null
           ? null
           : TextButton.icon(

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice_widgets.dart
@@ -116,6 +116,7 @@ class _ExamConversation extends StatelessWidget {
               padding: const EdgeInsets.only(bottom: 12),
               child: PracticeMessageBubble(
                 message: message,
+                practiceController: controller,
                 feedbackProjection: projection,
                 onTranslate: assistant ? onTranslateQuestion : null,
                 actions: assistant

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -749,6 +749,7 @@ class _SceneConversationMessageList extends StatelessWidget {
             PracticeMessageBubble(
               key: ValueKey('practice-${message.role.name}-${message.id}'),
               message: message,
+              practiceController: controller,
               feedbackProjection: _feedbackProjection(message),
               onFeedbackRepractice: controller.canStartSpeechFeedbackRetry
                   ? onRepractice

--- a/mobile/lib/features/coaching/practice/practice_controller.dart
+++ b/mobile/lib/features/coaching/practice/practice_controller.dart
@@ -2431,6 +2431,7 @@ final class PracticeController extends ChangeNotifier
             id: exchange.turn.id,
             role: PracticeMessageRole.user,
             text: exchange.turn.answerText,
+            audioAssetId: exchange.turn.audioAssetId,
             speechFeedbackStatusUrl: exchange.turn.speechFeedbackStatusUrl,
           ),
         ],

--- a/mobile/lib/features/coaching/practice/practice_message_bubble.dart
+++ b/mobile/lib/features/coaching/practice/practice_message_bubble.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/design/conversation_bubble_surface.dart';
 import 'package:speakup/design/conversation_message_content.dart';
+import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/coaching/evaluation/inline_speech_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
+import 'package:speakup/features/coaching/practice/practice_controller.dart';
 
 final class PracticeMessageBubble extends StatefulWidget {
   const PracticeMessageBubble({
     required this.message,
     this.feedbackProjection,
+    this.practiceController,
     this.onFeedbackRepractice,
     this.messageTextVisible = true,
     this.onTranslate,
@@ -21,6 +24,7 @@ final class PracticeMessageBubble extends StatefulWidget {
 
   final PracticeMessage message;
   final SpeechFeedbackProjection? feedbackProjection;
+  final PracticeController? practiceController;
   final ValueChanged<SpeechFeedbackItem>? onFeedbackRepractice;
   final bool messageTextVisible;
   final Future<String> Function(PracticeMessage message)? onTranslate;
@@ -36,6 +40,29 @@ final class _PracticeMessageBubbleState extends State<PracticeMessageBubble> {
   Widget build(BuildContext context) {
     final message = widget.message;
     final user = message.role == PracticeMessageRole.user;
+    final audioAssetId = message.audioAssetId;
+    final practiceController = widget.practiceController;
+    final recordingAvailable =
+        audioAssetId != null &&
+        practiceController != null &&
+        practiceController.recordings.any(
+          (recording) => recording.audioAssetId == audioAssetId,
+        );
+    final recordingAction = !user || audioAssetId == null
+        ? null
+        : InlineVoicePlaybackAction(
+            key: Key('practice-user-voice-play-${message.id}'),
+            loading:
+                practiceController?.isRecordingAudioLoading(audioAssetId) ??
+                false,
+            playing:
+                practiceController?.isRecordingAudioPlaying(audioAssetId) ??
+                false,
+            onPressed:
+                recordingAvailable && practiceController.canUsePracticeAudio
+                ? () => practiceController.toggleRecordingAudio(audioAssetId)
+                : null,
+          );
     return ConversationBubbleSurface(
       bubbleKey: Key('practice-message-${message.id}'),
       isUser: user,
@@ -66,10 +93,13 @@ final class _PracticeMessageBubbleState extends State<PracticeMessageBubble> {
                 ? const <Widget>[]
                 : <Widget>[widget.actions!],
           ),
-          if (user && widget.feedbackProjection != null) ...[
+          if (user &&
+              (widget.feedbackProjection != null ||
+                  recordingAction != null)) ...[
             const SizedBox(height: SpeakUpDesign.space4),
             InlineSpeechFeedback(
               projection: widget.feedbackProjection,
+              leading: recordingAction,
               onRepractice: widget.onFeedbackRepractice,
             ),
           ],

--- a/mobile/lib/features/coaching/practice/practice_models.dart
+++ b/mobile/lib/features/coaching/practice/practice_models.dart
@@ -11,12 +11,14 @@ final class PracticeMessage {
     required this.id,
     required this.role,
     required this.text,
+    this.audioAssetId,
     this.speechFeedbackStatusUrl,
   });
 
   final String id;
   final PracticeMessageRole role;
   final String text;
+  final String? audioAssetId;
   final String? speechFeedbackStatusUrl;
 }
 

--- a/mobile/lib/features/coaching/practice/wire_practice_client.dart
+++ b/mobile/lib/features/coaching/practice/wire_practice_client.dart
@@ -1432,6 +1432,7 @@ PracticeTurnConfirmation _confirmationFromState(
       id: turn.id,
       role: PracticeMessageRole.user,
       text: turn.answerText,
+      audioAssetId: turn.audioAssetId,
       speechFeedbackStatusUrl: turn.speechFeedbackStatusUrl,
     ),
     completedTurns: state.completedTurns,

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -814,6 +814,7 @@ class _ConversationPanel extends StatelessWidget {
                           children: [
                             PracticeMessageBubble(
                               message: message,
+                              practiceController: controller,
                               feedbackProjection: projection,
                               messageTextVisible: true,
                               onTranslate: assistant

--- a/mobile/test/coaching/practice/practice_message_bubble_test.dart
+++ b/mobile/test/coaching/practice/practice_message_bubble_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/practice_conversation_components.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 
@@ -89,5 +90,30 @@ void main() {
 
     expect(actionCalls, 1);
     expect(find.text('查看反馈'), findsOneWidget);
+  });
+
+  testWidgets('reuses the inline original-voice action for a recorded answer', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PracticeMessageBubble(
+            message: PracticeMessage(
+              id: 'practice-user-voice',
+              role: PracticeMessageRole.user,
+              text: 'I led the migration.',
+              audioAssetId: 'audio-asset-1',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byKey(const Key('practice-user-voice-play-practice-user-voice')),
+      findsOneWidget,
+    );
+    expect(find.byType(InlineVoicePlaybackAction), findsOneWidget);
   });
 }

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -489,62 +489,56 @@ void main() {
     expect(find.byKey(const Key('scenario-record')), findsOneWidget);
   });
 
-  testWidgets(
-    'keeps pending feedback silent without breaking the composer row',
-    (tester) async {
-      final controller = await _scenarioController(
-        practiceClient: _AsyncReviewPracticeClient(),
-      );
-      addTearDown(controller.dispose);
-      for (var turn = 0; turn < 3; turn++) {
-        await controller.startRecording();
-        await controller.stopRecording();
-        await controller.confirmTranscript();
-      }
-      expect(controller.recordingState, PracticeRecordingState.completed);
+  testWidgets('shows pending optimization without breaking the composer row', (
+    tester,
+  ) async {
+    final controller = await _scenarioController(
+      practiceClient: _AsyncReviewPracticeClient(),
+    );
+    addTearDown(controller.dispose);
+    for (var turn = 0; turn < 3; turn++) {
+      await controller.startRecording();
+      await controller.stopRecording();
+      await controller.confirmTranscript();
+    }
+    expect(controller.recordingState, PracticeRecordingState.completed);
 
-      final feedbackController = SpeechFeedbackController(
-        client: _PendingSpeechFeedbackClient(),
-      );
-      addTearDown(feedbackController.dispose);
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: SpeakUpTheme.light,
-          home: ScenarioPracticePage(
-            practiceController: controller,
-            speechFeedbackController: feedbackController,
-          ),
+    final feedbackController = SpeechFeedbackController(
+      client: _PendingSpeechFeedbackClient(),
+    );
+    addTearDown(feedbackController.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SpeakUpTheme.light,
+        home: ScenarioPracticePage(
+          practiceController: controller,
+          speechFeedbackController: feedbackController,
         ),
-      );
-      await tester.pump();
+      ),
+    );
+    await tester.pump();
 
-      expect(tester.takeException(), isNull);
-      expect(
-        find.byKey(const Key('speech-feedback-loading-indicator')),
-        findsNothing,
-      );
-      expect(find.byType(SpeechFeedbackDisclosure), findsNothing);
-      expect(find.text('正在生成评分与纠错…'), findsNothing);
-      expect(
-        find.byKey(const Key('scenario-completion-sheet')),
-        findsOneWidget,
-      );
-      expect(find.text('场景练习已完成'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(const Key('inline-language-optimizing')), findsWidgets);
+    expect(find.text('优化中'), findsNothing);
+    expect(find.byType(SpeechFeedbackDisclosure), findsNothing);
+    expect(find.text('正在生成评分与纠错…'), findsNothing);
+    expect(find.byKey(const Key('scenario-completion-sheet')), findsOneWidget);
+    expect(find.text('场景练习已完成'), findsOneWidget);
 
-      await tester.timedDrag(
-        find.byKey(const Key('scenario-completion-drag-region')),
-        const Offset(0, 200),
-        const Duration(milliseconds: 600),
-      );
-      await tester.pumpAndSettle();
+    await tester.timedDrag(
+      find.byKey(const Key('scenario-completion-drag-region')),
+      const Offset(0, 200),
+      const Duration(milliseconds: 600),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.byKey(const Key('scenario-completion-sheet')), findsNothing);
-      expect(
-        find.byKey(const Key('scenario-conversation-history')),
-        findsOneWidget,
-      );
-    },
-  );
+    expect(find.byKey(const Key('scenario-completion-sheet')), findsNothing);
+    expect(
+      find.byKey(const Key('scenario-conversation-history')),
+      findsOneWidget,
+    );
+  });
 
   testWidgets('hands completed scenario to the generic completion callback', (
     tester,

--- a/mobile/test/coaching/practice/wire_practice_client_test.dart
+++ b/mobile/test/coaching/practice/wire_practice_client_test.dart
@@ -874,7 +874,7 @@ void main() {
     transport.expectDone();
   });
 
-  test('retains a valid optional audio asset', () async {
+  test('retains current-turn audio and feedback without a restore', () async {
     final state = <String, Object?>{
       ..._sessionJson(),
       'session_version': 2,
@@ -898,6 +898,7 @@ void main() {
         'effective_turns': 1,
         'session_completed': false,
         'audio_asset_id': '00000000-0000-4000-8000-000000000001',
+        'speech_feedback_status_url': '/v1/practice-turns/$_turnId/evaluation',
       },
     };
     final transport = _Transport([
@@ -916,6 +917,14 @@ void main() {
     );
 
     expect(confirmation.audioAssetId, '00000000-0000-4000-8000-000000000001');
+    expect(
+      confirmation.answer.audioAssetId,
+      '00000000-0000-4000-8000-000000000001',
+    );
+    expect(
+      confirmation.answer.speechFeedbackStatusUrl,
+      '/v1/practice-turns/$_turnId/evaluation',
+    );
     transport.expectDone();
   });
 

--- a/mobile/test/design/practice_conversation_components_test.dart
+++ b/mobile/test/design/practice_conversation_components_test.dart
@@ -41,6 +41,34 @@ void main() {
     expect(find.text('I already have a plan.'), findsOneWidget);
   });
 
+  testWidgets('icon-only feedback hides ready and loading labels', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              InlineLanguageFeedback(
+                polish: InlineLanguageSuggestion(text: 'A better answer.'),
+                optimizeIconOnly: true,
+              ),
+              InlineLanguageFeedback(
+                feedbackLoading: true,
+                optimizeIconOnly: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('优化'), findsNothing);
+    expect(find.text('优化中'), findsNothing);
+    expect(find.byKey(const Key('inline-language-optimize')), findsOneWidget);
+    expect(find.byKey(const Key('inline-language-optimizing')), findsOneWidget);
+  });
+
   testWidgets('shared recording composer shows the live transcript', (
     tester,
   ) async {

--- a/mobile/test/review/turn_feedback_page_integration_test.dart
+++ b/mobile/test/review/turn_feedback_page_integration_test.dart
@@ -13,6 +13,7 @@ import 'package:speakup/features/coaching/practice/practice_client.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
+import 'package:speakup/features/coaching/scenario/scenario_practice.dart';
 import 'package:speakup/features/coaching/evaluation/agent_conversation_feedback_presenter.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_client.dart';
@@ -81,6 +82,51 @@ void main() {
   );
 
   testWidgets(
+    'Scenario practice reuses correction and polish from the shared feedback UI',
+    (tester) async {
+      final feedback = _practiceFeedback();
+      final client = _Client(feedback);
+      final feedbackController = SpeechFeedbackController(
+        client: client,
+        pollInterval: Duration.zero,
+        maximumPollAttempts: 1,
+      );
+      final snapshot = _practiceSnapshot(feedback.statusUrl);
+      final practiceController = PracticeController(
+        client: _PracticeClient(snapshot),
+      );
+      addTearDown(feedbackController.dispose);
+      addTearDown(practiceController.dispose);
+      await _restorePractice(practiceController, snapshot);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ScenarioPracticePage(
+            practiceController: practiceController,
+            speechFeedbackController: feedbackController,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(client.calls, 1);
+      expect(find.text('优化'), findsNothing);
+      expect(find.byKey(const Key('inline-language-optimize')), findsOneWidget);
+      expect(find.text('I managed'), findsNothing);
+      expect(find.text('I handled the release successfully.'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('inline-language-optimize')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('inline-language-correction-diff')),
+        findsOneWidget,
+      );
+      expect(find.text('I handled the release successfully.'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'Practice SAME_QUESTION reuses recorder and never advances progress',
     (tester) async {
       final feedback = _practiceFeedback();
@@ -108,7 +154,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(client.calls, 1);
-      expect(find.text('优化'), findsOneWidget);
+      expect(find.text('优化'), findsNothing);
+      expect(find.byKey(const Key('inline-language-optimize')), findsOneWidget);
       expect(find.text('I managed'), findsNothing);
 
       await tester.tap(find.byKey(const Key('inline-language-optimize')));
@@ -469,6 +516,22 @@ SpeechFeedback _practiceFeedback({bool insufficient = false}) {
               explanation: 'Use the past tense for the completed release.',
               suggestedText: 'I managed',
               repracticeMode: SpeechFeedbackRepracticeMode.sameQuestion,
+              createdAt: DateTime.utc(2026, 7, 30, 10, 1, 1),
+            ),
+            SpeechFeedbackItem(
+              feedbackItemId: 'item_practice_002',
+              evaluationId: '10000000-0000-4000-8000-000000000020',
+              position: 2,
+              kind: SpeechFeedbackItemKind.recommendedExpression,
+              anchor: const SpeechFeedbackAnchor(
+                evidenceRefId: 'practice_turn_001',
+                startUtf8Byte: 0,
+                endUtf8Byte: 8,
+                originalExcerpt: 'I manage',
+              ),
+              explanation: 'Use a more natural completed-action expression.',
+              suggestedText: 'I handled the release successfully.',
+              repracticeMode: SpeechFeedbackRepracticeMode.none,
               createdAt: DateTime.utc(2026, 7, 30, 10, 1, 1),
             ),
           ],

--- a/server/internal/coaching/practice/execution_policy.go
+++ b/server/internal/coaching/practice/execution_policy.go
@@ -185,6 +185,7 @@ func resolveSessionPolicyRegistration(
 		maxEffectiveTurns:       6,
 		coverageCheckpointTurn:  4,
 		maxFollowUpsPerQuestion: 1,
+		speechFeedbackAllowed:   true,
 	}
 	switch reference {
 	case GenericPracticeSessionPolicy,

--- a/server/internal/coaching/practice/execution_policy_test.go
+++ b/server/internal/coaching/practice/execution_policy_test.go
@@ -49,6 +49,7 @@ func TestResolveSessionPolicyUsesExactReference(t *testing.T) {
 				policy.RetryAllowed != test.retry ||
 				policy.QuestionTranslationAllowed != test.readAids ||
 				policy.QuestionTipsAllowed != test.readAids ||
+				!policy.SpeechFeedbackAllowed ||
 				policy.MaxFollowUpsPerQuestion != test.followUps ||
 				!ValidSessionPolicy(
 					test.reference,
@@ -92,6 +93,55 @@ func TestValidSessionPolicyRejectsPolicyValueThatContradictsReference(
 		policy,
 	) {
 		t.Fatal("daily policy accepted contradictory retry value")
+	}
+}
+
+func TestEverySessionPolicyAllowsSpeechFeedback(t *testing.T) {
+	t.Parallel()
+	registrations := []struct {
+		reference string
+		mode      PracticeMode
+	}{
+		{GenericPracticeSessionPolicy, PracticeModeFullSimulation},
+		{DailyPracticeSessionPolicy, PracticeModeFullSimulation},
+		{WorkplacePracticeSessionPolicy, PracticeModeFullSimulation},
+		{InterviewPracticeSessionPolicy, PracticeModeFullSimulation},
+		{InterviewUserControlledSessionPolicy, PracticeModeFullSimulation},
+		{ExamPracticeSessionPolicy, PracticeModeFullSimulation},
+		{DailyHotelCheckinIssueSessionPolicy, PracticeModeFullSimulation},
+		{WorkplaceProgressRiskUpdateSessionPolicy, PracticeModeFullSimulation},
+		{InterviewProjectDeepDiveSessionPolicy, PracticeModeFullSimulation},
+		{
+			InterviewProjectDeepDiveUserControlledSessionPolicy,
+			PracticeModeFullSimulation,
+		},
+		{IELTSSpeakingPart1SessionPolicy, PracticeModePart1},
+		{IELTSSpeakingPart2SessionPolicy, PracticeModePart2},
+		{IELTSSpeakingPart3SessionPolicy, PracticeModePart3},
+		{IELTSSpeakingFullMockSessionPolicy, PracticeModeFullMock},
+	}
+	prompt := ScenePrompt{
+		TurnBlueprints: []string{"one", "two", "three", "four"},
+	}
+	for _, registration := range registrations {
+		registration := registration
+		t.Run(registration.reference, func(t *testing.T) {
+			policy, err := ResolveSessionPolicy(
+				registration.reference,
+				prompt,
+				PracticeOption{
+					Mode:                     registration.mode,
+					SuggestedDurationSeconds: 600,
+				},
+				0,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !policy.SpeechFeedbackAllowed {
+				t.Fatalf("speech feedback disabled: %#v", policy)
+			}
+		})
 	}
 }
 

--- a/server/internal/coaching/practice/interaction/round_orchestrator.go
+++ b/server/internal/coaching/practice/interaction/round_orchestrator.go
@@ -64,44 +64,30 @@ type PracticePort interface {
 	) (string, error)
 }
 
-type TurnFeedbackReference struct {
-	StatusURL  string
-	Applicable bool
-}
-
-type TurnFeedbackPort interface {
-	EnsureTurn(
-		context.Context,
-		requestcontext.Actor,
-		string,
-		string,
-	) (TurnFeedbackReference, error)
-}
-
 // RoundOrchestrator owns the cross-module voice-round saga. It never
 // reaches into a module Repository and relies on stable Turn and Session IDs
 // for idempotent recovery after any completed step.
 type RoundOrchestrator struct {
 	rounds   RoundPort
 	practice PracticePort
-	feedback TurnFeedbackPort
+	feedback TurnFeedbackStatusReader
 }
 
 func NewRoundOrchestrator(
 	rounds RoundPort,
 	practice PracticePort,
-	feedbackPorts ...TurnFeedbackPort,
+	feedbackReaders ...TurnFeedbackStatusReader,
 ) (*RoundOrchestrator, error) {
-	if rounds == nil || practice == nil || len(feedbackPorts) > 1 ||
-		(len(feedbackPorts) == 1 && feedbackPorts[0] == nil) {
+	if rounds == nil || practice == nil || len(feedbackReaders) > 1 ||
+		(len(feedbackReaders) == 1 && feedbackReaders[0] == nil) {
 		return nil, errors.New("practice interaction: round dependency is required")
 	}
 	orchestrator := &RoundOrchestrator{
 		rounds:   rounds,
 		practice: practice,
 	}
-	if len(feedbackPorts) == 1 {
-		orchestrator.feedback = feedbackPorts[0]
+	if len(feedbackReaders) == 1 {
+		orchestrator.feedback = feedbackReaders[0]
 	}
 	return orchestrator, nil
 }
@@ -197,22 +183,21 @@ func (orchestrator *RoundOrchestrator) attachTurnFeedback(
 	if orchestrator.feedback == nil {
 		return turn, nil
 	}
-	reference, err := orchestrator.feedback.EnsureTurn(
+	statusURL, found, err := orchestrator.feedback.StatusURLForTurn(
 		ctx,
 		actor,
-		turn.SessionID,
 		turn.ID,
 	)
 	if err != nil {
 		return practice.Turn{}, err
 	}
-	if !reference.Applicable {
+	if !found {
 		return turn, nil
 	}
-	if strings.TrimSpace(reference.StatusURL) == "" {
+	if strings.TrimSpace(statusURL) == "" {
 		return practice.Turn{}, ErrInvalidContext
 	}
-	turn.SpeechFeedbackStatusURL = reference.StatusURL
+	turn.SpeechFeedbackStatusURL = statusURL
 	return turn, nil
 }
 
@@ -255,7 +240,11 @@ func (orchestrator *RoundOrchestrator) SubmitText(
 	if err != nil {
 		return practice.Turn{}, err
 	}
-	return orchestrator.finishTurn(ctx, actor, candidate, turn)
+	turn, err = orchestrator.finishTurn(ctx, actor, candidate, turn)
+	if err != nil {
+		return practice.Turn{}, err
+	}
+	return orchestrator.attachTurnFeedback(ctx, actor, turn)
 }
 
 func (orchestrator *RoundOrchestrator) finishTurn(

--- a/server/internal/coaching/practice/interaction/round_orchestrator_test.go
+++ b/server/internal/coaching/practice/interaction/round_orchestrator_test.go
@@ -40,6 +40,38 @@ func TestRoundConfirmReturnsAtomicPracticeTurn(t *testing.T) {
 	}
 }
 
+func TestTextAnswerReturnsTurnFeedbackWithoutSessionRestore(t *testing.T) {
+	candidate := roundCandidate()
+	turn := roundTurn(candidate)
+	rounds := &roundVoice{candidate: candidate, turn: turn}
+	orchestrator, err := NewRoundOrchestrator(
+		rounds,
+		roundPractice{},
+		roundFeedback{},
+	)
+	if err != nil {
+		t.Fatalf("NewRoundOrchestrator: %v", err)
+	}
+
+	got, err := orchestrator.SubmitText(
+		context.Background(),
+		roundActor(),
+		SubmitTextAnswerCommand{
+			SessionID:      turn.SessionID,
+			QuestionID:     turn.QuestionID,
+			AnswerText:     candidate.Transcript,
+			IdempotencyKey: "text-1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("SubmitText: %v", err)
+	}
+	if got.ID != turn.ID ||
+		got.SpeechFeedbackStatusURL != "/v1/feedback/turn-1" {
+		t.Fatalf("Turn = %#v", got)
+	}
+}
+
 func TestRoundRejectsTurnWithoutAtomicProgress(t *testing.T) {
 	candidate := roundCandidate()
 	turn := roundTurn(candidate)
@@ -140,16 +172,12 @@ func (roundPractice) ResolveActorParticipant(
 
 type roundFeedback struct{}
 
-func (roundFeedback) EnsureTurn(
+func (roundFeedback) StatusURLForTurn(
 	_ context.Context,
 	_ requestcontext.Actor,
-	_ string,
 	turnID string,
-) (TurnFeedbackReference, error) {
-	return TurnFeedbackReference{
-		StatusURL:  "/v1/feedback/" + turnID,
-		Applicable: true,
-	}, nil
+) (string, bool, error) {
+	return "/v1/feedback/" + turnID, true, nil
 }
 
 func roundActor() requestcontext.Actor {

--- a/server/internal/coaching/practice/interaction/runtime.go
+++ b/server/internal/coaching/practice/interaction/runtime.go
@@ -43,7 +43,6 @@ type RuntimeConfiguration struct {
 	AnswerTipGenerator AnswerTipGenerator
 	Recordings         RecordingUploader
 	ASRLease           time.Duration
-	Feedback           TurnFeedbackPort
 	FeedbackReader     TurnFeedbackStatusReader
 }
 
@@ -100,14 +99,14 @@ func NewRuntimeApplications(
 		return nil, nil, err
 	}
 
-	feedbackPorts := make([]TurnFeedbackPort, 0, 1)
-	if configuration.Feedback != nil {
-		feedbackPorts = append(feedbackPorts, configuration.Feedback)
+	feedbackReaders := make([]TurnFeedbackStatusReader, 0, 1)
+	if configuration.FeedbackReader != nil {
+		feedbackReaders = append(feedbackReaders, configuration.FeedbackReader)
 	}
 	orchestrator, err := NewRoundOrchestrator(
 		roundService,
 		participantResolver,
-		feedbackPorts...,
+		feedbackReaders...,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/server/internal/coaching/practice/session_application_test.go
+++ b/server/internal/coaching/practice/session_application_test.go
@@ -277,6 +277,7 @@ func practicePlanFixture() PlanProjection {
 			CoverageCheckpointTurn:   4,
 			MaxFollowUpsPerQuestion:  1,
 			EarlyCompletionRule:      EarlyCompletionCoverageSatisfiedAfterCheckpoint,
+			SpeechFeedbackAllowed:    true,
 		},
 		PracticeObjectives: []PracticeObjective{{
 			ID: "clarity", Description: "clarity",


### PR DESCRIPTION
## 功能描述

- 在日常、职场、面试和 IELTS 等练习场景中复用首页的原声播放、优化中、纠错与润色入口
- 通用及考试 Session Policy 统一开放逐句反馈能力
- 文本回答确认后立即返回反馈地址，无需恢复会话才显示优化入口
- 保留证据不足时不生成纠错内容的既有语义

## 实现思路

- 将首页原声播放操作提取为共享 `InlineVoicePlaybackAction`
- 场景消息复用 `InlineLanguageFeedback`，以图标展示反馈生成中和已就绪状态
- 在 Practice 消息投影中保留录音资产与反馈地址，覆盖即时确认和恢复路径
- 后端统一使用反馈状态读取端口，为文本回答补齐原子确认后的反馈地址

## 可复现测试

1. `cd server && go test ./...`
2. `cd mobile && flutter test test/design/practice_conversation_components_test.dart test/coaching/practice/practice_message_bubble_test.dart test/coaching/practice/scenario_practice_test.dart test/coaching/practice/wire_practice_client_test.dart test/review/turn_feedback_page_integration_test.dart test/coaching/practice/ielts_mock_practice_test.dart`
3. 启动真实后端进入任一新练习场景，提交英文语音或文本回答
4. 确认气泡先显示优化中图标，反馈完成后可展开纠错与更自然的表达，并可播放原声

Closes #1010