### PR TITLE
fix(staging): 隔离 RootlessKit 临时目录

### DIFF
--- a/deploy/staging/host/rootless-docker.service
+++ b/deploy/staging/host/rootless-docker.service
@@ -5,6 +5,7 @@ Documentation=https://docs.docker.com/engine/security/rootless/
 [Service]
 Environment=HOME=/var/lib/speakup/staging-runtime
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=TMPDIR=%t
 Environment=DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=%t/speakup-staging-rootlesskit
 ExecStart=/usr/bin/dockerd-rootless.sh --host=unix://%t/docker.sock --config-file=/var/lib/speakup/staging-runtime/.config/docker/daemon.json
 ExecStartPost=/usr/bin/chmod 0600 %t/docker.sock

--- a/deploy/staging/test-host-access.sh
+++ b/deploy/staging/test-host-access.sh
@@ -63,6 +63,7 @@ assert_line 'exec /usr/bin/sudo -n -u speakup-staging-runtime -- \' \
 assert_line '  /usr/local/libexec/speakup-staging-broker' "$host_contract/ssh-gate"
 assert_line 'ExecStart=/usr/bin/dockerd-rootless.sh --host=unix://%t/docker.sock --config-file=/var/lib/speakup/staging-runtime/.config/docker/daemon.json' \
   "$host_contract/rootless-docker.service"
+assert_line 'Environment=TMPDIR=%t' "$host_contract/rootless-docker.service"
 if grep -Fq '/var/run/docker.sock' "$host_contract/rootless-docker.service"; then
   fail "rootless unit references the rootful Docker socket"
 fi


### PR DESCRIPTION
## 功能描述

- 修复共享主机 `/tmp` 不可写时 RootlessKit 无法启动的问题。
- 仅为 SpeakUp Rootless Docker user service 指定该用户自己的 systemd runtime 目录作为 `TMPDIR`。
- 不修改服务器全局 `/tmp` 权限，不影响其他项目。

## 实现思路

- 在受版本控制的 user unit 中设置 `Environment=TMPDIR=%t`。
- 复用 systemd 已为该用户创建且私有的 `/run/user/<uid>`。
- 增加精确契约断言，防止后续移除该隔离设置。

## 可复现测试

```bash
bash -n deploy/staging/host/bootstrap.sh deploy/staging/host/validate.sh deploy/staging/test-host-access.sh
make check-staging-host-access
git diff --check
```

本地结果：全部通过。

Closes #1019

Reviewers: @gangcaiyoule @jyqin0203 @Scorbunny2
