### PR TITLE
fix(staging): 兼容 Ubuntu 24.04 OpenSSH Match 规则

### DIFF
--- a/deploy/staging/host/sshd_config
+++ b/deploy/staging/host/sshd_config
@@ -1,3 +1,5 @@
+PermitUserEnvironment no
+
 Match User speakup-staging-ci
     AuthenticationMethods publickey
     PubkeyAuthentication yes
@@ -11,7 +13,6 @@ Match User speakup-staging-ci
     X11Forwarding no
     PermitTunnel no
     PermitUserRC no
-    PermitUserEnvironment no
     PermitOpen none
     PermitListen none
     GatewayPorts no

--- a/deploy/staging/test-host-access.sh
+++ b/deploy/staging/test-host-access.sh
@@ -44,6 +44,8 @@ done
 [[ "$(<"$host_contract/sudoers")" == \
   'speakup-staging-ci ALL=(speakup-staging-runtime) NOPASSWD: /usr/local/libexec/speakup-staging-broker ""' ]] ||
   fail "sudoers must permit only the no-argument broker command"
+[[ "$(head -n 1 "$host_contract/sshd_config")" == 'PermitUserEnvironment no' ]] ||
+  fail "PermitUserEnvironment must be disabled before the Match block"
 assert_line 'Match User speakup-staging-ci' "$host_contract/sshd_config"
 assert_line '    AuthenticationMethods publickey' "$host_contract/sshd_config"
 assert_line '    PasswordAuthentication no' "$host_contract/sshd_config"


### PR DESCRIPTION
## 功能描述

- 修复 Ubuntu 24.04 OpenSSH 拒绝 Staging CI drop-in 的问题。
- 将 `PermitUserEnvironment no` 从不允许的 `Match` 块移至全局段。
- 其余 CI 用户 SSH 限制保持不变。

## 验证

```bash
make check-staging-host-access
git diff --check
```

- 本地契约测试通过。
- 已将修复后的配置上传到目标主机临时路径，`/usr/sbin/sshd -t -f ...` 实测通过。

Closes #1022

Reviewers: @gangcaiyoule @jyqin0203 @Scorbunny2
