### PR TITLE
fix(mobile): 统一 iOS 底部导航间距

### DIFF
--- a/mobile/lib/app/platform_navigation_bar.dart
+++ b/mobile/lib/app/platform_navigation_bar.dart
@@ -33,12 +33,16 @@ class PlatformNavigationBar extends StatelessWidget {
 
   static const contentHeight = 64.0;
   static const minimumBottomInset = 10.0;
+  static const iosVerticalOffset = 12.0;
 
   final List<PlatformNavigationDestination> destinations;
   final int selectedIndex;
   final Future<int> Function(int) onDestinationSelected;
 
-  static double heightFor(BuildContext context) => contentHeight;
+  static double heightFor(BuildContext context) =>
+      defaultTargetPlatform == TargetPlatform.iOS && !kIsWeb
+      ? contentHeight - iosVerticalOffset
+      : contentHeight;
 
   @override
   Widget build(BuildContext context) {
@@ -46,10 +50,13 @@ class PlatformNavigationBar extends StatelessWidget {
       return SizedBox(
         key: const Key('primary-navigation'),
         height: contentHeight + MediaQuery.viewPaddingOf(context).bottom,
-        child: _NativeIosTabBar(
-          destinations: destinations,
-          selectedIndex: selectedIndex,
-          onDestinationSelected: onDestinationSelected,
+        child: Transform.translate(
+          offset: const Offset(0, iosVerticalOffset),
+          child: _NativeIosTabBar(
+            destinations: destinations,
+            selectedIndex: selectedIndex,
+            onDestinationSelected: onDestinationSelected,
+          ),
         ),
       );
     }

--- a/mobile/lib/app/platform_navigation_bar.dart
+++ b/mobile/lib/app/platform_navigation_bar.dart
@@ -50,8 +50,8 @@ class PlatformNavigationBar extends StatelessWidget {
       return SizedBox(
         key: const Key('primary-navigation'),
         height: contentHeight + MediaQuery.viewPaddingOf(context).bottom,
-        child: Transform.translate(
-          offset: const Offset(0, iosVerticalOffset),
+        child: Padding(
+          padding: const EdgeInsets.only(top: iosVerticalOffset),
           child: _NativeIosTabBar(
             destinations: destinations,
             selectedIndex: selectedIndex,

--- a/mobile/test/app/platform_navigation_bar_ios_test.dart
+++ b/mobile/test/app/platform_navigation_bar_ios_test.dart
@@ -71,7 +71,7 @@ void main() {
       expect(platformViewRect.left, navigationRect.left);
       expect(platformViewRect.right, navigationRect.right);
       expect(platformViewRect.top - navigationRect.top, 12);
-      expect(platformViewRect.bottom - navigationRect.bottom, 12);
+      expect(platformViewRect.bottom, navigationRect.bottom);
       expect(
         PlatformNavigationBar.heightFor(
           tester.element(find.byKey(const Key('primary-navigation'))),

--- a/mobile/test/app/platform_navigation_bar_ios_test.dart
+++ b/mobile/test/app/platform_navigation_bar_ios_test.dart
@@ -64,6 +64,20 @@ void main() {
 
       expect(find.byType(UiKitView), findsOneWidget);
       expect(find.byType(GestureDetector), findsNothing);
+      final navigationRect = tester.getRect(
+        find.byKey(const Key('primary-navigation')),
+      );
+      final platformViewRect = tester.getRect(find.byType(UiKitView));
+      expect(platformViewRect.left, navigationRect.left);
+      expect(platformViewRect.right, navigationRect.right);
+      expect(platformViewRect.top - navigationRect.top, 12);
+      expect(platformViewRect.bottom - navigationRect.bottom, 12);
+      expect(
+        PlatformNavigationBar.heightFor(
+          tester.element(find.byKey(const Key('primary-navigation'))),
+        ),
+        52,
+      );
       final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
       expect(platformView.viewType, 'speakup/native_tab_bar');
       expect(platformView.creationParams, <String, Object>{


### PR DESCRIPTION
## 功能描述

- 统一 iOS 对话页输入框与底部导航胶囊的左右宽度
- 将原生底部导航向下偏移 12pt，使底部留白更接近侧边基准
- 同步导航视觉偏移与输入框布局占位，将两层胶囊间距恢复到约 10pt

## 实现思路

- 保留 `UITabBar` 原生 safe-area 高度和交互通道
- 仅对 iOS 原生 PlatformView 应用垂直偏移
- `heightFor` 使用同一偏移量补偿对话输入框位置，避免视觉移动后产生额外空隙
- 增加 iOS 布局回归断言，覆盖宽度、垂直偏移和占位高度

## 可复现测试

```bash
cd mobile
flutter test test/app/platform_navigation_bar_ios_test.dart test/speak_up_app_test.dart
flutter analyze
```

视觉验证：

```bash
SPEAKUP_DEV_PORT=18082 make dev-ios-simulator
```

已在 iPhone 17 Pro / iOS 26.5 模拟器上使用真实后端验证，数字人禁用。

Closes #1021