### PR TITLE
fix(mobile): gate question playback by practice phase

### DIFF
--- a/mobile/lib/app/speak_up_app.dart
+++ b/mobile/lib/app/speak_up_app.dart
@@ -580,7 +580,7 @@ class _AuthenticatedNavigatorState extends State<_AuthenticatedNavigator> {
       avatarSurfaceVisible: avatar?.surfaceVisible ?? true,
       avatarStatusLabel: avatar?.statusLabel,
       onBeforeUserTurn: avatar?.interruptForUserTurn,
-      onReplayQuestionWithAvatar: avatar?.onReplayQuestion,
+      onPlayQuestionWithAvatar: avatar?.onPlayQuestion,
       avatarReplayLoading: avatar?.replayLoading ?? false,
       avatarReplayPlaying: avatar?.replayPlaying ?? false,
     );

--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -82,7 +82,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
     this.avatarSurfaceVisible = true,
     this.avatarStatusLabel,
     this.onBeforeUserTurn,
-    this.onReplayQuestionWithAvatar,
+    this.onPlayQuestionWithAvatar,
     this.avatarReplayLoading = false,
     this.avatarReplayPlaying = false,
     this.now = DateTime.now,
@@ -101,7 +101,7 @@ class IeltsSpeakingMockPage extends StatefulWidget {
   final bool avatarSurfaceVisible;
   final String? avatarStatusLabel;
   final Future<void> Function()? onBeforeUserTurn;
-  final Future<void> Function()? onReplayQuestionWithAvatar;
+  final Future<bool> Function()? onPlayQuestionWithAvatar;
   final bool avatarReplayLoading;
   final bool avatarReplayPlaying;
   final DateTime Function() now;
@@ -676,10 +676,6 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     }
     _autoNarratedQuestionId = questionId;
     _autoNarratedQuestionText = questionText;
-    if (widget.controller.currentQuestion?.speechPath != null &&
-        widget.onReplayQuestionWithAvatar != null) {
-      return;
-    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || _progress?.phase != phase) {
         return;
@@ -688,14 +684,11 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     });
   }
 
-  Future<void> _playQuestionNarration(String questionId, String text) async {
+  Future<bool> _playQuestionNarration(String questionId, String text) async {
     final currentQuestion = widget.controller.currentQuestion;
-    final replayWithAvatar = widget.onReplayQuestionWithAvatar;
-    if (currentQuestion?.id == questionId &&
-        currentQuestion?.speechPath != null &&
-        replayWithAvatar != null) {
-      await replayWithAvatar();
-      return;
+    final playWithAvatar = widget.onPlayQuestionWithAvatar;
+    if (currentQuestion?.id == questionId && playWithAvatar != null) {
+      return playWithAvatar();
     }
     if (_progress?.phase == IeltsMockPhase.part1 &&
         currentQuestion?.id == questionId &&
@@ -705,16 +698,16 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _playingQuestionId = null;
       _questionNarrationErrorId = null;
       await widget.controller.toggleQuestionAudio();
-      return;
+      return true;
     }
     if (_playingQuestionId == questionId) {
       await _stopQuestionNarration();
-      return;
+      return false;
     }
     final generation = ++_questionNarrationGeneration;
     await _stopExaminerSpeakerSafely();
     if (!mounted || generation != _questionNarrationGeneration) {
-      return;
+      return false;
     }
     setState(() {
       _playingQuestionId = questionId;
@@ -727,10 +720,12 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       } else {
         await speaker.speak(text);
       }
+      return true;
     } catch (_) {
       if (mounted && generation == _questionNarrationGeneration) {
         setState(() => _questionNarrationErrorId = questionId);
       }
+      return false;
     } finally {
       if (mounted && generation == _questionNarrationGeneration) {
         setState(() => _playingQuestionId = null);
@@ -1031,7 +1026,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     if (progress == null || !_introNarrated || _narrationBusy) {
       return;
     }
-    await _examinerSpeaker.stop();
+    await _stopQuestionNarration();
     await _setProgress(
       progress.copyWith(
         phase: IeltsMockPhase.part2CueCard,
@@ -1076,6 +1071,10 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       _narrationError = null;
     });
     try {
+      await _stopQuestionNarration();
+      if (!mounted || _progress?.phase != IeltsMockPhase.part2Intro) {
+        return;
+      }
       await _examinerSpeaker.speak(_part2IntroNarration);
       if (!mounted || _progress?.phase != IeltsMockPhase.part2Intro) {
         return;
@@ -1102,8 +1101,15 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
     });
     var completed = false;
     try {
-      await _examinerSpeaker.speak(_currentQuestionText());
-      completed = mounted && _progress?.phase == IeltsMockPhase.part2CueCard;
+      final question = widget.controller.currentQuestion;
+      if (question == null) {
+        throw StateError('IELTS Part 2 Cue Card is unavailable.');
+      }
+      completed =
+          await _playQuestionNarration(question.id, question.text) &&
+          mounted &&
+          _progress?.phase == IeltsMockPhase.part2CueCard &&
+          widget.controller.currentQuestion?.id == question.id;
     } catch (_) {
       if (mounted && _progress?.phase == IeltsMockPhase.part2CueCard) {
         setState(() => _narrationError = 'Cue Card 播放失败，请重试。');

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -30,6 +30,7 @@ class ScenarioPracticePage extends StatefulWidget {
     this.avatarStatusLabel,
     this.onBeforeStartRecording,
     this.onBeforeSubmitText,
+    this.onPlayQuestion,
     this.onReplayQuestion,
     this.questionSpeaker,
     this.onPracticeCompleted,
@@ -48,6 +49,7 @@ class ScenarioPracticePage extends StatefulWidget {
   final String? avatarStatusLabel;
   final ScenarioAsyncAction? onBeforeStartRecording;
   final ScenarioAsyncAction? onBeforeSubmitText;
+  final Future<bool> Function()? onPlayQuestion;
   final ScenarioAsyncAction? onReplayQuestion;
   final PracticePromptSpeaker? questionSpeaker;
   final Future<bool> Function()? onPracticeCompleted;
@@ -83,6 +85,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
   String? _visibleTipQuestionId;
   String? _playingQuestionId;
   String? _questionNarrationErrorId;
+  String? _autoNarratedQuestionId;
   int _questionNarrationGeneration = 0;
 
   bool get _isInterview =>
@@ -98,6 +101,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     _syncSpeechFeedbackSources();
     _syncRecordingTimer();
     _scheduleConversationScrollToBottom(animated: false);
+    _scheduleQuestionNarration();
   }
 
   @override
@@ -120,6 +124,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       _visibleTipQuestionId = null;
       _questionTranslations.clear();
       _questionNarrationGeneration++;
+      _autoNarratedQuestionId = null;
       _playingQuestionId = null;
       _questionNarrationErrorId = null;
       unawaited(oldWidget.practiceController.stopPracticeAudio(notify: false));
@@ -130,6 +135,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
       }
       widget.practiceController.addListener(_handleControllerState);
       _syncRecordingTimer();
+      _scheduleQuestionNarration();
     }
     _syncSpeechFeedbackSources();
   }
@@ -270,6 +276,45 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     }
   }
 
+  void _scheduleQuestionNarration() {
+    if (widget.onPlayQuestion == null) {
+      // Without an avatar session the PracticeController owns automatic
+      // realtime question speech.
+      return;
+    }
+    final question = widget.practiceController.currentQuestion;
+    if (question == null || _autoNarratedQuestionId == question.id) {
+      return;
+    }
+    _autoNarratedQuestionId = question.id;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          widget.practiceController.currentQuestion?.id != question.id) {
+        return;
+      }
+      unawaited(_playCurrentQuestion(question));
+    });
+  }
+
+  Future<void> _playCurrentQuestion(PracticeQuestion question) async {
+    final playWithAvatar = widget.onPlayQuestion;
+    if (playWithAvatar == null) {
+      await _playQuestion(question.presentation);
+      return;
+    }
+    final generation = ++_questionNarrationGeneration;
+    if (mounted) {
+      setState(() => _questionNarrationErrorId = null);
+    }
+    final completed = await playWithAvatar();
+    if (!completed &&
+        mounted &&
+        generation == _questionNarrationGeneration &&
+        widget.practiceController.currentQuestion?.id == question.id) {
+      setState(() => _questionNarrationErrorId = question.id);
+    }
+  }
+
   Future<void> _stopQuestionNarration() async {
     _questionNarrationGeneration++;
     await widget.practiceController.stopPracticeAudio();
@@ -313,6 +358,7 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
     _syncRecordingTimer();
     _syncSpeechFeedbackSources();
     setState(() {});
+    _scheduleQuestionNarration();
     if (shouldFollowConversation) {
       _scheduleConversationScrollToBottom();
     }

--- a/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice_session.dart
@@ -15,12 +15,23 @@ typedef AvatarControllerFactory = AvatarController Function();
 typedef PracticeAvatarSessionBuilder =
     Widget Function(BuildContext context, PracticeAvatarSessionView avatar);
 
+typedef PracticeQuestionPlayback = Future<bool> Function();
+
+final class _QuestionPlaybackRequest {
+  _QuestionPlaybackRequest(this.questionId);
+
+  final String questionId;
+  final Completer<bool> completer = Completer<bool>();
+  bool started = false;
+}
+
 final class PracticeAvatarSessionView {
   const PracticeAvatarSessionView({
     required this.surfaceBuilder,
     required this.surfaceVisible,
     required this.statusLabel,
     required this.interruptForUserTurn,
+    required this.onPlayQuestion,
     required this.onReplayQuestion,
     required this.replayLoading,
     required this.replayPlaying,
@@ -30,6 +41,7 @@ final class PracticeAvatarSessionView {
   final bool surfaceVisible;
   final String? statusLabel;
   final Future<void> Function() interruptForUserTurn;
+  final PracticeQuestionPlayback? onPlayQuestion;
   final Future<void> Function()? onReplayQuestion;
   final bool replayLoading;
   final bool replayPlaying;
@@ -91,6 +103,7 @@ class ScenarioPracticeSession extends StatelessWidget {
         avatarStatusLabel: avatar.statusLabel,
         onBeforeStartRecording: avatar.interruptForUserTurn,
         onBeforeSubmitText: avatar.interruptForUserTurn,
+        onPlayQuestion: avatar.onPlayQuestion,
         onReplayQuestion: avatar.onReplayQuestion,
         onPracticeCompleted: onPracticeCompleted,
         onOpenReport: onOpenReport,
@@ -113,7 +126,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
   Timer? _readinessTimer;
   Timer? _reconnectTimer;
   String? _connectionAttemptedSessionId;
-  String? _autoHandledQuestionId;
+  _QuestionPlaybackRequest? _questionPlaybackRequest;
   String? _observedQuestionId;
   bool _readinessExpired = false;
   bool _connectionInFlight = false;
@@ -162,9 +175,9 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       return;
     }
     oldWidget.practiceController.removeListener(_handlePracticeState);
+    _cancelQuestionPlaybackRequest();
     widget.practiceController.addListener(_handlePracticeState);
     _observedQuestionId = widget.practiceController.questionId;
-    _autoHandledQuestionId = null;
     _generation++;
     _scheduleSync();
   }
@@ -175,8 +188,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     _generation++;
     _cancelConnectionTimers();
     if (!_foreground) {
-      // Never replay an interrupted question just because the App resumes.
-      _autoHandledQuestionId = widget.practiceController.questionId;
+      _cancelQuestionPlaybackRequest();
     }
     _queueLifecycleReconciliation(replaceController: !_foreground);
   }
@@ -262,7 +274,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     final questionId = widget.practiceController.questionId;
     if (questionId != _observedQuestionId) {
       _observedQuestionId = questionId;
-      _autoHandledQuestionId = null;
+      _cancelQuestionPlaybackRequest();
       _generation++;
       if (_hasLiveAvatarController) {
         unawaited(_avatarController.interrupt());
@@ -360,10 +372,13 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     if (_disposed || !_foreground || !_hasLiveAvatarController) {
       return;
     }
+    final request = _questionPlaybackRequest;
     final question = widget.practiceController.currentQuestion;
-    if (question == null ||
+    if (request == null ||
+        request.started ||
+        question == null ||
+        question.id != request.questionId ||
         _speechInFlight ||
-        question.id == _autoHandledQuestionId ||
         !_canSpeakNow(widget.practiceController)) {
       return;
     }
@@ -382,12 +397,21 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     if (!readyForQuestion) {
       return;
     }
-    _autoHandledQuestionId = question.id;
-    if (widget.practiceController.supportsRealtimeQuestionSpeech) {
-      await _speakRealtimeQuestion(question);
-      return;
+    request.started = true;
+    var completed = false;
+    try {
+      completed = widget.practiceController.supportsRealtimeQuestionSpeech
+          ? await _speakRealtimeQuestion(question)
+          : await _speakQuestion(question);
+    } on Object {
+      completed = false;
     }
-    await _speakQuestion(question);
+    if (identical(_questionPlaybackRequest, request)) {
+      _questionPlaybackRequest = null;
+      if (!request.completer.isCompleted) {
+        request.completer.complete(completed);
+      }
+    }
   }
 
   Future<void> _connect(String sessionId) async {
@@ -571,22 +595,22 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     });
   }
 
-  Future<void> _speakQuestion(
+  Future<bool> _speakQuestion(
     PracticeQuestion question, {
     bool replay = false,
   }) async {
     if (!_hasLiveAvatarController) {
-      return;
+      return false;
     }
     final avatarController = _avatarController;
     final mediaClient = widget.practiceController.mediaClient;
     final speechPath = question.speechPath;
     if (_speechInFlight || mediaClient == null || speechPath == null) {
-      return;
+      return false;
     }
     final sessionId = widget.practiceController.practiceSessionId;
     if (sessionId == null || question.sessionId != sessionId) {
-      return;
+      return false;
     }
     final generation = ++_generation;
     _speechInFlight = true;
@@ -608,16 +632,24 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
         speechPath: speechPath,
         avatarController: avatarController,
       )) {
-        return;
+        return false;
       }
       _replayLoading = false;
       if (mounted) {
         setState(() {});
       }
       await avatarController.speakWav(bytes);
+      return _speechFenceMatches(
+        generation: generation,
+        sessionId: sessionId,
+        questionId: question.id,
+        speechPath: speechPath,
+        avatarController: avatarController,
+      );
     } catch (_) {
       // The scenario remains usable through text/recording when media or the
       // provider is unavailable. A replay tap can retry the same question.
+      return false;
     } finally {
       if (bytes != null) {
         try {
@@ -635,22 +667,23 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
     }
   }
 
-  Future<void> _speakRealtimeQuestion(
+  Future<bool> _speakRealtimeQuestion(
     PracticeQuestion question, {
     bool replay = false,
   }) async {
     if (_speechInFlight || !_hasLiveAvatarController) {
-      return;
+      return false;
     }
     final sessionId = widget.practiceController.practiceSessionId;
     if (sessionId == null || question.sessionId != sessionId) {
-      return;
+      return false;
     }
     final avatarController = _avatarController;
     final nativeOutput = widget.practiceController.questionSpeechPlayer;
     if (nativeOutput == null) {
-      return;
+      return false;
     }
+    final generation = ++_generation;
     _speechInFlight = true;
     if (replay) {
       _replayLoading = true;
@@ -666,6 +699,13 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
           _readinessExpired,
         ),
       );
+      return !_disposed &&
+          _foreground &&
+          generation == _generation &&
+          widget.practiceController.practiceSessionId == sessionId &&
+          widget.practiceController.currentQuestion?.id == question.id;
+    } on Object {
+      return false;
     } finally {
       _speechInFlight = false;
       _replayLoading = false;
@@ -673,6 +713,33 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
         setState(() {});
       }
       _scheduleSync();
+    }
+  }
+
+  Future<bool> _requestCurrentQuestionPlayback() {
+    if (_disposed || !_foreground) {
+      return Future<bool>.value(false);
+    }
+    final question = widget.practiceController.currentQuestion;
+    if (question == null) {
+      return Future<bool>.value(false);
+    }
+    final existing = _questionPlaybackRequest;
+    if (existing?.questionId == question.id) {
+      return existing!.completer.future;
+    }
+    _cancelQuestionPlaybackRequest();
+    final request = _QuestionPlaybackRequest(question.id);
+    _questionPlaybackRequest = request;
+    _scheduleSync();
+    return request.completer.future;
+  }
+
+  void _cancelQuestionPlaybackRequest() {
+    final request = _questionPlaybackRequest;
+    _questionPlaybackRequest = null;
+    if (request != null && !request.completer.isCompleted) {
+      request.completer.complete(false);
     }
   }
 
@@ -704,21 +771,23 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
       await _interruptForUserTurn();
       return;
     }
-    if (widget.practiceController.supportsRealtimeQuestionSpeech) {
-      final question = widget.practiceController.currentQuestion;
-      if (question != null) {
-        await _speakRealtimeQuestion(question, replay: true);
-      }
-      return;
+    _replayLoading = true;
+    if (mounted) {
+      setState(() {});
     }
-    final question = widget.practiceController.currentQuestion;
-    if (question != null) {
-      await _speakQuestion(question, replay: true);
+    try {
+      await _requestCurrentQuestionPlayback();
+    } finally {
+      _replayLoading = false;
+      if (mounted) {
+        setState(() {});
+      }
     }
   }
 
   Future<void> _interruptForUserTurn() async {
     _generation++;
+    _cancelQuestionPlaybackRequest();
     final operations = <Future<void>>[
       _bestEffort(
         () => widget.practiceController.stopPracticeAudio(notify: false),
@@ -790,6 +859,9 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
             _hasLiveAvatarController && avatarController.state.canUseAvatar,
         statusLabel: _avatarStatusLabel,
         interruptForUserTurn: _interruptForUserTurn,
+        onPlayQuestion: !widget.practiceController.canPlayQuestionAudio
+            ? null
+            : _requestCurrentQuestionPlayback,
         onReplayQuestion: !widget.practiceController.canPlayQuestionAudio
             ? null
             : _replayQuestion,
@@ -806,6 +878,7 @@ class _PracticeAvatarSessionState extends State<PracticeAvatarSession>
   void dispose() {
     _disposed = true;
     _generation++;
+    _cancelQuestionPlaybackRequest();
     _connectionOperationId++;
     _cancelConnectionTimers();
     WidgetsBinding.instance.removeObserver(this);

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -305,6 +305,66 @@ void main() {
     },
   );
 
+  testWidgets('Part 2 gates avatar and native fallback speech behind Start', (
+    tester,
+  ) async {
+    final now = DateTime.utc(2026, 8, 3, 5);
+    final speaker = _ControlledExaminerSpeaker();
+    final cueCardPlayback = Completer<bool>();
+    var questionPlaybackCalls = 0;
+    final practice = _IeltsPracticeClient(initialCompleted: 8);
+    final controller = PracticeController(
+      client: practice,
+      recorder: _Recorder(),
+    );
+    final store = _MemoryProgressStore();
+    addTearDown(controller.dispose);
+    await _activatePractice(controller, practice, _ieltsScene);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: IeltsSpeakingMockPage(
+          controller: controller,
+          progressStore: store,
+          examinerSpeaker: speaker,
+          onPlayQuestionWithAvatar: () {
+            questionPlaybackCalls++;
+            return cueCardPlayback.future;
+          },
+          now: () => now,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('进入 Part 2'));
+    await tester.pump();
+    speaker.completeCurrent();
+    await tester.pump();
+
+    expect(store.value?.phase, IeltsMockPhase.part2Intro);
+    expect(questionPlaybackCalls, 0);
+    expect(store.value?.preparationDeadline, isNull);
+
+    await tester.tap(find.byKey(const Key('ielts-mock-part-2-start')));
+    await tester.pump();
+
+    expect(store.value?.phase, IeltsMockPhase.part2CueCard);
+    expect(questionPlaybackCalls, 1);
+    expect(store.value?.preparationDeadline, isNull);
+
+    cueCardPlayback.complete(true);
+    await tester.pump();
+    await tester.pump();
+
+    expect(store.value?.phase, IeltsMockPhase.part2Preparation);
+    expect(
+      store.value?.preparationDeadline,
+      now.add(const Duration(minutes: 1)),
+    );
+    expect(questionPlaybackCalls, 1);
+  });
+
   testWidgets(
     'Part 2 section hides the Cue Card after formal recording starts',
     (tester) async {

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -19,6 +19,54 @@ import 'avatar/avatar_test_fakes.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  testWidgets('waits for an explicit question playback request', (
+    tester,
+  ) async {
+    final media = _RealtimeQuestionMediaClient()..release();
+    final nativePlayer = _RecordingPCMStreamPlayer();
+    final practiceController = PracticeController(
+      client: FakePracticeClient(),
+      mediaClient: media,
+      audioPlayer: _SilentPracticeAudioPlayer(),
+      questionSpeechPlayer: nativePlayer,
+      automaticQuestionSpeechEnabled: false,
+    );
+    addTearDown(practiceController.dispose);
+    await activateTestPractice(
+      controller: practiceController,
+      scene: testScenes[2],
+    );
+    final renderer = FakeAvatarRenderer();
+    final avatarController = _avatarController(renderer);
+    PracticeAvatarSessionView? sessionView;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PracticeAvatarSession(
+          practiceController: practiceController,
+          avatarControllerFactory: () => avatarController,
+          surfaceKey: const Key('explicit-playback-surface'),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return avatar.surfaceBuilder?.call(context) ??
+                const SizedBox.expand();
+          },
+        ),
+      ),
+    );
+    await _pumpUntil(tester, () => sessionView?.surfaceVisible ?? false);
+
+    expect(renderer.sends, isEmpty);
+    expect(nativePlayer.events, isEmpty);
+
+    final completed = sessionView!.onPlayQuestion!();
+    await tester.pumpAndSettle();
+
+    expect(await completed, isTrue);
+    expect(renderer.sends.map((send) => send.end), <bool>[false, true]);
+    expect(nativePlayer.events, isEmpty);
+  });
+
   testWidgets('routes realtime question PCM exclusively through the avatar', (
     tester,
   ) async {
@@ -62,8 +110,10 @@ void main() {
       ),
     );
     await tester.pump();
+    final firstPlayback = sessionView!.onPlayQuestion!();
     media.release();
     await tester.pumpAndSettle();
+    expect(await firstPlayback, isTrue);
 
     expect(renderer.sends.map((send) => send.bytes), <Uint8List>[
       Uint8List.fromList(<int>[1, 2, 3, 4]),
@@ -79,7 +129,9 @@ void main() {
       isTrue,
     );
     expect(practiceController.questionId, isNot(firstQuestionId));
+    final secondPlayback = sessionView!.onPlayQuestion!();
     await tester.pumpAndSettle();
+    expect(await secondPlayback, isTrue);
     expect(
       renderer.sends.length,
       4,
@@ -162,20 +214,26 @@ void main() {
       fallbackStop: () async {},
       delay: (_) async {},
     );
+    PracticeAvatarSessionView? sessionView;
     await tester.pumpWidget(
       MaterialApp(
         home: PracticeAvatarSession(
           practiceController: practiceController,
           avatarControllerFactory: () => avatarController,
           surfaceKey: const Key('ielts-avatar-surface'),
-          builder: (context, avatar) =>
-              avatar.surfaceBuilder?.call(context) ?? const SizedBox.expand(),
+          builder: (context, avatar) {
+            sessionView = avatar;
+            return avatar.surfaceBuilder?.call(context) ??
+                const SizedBox.expand();
+          },
         ),
       ),
     );
     await tester.pump();
+    final playback = sessionView!.onPlayQuestion!();
     media.release();
     await tester.pumpAndSettle();
+    expect(await playback, isTrue);
 
     expect(renderer.sends.map((send) => send.end), <bool>[false, true]);
     expect(nativePlayer.events, isEmpty);
@@ -207,18 +265,23 @@ void main() {
         fallbackStop: () async {},
         delay: (_) async {},
       );
+      PracticeAvatarSessionView? sessionView;
       await tester.pumpWidget(
         MaterialApp(
           home: PracticeAvatarSession(
             practiceController: practiceController,
             avatarControllerFactory: () => avatarController,
             surfaceKey: const Key('disconnect-before-pcm-surface'),
-            builder: (context, avatar) =>
-                avatar.surfaceBuilder?.call(context) ?? const SizedBox.expand(),
+            builder: (context, avatar) {
+              sessionView = avatar;
+              return avatar.surfaceBuilder?.call(context) ??
+                  const SizedBox.expand();
+            },
           ),
         ),
       );
       await tester.pump();
+      final playback = sessionView!.onPlayQuestion!();
       media.release();
       await _pumpUntil(tester, () => renderer.interruptCount == 1);
 
@@ -230,6 +293,7 @@ void main() {
       );
       renderer.interruptGate!.complete();
       await tester.pumpAndSettle();
+      expect(await playback, isTrue);
 
       expect(renderer.sends, isEmpty);
       expect(nativePlayer.events, <String>[
@@ -346,7 +410,7 @@ void main() {
         ),
       ),
     );
-    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await _pumpUntil(tester, () => sessionView?.surfaceVisible ?? false);
     await tester.pump();
     expect(sessionView?.surfaceVisible, isTrue);
     expect(find.byKey(const Key('static-fallback')), findsNothing);
@@ -429,7 +493,7 @@ void main() {
         ),
       ),
     );
-    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await _pumpUntil(tester, () => sessionView?.surfaceVisible ?? false);
     await tester.pump();
 
     firstRenderer.emit(
@@ -495,7 +559,7 @@ void main() {
         ),
       ),
     );
-    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await _pumpUntil(tester, () => sessionView?.surfaceVisible ?? false);
     await tester.pump();
 
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
@@ -552,6 +616,7 @@ void main() {
     );
     await _pumpUntil(tester, () => renderers[0].preparedGrant != null);
     await tester.pump();
+    final playback = sessionView!.onPlayQuestion!();
 
     renderers[0].emit(
       const AvatarRendererState(
@@ -604,6 +669,7 @@ void main() {
       'append:4',
       'finish',
     ]);
+    expect(await playback, isTrue);
 
     await tester.pump(const Duration(seconds: 2));
     expect(factoryCalls, 3);
@@ -784,7 +850,7 @@ void main() {
         ),
       ),
     );
-    await _pumpUntil(tester, () => firstRenderer.sends.length == 2);
+    await _pumpUntil(tester, () => sessionView?.surfaceVisible ?? false);
     await tester.pump();
     expect(sessionView?.surfaceVisible, isTrue);
     expect(find.byKey(const Key('static-fallback')), findsNothing);

--- a/mobile/test/coaching/practice/scenario_practice_session_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_session_test.dart
@@ -22,7 +22,7 @@ void main() {
   testWidgets('waits for an explicit question playback request', (
     tester,
   ) async {
-    final media = _RealtimeQuestionMediaClient()..release();
+    final media = _RealtimeQuestionMediaClient();
     final nativePlayer = _RecordingPCMStreamPlayer();
     final practiceController = PracticeController(
       client: FakePracticeClient(),
@@ -60,9 +60,13 @@ void main() {
     expect(nativePlayer.events, isEmpty);
 
     final completed = sessionView!.onPlayQuestion!();
+    final duplicate = sessionView!.onPlayQuestion!();
+    expect(identical(completed, duplicate), isTrue);
+    media.release();
     await tester.pumpAndSettle();
 
     expect(await completed, isTrue);
+    expect(await duplicate, isTrue);
     expect(renderer.sends.map((send) => send.end), <bool>[false, true]);
     expect(nativePlayer.events, isEmpty);
   });

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -55,6 +55,65 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('requests every scenario question from the playback owner once', (
+    tester,
+  ) async {
+    final controller = await _scenarioController();
+    addTearDown(controller.dispose);
+    final playedQuestionIds = <String>[];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ScenarioPracticePage(
+          practiceController: controller,
+          onPlayQuestion: () async {
+            playedQuestionIds.add(controller.currentQuestion!.id);
+            return true;
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final firstQuestionId = controller.currentQuestion!.id;
+    expect(playedQuestionIds, <String>[firstQuestionId]);
+
+    await tester.pump();
+    expect(playedQuestionIds, <String>[firstQuestionId]);
+
+    await controller.submitPracticeText('I have a reservation under Chen.');
+    await tester.pump();
+    await tester.pump();
+
+    final secondQuestionId = controller.currentQuestion!.id;
+    expect(secondQuestionId, isNot(firstQuestionId));
+    expect(playedQuestionIds, <String>[firstQuestionId, secondQuestionId]);
+  });
+
+  testWidgets('offers question replay when owned playback fails', (
+    tester,
+  ) async {
+    final controller = await _scenarioController();
+    addTearDown(controller.dispose);
+    var playbackCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ScenarioPracticePage(
+          practiceController: controller,
+          onPlayQuestion: () async {
+            playbackCalls++;
+            return false;
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(playbackCalls, 1);
+    expect(find.text('重试朗读'), findsOneWidget);
+  });
+
   testWidgets('hides round progress and lets open scenarios finish manually', (
     tester,
   ) async {


### PR DESCRIPTION
## 功能描述

修复 IELTS Speaking Part 2 说明页同时播放当前说明和下一页 Cue Card 的问题。数字人画面不可用、降级为静态人物和原生 PCM 语音时同样遵循页面阶段门禁。

Closes #1025

## 实现思路

- 取消 `PracticeAvatarSession` 仅根据 `currentQuestion` 自动播放题目录音的行为，改为页面显式发起带题目 ID 的播放请求。
- 请求在数字人连接、就绪和降级期间持续受 session/question/generation fence 约束；切题、切换 controller、进入后台、用户打断或 dispose 时取消。
- 普通情景练习页面在题目变更后显式请求播放；无数字人会话时仍由 `PracticeController` 保持原有自动语音职责。
- IELTS Part 1/Part 3 在对应阶段显式播题；Part 2 只在用户点击 `I understand — Start`、阶段进入 Cue Card 后播放题目，播放完成后才开始准备倒计时。
- 数字人和原生静态降级共用同一播放门禁，避免双路音频和提前播放。

## 可复现测试

1. 连接 Android 真机并启动本地后端：`SPEAKUP_DEV_PORT=18082 make dev-android`。
2. 进入 IELTS Speaking Mock，并进入 Part 2 说明页。
3. 确认只听到说明独白，未点击 Start 前没有 Cue Card 录音。
4. 点击 `I understand — Start`，确认 Cue Card 仅播放一次，播放完成后开始 1 分钟准备倒计时。
5. 令数字人画面不可用、降级为静态人物，重复步骤 2-4，确认行为一致且没有双路语音。

## 验证结果

- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze --no-pub`：No issues found
- `flutter test --no-pub`：840 tests passed
- Huawei Android 真机：staging debug APK 构建、安装及 Dart VM 连接成功
- 本地后端 `/health` 与 `/readyz` 均通过
- 用户真机听感复测通过