### PR TITLE
fix(staging): 收口 Ubuntu 24.04 主机运行契约

### DIFF
--- a/deploy/staging/README.md
+++ b/deploy/staging/README.md
@@ -73,7 +73,7 @@ pass the CI public key (never its private key) explicitly:
 
 ```sh
 cd server
-CGO_ENABLED=0 go build -trimpath \
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath \
   -o /tmp/speakup-staging-broker ./cmd/staging-broker
 cd ..
 contract_revision="$(git rev-parse HEAD)"
@@ -94,8 +94,9 @@ broker is `/usr/local/libexec/speakup-staging-broker`; its state is
 `/var/lib/speakup/staging-broker`, and the shared lock directory is
 `/run/lock/xe3-speakup-staging`.
 
-The CI account has a locked password, a root-owned non-writable home, no
-supplementary groups, and `/bin/bash` only because OpenSSH evaluates
+The CI account receives a random password that is never retained, has a
+root-owned non-writable home, no supplementary groups, and `/bin/bash` only
+because OpenSSH evaluates
 `ForceCommand` through the account shell. The `Match User` policy and the
 authorized key's `restrict` option both disable passwords, keyboard-interactive
 authentication, PTY, agent, TCP/stream-local/X11 forwarding, tunnels, and user
@@ -113,6 +114,10 @@ group, and uses only `unix:///run/user/<runtime-uid>/docker.sock`. Its user
 service pins `HOME=/var/lib/speakup/staging-runtime`, the rootless socket, and
 the Docker data root. Neither identity may read or write a rootful Docker
 socket.
+
+The bootstrap rejects a non-Linux-amd64 broker and refuses to mutate the host
+unless the shared `/tmp` directory is root-owned mode `1777`. It never repairs
+that shared host path automatically.
 
 The bootstrap does not create `staging-runtime.env`, the referenced Server
 environment, a GHCR credential, an SSH private key, or any provider Secret.

--- a/deploy/staging/host/bootstrap.sh
+++ b/deploy/staging/host/bootstrap.sh
@@ -125,7 +125,7 @@ require_source_file() {
 }
 
 require_shared_tmp() {
-  local path mode owner group expected_uid expected_gid expected_mode
+  local path mode owner group expected_uid expected_gid
   path=$(host_path /tmp)
   [[ ! -L "$path" && -d "$path" ]] || fail "/tmp must be a real directory"
   mode=$(path_mode "$path") || fail "cannot inspect /tmp mode"
@@ -134,15 +134,15 @@ require_shared_tmp() {
   if (( test_mode )); then
     expected_uid=$(path_owner "$host_root") || fail "cannot inspect test root owner"
     expected_gid=$test_owner_gid
-    expected_mode=777
+    [[ "$mode" == 777 || "$mode" == 1777 ]] ||
+      fail "/tmp must have mode 1777"
     [[ -k "$path" ]] || fail "/tmp must have the sticky bit"
   else
     expected_uid=0
     expected_gid=0
-    expected_mode=1777
+    [[ "$mode" == 1777 ]] || fail "/tmp must have mode 1777"
   fi
-  [[ "$mode" == "$expected_mode" && "$owner" == "$expected_uid" &&
-     "$group" == "$expected_gid" ]] ||
+  [[ "$owner" == "$expected_uid" && "$group" == "$expected_gid" ]] ||
     fail "/tmp must be owned by root:root with mode 1777"
 }
 

--- a/deploy/staging/host/bootstrap.sh
+++ b/deploy/staging/host/bootstrap.sh
@@ -124,6 +124,35 @@ require_source_file() {
     fail "$description must be a non-empty regular file"
 }
 
+require_shared_tmp() {
+  local path mode owner group expected_uid expected_gid expected_mode
+  path=$(host_path /tmp)
+  [[ ! -L "$path" && -d "$path" ]] || fail "/tmp must be a real directory"
+  mode=$(path_mode "$path") || fail "cannot inspect /tmp mode"
+  owner=$(path_owner "$path") || fail "cannot inspect /tmp owner"
+  group=$(path_group "$path") || fail "cannot inspect /tmp group"
+  if (( test_mode )); then
+    expected_uid=$(path_owner "$host_root") || fail "cannot inspect test root owner"
+    expected_gid=$test_owner_gid
+    expected_mode=777
+    [[ -k "$path" ]] || fail "/tmp must have the sticky bit"
+  else
+    expected_uid=0
+    expected_gid=0
+    expected_mode=1777
+  fi
+  [[ "$mode" == "$expected_mode" && "$owner" == "$expected_uid" &&
+     "$group" == "$expected_gid" ]] ||
+    fail "/tmp must be owned by root:root with mode 1777"
+}
+
+require_linux_amd64_elf() {
+  local path=$1 header
+  header=$(od -An -tx1 -N20 -- "$path" | tr -d '[:space:]')
+  [[ "$header" =~ ^7f454c46020101[0-9a-f]{18}(0200|0300)3e00$ ]] ||
+    fail "broker binary must be a Linux amd64 ELF executable"
+}
+
 install_directory() {
   local logical_path=$1
   local owner=$2
@@ -204,6 +233,35 @@ ensure_identity() {
       "$name"
   fi
   require_exact_user "$name" "$name" "$home" "$shell"
+}
+
+require_password_state() {
+  local name=$1 expected=$2 status state
+  status=$(passwd -S "$name") || fail "cannot inspect password status for $name"
+  read -r _ state _ <<<"$status"
+  case "$expected" in
+    locked)
+      [[ "$state" == L || "$state" == LK ]] ||
+        fail "$name password must be locked"
+      ;;
+    usable)
+      [[ "$state" == P ]] || fail "$name account must be usable by OpenSSH"
+      ;;
+  esac
+}
+
+ensure_ci_account_usable() {
+  local status state generated_password
+  status=$(passwd -S "$ci_user") ||
+    fail "cannot inspect password status for $ci_user"
+  read -r _ state _ <<<"$status"
+  if [[ "$state" != P ]]; then
+    generated_password=$(openssl rand -hex 48) ||
+      fail "cannot generate the CI account password hash input"
+    printf '%s:%s\n' "$ci_user" "$generated_password" | chpasswd
+    generated_password=""
+  fi
+  require_password_state "$ci_user" usable
 }
 
 require_subordinate_ids() {
@@ -395,11 +453,13 @@ done <"$ssh_public_key_file"
   fail "SSH public key must contain one bare Ed25519 public key"
 
 for command in \
-  awk chgrp chmod chown cmp env getent groupadd id install ln loginctl mktemp mv \
-  rm runuser sleep sshd stat systemctl systemd-tmpfiles useradd \
+  awk chgrp chmod chown chpasswd cmp env getent groupadd id install ln loginctl \
+  mktemp mv od openssl passwd rm runuser sleep sshd stat systemctl \
+  systemd-tmpfiles tr useradd \
   visudo; do
   require_command "$command"
 done
+require_linux_amd64_elf "$broker_binary"
 
 for rootless_binary in \
   /usr/bin/docker \
@@ -413,11 +473,14 @@ require_host_executable /usr/sbin/nologin
 require_id_map_helper /usr/bin/newuidmap
 require_id_map_helper /usr/bin/newgidmap
 require_user_namespace_support
+require_shared_tmp
 
 ensure_identity "$runtime_user" "$runtime_home" /usr/sbin/nologin \
   "SpeakUp Staging runtime"
 ensure_identity "$ci_user" "$ci_home" /bin/bash \
   "SpeakUp Staging CI forced command"
+require_password_state "$runtime_user" locked
+ensure_ci_account_usable
 runtime_uid=$(id -u "$runtime_user")
 runtime_gid=$(id -g "$runtime_user")
 [[ "$(id -u "$ci_user")" != "$runtime_uid" ]] ||
@@ -435,7 +498,7 @@ install_directory "$runtime_home/.config/systemd" root "$runtime_user" 750
 install_directory "$runtime_home/.config/systemd/user" root "$runtime_user" 750
 install_directory "$rootless_wants_directory" root "$runtime_user" 750
 install_directory "$runtime_home/.docker" "$runtime_user" "$runtime_user" 700
-install_directory "$runtime_home/docker-data" "$runtime_user" "$runtime_user" 700
+install_directory "$runtime_home/docker-data" "$runtime_user" "$runtime_user" 710
 install_directory /var/lib/speakup/staging-broker "$runtime_user" "$runtime_user" 700
 install_directory /var/lib/speakup/staging-broker/manifests "$runtime_user" "$runtime_user" 700
 install_directory /var/lib/speakup/staging-broker/receipts "$runtime_user" "$runtime_user" 700
@@ -487,7 +550,7 @@ cleanup() {
 }
 trap cleanup EXIT
 printf 'restrict %s\n' "$public_key" >"$authorized_keys_temporary"
-install_file "$authorized_keys_temporary" "$authorized_keys_file" root root 600
+install_file "$authorized_keys_temporary" "$authorized_keys_file" root root 644
 
 release_logical="$control_root/releases/$contract_revision"
 release_path=$(host_path "$release_logical")

--- a/deploy/staging/host/rootless-docker.service
+++ b/deploy/staging/host/rootless-docker.service
@@ -5,7 +5,6 @@ Documentation=https://docs.docker.com/engine/security/rootless/
 [Service]
 Environment=HOME=/var/lib/speakup/staging-runtime
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-Environment=TMPDIR=%t
 Environment=DOCKERD_ROOTLESS_ROOTLESSKIT_STATE_DIR=%t/speakup-staging-rootlesskit
 ExecStart=/usr/bin/dockerd-rootless.sh --host=unix://%t/docker.sock --config-file=/var/lib/speakup/staging-runtime/.config/docker/daemon.json
 ExecStartPost=/usr/bin/chmod 0600 %t/docker.sock

--- a/deploy/staging/host/validate.sh
+++ b/deploy/staging/host/validate.sh
@@ -150,6 +150,24 @@ require_file() {
     fail "$description has owner:group/mode $owner:$group/$mode; expected $expected_uid:$expected_gid/$expected_mode"
 }
 
+require_regular_file() {
+  local description=$1
+  local logical_path=$2
+  local expected_uid=$3
+  local expected_gid=$4
+  local expected_mode=$5
+  local path mode owner group
+  path=$(host_path "$logical_path")
+  [[ ! -L "$path" && -f "$path" ]] ||
+    fail "$description must be a regular file"
+  mode=$(path_mode "$path") || fail "cannot inspect $description mode"
+  owner=$(path_owner "$path") || fail "cannot inspect $description owner"
+  group=$(path_group "$path") || fail "cannot inspect $description group"
+  [[ "$mode" == "$expected_mode" && "$owner" == "$expected_uid" &&
+     "$group" == "$expected_gid" ]] ||
+    fail "$description has owner:group/mode $owner:$group/$mode; expected $expected_uid:$expected_gid/$expected_mode"
+}
+
 require_private_runtime_file() {
   local description=$1
   local logical_path=$2
@@ -198,6 +216,7 @@ require_exact_user() {
   local name=$1
   local expected_home=$2
   local expected_shell=$3
+  local expected_password_state=$4
   local entry group_entry entry_name password uid gid gecos home shell
   local group_name group_password group_gid group_memberships password_status
   local -a group_ids
@@ -220,8 +239,16 @@ require_exact_user() {
 
   password_status=$(passwd -S "$name") || fail "cannot inspect password status for $name"
   read -r _ password_state _ <<<"$password_status"
-  [[ "$password_state" == L || "$password_state" == LK ]] ||
-    fail "$name password must be locked"
+  case "$expected_password_state" in
+    locked)
+      [[ "$password_state" == L || "$password_state" == LK ]] ||
+        fail "$name password must be locked"
+      ;;
+    usable)
+      [[ "$password_state" == P ]] ||
+        fail "$name account must be usable by OpenSSH"
+      ;;
+  esac
   printf '%s %s\n' "$uid" "$gid"
 }
 
@@ -350,9 +377,9 @@ for command in \
 done
 
 runtime_identity=$(
-  require_exact_user "$runtime_user" "$runtime_home" /usr/sbin/nologin
+  require_exact_user "$runtime_user" "$runtime_home" /usr/sbin/nologin locked
 ) || exit 1
-ci_identity=$(require_exact_user "$ci_user" "$ci_home" /bin/bash) || exit 1
+ci_identity=$(require_exact_user "$ci_user" "$ci_home" /bin/bash usable) || exit 1
 read -r runtime_uid runtime_gid <<<"$runtime_identity"
 read -r ci_uid ci_gid <<<"$ci_identity"
 [[ "$runtime_uid" != "$ci_uid" ]] || fail "CI and runtime UIDs must differ"
@@ -363,7 +390,7 @@ require_directory "runtime home" "$runtime_home" "$expected_root_uid" "$runtime_
 require_directory "runtime Docker credential directory" "$runtime_home/.docker" \
   "$runtime_uid" "$runtime_gid" 700
 require_directory "rootless Docker data directory" "$runtime_home/docker-data" \
-  "$runtime_uid" "$runtime_gid" 700
+  "$runtime_uid" "$runtime_gid" 710
 require_directory "broker state" "$broker_state" "$runtime_uid" "$runtime_gid" 700
 require_directory "broker manifest state" "$broker_state/manifests" \
   "$runtime_uid" "$runtime_gid" 700
@@ -411,7 +438,7 @@ cmp -s "$script_directory/daemon.json" "$(host_path "$rootless_daemon_config")" 
 
 authorized_keys_path=$(host_path "$authorized_keys_file")
 require_file "CI authorized key" "$authorized_keys_file" \
-  "$expected_root_uid" "$expected_root_gid" 600
+  "$expected_root_uid" "$expected_root_gid" 644
 authorized_key=""
 authorized_key_line_count=0
 while IFS= read -r key_line || [[ -n "$key_line" ]]; do
@@ -545,7 +572,7 @@ lock_path=$(host_path "$lock_directory")
 while IFS= read -r -d '' lock_file; do
   lock_name=${lock_file##*/}
   case "$lock_name" in broker.lock | deploy.lock) ;; *) fail "unexpected Staging lock file" ;; esac
-  require_file "Staging lock" "$lock_directory/$lock_name" \
+  require_regular_file "Staging lock" "$lock_directory/$lock_name" \
     "$runtime_uid" "$runtime_gid" 600
 done < <(find "$lock_path" -mindepth 1 -maxdepth 1 -print0)
 
@@ -564,10 +591,8 @@ rootless_socket_path=$(host_path "$rootless_socket")
 is_socket "$rootless_socket_path" || fail "rootless Docker socket is unavailable"
 socket_mode=$(path_mode "$rootless_socket_path") || fail "cannot inspect rootless socket mode"
 socket_owner=$(path_owner "$rootless_socket_path") || fail "cannot inspect rootless socket owner"
-socket_group=$(path_group "$rootless_socket_path") || fail "cannot inspect rootless socket group"
-[[ "$socket_mode" == 600 && "$socket_owner" == "$runtime_uid" &&
-   "$socket_group" == "$runtime_gid" ]] ||
-  fail "rootless Docker socket has the wrong owner, group, or mode"
+[[ "$socket_mode" == 600 && "$socket_owner" == "$runtime_uid" ]] ||
+  fail "rootless Docker socket has the wrong owner or mode"
 assert_user_cannot_access "$ci_user" "rootless Docker socket" "$rootless_socket"
 
 runtime_systemctl=(

--- a/deploy/staging/test-host-access.sh
+++ b/deploy/staging/test-host-access.sh
@@ -65,7 +65,9 @@ assert_line 'exec /usr/bin/sudo -n -u speakup-staging-runtime -- \' \
 assert_line '  /usr/local/libexec/speakup-staging-broker' "$host_contract/ssh-gate"
 assert_line 'ExecStart=/usr/bin/dockerd-rootless.sh --host=unix://%t/docker.sock --config-file=/var/lib/speakup/staging-runtime/.config/docker/daemon.json' \
   "$host_contract/rootless-docker.service"
-assert_line 'Environment=TMPDIR=%t' "$host_contract/rootless-docker.service"
+if grep -Fq 'Environment=TMPDIR=' "$host_contract/rootless-docker.service"; then
+  fail "rootless unit overrides TMPDIR even though RootlessKit uses host /tmp"
+fi
 if grep -Fq '/var/run/docker.sock' "$host_contract/rootless-docker.service"; then
   fail "rootless unit references the rootful Docker socket"
 fi
@@ -88,6 +90,7 @@ export MOCK_FIXTURE_GID="$fixture_gid"
 export MOCK_CI_UID="$ci_uid"
 export MOCK_CI_GID="$ci_gid"
 export MOCK_HOST_ROOT="$fixture_root"
+export MOCK_PASSWORD_SET="$temporary_directory/ci-password-set"
 
 cat >"$mock_bin/getent" <<'EOF'
 #!/usr/bin/env bash
@@ -136,7 +139,27 @@ cat >"$mock_bin/passwd" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 [[ "$1" == -S && -n "${2:-}" ]]
-printf '%s L 2026-08-26 0 99999 7 -1\n' "$2"
+if [[ "$2" == speakup-staging-ci && -f "$MOCK_PASSWORD_SET" ]]; then
+  state=P
+else
+  state=L
+fi
+printf '%s %s 2026-08-26 0 99999 7 -1\n' "$2" "$state"
+EOF
+
+cat >"$mock_bin/openssl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == rand && "$2" == -hex && "$3" == 48 ]]
+printf '%096d\n' 0
+EOF
+
+cat >"$mock_bin/chpasswd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=: read -r user password
+[[ "$user" == speakup-staging-ci && "$password" =~ ^[0-9a-f]{96}$ ]]
+: >"$MOCK_PASSWORD_SET"
 EOF
 
 cat >"$mock_bin/groupadd" <<'EOF'
@@ -283,11 +306,13 @@ for logical_directory in \
   /usr/sbin \
   /proc/sys/kernel \
   /proc/sys/user \
+  /tmp \
   /etc \
   /var/lib/systemd/linger \
   "/run/user/$fixture_uid"; do
   mkdir -p "$fixture_root$logical_directory"
 done
+chmod 1777 "$fixture_root/tmp"
 printf '#!/usr/bin/env sh\nexit 0\n' >"$fixture_root/bin/bash"
 printf '#!/usr/bin/env sh\nexit 1\n' >"$fixture_root/usr/sbin/nologin"
 chmod 755 "$fixture_root/bin/bash" "$fixture_root/usr/sbin/nologin"
@@ -311,10 +336,8 @@ chgrp "$fixture_gid" "$fixture_root/run/user/$fixture_uid" \
   "$fixture_root/run/user/$fixture_uid/docker.sock"
 
 broker_binary="$temporary_directory/speakup-staging-broker"
-cat >"$broker_binary" <<'EOF'
-#!/usr/bin/env sh
-exit 0
-EOF
+printf '\177ELF\002\001\001\000\000\000\000\000\000\000\000\000\002\000\076\000' \
+  >"$broker_binary"
 chmod 755 "$broker_binary"
 public_key_file="$temporary_directory/staging.pub"
 printf '%s\n' \
@@ -348,6 +371,18 @@ expect_failure "relative bootstrap input" \
   --contract-revision "$contract_revision" \
   --ssh-public-key-file "$public_key_file"
 
+cp "$broker_binary" "$temporary_directory/broker.good"
+printf '#!/usr/bin/env sh\nexit 0\n' >"$broker_binary"
+chmod 755 "$broker_binary"
+expect_failure "non-Linux-amd64 broker" \
+  "${host_environment[@]}" "${bootstrap_command[@]}"
+cp "$temporary_directory/broker.good" "$broker_binary"
+
+chmod 755 "$fixture_root/tmp"
+expect_failure "unsafe shared tmp" \
+  "${host_environment[@]}" "${bootstrap_command[@]}"
+chmod 1777 "$fixture_root/tmp"
+
 mv "$fixture_root/usr/bin/slirp4netns" "$temporary_directory/slirp4netns"
 expect_failure "missing rootless prerequisite" \
   "${host_environment[@]}" "${bootstrap_command[@]}"
@@ -355,6 +390,7 @@ mv "$temporary_directory/slirp4netns" "$fixture_root/usr/bin/slirp4netns"
 
 "${host_environment[@]}" "${bootstrap_command[@]}" \
   >"$temporary_directory/bootstrap.log"
+[[ -f "$MOCK_PASSWORD_SET" ]] || fail "bootstrap did not make the CI account usable"
 
 rootless_enablement_link="$fixture_root/var/lib/speakup/staging-runtime/.config/systemd/user/default.target.wants/speakup-staging-rootless-docker.service"
 [[ -L "$rootless_enablement_link" ]] ||
@@ -379,6 +415,9 @@ printf '%s\n' 'APP_ENV=staging-fixture' >"$server_env"
 printf '%s\n' '{"auths":{"ghcr.io":{"auth":"fixture"}}}' >"$registry_config"
 chmod 600 "$runtime_env" "$server_env" "$registry_config"
 chgrp "$fixture_gid" "$runtime_env" "$server_env" "$registry_config"
+: >"$fixture_root/run/lock/xe3-speakup-staging/deploy.lock"
+chmod 600 "$fixture_root/run/lock/xe3-speakup-staging/deploy.lock"
+chgrp "$fixture_gid" "$fixture_root/run/lock/xe3-speakup-staging/deploy.lock"
 
 "${host_environment[@]}" "$host_contract/validate.sh" \
   >"$temporary_directory/validate.log"
@@ -401,12 +440,12 @@ cp "$fixture_root/etc/ssh/authorized_keys/speakup-staging-ci" \
   "$temporary_directory/authorized-key.good"
 sed 's/^restrict //' "$temporary_directory/authorized-key.good" \
   >"$fixture_root/etc/ssh/authorized_keys/speakup-staging-ci"
-chmod 600 "$fixture_root/etc/ssh/authorized_keys/speakup-staging-ci"
+chmod 644 "$fixture_root/etc/ssh/authorized_keys/speakup-staging-ci"
 expect_failure "unrestricted SSH key" \
   "${host_environment[@]}" "$host_contract/validate.sh"
 cp "$temporary_directory/authorized-key.good" \
   "$fixture_root/etc/ssh/authorized_keys/speakup-staging-ci"
-chmod 600 "$fixture_root/etc/ssh/authorized_keys/speakup-staging-ci"
+chmod 644 "$fixture_root/etc/ssh/authorized_keys/speakup-staging-ci"
 
 chmod 644 "$runtime_env"
 expect_failure "world-readable runtime environment" \


### PR DESCRIPTION
## 功能描述

收口 Ubuntu 24.04 Staging 主机上已实际复现的运行契约差异，避免 bootstrap 或 validator 对安全且正常的主机状态产生误判。

Closes #1027

## 实现思路

- CI 账号使用不留存的随机密码，仅让 OpenSSH 账号状态可用；SSH 仍强制公钥并禁用密码认证，runtime 账号继续锁定。
- 公钥文件由 root 管理并使用 `0644`；CI 用户仍不可写。
- bootstrap 仅接受 Linux amd64 ELF Broker，并在变更主机前校验共享 `/tmp` 为 root:root `1777`。
- 移除无效的 rootless Docker `TMPDIR` 覆盖，按 Docker 实际初始化状态校验数据目录、空锁文件和私有 socket。
- README 明确 Linux amd64 交叉构建命令和主机前置条件。

## 可复现测试

```bash
./deploy/staging/test-host-access.sh
```

本地结果：通过，包含两次重复 bootstrap、错误 Broker 架构、错误 `/tmp`、空锁文件、账号状态和隔离权限用例。

真实 Staging 主机（Ubuntu 24.04）验证：

1. 使用提交 `830aee0d7c909f66a8fffc7379eab3abbb029be6` 连续执行 bootstrap 两次；
2. 执行 `deploy/staging/host/validate.sh`；
3. 使用受限 CI SSH 身份执行 Broker `inspect`；
4. 确认既有 Server、Portal、PostgreSQL 三个 Staging 容器保持 healthy。

以上全部通过；未替换或停止既有 Staging 容器。
