### PR TITLE
ops(release): 建立 Production 人工审批部署链

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,538 @@
+name: Deploy Production Candidate
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy Staging Candidate
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: production-deployment
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    name: Authorize the successful Staging Candidate
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      android_artifact: ${{ steps.candidate.outputs.android_artifact }}
+      candidate_run_id: ${{ steps.receipt.outputs.candidate_run_id }}
+      candidate_sha: ${{ steps.receipt.outputs.candidate_sha }}
+      manifest_artifact: ${{ steps.candidate.outputs.manifest_artifact }}
+      staging_receipt_sha256: ${{ steps.receipt.outputs.sha256 }}
+      staging_run_attempt: ${{ steps.staging.outputs.run_attempt }}
+      staging_run_id: ${{ steps.staging.outputs.run_id }}
+      version: ${{ steps.receipt.outputs.version }}
+    steps:
+      - name: Require the successful official Staging workflow
+        id: staging
+        env:
+          STAGING_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          STAGING_EVENT: ${{ github.event.workflow_run.event }}
+          STAGING_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          STAGING_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          STAGING_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          STAGING_PATH: ${{ github.event.workflow_run.path }}
+          STAGING_REPOSITORY: ${{ github.repository }}
+          STAGING_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          STAGING_RUN_ID: ${{ github.event.workflow_run.id }}
+          STAGING_WORKFLOW: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          if [[ "$STAGING_REPOSITORY" != "1024XEngineer/XE3-ESL" ||
+                "$STAGING_HEAD_REPOSITORY" != "$STAGING_REPOSITORY" ||
+                "$STAGING_WORKFLOW" != "Deploy Staging Candidate" ||
+                "$STAGING_PATH" != ".github/workflows/staging-deploy.yml" ||
+                "$STAGING_EVENT" != "workflow_run" ||
+                "$STAGING_CONCLUSION" != "success" ||
+                "$STAGING_HEAD_BRANCH" != "main" ||
+                ! "$STAGING_HEAD_SHA" =~ ^[0-9a-f]{40}$ ||
+                ! "$STAGING_RUN_ID" =~ ^[1-9][0-9]*$ ||
+                ! "$STAGING_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Only the successful official main Staging workflow may request Production." >&2
+            exit 1
+          fi
+          printf 'run_id=%s\n' "$STAGING_RUN_ID" >> "$GITHUB_OUTPUT"
+          printf 'run_attempt=%s\n' "$STAGING_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+          printf 'sha=%s\n' "$STAGING_HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Download the exact Staging deployment receipt
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: staging-deployment-${{ steps.staging.outputs.run_id }}-${{ steps.staging.outputs.run_attempt }}
+          path: ${{ runner.temp }}/staging-receipt
+          run-id: ${{ steps.staging.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate the Staging deployment receipt
+        id: receipt
+        env:
+          STAGING_DIRECTORY: ${{ runner.temp }}/staging-receipt
+          STAGING_HEAD_SHA: ${{ steps.staging.outputs.sha }}
+          STAGING_RUN_ATTEMPT: ${{ steps.staging.outputs.run_attempt }}
+          STAGING_RUN_ID: ${{ steps.staging.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          mapfile -d '' files < <(
+            find "$STAGING_DIRECTORY" -mindepth 1 -maxdepth 1 -type f -print0
+          )
+          [[ "${#files[@]}" == 1 ]]
+          receipt="${files[0]}"
+          [[ ! -L "$receipt" && -s "$receipt" ]]
+          jq -e \
+            --arg git_sha "$STAGING_HEAD_SHA" \
+            --argjson run_id "$STAGING_RUN_ID" \
+            --argjson run_attempt "$STAGING_RUN_ATTEMPT" '
+              type == "object" and
+              keys == ["action", "ok", "protocol_version", "receipt", "receipt_sha256"] and
+              .protocol_version == 1 and .ok == true and .action == "deploy" and
+              (.receipt_sha256 | type == "string" and test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+              (.receipt | type == "object" and
+                keys == [
+                  "candidate_run_id", "database_schema_version", "deployment_run_attempt",
+                  "deployment_run_id", "environment", "git_sha", "manifest_sha256",
+                  "operation", "portal_container_id", "portal_image_digest",
+                  "postgres_container_id", "previous_receipt_sha256", "receipt_version",
+                  "recorded_at_utc", "repository", "rollback_target_receipt_sha256",
+                  "server_container_id", "server_image_digest", "version", "version_code"
+                ] and
+                .receipt_version == 2 and .environment == "staging" and
+                .operation == "deploy" and .repository == "1024XEngineer/XE3-ESL" and
+                .git_sha == $git_sha and
+                .deployment_run_id == $run_id and
+                .deployment_run_attempt == $run_attempt and
+                (.candidate_run_id | type == "number" and . >= 1 and . == floor) and
+                (.version | type == "string" and test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$")) and
+                (.version_code | type == "number" and . >= 1 and . == floor) and
+                (.database_schema_version | type == "number" and . >= 1 and . == floor) and
+                (.manifest_sha256 | type == "string" and test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+                (.portal_image_digest | test("^sha256:[0-9a-f]{64}$")) and
+                (.server_image_digest | test("^sha256:[0-9a-f]{64}$")) and
+                (.portal_container_id | test("^[0-9a-f]{12,64}$")) and
+                (.server_container_id | test("^[0-9a-f]{12,64}$")) and
+                (.postgres_container_id | test("^[0-9a-f]{12,64}$")) and
+                ((.previous_receipt_sha256 == null) or
+                  (.previous_receipt_sha256 | test("^[0-9a-f]{64}$"))) and
+                .rollback_target_receipt_sha256 == null)
+            ' "$receipt" >/dev/null
+          embedded_sha256="$(jq -cj '.receipt' "$receipt" | sha256sum | cut -d ' ' -f 1)"
+          [[ "$embedded_sha256" == "$(jq -er '.receipt_sha256' "$receipt")" ]]
+          printf 'candidate_run_id=%s\n' "$(jq -er '.receipt.candidate_run_id' "$receipt")" >> "$GITHUB_OUTPUT"
+          printf 'candidate_sha=%s\n' "$(jq -er '.receipt.git_sha' "$receipt")" >> "$GITHUB_OUTPUT"
+          printf 'sha256=%s\n' "$(sha256sum "$receipt" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+          printf 'version=%s\n' "$(jq -er '.receipt.version' "$receipt")" >> "$GITHUB_OUTPUT"
+
+      - name: Select the matching immutable Candidate artifacts
+        id: candidate
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          CANDIDATE_RUN_ID: ${{ steps.receipt.outputs.candidate_run_id }}
+          CANDIDATE_SHA: ${{ steps.receipt.outputs.candidate_sha }}
+          VERSION: ${{ steps.receipt.outputs.version }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const runId = Number(process.env.CANDIDATE_RUN_ID);
+            const candidate = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            const run = candidate.data;
+            const workflow = await github.rest.actions.getWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: run.workflow_id,
+            });
+            if (
+              run.id !== runId ||
+              run.name !== "Release Candidate" ||
+              run.path !== ".github/workflows/release-candidate.yml" ||
+              run.repository?.full_name !== "1024XEngineer/XE3-ESL" ||
+              run.head_repository?.full_name !== "1024XEngineer/XE3-ESL" ||
+              run.event !== "push" ||
+              run.head_branch !== "main" ||
+              run.head_sha !== process.env.CANDIDATE_SHA ||
+              run.status !== "completed" ||
+              run.conclusion !== "success" ||
+              workflow.data.name !== "Release Candidate" ||
+              workflow.data.path !== ".github/workflows/release-candidate.yml" ||
+              workflow.data.state !== "active"
+            ) {
+              core.setFailed(`Run ${runId} is not the matching official main Candidate.`);
+              return;
+            }
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100,
+              },
+            );
+            const manifestName = `speakup-v${process.env.VERSION}-release-manifest`;
+            const androidName = `speakup-v${process.env.VERSION}-android`;
+            const selectOne = (name) => {
+              const selected = artifacts.filter(
+                (artifact) => artifact.name === name && !artifact.expired,
+              );
+              if (selected.length !== 1) {
+                core.setFailed(`Candidate run ${runId} has ${selected.length} ${name} artifacts.`);
+                return null;
+              }
+              return selected[0].name;
+            };
+            const manifestArtifact = selectOne(manifestName);
+            const androidArtifact = selectOne(androidName);
+            if (!manifestArtifact || !androidArtifact) return;
+            core.setOutput("manifest_artifact", manifestArtifact);
+            core.setOutput("android_artifact", androidArtifact);
+
+  deploy:
+    name: Approve and deploy the immutable Candidate
+    needs: authorize
+    environment:
+      name: production
+      url: https://speak-up.top
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out the exact Candidate commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.candidate_sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.18.0"
+
+      - name: Download the Candidate release manifest
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: ${{ needs.authorize.outputs.manifest_artifact }}
+          path: ${{ runner.temp }}/candidate-manifest
+          run-id: ${{ needs.authorize.outputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download the already signed Android artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: ${{ needs.authorize.outputs.android_artifact }}
+          path: ${{ runner.temp }}/candidate-android
+          run-id: ${{ needs.authorize.outputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download the approved Staging receipt
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: staging-deployment-${{ needs.authorize.outputs.staging_run_id }}-${{ needs.authorize.outputs.staging_run_attempt }}
+          path: ${{ runner.temp }}/staging-receipt
+          run-id: ${{ needs.authorize.outputs.staging_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Revalidate the bound Candidate artifacts
+        id: artifacts
+        env:
+          ANDROID_DIRECTORY: ${{ runner.temp }}/candidate-android
+          CANDIDATE_RUN_ID: ${{ needs.authorize.outputs.candidate_run_id }}
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          MANIFEST_DIRECTORY: ${{ runner.temp }}/candidate-manifest
+          STAGING_DIRECTORY: ${{ runner.temp }}/staging-receipt
+          STAGING_RECEIPT_SHA256: ${{ needs.authorize.outputs.staging_receipt_sha256 }}
+          STAGING_RUN_ATTEMPT: ${{ needs.authorize.outputs.staging_run_attempt }}
+          STAGING_RUN_ID: ${{ needs.authorize.outputs.staging_run_id }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          manifest="$MANIFEST_DIRECTORY/release-manifest.json"
+          [[ ! -L "$manifest" && -s "$manifest" ]]
+          [[ "$(find "$MANIFEST_DIRECTORY" -mindepth 1 -maxdepth 1 | wc -l)" == 1 ]]
+          mapfile -d '' staging_files < <(
+            find "$STAGING_DIRECTORY" -mindepth 1 -maxdepth 1 -type f -print0
+          )
+          [[ "${#staging_files[@]}" == 1 ]]
+          staging_receipt="${staging_files[0]}"
+          [[ ! -L "$staging_receipt" && -s "$staging_receipt" ]]
+          [[ "$(sha256sum "$staging_receipt" | cut -d ' ' -f 1)" == "$STAGING_RECEIPT_SHA256" ]]
+
+          production_apk="speakup-v$VERSION-production-arm64.apk"
+          staging_apk="speakup-v$VERSION-staging-arm64.apk"
+          expected_android_files="$(printf '%s\n' \
+            SHA256SUMS \
+            apk-certificate-sha256.txt \
+            "$production_apk" \
+            "$staging_apk" | sort)"
+          actual_android_files="$(
+            find "$ANDROID_DIRECTORY" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort
+          )"
+          [[ "$actual_android_files" == "$expected_android_files" ]]
+          for file in SHA256SUMS apk-certificate-sha256.txt "$production_apk" "$staging_apk"; do
+            [[ ! -L "$ANDROID_DIRECTORY/$file" && -f "$ANDROID_DIRECTORY/$file" && -s "$ANDROID_DIRECTORY/$file" ]]
+          done
+          (cd "$ANDROID_DIRECTORY" && sha256sum --strict --check SHA256SUMS)
+
+          manifest_sha256="$(sha256sum "$manifest" | cut -d ' ' -f 1)"
+          jq -e \
+            --arg git_sha "$CANDIDATE_SHA" \
+            --arg manifest_sha256 "$manifest_sha256" \
+            --arg quality_run_url "https://github.com/1024XEngineer/XE3-ESL/actions/runs/$CANDIDATE_RUN_ID" \
+            --arg version "$VERSION" \
+            --argjson candidate_run_id "$CANDIDATE_RUN_ID" \
+            --argjson staging_run_id "$STAGING_RUN_ID" \
+            --argjson staging_run_attempt "$STAGING_RUN_ATTEMPT" \
+            --slurpfile manifest "$manifest" '
+              ($manifest | length == 1) and
+              ($manifest[0] | .git_sha == $git_sha and .version == $version and
+                .quality_run_url == $quality_run_url) and
+              .receipt.manifest_sha256 == $manifest_sha256 and
+              .receipt.git_sha == $git_sha and
+              .receipt.version == $manifest[0].version and
+              .receipt.version_code == $manifest[0].version_code and
+              .receipt.database_schema_version == $manifest[0].database_schema_version and
+              .receipt.portal_image_digest == $manifest[0].portal_image_digest and
+              .receipt.server_image_digest == $manifest[0].server_image_digest and
+              .receipt.candidate_run_id == $candidate_run_id and
+              .receipt.deployment_run_id == $staging_run_id and
+              .receipt.deployment_run_attempt == $staging_run_attempt
+            ' "$staging_receipt" >/dev/null
+          [[ "$(tr -d '[:space:]' < "$ANDROID_DIRECTORY/apk-certificate-sha256.txt")" == \
+            "$(jq -er '.apk_certificate_sha256' "$manifest")" ]]
+          [[ "$(sha256sum "$ANDROID_DIRECTORY/$staging_apk" | cut -d ' ' -f 1)" == \
+            "$(jq -er '.staging_apk_sha256' "$manifest")" ]]
+          [[ "$(sha256sum "$ANDROID_DIRECTORY/$production_apk" | cut -d ' ' -f 1)" == \
+            "$(jq -er '.production_apk_sha256' "$manifest")" ]]
+          [[ "$(stat -c '%s' "$ANDROID_DIRECTORY/$production_apk")" == \
+            "$(jq -er '.production_apk_size_bytes' "$manifest")" ]]
+          printf 'manifest=%s\n' "$manifest" >> "$GITHUB_OUTPUT"
+          printf 'manifest_sha256=%s\n' "$manifest_sha256" >> "$GITHUB_OUTPUT"
+          printf 'production_apk=%s\n' "$ANDROID_DIRECTORY/$production_apk" >> "$GITHUB_OUTPUT"
+          printf 'staging_receipt=%s\n' "$staging_receipt" >> "$GITHUB_OUTPUT"
+
+      - name: Build the immutable Android download payload
+        id: bundle
+        env:
+          MANIFEST_FILE: ${{ steps.artifacts.outputs.manifest }}
+          PRODUCTION_APK: ${{ steps.artifacts.outputs.production_apk }}
+          STAGING_RECEIPT: ${{ steps.artifacts.outputs.staging_receipt }}
+        run: |
+          set -euo pipefail
+          payload="$RUNNER_TEMP/production-payload"
+          install -d -m 700 "$payload"
+          published_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          node tools/android-download/bundle.mjs \
+            --manifest "$MANIFEST_FILE" \
+            --production-apk "$PRODUCTION_APK" \
+            --published-at "$published_at" \
+            --output "$payload/bundle"
+          install -m 600 "$MANIFEST_FILE" "$payload/release-manifest.json"
+          install -m 600 \
+            "$STAGING_RECEIPT" \
+            "$payload/staging-receipt.json"
+          printf 'directory=%s\n' "$payload" >> "$GITHUB_OUTPUT"
+          printf 'manifest_sha256=%s\n' \
+            "$(sha256sum "$payload/bundle/bundle-manifest.json" | cut -d ' ' -f 1)" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Install the restricted Production SSH identity
+        env:
+          DEPLOY_HOST: ${{ vars.PRODUCTION_DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ vars.PRODUCTION_DEPLOY_PORT }}
+          DEPLOY_USER: ${{ vars.PRODUCTION_DEPLOY_USER }}
+          KNOWN_HOSTS: ${{ secrets.PRODUCTION_DEPLOY_KNOWN_HOSTS }}
+          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_DEPLOY_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          [[ "$DEPLOY_HOST" =~ ^[A-Za-z0-9.-]+$ ]]
+          [[ "$DEPLOY_PORT" =~ ^[0-9]+$ ]] && (( DEPLOY_PORT >= 1 && DEPLOY_PORT <= 65535 ))
+          [[ "$DEPLOY_USER" == "speakup-production-ci" ]]
+          [[ -n "$KNOWN_HOSTS" && -n "$SSH_PRIVATE_KEY" ]]
+          install -d -m 700 "$RUNNER_TEMP/production-ssh"
+          printf '%s\n' "$KNOWN_HOSTS" > "$RUNNER_TEMP/production-ssh/known_hosts"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$RUNNER_TEMP/production-ssh/id_ed25519"
+          chmod 600 \
+            "$RUNNER_TEMP/production-ssh/known_hosts" \
+            "$RUNNER_TEMP/production-ssh/id_ed25519"
+
+      - name: Deploy through the restricted Production broker
+        id: deploy
+        env:
+          BUNDLE_MANIFEST_SHA256: ${{ steps.bundle.outputs.manifest_sha256 }}
+          CANDIDATE_RUN_ID: ${{ needs.authorize.outputs.candidate_run_id }}
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          DEPLOY_HOST: ${{ vars.PRODUCTION_DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ vars.PRODUCTION_DEPLOY_PORT }}
+          DEPLOY_USER: ${{ vars.PRODUCTION_DEPLOY_USER }}
+          MANIFEST_SHA256: ${{ steps.artifacts.outputs.manifest_sha256 }}
+          PAYLOAD_DIRECTORY: ${{ steps.bundle.outputs.directory }}
+          STAGING_RECEIPT_SHA256: ${{ needs.authorize.outputs.staging_receipt_sha256 }}
+          STAGING_RUN_ATTEMPT: ${{ needs.authorize.outputs.staging_run_attempt }}
+          STAGING_RUN_ID: ${{ needs.authorize.outputs.staging_run_id }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          ssh_options=(
+            -i "$RUNNER_TEMP/production-ssh/id_ed25519"
+            -o BatchMode=yes
+            -o IdentitiesOnly=yes
+            -o StrictHostKeyChecking=yes
+            -o "UserKnownHostsFile=$RUNNER_TEMP/production-ssh/known_hosts"
+            -o ConnectTimeout=15
+            -p "$DEPLOY_PORT"
+          )
+          inspect_directory="$RUNNER_TEMP/production-inspect"
+          inspect_response="$RUNNER_TEMP/production-inspect-response.json"
+          install -d -m 700 "$inspect_directory"
+          jq -cn '{protocol_version:1,action:"inspect"}' > "$inspect_directory/request.json"
+          tar --format=ustar --no-recursion -C "$inspect_directory" \
+            -cf - request.json | \
+            ssh "${ssh_options[@]}" "$DEPLOY_USER@$DEPLOY_HOST" > "$inspect_response"
+          jq -e '
+            type == "object" and
+            keys == ["action", "current_receipt_sha256", "ok", "protocol_version", "receipt"] and
+            .protocol_version == 1 and .ok == true and .action == "inspect" and
+            (.current_receipt_sha256 | type == "string" and test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+            .receipt.environment == "production" and
+            .receipt.repository == "1024XEngineer/XE3-ESL" and
+            (.receipt.operation == "baseline" or .receipt.operation == "deploy") and
+            (.receipt.production_engine_receipt_sha256 | test("^[0-9a-f]{64}$"))
+          ' "$inspect_response" >/dev/null
+          expected_current="$(jq -er '.current_receipt_sha256' "$inspect_response")"
+          expected_engine="$(jq -er '.receipt.production_engine_receipt_sha256' "$inspect_response")"
+
+          jq -cn \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson candidate_run_id "$CANDIDATE_RUN_ID" \
+            --argjson staging_run_id "$STAGING_RUN_ID" \
+            --argjson staging_run_attempt "$STAGING_RUN_ATTEMPT" \
+            --argjson deployment_run_id "$GITHUB_RUN_ID" \
+            --argjson deployment_run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg expected_current_receipt_sha256 "$expected_current" \
+            --arg manifest_sha256 "$MANIFEST_SHA256" \
+            --arg staging_receipt_sha256 "$STAGING_RECEIPT_SHA256" \
+            --arg bundle_manifest_sha256 "$BUNDLE_MANIFEST_SHA256" \
+            '{
+              protocol_version: 1,
+              action: "deploy",
+              repository: $repository,
+              candidate_run_id: $candidate_run_id,
+              staging_run_id: $staging_run_id,
+              staging_run_attempt: $staging_run_attempt,
+              deployment_run_id: $deployment_run_id,
+              deployment_run_attempt: $deployment_run_attempt,
+              expected_current_receipt_sha256: $expected_current_receipt_sha256,
+              manifest_sha256: $manifest_sha256,
+              staging_receipt_sha256: $staging_receipt_sha256,
+              bundle_manifest_sha256: $bundle_manifest_sha256
+            }' > "$PAYLOAD_DIRECTORY/request.json"
+
+          apk="speakup-v$VERSION-production-arm64.apk"
+          payload_files=(
+            request.json
+            release-manifest.json
+            staging-receipt.json
+            bundle/bundle-manifest.json
+            "bundle/downloads/android/v$VERSION/release.json"
+            "bundle/downloads/android/v$VERSION/$apk"
+            "bundle/downloads/android/v$VERSION/$apk.sha256"
+          )
+          deploy_response="$RUNNER_TEMP/production-deploy-response.json"
+          tar --format=ustar --no-recursion -C "$PAYLOAD_DIRECTORY" \
+            -cf - "${payload_files[@]}" | \
+            ssh "${ssh_options[@]}" "$DEPLOY_USER@$DEPLOY_HOST" > "$deploy_response"
+          jq -e \
+            --arg bundle_manifest_sha256 "$BUNDLE_MANIFEST_SHA256" \
+            --arg expected_current "$expected_current" \
+            --arg expected_engine "$expected_engine" \
+            --arg git_sha "$CANDIDATE_SHA" \
+            --arg manifest_sha256 "$MANIFEST_SHA256" \
+            --arg staging_receipt_sha256 "$STAGING_RECEIPT_SHA256" \
+            --arg version "$VERSION" \
+            --argjson candidate_run_id "$CANDIDATE_RUN_ID" \
+            --argjson staging_run_id "$STAGING_RUN_ID" \
+            --argjson staging_run_attempt "$STAGING_RUN_ATTEMPT" \
+            --argjson deployment_run_id "$GITHUB_RUN_ID" \
+            --argjson deployment_run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --slurpfile manifest "$PAYLOAD_DIRECTORY/release-manifest.json" '
+              type == "object" and
+              keys == ["action", "current_receipt_sha256", "ok", "protocol_version", "receipt"] and
+              .protocol_version == 1 and .ok == true and .action == "deploy" and
+              (.current_receipt_sha256 | type == "string" and test("^[0-9a-f]{64}$") and test("[1-9a-f]")) and
+              .receipt.receipt_version == 1 and
+              .receipt.environment == "production" and .receipt.operation == "deploy" and
+              .receipt.repository == "1024XEngineer/XE3-ESL" and
+              .receipt.manifest_sha256 == $manifest_sha256 and
+              .receipt.version == $version and .receipt.version_code == $manifest[0].version_code and
+              .receipt.git_sha == $git_sha and
+              .receipt.database_schema_version == $manifest[0].database_schema_version and
+              .receipt.portal_image_digest == $manifest[0].portal_image_digest and
+              .receipt.server_image_digest == $manifest[0].server_image_digest and
+              .receipt.production_apk_file == $manifest[0].production_apk_file and
+              .receipt.production_apk_sha256 == $manifest[0].production_apk_sha256 and
+              .receipt.apk_certificate_sha256 == $manifest[0].apk_certificate_sha256 and
+              .receipt.android_bundle_manifest_sha256 == $bundle_manifest_sha256 and
+              .receipt.candidate_run_id == $candidate_run_id and
+              .receipt.staging_run_id == $staging_run_id and
+              .receipt.staging_run_attempt == $staging_run_attempt and
+              .receipt.staging_receipt_sha256 == $staging_receipt_sha256 and
+              .receipt.deployment_run_id == $deployment_run_id and
+              .receipt.deployment_run_attempt == $deployment_run_attempt and
+              .receipt.previous_receipt_sha256 == $expected_current and
+              .receipt.production_engine_previous_receipt_sha256 == $expected_engine and
+              (.receipt.production_engine_receipt_sha256 | test("^[0-9a-f]{64}$")) and
+              (.receipt.portal_container_id | test("^[0-9a-f]{12,64}$")) and
+              (.receipt.server_container_id | test("^[0-9a-f]{12,64}$")) and
+              (.receipt.postgres_container_id | test("^[0-9a-f]{12,64}$")) and
+              (.receipt.postgres_backup_id | type == "string" and length > 0) and
+              (.receipt.portal_backup_id | type == "string" and length > 0)
+            ' "$deploy_response" >/dev/null
+          embedded_sha256="$(jq -cj '.receipt' "$deploy_response" | sha256sum | cut -d ' ' -f 1)"
+          [[ "$embedded_sha256" == "$(jq -er '.current_receipt_sha256' "$deploy_response")" ]]
+          printf 'response=%s\n' "$deploy_response" >> "$GITHUB_OUTPUT"
+          printf 'receipt_sha256=%s\n' "$embedded_sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the public Production edge
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --location --max-time 20 \
+            https://speak-up.top/ >/dev/null
+          curl --fail --silent --show-error --max-time 20 \
+            https://api.speak-up.top/health >/dev/null
+
+      - name: Upload the Production deployment receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: production-deployment-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.deploy.outputs.response }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Record the Production deployment
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          RECEIPT_SHA256: ${{ steps.deploy.outputs.receipt_sha256 }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          {
+            printf '## Production deployment\n\n'
+            printf -- '- Version: `%s`\n' "$VERSION"
+            printf -- '- Commit: `%s`\n' "$CANDIDATE_SHA"
+            printf -- '- Receipt: `%s`\n' "$RECEIPT_SHA256"
+            printf -- '- Portal: https://speak-up.top\n'
+            printf -- '- API: https://api.speak-up.top/health\n'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove the Production SSH identity
+        if: always()
+        run: |
+          shred -u "$RUNNER_TEMP/production-ssh/id_ed25519" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/production-ssh/known_hosts"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -91,7 +91,7 @@ jobs:
                   set_all_checks
                   android_release=true
                   ;;
-                .github/workflows/production-probe.yml)
+                .github/workflows/production-probe.yml|.github/workflows/production-deploy.yml|tools/production-deploy/*)
                   deploy=true
                   ;;
                 .github/workflows/database.yml|.github/workflows/coverage-comment.yml|tools/release-candidate/*)

--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,9 @@ check-observability:
 	./deploy/observability/test-nginx.sh
 
 check-production-deploy:
+	node --test tools/production-deploy/*.test.mjs
+	cd server && go test -count=1 ./cmd/production-broker
+	./deploy/production/test-host-access.sh
 	./deploy/production/test.sh
 
 check-production-nginx:

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -582,6 +582,85 @@ separate reviewed disaster-recovery runbook, an explicit outage, a named backup
 ID, and operator approval. Image rollback must never silently restore this
 database.
 
+## Approved Production deployment
+
+`Production Deploy` starts only after the official repository's
+`Deploy Staging Candidate` run succeeds. The authorization job verifies the
+official `main` commit, successful Release Candidate run, immutable Candidate
+manifest and Android artifact, and the exact Staging deployment receipt. It
+does not rebuild an image or APK. The deploy job then enters the GitHub
+`production` Environment; its Secrets are unavailable until a required
+reviewer approves the deployment.
+
+Configure that Environment with a required reviewer, disallow self-approval,
+and allow only `main`. Add these Environment values:
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| Variable | `PRODUCTION_DEPLOY_HOST` | Production SSH host or IP |
+| Variable | `PRODUCTION_DEPLOY_PORT` | Production SSH port, normally `22` |
+| Variable | `PRODUCTION_DEPLOY_USER` | Exactly `speakup-production-ci` |
+| Secret | `PRODUCTION_DEPLOY_KNOWN_HOSTS` | Verified ED25519 host-key line |
+| Secret | `PRODUCTION_DEPLOY_SSH_PRIVATE_KEY` | Private half of the dedicated CI key |
+
+The private key is used only after Environment approval. The matching public
+key is installed with `restrict`, an sshd `ForceCommand`, and an exact sudoers
+rule. It cannot request a shell, command, TTY, tunnel, `scp`, or `sftp`. The
+root broker accepts only a bounded tar protocol on standard input and invokes
+the fixed Production `manage.sh deploy` argument contract. Request fields
+cannot override the environment file, control checkout, state directory,
+receipt location, Docker access, backup programs, Nginx path, or public root.
+
+Build and install the reviewed host contract once from the commit being
+deployed. The bootstrap does not create a key or copy a private key:
+
+```sh
+cd server
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath \
+  -o /tmp/speakup-production-broker ./cmd/production-broker
+cd ..
+sudo ./deploy/production/host/bootstrap.sh \
+  --broker-binary /tmp/speakup-production-broker \
+  --contract-directory "$PWD" \
+  --contract-revision "$(git rev-parse HEAD)" \
+  --ssh-public-key-file /root/speakup-production-ci.pub
+```
+
+Before the first automated deployment, establish the current live release as
+the broker baseline. Use its already-audited `release-manifest.json` and current
+immutable Production receipt. If that receipt does not yet exist, create it
+once with `manage.sh baseline`; `baseline` verifies the live containers, Nginx,
+backup configuration, volumes, schema, and digest identity without redeploying
+them:
+
+```sh
+sudo install -d -o root -g root -m 0700 /var/lib/speakup/production-bootstrap
+sudo /opt/xe3-speakup-production-control/current/deploy/production/manage.sh \
+  baseline \
+  --manifest /var/lib/speakup/production-bootstrap/release-manifest.json \
+  --env-file /etc/speakup/production.env \
+  --receipt /var/lib/speakup/production-bootstrap/baseline-receipt.json
+sudo /usr/local/libexec/speakup-production-broker initialize \
+  --manifest /var/lib/speakup/production-bootstrap/release-manifest.json \
+  --receipt /var/lib/speakup/production-bootstrap/baseline-receipt.json
+sudo ./deploy/production/host/validate.sh
+```
+
+Each approved run streams only `request.json`, the Candidate manifest, the
+Staging receipt, and the versioned Android download bundle. The broker checks
+their hashes and cross-links before `manage.sh` performs its existing backup
+gates and digest-only deployment. Success stores content-addressed engine and
+audit receipts, atomically advances the current pointer, verifies the public
+Portal and API, and uploads the broker response as a 90-day Actions artifact.
+It publishes the versioned APK files but deliberately does not activate the
+public APK pointer and does not create a stable Tag or GitHub Release.
+
+If `manage.sh` fails, the broker leaves the previous current pointer unchanged
+and retains `pending.json` plus any engine receipt as recovery evidence. Later
+deployments fail with `recovery_required`; inspect the live state and evidence,
+then use the existing reviewed rollback procedure. Do not delete pending state
+merely to make CI green.
+
 ## Reproducible checks
 
 ```sh
@@ -589,6 +668,8 @@ make check-production-backup
 make check-production-rehearsal
 make check-android-download
 make check-production-deploy
+./deploy/production/test-host-access.sh
+cd server && go test -count=1 ./cmd/production-broker
 make check-production-nginx
 make check-offline-release
 ```

--- a/deploy/production/host/bootstrap.sh
+++ b/deploy/production/host/bootstrap.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly ci_user="speakup-production-ci"
+readonly ci_home="/var/empty/speakup-production-ci"
+readonly broker_path="/usr/local/libexec/speakup-production-broker"
+readonly gate_path="/usr/local/libexec/speakup-production-ssh-gate"
+readonly control_root="/opt/xe3-speakup-production-control"
+readonly state_root="/var/lib/speakup/production-broker"
+readonly sshd_drop_in="/etc/ssh/sshd_config.d/60-speakup-production-ci.conf"
+readonly authorized_keys_file="/etc/ssh/authorized_keys/speakup-production-ci"
+readonly sudoers_file="/etc/sudoers.d/speakup-production-ci"
+readonly tmpfiles_file="/etc/tmpfiles.d/xe3-speakup-production-broker.conf"
+readonly trusted_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+readonly script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+PATH=$trusted_path
+export PATH
+(( EUID == 0 )) || { printf '%s\n' 'production host bootstrap: run as root' >&2; exit 1; }
+
+fail() { printf 'production host bootstrap: %s\n' "$*" >&2; exit 1; }
+usage() {
+  cat >&2 <<'EOF'
+Usage: bootstrap.sh \
+  --broker-binary ABS \
+  --contract-directory ABS \
+  --contract-revision 40HEX \
+  --ssh-public-key-file ABS
+EOF
+}
+
+safe_absolute_path() {
+  [[ "$1" == /* && "$1" != *//* && "$1" != */../* && "$1" != */./* &&
+     "$1" != */.. && "$1" != */. ]]
+}
+
+require_source_file() {
+  [[ ! -L "$2" && -f "$2" && -s "$2" ]] || fail "$1 must be a non-empty regular file"
+}
+
+require_linux_amd64_elf() {
+  local header
+  header=$(od -An -tx1 -N20 -- "$1" | tr -d '[:space:]')
+  [[ "$header" =~ ^7f454c46020101[0-9a-f]{18}(0200|0300)3e00$ ]] ||
+    fail "broker binary must be a Linux amd64 ELF executable"
+}
+
+broker_binary=""
+contract_directory=""
+contract_revision=""
+ssh_public_key_file=""
+while (( $# > 0 )); do
+  case "$1" in
+    --broker-binary|--contract-directory|--contract-revision|--ssh-public-key-file)
+      (( $# >= 2 )) || fail "$1 requires one value"
+      flag=$1
+      value=$2
+      case "$flag" in
+        --broker-binary) [[ -z "$broker_binary" ]] || fail "$flag is duplicated"; broker_binary=$value ;;
+        --contract-directory) [[ -z "$contract_directory" ]] || fail "$flag is duplicated"; contract_directory=$value ;;
+        --contract-revision) [[ -z "$contract_revision" ]] || fail "$flag is duplicated"; contract_revision=$value ;;
+        --ssh-public-key-file) [[ -z "$ssh_public_key_file" ]] || fail "$flag is duplicated"; ssh_public_key_file=$value ;;
+      esac
+      shift 2
+      ;;
+    *) usage; fail "unsupported argument: $1" ;;
+  esac
+done
+
+[[ -n "$broker_binary" && -n "$contract_directory" && -n "$contract_revision" && -n "$ssh_public_key_file" ]] || { usage; fail "all arguments are required"; }
+safe_absolute_path "$broker_binary" || fail "broker binary path is unsafe"
+safe_absolute_path "$contract_directory" || fail "contract directory path is unsafe"
+safe_absolute_path "$ssh_public_key_file" || fail "SSH public key path is unsafe"
+[[ "$contract_revision" =~ ^[0-9a-f]{40}$ ]] || fail "contract revision must be a full lowercase SHA"
+[[ ! -L "$contract_directory" && -d "$contract_directory" ]] || fail "contract directory must be real"
+require_source_file "broker binary" "$broker_binary"
+[[ -x "$broker_binary" ]] || fail "broker binary is not executable"
+require_source_file "SSH public key" "$ssh_public_key_file"
+for file in deploy/production/manage.sh deploy/production/compose.yaml deploy/production/nginx.conf.template deploy/android-download/manage.sh; do
+  require_source_file "$file" "$contract_directory/$file"
+done
+require_linux_amd64_elf "$broker_binary"
+
+public_key=""
+line_count=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+  line_count=$((line_count + 1))
+  public_key=${line%$'\r'}
+done < "$ssh_public_key_file"
+(( line_count == 1 )) || fail "SSH public key file must contain one line"
+[[ "$public_key" =~ ^ssh-ed25519[[:space:]][A-Za-z0-9+/]+={0,3}([[:space:]][^[:cntrl:]]+)?$ ]] ||
+  fail "SSH public key must be one Ed25519 key"
+
+for command in awk chmod chown chpasswd cmp getent groupadd id install ln mktemp mv od openssl passwd rm sshd stat systemctl systemd-tmpfiles tr useradd visudo wc; do
+  command -v "$command" >/dev/null 2>&1 || fail "$command is required"
+done
+
+getent group "$ci_user" >/dev/null || groupadd "$ci_user"
+getent passwd "$ci_user" >/dev/null || useradd --gid "$ci_user" --home-dir "$ci_home" --no-create-home --shell /bin/bash --comment "SpeakUp Production CI forced command" --password '!' "$ci_user"
+[[ "$(id -u "$ci_user")" != 0 ]] || fail "CI account cannot be root"
+[[ "$(id -G "$ci_user" | wc -w | tr -d ' ')" == 1 ]] || fail "CI account must not have supplementary groups"
+if [[ "$(passwd -S "$ci_user" | awk '{print $2}')" != P ]]; then
+  printf '%s:%s\n' "$ci_user" "$(openssl rand -hex 48)" | chpasswd
+fi
+
+install -d -o root -g root -m 755 /var/empty /var/lib/speakup /usr/local/libexec /etc/ssh/authorized_keys /etc/ssh/sshd_config.d /etc/sudoers.d /etc/tmpfiles.d
+install -d -o root -g root -m 555 "$ci_home"
+install -d -o root -g root -m 700 "$state_root" "$state_root/manifests" "$state_root/engine-receipts" "$state_root/audit-receipts" "$state_root/incoming"
+install -d -o root -g root -m 755 "$control_root" "$control_root/releases"
+install -d -o root -g root -m 700 /run/lock/xe3-speakup-production-broker
+
+install -o root -g root -m 0555 "$broker_binary" "$broker_path"
+install -o root -g root -m 0555 "$script_directory/ssh-gate" "$gate_path"
+install -o root -g root -m 0644 "$script_directory/sshd_config" "$sshd_drop_in"
+install -o root -g root -m 0440 "$script_directory/sudoers" "$sudoers_file"
+install -o root -g root -m 0444 "$script_directory/tmpfiles.conf" "$tmpfiles_file"
+
+key_temporary=$(mktemp)
+trap 'rm -f -- "$key_temporary"' EXIT
+printf 'restrict %s\n' "$public_key" > "$key_temporary"
+install -o root -g root -m 0644 "$key_temporary" "$authorized_keys_file"
+
+release="$control_root/releases/$contract_revision"
+if [[ -e "$release" || -L "$release" ]]; then
+  [[ ! -L "$release" && -d "$release" ]] || fail "existing contract revision is invalid"
+  for file in deploy/production/manage.sh deploy/production/compose.yaml deploy/production/nginx.conf.template deploy/android-download/manage.sh; do
+    cmp -s "$contract_directory/$file" "$release/$file" || fail "existing contract revision differs: $file"
+  done
+else
+  snapshot=$(mktemp -d "$control_root/releases/.${contract_revision}.XXXXXX")
+  install -d -m 0555 "$snapshot/deploy/production" "$snapshot/deploy/android-download"
+  install -m 0555 "$contract_directory/deploy/production/manage.sh" "$snapshot/deploy/production/manage.sh"
+  install -m 0444 "$contract_directory/deploy/production/compose.yaml" "$snapshot/deploy/production/compose.yaml"
+  install -m 0444 "$contract_directory/deploy/production/nginx.conf.template" "$snapshot/deploy/production/nginx.conf.template"
+  install -m 0555 "$contract_directory/deploy/android-download/manage.sh" "$snapshot/deploy/android-download/manage.sh"
+  chown -R root:root "$snapshot"
+  chmod 0555 "$snapshot" "$snapshot/deploy"
+  mv -- "$snapshot" "$release"
+fi
+
+current_temporary=$(mktemp "$control_root/.current.XXXXXX")
+rm -f "$current_temporary"
+ln -s "releases/$contract_revision" "$current_temporary"
+mv -Tf "$current_temporary" "$control_root/current"
+
+visudo -cf "$sudoers_file" >/dev/null
+sshd -t
+systemd-tmpfiles --create "$tmpfiles_file"
+systemctl reload ssh
+printf 'Production forced-command host boundary installed at revision %s.\n' "$contract_revision"

--- a/deploy/production/host/ssh-gate
+++ b/deploy/production/host/ssh-gate
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+  printf 'production SSH gate: %s\n' "$*" >&2
+  exit 1
+}
+
+(( $# == 0 )) || fail "arguments are not accepted"
+[[ -z "${SSH_ORIGINAL_COMMAND:-}" ]] ||
+  fail "remote commands and subsystems are not accepted"
+
+unset SSH_ORIGINAL_COMMAND
+exec /usr/bin/sudo -n -u root -- \
+  /usr/local/libexec/speakup-production-broker

--- a/deploy/production/host/sshd_config
+++ b/deploy/production/host/sshd_config
@@ -1,0 +1,9 @@
+Match User speakup-production-ci
+    AuthenticationMethods publickey
+    AuthorizedKeysFile /etc/ssh/authorized_keys/speakup-production-ci
+    ForceCommand /usr/local/libexec/speakup-production-ssh-gate
+    DisableForwarding yes
+    PermitTTY no
+    PasswordAuthentication no
+    KbdInteractiveAuthentication no
+    X11Forwarding no

--- a/deploy/production/host/sudoers
+++ b/deploy/production/host/sudoers
@@ -1,0 +1,1 @@
+speakup-production-ci ALL=(root) NOPASSWD: /usr/local/libexec/speakup-production-broker ""

--- a/deploy/production/host/tmpfiles.conf
+++ b/deploy/production/host/tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/lock/xe3-speakup-production-broker 0700 root root -

--- a/deploy/production/host/validate.sh
+++ b/deploy/production/host/validate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly ci_user="speakup-production-ci"
+readonly broker="/usr/local/libexec/speakup-production-broker"
+readonly gate="/usr/local/libexec/speakup-production-ssh-gate"
+readonly state="/var/lib/speakup/production-broker"
+readonly env_file="/etc/speakup/production.env"
+
+(( EUID == 0 )) || { printf '%s\n' 'production host validation: run as root' >&2; exit 1; }
+(( $# == 0 )) || { printf '%s\n' 'Usage: validate.sh' >&2; exit 1; }
+fail() { printf 'production host validation: %s\n' "$*" >&2; exit 1; }
+
+require_file() {
+  local description=$1 path=$2 mode=$3
+  [[ ! -L "$path" && -f "$path" && -s "$path" ]] || fail "$description is missing"
+  [[ "$(stat -c '%u:%g:%a' "$path")" == "0:0:$mode" ]] || fail "$description has the wrong owner or mode"
+}
+require_directory() {
+  local description=$1 path=$2 mode=$3
+  [[ ! -L "$path" && -d "$path" ]] || fail "$description is missing"
+  [[ "$(stat -c '%u:%g:%a' "$path")" == "0:0:$mode" ]] || fail "$description has the wrong owner or mode"
+}
+
+entry=$(getent passwd "$ci_user") || fail "CI account is missing"
+IFS=: read -r name _ uid gid _ home shell <<< "$entry"
+[[ "$name" == "$ci_user" && "$uid" != 0 && "$home" == /var/empty/speakup-production-ci && "$shell" == /bin/bash ]] || fail "CI account identity is invalid"
+[[ "$(id -G "$ci_user" | wc -w | tr -d ' ')" == 1 ]] || fail "CI account has supplementary groups"
+[[ "$(passwd -S "$ci_user" | awk '{print $2}')" == P ]] || fail "CI account cannot authenticate with its restricted key"
+
+require_file "broker" "$broker" 555
+require_file "SSH gate" "$gate" 555
+require_file "sshd drop-in" /etc/ssh/sshd_config.d/60-speakup-production-ci.conf 644
+require_file "authorized key" /etc/ssh/authorized_keys/speakup-production-ci 644
+require_file "sudoers policy" /etc/sudoers.d/speakup-production-ci 440
+require_file "Production environment" "$env_file" 600
+for directory in "$state" "$state/manifests" "$state/engine-receipts" "$state/audit-receipts" "$state/incoming" /run/lock/xe3-speakup-production-broker; do
+  require_directory "broker directory" "$directory" 700
+done
+[[ -L /opt/xe3-speakup-production-control/current ]] || fail "current contract pointer is missing"
+require_file "Production manage contract" /opt/xe3-speakup-production-control/current/deploy/production/manage.sh 555
+require_file "Production Compose contract" /opt/xe3-speakup-production-control/current/deploy/production/compose.yaml 444
+require_file "Production Nginx contract" /opt/xe3-speakup-production-control/current/deploy/production/nginx.conf.template 444
+require_file "Android publication contract" /opt/xe3-speakup-production-control/current/deploy/android-download/manage.sh 555
+
+grep -Fxq 'restrict '"$(cut -d ' ' -f 2- /etc/ssh/authorized_keys/speakup-production-ci)" /etc/ssh/authorized_keys/speakup-production-ci || fail "authorized key is not restricted"
+visudo -cf /etc/sudoers.d/speakup-production-ci >/dev/null
+sudo -n -l -U "$ci_user" -u root -- "$broker" >/dev/null || fail "CI cannot call the no-argument broker"
+if sudo -n -l -U "$ci_user" -u root -- "$broker" unexpected >/dev/null 2>&1; then fail "CI can pass broker arguments"; fi
+
+effective=$(sshd -T -C "user=$ci_user,host=localhost,addr=127.0.0.1")
+for expected in \
+  'authenticationmethods publickey' \
+  'authorizedkeysfile /etc/ssh/authorized_keys/speakup-production-ci' \
+  'forcecommand /usr/local/libexec/speakup-production-ssh-gate' \
+  'disableforwarding yes' \
+  'permittty no' \
+  'passwordauthentication no' \
+  'kbdinteractiveauthentication no' \
+  'x11forwarding no'; do
+  grep -Fxq "$expected" <<< "$effective" || fail "effective sshd setting is missing: $expected"
+done
+
+temporary=$(mktemp -d)
+trap 'rm -rf -- "$temporary"' EXIT
+printf '%s\n' '{"protocol_version":1,"action":"inspect"}' > "$temporary/request.json"
+tar -C "$temporary" -cf - request.json | "$broker" | jq -e '.protocol_version == 1 and .ok == true and .action == "inspect" and (.current_receipt_sha256 | test("^[0-9a-f]{64}$"))' >/dev/null || fail "broker state inspection failed"
+printf '%s\n' 'Production CI is limited to the forced no-argument deployment broker.'

--- a/deploy/production/test-host-access.sh
+++ b/deploy/production/test-host-access.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly host="$directory/host"
+
+fail() { printf 'production host contract test: %s\n' "$*" >&2; exit 1; }
+for script in "$host/bootstrap.sh" "$host/validate.sh" "$host/ssh-gate"; do bash -n "$script"; done
+
+[[ "$(< "$host/sudoers")" == 'speakup-production-ci ALL=(root) NOPASSWD: /usr/local/libexec/speakup-production-broker ""' ]] || fail "sudoers is not the exact no-argument broker rule"
+grep -Fxq '    ForceCommand /usr/local/libexec/speakup-production-ssh-gate' "$host/sshd_config" || fail "forced command is missing"
+grep -Fxq '    DisableForwarding yes' "$host/sshd_config" || fail "forwarding is not disabled"
+grep -Fxq '    PermitTTY no' "$host/sshd_config" || fail "TTY is not disabled"
+grep -Fq "printf 'restrict %s\\n'" "$host/bootstrap.sh" || fail "bootstrap does not restrict the authorized key"
+grep -Fq 'deploy/production/manage.sh' "$host/bootstrap.sh" || fail "bootstrap does not snapshot the Production contract"
+grep -Fq 'deploy/android-download/manage.sh' "$host/bootstrap.sh" || fail "bootstrap does not snapshot Android publication"
+
+temporary=$(mktemp -d)
+trap 'rm -rf -- "$temporary"' EXIT
+mkdir -p "$temporary/bin"
+cat > "$temporary/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+printf '%q\n' "$@" > "$PRODUCTION_TEST_SUDO_ARGS"
+EOF
+chmod 755 "$temporary/bin/sudo"
+sed "s|/usr/bin/sudo|$temporary/bin/sudo|" "$host/ssh-gate" > "$temporary/ssh-gate"
+chmod 755 "$temporary/ssh-gate"
+PRODUCTION_TEST_SUDO_ARGS="$temporary/args" "$temporary/ssh-gate"
+arguments=()
+while IFS= read -r argument; do arguments+=("$argument"); done < "$temporary/args"
+[[ "${arguments[*]}" == '-n -u root -- /usr/local/libexec/speakup-production-broker' ]] || fail "gate invokes an unexpected command"
+if SSH_ORIGINAL_COMMAND='scp -t /tmp/file' PRODUCTION_TEST_SUDO_ARGS="$temporary/args" "$temporary/ssh-gate" >/dev/null 2>&1; then fail "gate accepted scp"; fi
+if PRODUCTION_TEST_SUDO_ARGS="$temporary/args" "$temporary/ssh-gate" unexpected >/dev/null 2>&1; then fail "gate accepted arguments"; fi
+
+printf '%s\n' 'Production host access contract tests passed.'

--- a/server/cmd/production-broker/main.go
+++ b/server/cmd/production-broker/main.go
@@ -1,0 +1,1414 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	protocolVersion      = 1
+	officialRepository   = "1024XEngineer/XE3-ESL"
+	productionManagePath = "/opt/xe3-speakup-production-control/current/deploy/production/manage.sh"
+	productionEnvFile    = "/etc/speakup/production.env"
+	productionStateDir   = "/var/lib/speakup/production-broker"
+	productionLockFile   = "/run/lock/xe3-speakup-production-broker/broker.lock"
+	productionPATH       = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	requestLimit         = int64(256 * 1024 * 1024)
+	metadataLimit        = int64(128 * 1024)
+	apkLimit             = int64(250 * 1024 * 1024)
+	maxJSONDepth         = 64
+	maxSafeInteger       = int64(9007199254740991)
+)
+
+var (
+	sha256Pattern         = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	gitSHAPattern         = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	digestPattern         = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	versionPattern        = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+	containerIDPattern    = regexp.MustCompile(`^[0-9a-f]{12,64}$`)
+	postgresBackupPattern = regexp.MustCompile(`^[0-9]{8}T[0-9]{6}Z-predeploy$`)
+	portalBackupPattern   = regexp.MustCompile(`^[0-9]{8}T[0-9]{9}Z$`)
+)
+
+type commandRunner func(context.Context, string, []string, []string) error
+
+type Config struct {
+	Repository     string
+	ManagePath     string
+	Environment    string
+	StateDir       string
+	LockFile       string
+	PATH           string
+	RequestTimeout time.Duration
+	DeployTimeout  time.Duration
+	Now            func() time.Time
+	RunCommand     commandRunner
+	OwnerUID       uint32
+}
+
+type brokerError struct{ code string }
+
+func (e *brokerError) Error() string { return e.code }
+func failure(code string) error      { return &brokerError{code: code} }
+
+func errorCode(err error) string {
+	var target *brokerError
+	if errors.As(err, &target) {
+		return target.code
+	}
+	return "internal_error"
+}
+
+type request struct {
+	Action                       string
+	Repository                   string
+	CandidateRunID               int64
+	StagingRunID                 int64
+	StagingRunAttempt            int64
+	DeploymentRunID              int64
+	DeploymentRunAttempt         int64
+	ExpectedCurrentReceiptSHA256 *string
+	ManifestSHA256               string
+	StagingReceiptSHA256         string
+	BundleManifestSHA256         string
+}
+
+type releaseManifest struct {
+	SHA256                string
+	Version               string
+	VersionCode           int64
+	GitSHA                string
+	DatabaseSchemaVersion int64
+	PortalImageDigest     string
+	ServerImageDigest     string
+	ProductionAPKFile     string
+	ProductionAPKSize     int64
+	ProductionAPKSHA256   string
+	APKCertificateSHA256  string
+}
+
+type stagingReceipt struct {
+	ManifestSHA256        string
+	Version               string
+	VersionCode           int64
+	GitSHA                string
+	DatabaseSchemaVersion int64
+	PortalImageDigest     string
+	ServerImageDigest     string
+	CandidateRunID        int64
+	DeploymentRunID       int64
+	DeploymentRunAttempt  int64
+}
+
+type engineReceipt struct {
+	ManifestSHA256              string
+	Version                     string
+	VersionCode                 int64
+	GitSHA                      string
+	DatabaseSchemaVersion       int64
+	PortalImageDigest           string
+	ServerImageDigest           string
+	ProductionAPKFile           string
+	ProductionAPKSize           int64
+	ProductionAPKSHA256         string
+	APKCertificateSHA256        string
+	PortalContainerID           string
+	ServerContainerID           string
+	PostgresContainerID         string
+	PostgresBackupID            *string
+	PortalBackupID              *string
+	AndroidBundleManifestSHA256 *string
+	PreviousReceiptSHA256       *string
+	RecordedAtUTC               string
+	Operation                   string
+}
+
+type auditReceipt struct {
+	ReceiptVersion                        int     `json:"receipt_version"`
+	Environment                           string  `json:"environment"`
+	Operation                             string  `json:"operation"`
+	Repository                            string  `json:"repository"`
+	ManifestSHA256                        string  `json:"manifest_sha256"`
+	Version                               string  `json:"version"`
+	VersionCode                           int64   `json:"version_code"`
+	GitSHA                                string  `json:"git_sha"`
+	DatabaseSchemaVersion                 int64   `json:"database_schema_version"`
+	PortalImageDigest                     string  `json:"portal_image_digest"`
+	ServerImageDigest                     string  `json:"server_image_digest"`
+	ProductionAPKFile                     string  `json:"production_apk_file"`
+	ProductionAPKSHA256                   string  `json:"production_apk_sha256"`
+	APKCertificateSHA256                  string  `json:"apk_certificate_sha256"`
+	PortalContainerID                     string  `json:"portal_container_id"`
+	ServerContainerID                     string  `json:"server_container_id"`
+	PostgresContainerID                   string  `json:"postgres_container_id"`
+	PostgresBackupID                      *string `json:"postgres_backup_id"`
+	PortalBackupID                        *string `json:"portal_backup_id"`
+	AndroidBundleManifestSHA256           *string `json:"android_bundle_manifest_sha256"`
+	CandidateRunID                        *int64  `json:"candidate_run_id"`
+	StagingRunID                          *int64  `json:"staging_run_id"`
+	StagingRunAttempt                     *int64  `json:"staging_run_attempt"`
+	StagingReceiptSHA256                  *string `json:"staging_receipt_sha256"`
+	DeploymentRunID                       *int64  `json:"deployment_run_id"`
+	DeploymentRunAttempt                  *int64  `json:"deployment_run_attempt"`
+	PreviousReceiptSHA256                 *string `json:"previous_receipt_sha256"`
+	ProductionEngineReceiptSHA256         string  `json:"production_engine_receipt_sha256"`
+	ProductionEnginePreviousReceiptSHA256 *string `json:"production_engine_previous_receipt_sha256"`
+	RecordedAtUTC                         string  `json:"recorded_at_utc"`
+}
+
+type response struct {
+	ProtocolVersion      int          `json:"protocol_version"`
+	OK                   bool         `json:"ok"`
+	Action               string       `json:"action"`
+	CurrentReceiptSHA256 string       `json:"current_receipt_sha256"`
+	Receipt              auditReceipt `json:"receipt"`
+}
+
+type errorResponse struct {
+	ProtocolVersion int    `json:"protocol_version"`
+	OK              bool   `json:"ok"`
+	Error           string `json:"error"`
+}
+
+func main() {
+	config, err := productionConfig()
+	if err != nil {
+		_ = writeJSON(os.Stdout, errorResponse{ProtocolVersion: protocolVersion, Error: errorCode(err)})
+		os.Exit(1)
+	}
+	if len(os.Args) == 6 && os.Args[1] == "initialize" && os.Args[2] == "--manifest" && os.Args[4] == "--receipt" && os.Getenv("SSH_CONNECTION") == "" && os.Getenv("SSH_ORIGINAL_COMMAND") == "" {
+		if err := initializeState(config, os.Args[3], os.Args[5]); err != nil {
+			fmt.Fprintln(os.Stderr, errorCode(err))
+			os.Exit(1)
+		}
+		return
+	}
+	os.Exit(runCLI(os.Args, os.Getenv("SSH_ORIGINAL_COMMAND"), os.Stdin, os.Stdout, config))
+}
+
+func productionConfig() (Config, error) {
+	if os.Geteuid() != 0 {
+		return Config{}, failure("invalid_runtime_identity")
+	}
+	account, err := user.LookupId("0")
+	if err != nil || account.Uid != "0" {
+		return Config{}, failure("invalid_runtime_identity")
+	}
+	return Config{
+		Repository:     officialRepository,
+		ManagePath:     productionManagePath,
+		Environment:    productionEnvFile,
+		StateDir:       productionStateDir,
+		LockFile:       productionLockFile,
+		PATH:           productionPATH,
+		RequestTimeout: 30 * time.Second,
+		DeployTimeout:  20 * time.Minute,
+		Now:            time.Now,
+		RunCommand:     runCommand,
+		OwnerUID:       0,
+	}, nil
+}
+
+func runCLI(arguments []string, originalCommand string, input io.Reader, output io.Writer, config Config) int {
+	if len(arguments) != 1 || originalCommand != "" {
+		_ = writeJSON(output, errorResponse{ProtocolVersion: protocolVersion, Error: "invalid_invocation"})
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), config.RequestTimeout+config.DeployTimeout)
+	defer cancel()
+	result, err := execute(ctx, input, config)
+	if err != nil {
+		_ = writeJSON(output, errorResponse{ProtocolVersion: protocolVersion, Error: errorCode(err)})
+		return 1
+	}
+	if err := writeJSON(output, result); err != nil {
+		return 1
+	}
+	return 0
+}
+
+func execute(ctx context.Context, input io.Reader, config Config) (response, error) {
+	if err := validateConfig(config); err != nil {
+		return response{}, err
+	}
+	store, err := openStateStore(config.StateDir, config.OwnerUID)
+	if err != nil {
+		return response{}, err
+	}
+	lock, err := acquireLock(ctx, config.LockFile, config.OwnerUID)
+	if err != nil {
+		return response{}, failure("operation_timeout")
+	}
+	defer lock.close()
+
+	payload, err := readPayload(input, store.incomingDir)
+	if err != nil {
+		return response{}, err
+	}
+	defer os.RemoveAll(payload.root)
+	requestContents, err := os.ReadFile(payload.files["request.json"])
+	if err != nil {
+		return response{}, failure("invalid_request")
+	}
+	req, err := parseRequest(requestContents)
+	if err != nil {
+		return response{}, err
+	}
+	current, currentSHA, err := store.loadCurrent()
+	if err != nil {
+		return response{}, err
+	}
+	if current == nil {
+		return response{}, failure("state_uninitialized")
+	}
+	if req.Action == "inspect" {
+		if len(payload.files) != 1 {
+			return response{}, failure("invalid_request")
+		}
+		return response{ProtocolVersion: protocolVersion, OK: true, Action: "inspect", CurrentReceiptSHA256: currentSHA, Receipt: *current}, nil
+	}
+	if req.Action != "deploy" || req.Repository != config.Repository {
+		return response{}, failure("invalid_request")
+	}
+	return deploy(ctx, store, config, payload, req, *current, currentSHA)
+}
+
+func deploy(ctx context.Context, store *stateStore, config Config, payload extractedPayload, req request, current auditReceipt, currentSHA string) (response, error) {
+	if req.ExpectedCurrentReceiptSHA256 == nil || *req.ExpectedCurrentReceiptSHA256 != currentSHA {
+		return response{}, failure("state_conflict")
+	}
+	if err := store.requireNoPending(); err != nil {
+		return response{}, err
+	}
+	manifestPath := payload.files["release-manifest.json"]
+	stagingPath := payload.files["staging-receipt.json"]
+	if manifestPath == "" || stagingPath == "" {
+		return response{}, failure("invalid_request")
+	}
+	manifestContents, err := os.ReadFile(manifestPath)
+	if err != nil || sha256Bytes(manifestContents) != req.ManifestSHA256 {
+		return response{}, failure("invalid_request")
+	}
+	manifest, err := parseReleaseManifest(manifestContents, req.CandidateRunID)
+	if err != nil {
+		return response{}, err
+	}
+	stagingContents, err := os.ReadFile(stagingPath)
+	if err != nil || sha256Bytes(stagingContents) != req.StagingReceiptSHA256 {
+		return response{}, failure("invalid_request")
+	}
+	staging, err := parseStagingReceipt(stagingContents)
+	if err != nil || !stagingMatches(staging, manifest, req) {
+		return response{}, failure("invalid_request")
+	}
+	bundlePath := filepath.Join(payload.root, "bundle")
+	if err := validateBundle(bundlePath, payload.files, manifest, req.BundleManifestSHA256); err != nil {
+		return response{}, err
+	}
+	currentEnginePath, currentEngine, err := store.loadEngine(current.ProductionEngineReceiptSHA256)
+	if err != nil || !engineMatchesAudit(currentEngine, current) {
+		return response{}, failure("state_invalid")
+	}
+	if req.CandidateRunID == valueOrZero(current.CandidateRunID) || manifest.VersionCode <= current.VersionCode {
+		return response{}, failure("release_not_newer")
+	}
+
+	journal := map[string]any{
+		"journal_version":         1,
+		"candidate_run_id":        req.CandidateRunID,
+		"staging_run_id":          req.StagingRunID,
+		"deployment_run_id":       req.DeploymentRunID,
+		"deployment_run_attempt":  req.DeploymentRunAttempt,
+		"manifest_sha256":         manifest.SHA256,
+		"previous_receipt_sha256": currentSHA,
+	}
+	journalContents, _ := json.Marshal(journal)
+	if err := writeNoClobber(store.pendingJournal, journalContents, 0o600); err != nil {
+		return response{}, failure("state_invalid")
+	}
+
+	deployContext, cancel := context.WithTimeout(ctx, config.DeployTimeout)
+	defer cancel()
+	arguments := []string{
+		"deploy",
+		"--manifest", manifestPath,
+		"--env-file", config.Environment,
+		"--bundle", bundlePath,
+		"--current-receipt", currentEnginePath,
+		"--receipt", store.pendingEngine,
+	}
+	environment := []string{"HOME=/root", "PATH=" + config.PATH}
+	if err := config.RunCommand(deployContext, config.ManagePath, arguments, environment); err != nil {
+		return response{}, failure("operation_failed")
+	}
+	engineContents, err := readSecureFile(store.pendingEngine, 0o444, metadataLimit, config.OwnerUID)
+	if err != nil {
+		return response{}, failure("operation_failed")
+	}
+	engine, err := parseEngineReceipt(engineContents)
+	if err != nil || !engineMatchesDeployment(engine, manifest, current.ProductionEngineReceiptSHA256, req.BundleManifestSHA256) {
+		return response{}, failure("operation_failed")
+	}
+	engineSHA := sha256Bytes(engineContents)
+	if err := store.storeObject(store.engineDir, engineSHA, engineContents); err != nil {
+		return response{}, err
+	}
+	if err := store.storeObject(store.manifestDir, manifest.SHA256, manifestContents); err != nil {
+		return response{}, err
+	}
+	newReceipt := deploymentAudit(config, req, manifest, engine, currentSHA, engineSHA)
+	newContents, err := json.Marshal(newReceipt)
+	if err != nil {
+		return response{}, failure("internal_error")
+	}
+	newSHA := sha256Bytes(newContents)
+	if err := store.storeObject(store.auditDir, newSHA, newContents); err != nil {
+		return response{}, err
+	}
+	if err := store.writeCurrent(newSHA); err != nil {
+		return response{}, err
+	}
+	if err := os.Remove(store.pendingEngine); err != nil {
+		return response{}, failure("state_invalid")
+	}
+	if err := os.Remove(store.pendingJournal); err != nil {
+		return response{}, failure("state_invalid")
+	}
+	return response{ProtocolVersion: protocolVersion, OK: true, Action: "deploy", CurrentReceiptSHA256: newSHA, Receipt: newReceipt}, nil
+}
+
+func deploymentAudit(config Config, req request, manifest releaseManifest, engine engineReceipt, previous string, engineSHA string) auditReceipt {
+	candidate, stagingRun, stagingAttempt := req.CandidateRunID, req.StagingRunID, req.StagingRunAttempt
+	deploymentRun, deploymentAttempt := req.DeploymentRunID, req.DeploymentRunAttempt
+	stagingSHA := req.StagingReceiptSHA256
+	return auditReceipt{
+		ReceiptVersion: 1, Environment: "production", Operation: "deploy", Repository: config.Repository,
+		ManifestSHA256: manifest.SHA256, Version: manifest.Version, VersionCode: manifest.VersionCode,
+		GitSHA: manifest.GitSHA, DatabaseSchemaVersion: manifest.DatabaseSchemaVersion,
+		PortalImageDigest: manifest.PortalImageDigest, ServerImageDigest: manifest.ServerImageDigest,
+		ProductionAPKFile: manifest.ProductionAPKFile, ProductionAPKSHA256: manifest.ProductionAPKSHA256,
+		APKCertificateSHA256: manifest.APKCertificateSHA256,
+		PortalContainerID:    engine.PortalContainerID, ServerContainerID: engine.ServerContainerID,
+		PostgresContainerID: engine.PostgresContainerID, PostgresBackupID: engine.PostgresBackupID,
+		PortalBackupID: engine.PortalBackupID, AndroidBundleManifestSHA256: engine.AndroidBundleManifestSHA256,
+		CandidateRunID: &candidate, StagingRunID: &stagingRun, StagingRunAttempt: &stagingAttempt,
+		StagingReceiptSHA256: &stagingSHA, DeploymentRunID: &deploymentRun,
+		DeploymentRunAttempt: &deploymentAttempt, PreviousReceiptSHA256: &previous,
+		ProductionEngineReceiptSHA256:         engineSHA,
+		ProductionEnginePreviousReceiptSHA256: engine.PreviousReceiptSHA256,
+		RecordedAtUTC:                         config.Now().UTC().Truncate(time.Second).Format("2006-01-02T15:04:05Z"),
+	}
+}
+
+func initializeState(config Config, manifestPath string, receiptPath string) error {
+	if err := validateConfig(config); err != nil {
+		return err
+	}
+	store, err := openStateStore(config.StateDir, config.OwnerUID)
+	if err != nil {
+		return err
+	}
+	lock, err := acquireLock(context.Background(), config.LockFile, config.OwnerUID)
+	if err != nil {
+		return failure("state_invalid")
+	}
+	defer lock.close()
+	if current, _, err := store.loadCurrent(); err != nil || current != nil {
+		return failure("state_already_initialized")
+	}
+	manifestContents, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return failure("invalid_baseline")
+	}
+	manifest, err := parseReleaseManifest(manifestContents, 0)
+	if err != nil {
+		return failure("invalid_baseline")
+	}
+	receiptContents, err := readExternalReceipt(receiptPath, config.OwnerUID)
+	if err != nil {
+		return failure("invalid_baseline")
+	}
+	engine, err := parseEngineReceipt(receiptContents)
+	if err != nil || !engineMatchesManifest(engine, manifest) {
+		return failure("invalid_baseline")
+	}
+	manifestSHA, engineSHA := manifest.SHA256, sha256Bytes(receiptContents)
+	if err := store.storeObject(store.manifestDir, manifestSHA, manifestContents); err != nil {
+		return err
+	}
+	if err := store.storeObject(store.engineDir, engineSHA, receiptContents); err != nil {
+		return err
+	}
+	baseline := auditReceipt{
+		ReceiptVersion: 1, Environment: "production", Operation: "baseline", Repository: config.Repository,
+		ManifestSHA256: manifestSHA, Version: manifest.Version, VersionCode: manifest.VersionCode,
+		GitSHA: manifest.GitSHA, DatabaseSchemaVersion: manifest.DatabaseSchemaVersion,
+		PortalImageDigest: manifest.PortalImageDigest, ServerImageDigest: manifest.ServerImageDigest,
+		ProductionAPKFile: manifest.ProductionAPKFile, ProductionAPKSHA256: manifest.ProductionAPKSHA256,
+		APKCertificateSHA256: manifest.APKCertificateSHA256,
+		PortalContainerID:    engine.PortalContainerID, ServerContainerID: engine.ServerContainerID,
+		PostgresContainerID:           engine.PostgresContainerID,
+		ProductionEngineReceiptSHA256: engineSHA,
+		RecordedAtUTC:                 config.Now().UTC().Truncate(time.Second).Format("2006-01-02T15:04:05Z"),
+	}
+	contents, _ := json.Marshal(baseline)
+	sha := sha256Bytes(contents)
+	if err := store.storeObject(store.auditDir, sha, contents); err != nil {
+		return err
+	}
+	return store.writeCurrent(sha)
+}
+
+func runCommand(ctx context.Context, name string, arguments []string, environment []string) error {
+	command := exec.CommandContext(ctx, name, arguments...)
+	command.Env = append([]string(nil), environment...)
+	command.Stdin = nil
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	return command.Run()
+}
+
+func validateConfig(config Config) error {
+	if config.Repository != officialRepository || config.ManagePath == "" || config.Environment == "" || config.StateDir == "" || config.LockFile == "" || config.PATH == "" || config.Now == nil || config.RunCommand == nil || config.RequestTimeout <= 0 || config.DeployTimeout <= 0 {
+		return failure("invalid_configuration")
+	}
+	for _, value := range []string{config.ManagePath, config.Environment, config.StateDir, config.LockFile} {
+		if !safeAbsolutePath(value) {
+			return failure("invalid_configuration")
+		}
+	}
+	return nil
+}
+
+func safeAbsolutePath(value string) bool {
+	return filepath.IsAbs(value) && filepath.Clean(value) == value && !strings.Contains(value, "//")
+}
+
+func writeJSON(output io.Writer, value any) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(value)
+}
+
+func valueOrZero(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+type extractedPayload struct {
+	root  string
+	files map[string]string
+}
+
+func readPayload(input io.Reader, incomingDir string) (extractedPayload, error) {
+	root, err := os.MkdirTemp(incomingDir, ".request-")
+	if err != nil {
+		return extractedPayload{}, failure("state_invalid")
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		os.RemoveAll(root)
+		return extractedPayload{}, failure("state_invalid")
+	}
+	result := extractedPayload{root: root, files: make(map[string]string)}
+	reader := tar.NewReader(io.LimitReader(input, requestLimit+1))
+	var total int64
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || header == nil || header.Typeflag != tar.TypeReg || header.Size <= 0 {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("invalid_request")
+		}
+		name := header.Name
+		if !validPayloadName(name) || header.Size > payloadFileLimit(name) {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("invalid_request")
+		}
+		if _, duplicate := result.files[name]; duplicate {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("invalid_request")
+		}
+		total += header.Size
+		if total > requestLimit {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("request_too_large")
+		}
+		target := filepath.Join(root, filepath.FromSlash(name))
+		if !strings.HasPrefix(target, root+string(os.PathSeparator)) {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("invalid_request")
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("invalid_request")
+		}
+		file, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("invalid_request")
+		}
+		written, copyErr := io.CopyN(file, reader, header.Size)
+		closeErr := file.Close()
+		if copyErr != nil || closeErr != nil || written != header.Size {
+			os.RemoveAll(root)
+			return extractedPayload{}, failure("invalid_request")
+		}
+		result.files[name] = target
+	}
+	if len(result.files) == 0 || len(result.files) > 7 || result.files["request.json"] == "" {
+		os.RemoveAll(root)
+		return extractedPayload{}, failure("invalid_request")
+	}
+	return result, nil
+}
+
+func validPayloadName(name string) bool {
+	if name == "request.json" || name == "release-manifest.json" || name == "staging-receipt.json" || name == "bundle/bundle-manifest.json" {
+		return true
+	}
+	if filepath.ToSlash(filepath.Clean(name)) != name || strings.HasPrefix(name, "/") || strings.Contains(name, "..") {
+		return false
+	}
+	parts := strings.Split(name, "/")
+	if len(parts) != 5 || parts[0] != "bundle" || parts[1] != "downloads" || parts[2] != "android" || !strings.HasPrefix(parts[3], "v") || !versionPattern.MatchString(strings.TrimPrefix(parts[3], "v")) {
+		return false
+	}
+	version := strings.TrimPrefix(parts[3], "v")
+	apk := "speakup-v" + version + "-production-arm64.apk"
+	return parts[4] == "release.json" || parts[4] == apk || parts[4] == apk+".sha256"
+}
+
+func payloadFileLimit(name string) int64 {
+	if strings.HasSuffix(name, ".apk") {
+		return apkLimit
+	}
+	return metadataLimit
+}
+
+func parseRequest(contents []byte) (request, error) {
+	value, err := decodeStrictJSON(contents)
+	if err != nil {
+		return request{}, failure("invalid_request")
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return request{}, failure("invalid_request")
+	}
+	integer, integerOK := integerValue(object["protocol_version"])
+	if !integerOK || integer != protocolVersion {
+		return request{}, failure("invalid_request")
+	}
+	action, ok := object["action"].(string)
+	if !ok {
+		return request{}, failure("invalid_request")
+	}
+	parsed := request{Action: action}
+	if action == "inspect" {
+		if !hasExactKeys(object, "protocol_version", "action") {
+			return request{}, failure("invalid_request")
+		}
+		return parsed, nil
+	}
+	if action != "deploy" || !hasExactKeys(object,
+		"protocol_version", "action", "repository", "candidate_run_id",
+		"staging_run_id", "staging_run_attempt", "deployment_run_id",
+		"deployment_run_attempt", "expected_current_receipt_sha256",
+		"manifest_sha256", "staging_receipt_sha256", "bundle_manifest_sha256") {
+		return request{}, failure("invalid_request")
+	}
+	parsed.Repository, ok = object["repository"].(string)
+	if !ok || parsed.Repository != officialRepository {
+		return request{}, failure("invalid_request")
+	}
+	integerFields := []struct {
+		name   string
+		target *int64
+	}{
+		{"candidate_run_id", &parsed.CandidateRunID},
+		{"staging_run_id", &parsed.StagingRunID},
+		{"staging_run_attempt", &parsed.StagingRunAttempt},
+		{"deployment_run_id", &parsed.DeploymentRunID},
+		{"deployment_run_attempt", &parsed.DeploymentRunAttempt},
+	}
+	for _, field := range integerFields {
+		*field.target, ok = positiveSafeInteger(object[field.name])
+		if !ok {
+			return request{}, failure("invalid_request")
+		}
+	}
+	expected, ok := object["expected_current_receipt_sha256"].(string)
+	if !ok || !validNonzeroSHA256(expected) {
+		return request{}, failure("invalid_request")
+	}
+	parsed.ExpectedCurrentReceiptSHA256 = &expected
+	for _, field := range []struct {
+		name   string
+		target *string
+	}{
+		{"manifest_sha256", &parsed.ManifestSHA256},
+		{"staging_receipt_sha256", &parsed.StagingReceiptSHA256},
+		{"bundle_manifest_sha256", &parsed.BundleManifestSHA256},
+	} {
+		*field.target, ok = object[field.name].(string)
+		if !ok || !validNonzeroSHA256(*field.target) {
+			return request{}, failure("invalid_request")
+		}
+	}
+	return parsed, nil
+}
+
+func parseReleaseManifest(contents []byte, candidateRunID int64) (releaseManifest, error) {
+	value, err := decodeStrictJSON(contents)
+	if err != nil {
+		return releaseManifest{}, failure("invalid_manifest")
+	}
+	object, ok := value.(map[string]any)
+	if !ok || !hasExactKeys(object,
+		"manifest_version", "version", "git_sha", "version_code", "portal_image",
+		"portal_image_digest", "server_image", "server_image_digest", "staging_apk_file",
+		"staging_apk_sha256", "production_apk_file", "production_apk_size_bytes",
+		"production_apk_sha256", "application_id", "minimum_android_api", "abis",
+		"apk_certificate_sha256", "database_schema_version", "quality_run_url") {
+		return releaseManifest{}, failure("invalid_manifest")
+	}
+	manifestVersion, ok := integerValue(object["manifest_version"])
+	version, versionOK := object["version"].(string)
+	gitSHA, gitOK := object["git_sha"].(string)
+	versionCode, codeOK := positiveSafeInteger(object["version_code"])
+	schema, schemaOK := positiveSafeInteger(object["database_schema_version"])
+	portalDigest, portalOK := object["portal_image_digest"].(string)
+	serverDigest, serverOK := object["server_image_digest"].(string)
+	apkFile, apkFileOK := object["production_apk_file"].(string)
+	apkSize, apkSizeOK := positiveSafeInteger(object["production_apk_size_bytes"])
+	apkSHA, apkSHAOK := object["production_apk_sha256"].(string)
+	certificate, certificateOK := object["apk_certificate_sha256"].(string)
+	qualityURL, qualityOK := object["quality_run_url"].(string)
+	abis, abisOK := object["abis"].([]any)
+	if !ok || manifestVersion != 1 || !versionOK || !versionPattern.MatchString(version) ||
+		!gitOK || !validNonzeroHex(gitSHA, gitSHAPattern) || !codeOK || !schemaOK ||
+		object["portal_image"] != "ghcr.io/1024xengineer/xe3-esl-portal" || !portalOK || !validDigest(portalDigest) ||
+		object["server_image"] != "ghcr.io/1024xengineer/xe3-esl-server" || !serverOK || !validDigest(serverDigest) ||
+		object["staging_apk_file"] != "speakup-v"+version+"-staging-arm64.apk" || !stringIsNonzeroSHA256(object["staging_apk_sha256"]) ||
+		!apkFileOK || apkFile != "speakup-v"+version+"-production-arm64.apk" || !apkSizeOK || !apkSHAOK || !validNonzeroSHA256(apkSHA) ||
+		object["application_id"] != "com.xengineer.speakup" || object["minimum_android_api"] != json.Number("24") ||
+		!abisOK || len(abis) != 1 || abis[0] != "arm64-v8a" || !certificateOK || !validNonzeroSHA256(certificate) || !qualityOK {
+		return releaseManifest{}, failure("invalid_manifest")
+	}
+	expectedPrefix := "https://github.com/1024XEngineer/XE3-ESL/actions/runs/"
+	if !strings.HasPrefix(qualityURL, expectedPrefix) {
+		return releaseManifest{}, failure("invalid_manifest")
+	}
+	runID, parseErr := strconv.ParseInt(strings.TrimPrefix(qualityURL, expectedPrefix), 10, 64)
+	if parseErr != nil || runID < 1 || (candidateRunID > 0 && runID != candidateRunID) {
+		return releaseManifest{}, failure("invalid_manifest")
+	}
+	return releaseManifest{
+		SHA256: sha256Bytes(contents), Version: version, VersionCode: versionCode, GitSHA: gitSHA,
+		DatabaseSchemaVersion: schema, PortalImageDigest: portalDigest, ServerImageDigest: serverDigest,
+		ProductionAPKFile: apkFile, ProductionAPKSize: apkSize, ProductionAPKSHA256: apkSHA,
+		APKCertificateSHA256: certificate,
+	}, nil
+}
+
+func parseStagingReceipt(contents []byte) (stagingReceipt, error) {
+	value, err := decodeStrictJSON(contents)
+	if err != nil {
+		return stagingReceipt{}, failure("invalid_staging_receipt")
+	}
+	top, ok := value.(map[string]any)
+	if !ok || !hasExactKeys(top, "protocol_version", "ok", "action", "receipt_sha256", "receipt") ||
+		top["protocol_version"] != json.Number("1") || top["ok"] != true || top["action"] != "deploy" || !stringIsNonzeroSHA256(top["receipt_sha256"]) {
+		return stagingReceipt{}, failure("invalid_staging_receipt")
+	}
+	receipt, ok := top["receipt"].(map[string]any)
+	if !ok || !hasExactKeys(receipt,
+		"receipt_version", "environment", "operation", "repository", "manifest_sha256", "version",
+		"version_code", "git_sha", "database_schema_version", "portal_image_digest", "server_image_digest",
+		"portal_container_id", "server_container_id", "postgres_container_id", "candidate_run_id",
+		"deployment_run_id", "deployment_run_attempt", "previous_receipt_sha256", "rollback_target_receipt_sha256",
+		"recorded_at_utc") || receipt["receipt_version"] != json.Number("2") || receipt["environment"] != "staging" ||
+		receipt["operation"] != "deploy" || receipt["repository"] != officialRepository || receipt["rollback_target_receipt_sha256"] != nil {
+		return stagingReceipt{}, failure("invalid_staging_receipt")
+	}
+	manifestSHA, a := receipt["manifest_sha256"].(string)
+	version, b := receipt["version"].(string)
+	versionCode, c := positiveSafeInteger(receipt["version_code"])
+	gitSHA, d := receipt["git_sha"].(string)
+	schema, e := positiveSafeInteger(receipt["database_schema_version"])
+	portalDigest, f := receipt["portal_image_digest"].(string)
+	serverDigest, g := receipt["server_image_digest"].(string)
+	candidateRun, h := positiveSafeInteger(receipt["candidate_run_id"])
+	deploymentRun, i := positiveSafeInteger(receipt["deployment_run_id"])
+	deploymentAttempt, j := positiveSafeInteger(receipt["deployment_run_attempt"])
+	if !a || !validNonzeroSHA256(manifestSHA) || !b || !versionPattern.MatchString(version) || !c || !d || !validNonzeroHex(gitSHA, gitSHAPattern) || !e || !f || !validDigest(portalDigest) || !g || !validDigest(serverDigest) || !h || !i || !j || !validContainerValue(receipt["portal_container_id"]) || !validContainerValue(receipt["server_container_id"]) || !validContainerValue(receipt["postgres_container_id"]) || !validOptionalSHA(receipt["previous_receipt_sha256"]) || !validTimestampValue(receipt["recorded_at_utc"]) {
+		return stagingReceipt{}, failure("invalid_staging_receipt")
+	}
+	if receipt["portal_container_id"] == receipt["server_container_id"] || receipt["portal_container_id"] == receipt["postgres_container_id"] || receipt["server_container_id"] == receipt["postgres_container_id"] {
+		return stagingReceipt{}, failure("invalid_staging_receipt")
+	}
+	return stagingReceipt{ManifestSHA256: manifestSHA, Version: version, VersionCode: versionCode, GitSHA: gitSHA, DatabaseSchemaVersion: schema, PortalImageDigest: portalDigest, ServerImageDigest: serverDigest, CandidateRunID: candidateRun, DeploymentRunID: deploymentRun, DeploymentRunAttempt: deploymentAttempt}, nil
+}
+
+func stagingMatches(staging stagingReceipt, manifest releaseManifest, req request) bool {
+	return staging.ManifestSHA256 == manifest.SHA256 && staging.Version == manifest.Version && staging.VersionCode == manifest.VersionCode && staging.GitSHA == manifest.GitSHA && staging.DatabaseSchemaVersion == manifest.DatabaseSchemaVersion && staging.PortalImageDigest == manifest.PortalImageDigest && staging.ServerImageDigest == manifest.ServerImageDigest && staging.CandidateRunID == req.CandidateRunID && staging.DeploymentRunID == req.StagingRunID && staging.DeploymentRunAttempt == req.StagingRunAttempt
+}
+
+func validateBundle(root string, files map[string]string, manifest releaseManifest, expectedManifestSHA string) error {
+	versionRoot := "bundle/downloads/android/v" + manifest.Version + "/"
+	apkName := manifest.ProductionAPKFile
+	expectedNames := []string{
+		"request.json", "release-manifest.json", "staging-receipt.json", "bundle/bundle-manifest.json",
+		versionRoot + "release.json", versionRoot + apkName, versionRoot + apkName + ".sha256",
+	}
+	actualNames := make([]string, 0, len(files))
+	for name := range files {
+		actualNames = append(actualNames, name)
+	}
+	sort.Strings(actualNames)
+	sort.Strings(expectedNames)
+	if strings.Join(actualNames, "\n") != strings.Join(expectedNames, "\n") {
+		return failure("invalid_bundle")
+	}
+	bundleManifestPath := files["bundle/bundle-manifest.json"]
+	bundleContents, err := os.ReadFile(bundleManifestPath)
+	if err != nil || sha256Bytes(bundleContents) != expectedManifestSHA {
+		return failure("invalid_bundle")
+	}
+	value, err := decodeStrictJSON(bundleContents)
+	if err != nil {
+		return failure("invalid_bundle")
+	}
+	object, ok := value.(map[string]any)
+	if !ok || !hasExactKeys(object, "bundle_version", "version", "published_at", "release_manifest_sha256", "files") ||
+		object["bundle_version"] != json.Number("1") || object["version"] != manifest.Version || object["release_manifest_sha256"] != manifest.SHA256 || !validTimestampValue(object["published_at"]) {
+		return failure("invalid_bundle")
+	}
+	entries, ok := object["files"].([]any)
+	if !ok || len(entries) != 3 {
+		return failure("invalid_bundle")
+	}
+	expectedFiles := map[string]bool{
+		strings.TrimPrefix(versionRoot+apkName, "bundle/"):           true,
+		strings.TrimPrefix(versionRoot+apkName+".sha256", "bundle/"): true,
+		strings.TrimPrefix(versionRoot+"release.json", "bundle/"):    true,
+	}
+	for _, rawEntry := range entries {
+		entry, ok := rawEntry.(map[string]any)
+		if !ok || !hasExactKeys(entry, "path", "size_bytes", "sha256") {
+			return failure("invalid_bundle")
+		}
+		path, pathOK := entry["path"].(string)
+		size, sizeOK := positiveSafeInteger(entry["size_bytes"])
+		sha, shaOK := entry["sha256"].(string)
+		if !pathOK || !expectedFiles[path] || !sizeOK || !shaOK || !validNonzeroSHA256(sha) {
+			return failure("invalid_bundle")
+		}
+		delete(expectedFiles, path)
+		file := files["bundle/"+path]
+		info, statErr := os.Stat(file)
+		fileSHA, hashErr := sha256File(file)
+		if statErr != nil || hashErr != nil || info.Size() != size || fileSHA != sha {
+			return failure("invalid_bundle")
+		}
+	}
+	if len(expectedFiles) != 0 {
+		return failure("invalid_bundle")
+	}
+	apkPath := files[versionRoot+apkName]
+	apkInfo, err := os.Stat(apkPath)
+	if err != nil || apkInfo.Size() != manifest.ProductionAPKSize {
+		return failure("invalid_bundle")
+	}
+	apkSHA, err := sha256File(apkPath)
+	if err != nil || apkSHA != manifest.ProductionAPKSHA256 {
+		return failure("invalid_bundle")
+	}
+	checksum, err := os.ReadFile(files[versionRoot+apkName+".sha256"])
+	if err != nil || string(checksum) != manifest.ProductionAPKSHA256+"  "+apkName+"\n" {
+		return failure("invalid_bundle")
+	}
+	metadataContents, err := os.ReadFile(files[versionRoot+"release.json"])
+	if err != nil {
+		return failure("invalid_bundle")
+	}
+	metadataValue, err := decodeStrictJSON(metadataContents)
+	if err != nil {
+		return failure("invalid_bundle")
+	}
+	metadata, ok := metadataValue.(map[string]any)
+	if !ok || !hasExactKeys(metadata, "metadata_version", "version", "version_code", "published_at", "file_name", "download_path", "size_bytes", "minimum_android_api", "abis", "apk_sha256", "apk_certificate_sha256") ||
+		metadata["metadata_version"] != json.Number("1") || metadata["version"] != manifest.Version || metadata["version_code"] != json.Number(strconv.FormatInt(manifest.VersionCode, 10)) ||
+		metadata["file_name"] != apkName || metadata["download_path"] != "/downloads/android/v"+manifest.Version+"/"+apkName || metadata["size_bytes"] != json.Number(strconv.FormatInt(manifest.ProductionAPKSize, 10)) ||
+		metadata["minimum_android_api"] != json.Number("24") || metadata["apk_sha256"] != manifest.ProductionAPKSHA256 || metadata["apk_certificate_sha256"] != manifest.APKCertificateSHA256 || !validTimestampValue(metadata["published_at"]) {
+		return failure("invalid_bundle")
+	}
+	abis, ok := metadata["abis"].([]any)
+	if !ok || len(abis) != 1 || abis[0] != "arm64-v8a" {
+		return failure("invalid_bundle")
+	}
+	_ = root
+	return nil
+}
+
+func parseEngineReceipt(contents []byte) (engineReceipt, error) {
+	value, err := decodeStrictJSON(contents)
+	if err != nil {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	object, ok := value.(map[string]any)
+	if !ok || !hasExactKeys(object,
+		"receipt_version", "environment", "operation", "manifest_sha256", "version", "version_code",
+		"git_sha", "database_schema_version", "portal_image_digest", "server_image_digest",
+		"production_apk_file", "production_apk_size_bytes", "production_apk_sha256", "apk_certificate_sha256",
+		"portal_container_id", "server_container_id", "postgres_container_id", "nginx_config_sha256", "nginx_config",
+		"postgres_backup_id", "portal_backup_id", "android_bundle_manifest_sha256", "previous_receipt_sha256",
+		"rollback_target_receipt_sha256", "recorded_at_utc") || object["receipt_version"] != json.Number("1") || object["environment"] != "production" {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	operation, opOK := object["operation"].(string)
+	manifestSHA, a := object["manifest_sha256"].(string)
+	version, b := object["version"].(string)
+	versionCode, c := positiveSafeInteger(object["version_code"])
+	gitSHA, d := object["git_sha"].(string)
+	schema, e := positiveSafeInteger(object["database_schema_version"])
+	portalDigest, f := object["portal_image_digest"].(string)
+	serverDigest, g := object["server_image_digest"].(string)
+	apkFile, h := object["production_apk_file"].(string)
+	apkSize, i := positiveSafeInteger(object["production_apk_size_bytes"])
+	apkSHA, j := object["production_apk_sha256"].(string)
+	certificate, k := object["apk_certificate_sha256"].(string)
+	portalID, l := object["portal_container_id"].(string)
+	serverID, m := object["server_container_id"].(string)
+	postgresID, n := object["postgres_container_id"].(string)
+	recordedAt, o := object["recorded_at_utc"].(string)
+	nginxConfig, p := object["nginx_config"].(string)
+	nginxSHA, q := object["nginx_config_sha256"].(string)
+	if !opOK || (operation != "baseline" && operation != "deploy" && operation != "rollback") || !a || !validNonzeroSHA256(manifestSHA) || !b || !versionPattern.MatchString(version) || !c || !d || !validNonzeroHex(gitSHA, gitSHAPattern) || !e || !f || !validDigest(portalDigest) || !g || !validDigest(serverDigest) || !h || apkFile != "speakup-v"+version+"-production-arm64.apk" || !i || !j || !validNonzeroSHA256(apkSHA) || !k || !validNonzeroSHA256(certificate) || !l || !validNonzeroHex(portalID, containerIDPattern) || !m || !validNonzeroHex(serverID, containerIDPattern) || !n || !validNonzeroHex(postgresID, containerIDPattern) || !o || !validUTCTimestamp(recordedAt) || !p || nginxConfig == "" || !q || !validNonzeroSHA256(nginxSHA) || sha256Bytes([]byte(nginxConfig)) != nginxSHA {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	postgresBackup, ok := optionalString(object["postgres_backup_id"])
+	if !ok {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	portalBackup, ok := optionalString(object["portal_backup_id"])
+	if !ok {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	bundleSHA, ok := optionalSHAValue(object["android_bundle_manifest_sha256"])
+	if !ok {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	previousSHA, ok := optionalSHAValue(object["previous_receipt_sha256"])
+	if !ok {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	rollbackSHA, ok := optionalSHAValue(object["rollback_target_receipt_sha256"])
+	if !ok {
+		return engineReceipt{}, failure("invalid_engine_receipt")
+	}
+	if operation == "deploy" {
+		if postgresBackup == nil || !postgresBackupPattern.MatchString(*postgresBackup) || portalBackup == nil || !portalBackupPattern.MatchString(*portalBackup) || bundleSHA == nil || previousSHA == nil || rollbackSHA != nil {
+			return engineReceipt{}, failure("invalid_engine_receipt")
+		}
+	} else if operation == "baseline" {
+		if postgresBackup != nil || portalBackup != nil || bundleSHA != nil || previousSHA != nil || rollbackSHA != nil {
+			return engineReceipt{}, failure("invalid_engine_receipt")
+		}
+	}
+	return engineReceipt{
+		ManifestSHA256: manifestSHA, Version: version, VersionCode: versionCode, GitSHA: gitSHA,
+		DatabaseSchemaVersion: schema, PortalImageDigest: portalDigest, ServerImageDigest: serverDigest,
+		ProductionAPKFile: apkFile, ProductionAPKSize: apkSize, ProductionAPKSHA256: apkSHA,
+		APKCertificateSHA256: certificate, PortalContainerID: portalID, ServerContainerID: serverID,
+		PostgresContainerID: postgresID, PostgresBackupID: postgresBackup, PortalBackupID: portalBackup,
+		AndroidBundleManifestSHA256: bundleSHA, PreviousReceiptSHA256: previousSHA,
+		RecordedAtUTC: recordedAt, Operation: operation,
+	}, nil
+}
+
+func engineMatchesManifest(engine engineReceipt, manifest releaseManifest) bool {
+	return engine.ManifestSHA256 == manifest.SHA256 && engine.Version == manifest.Version && engine.VersionCode == manifest.VersionCode && engine.GitSHA == manifest.GitSHA && engine.DatabaseSchemaVersion == manifest.DatabaseSchemaVersion && engine.PortalImageDigest == manifest.PortalImageDigest && engine.ServerImageDigest == manifest.ServerImageDigest && engine.ProductionAPKFile == manifest.ProductionAPKFile && engine.ProductionAPKSize == manifest.ProductionAPKSize && engine.ProductionAPKSHA256 == manifest.ProductionAPKSHA256 && engine.APKCertificateSHA256 == manifest.APKCertificateSHA256
+}
+
+func engineMatchesAudit(engine engineReceipt, audit auditReceipt) bool {
+	return engine.ManifestSHA256 == audit.ManifestSHA256 && engine.Version == audit.Version && engine.VersionCode == audit.VersionCode && engine.GitSHA == audit.GitSHA && engine.DatabaseSchemaVersion == audit.DatabaseSchemaVersion && engine.PortalImageDigest == audit.PortalImageDigest && engine.ServerImageDigest == audit.ServerImageDigest && engine.ProductionAPKFile == audit.ProductionAPKFile && engine.ProductionAPKSHA256 == audit.ProductionAPKSHA256 && engine.APKCertificateSHA256 == audit.APKCertificateSHA256 && engine.PortalContainerID == audit.PortalContainerID && engine.ServerContainerID == audit.ServerContainerID && engine.PostgresContainerID == audit.PostgresContainerID
+}
+
+func engineMatchesDeployment(engine engineReceipt, manifest releaseManifest, currentEngineSHA string, bundleSHA string) bool {
+	return engine.Operation == "deploy" && engineMatchesManifest(engine, manifest) && engine.PreviousReceiptSHA256 != nil && *engine.PreviousReceiptSHA256 == currentEngineSHA && engine.AndroidBundleManifestSHA256 != nil && *engine.AndroidBundleManifestSHA256 == bundleSHA
+}
+
+type stateStore struct {
+	root           string
+	manifestDir    string
+	engineDir      string
+	auditDir       string
+	incomingDir    string
+	currentPath    string
+	pendingJournal string
+	pendingEngine  string
+	ownerUID       uint32
+}
+
+func openStateStore(root string, ownerUID uint32) (*stateStore, error) {
+	store := &stateStore{
+		root:           root,
+		manifestDir:    filepath.Join(root, "manifests"),
+		engineDir:      filepath.Join(root, "engine-receipts"),
+		auditDir:       filepath.Join(root, "audit-receipts"),
+		incomingDir:    filepath.Join(root, "incoming"),
+		currentPath:    filepath.Join(root, "current"),
+		pendingJournal: filepath.Join(root, "pending.json"),
+		pendingEngine:  filepath.Join(root, "pending-engine.json"),
+		ownerUID:       ownerUID,
+	}
+	for _, directory := range []string{store.root, store.manifestDir, store.engineDir, store.auditDir, store.incomingDir} {
+		if err := ensurePrivateDirectory(directory, ownerUID); err != nil {
+			return nil, failure("state_invalid")
+		}
+	}
+	return store, nil
+}
+
+func ensurePrivateDirectory(path string, ownerUID uint32) error {
+	err := os.Mkdir(path, 0o700)
+	if err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o700 || !ownedByUID(info, ownerUID) {
+		return syscall.EPERM
+	}
+	return nil
+}
+
+func (store *stateStore) requireNoPending() error {
+	for _, path := range []string{store.pendingJournal, store.pendingEngine} {
+		if _, err := os.Lstat(path); err == nil || !errors.Is(err, os.ErrNotExist) {
+			return failure("recovery_required")
+		}
+	}
+	return nil
+}
+
+func (store *stateStore) loadCurrent() (*auditReceipt, string, error) {
+	contents, err := readSecureFile(store.currentPath, 0o600, 65, store.ownerUID)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", failure("state_invalid")
+	}
+	sha := strings.TrimSuffix(string(contents), "\n")
+	if len(contents) != 65 || !validNonzeroSHA256(sha) {
+		return nil, "", failure("state_invalid")
+	}
+	auditContents, err := readSecureFile(filepath.Join(store.auditDir, sha+".json"), 0o444, metadataLimit, store.ownerUID)
+	if err != nil || sha256Bytes(auditContents) != sha {
+		return nil, "", failure("state_invalid")
+	}
+	receipt, err := parseAuditReceipt(auditContents)
+	if err != nil {
+		return nil, "", err
+	}
+	return &receipt, sha, nil
+}
+
+func (store *stateStore) loadEngine(sha string) (string, engineReceipt, error) {
+	if !validNonzeroSHA256(sha) {
+		return "", engineReceipt{}, failure("state_invalid")
+	}
+	path := filepath.Join(store.engineDir, sha+".json")
+	contents, err := readSecureFile(path, 0o444, metadataLimit, store.ownerUID)
+	if err != nil || sha256Bytes(contents) != sha {
+		return "", engineReceipt{}, failure("state_invalid")
+	}
+	receipt, err := parseEngineReceipt(contents)
+	return path, receipt, err
+}
+
+func (store *stateStore) storeObject(directory string, sha string, contents []byte) error {
+	if !validNonzeroSHA256(sha) || sha256Bytes(contents) != sha {
+		return failure("state_invalid")
+	}
+	path := filepath.Join(directory, sha+".json")
+	if existing, err := readSecureFile(path, 0o444, int64(len(contents)+1), store.ownerUID); err == nil {
+		if bytes.Equal(existing, contents) {
+			return nil
+		}
+		return failure("state_invalid")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return failure("state_invalid")
+	}
+	if err := writeNoClobber(path, contents, 0o444); err != nil {
+		return failure("state_invalid")
+	}
+	return nil
+}
+
+func (store *stateStore) writeCurrent(sha string) error {
+	if !validNonzeroSHA256(sha) {
+		return failure("state_invalid")
+	}
+	temporary, err := os.CreateTemp(store.root, ".current-")
+	if err != nil {
+		return failure("state_invalid")
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return failure("state_invalid")
+	}
+	if _, err := temporary.WriteString(sha + "\n"); err != nil {
+		temporary.Close()
+		return failure("state_invalid")
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return failure("state_invalid")
+	}
+	if err := temporary.Close(); err != nil {
+		return failure("state_invalid")
+	}
+	if err := os.Rename(temporaryPath, store.currentPath); err != nil {
+		return failure("state_invalid")
+	}
+	directory, err := os.Open(store.root)
+	if err != nil {
+		return failure("state_invalid")
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return failure("state_invalid")
+	}
+	return nil
+}
+
+func parseAuditReceipt(contents []byte) (auditReceipt, error) {
+	value, err := decodeStrictJSON(contents)
+	if err != nil {
+		return auditReceipt{}, failure("state_invalid")
+	}
+	object, ok := value.(map[string]any)
+	if !ok || !hasExactKeys(object,
+		"receipt_version", "environment", "operation", "repository", "manifest_sha256", "version", "version_code", "git_sha",
+		"database_schema_version", "portal_image_digest", "server_image_digest", "production_apk_file", "production_apk_sha256",
+		"apk_certificate_sha256", "portal_container_id", "server_container_id", "postgres_container_id", "postgres_backup_id",
+		"portal_backup_id", "android_bundle_manifest_sha256", "candidate_run_id", "staging_run_id", "staging_run_attempt",
+		"staging_receipt_sha256", "deployment_run_id", "deployment_run_attempt", "previous_receipt_sha256",
+		"production_engine_receipt_sha256", "production_engine_previous_receipt_sha256", "recorded_at_utc") {
+		return auditReceipt{}, failure("state_invalid")
+	}
+	var receipt auditReceipt
+	if err := json.Unmarshal(contents, &receipt); err != nil || receipt.ReceiptVersion != 1 || receipt.Environment != "production" || (receipt.Operation != "baseline" && receipt.Operation != "deploy") || receipt.Repository != officialRepository || !validNonzeroSHA256(receipt.ManifestSHA256) || !versionPattern.MatchString(receipt.Version) || receipt.VersionCode < 1 || receipt.VersionCode > maxSafeInteger || !validNonzeroHex(receipt.GitSHA, gitSHAPattern) || receipt.DatabaseSchemaVersion < 1 || !validDigest(receipt.PortalImageDigest) || !validDigest(receipt.ServerImageDigest) || receipt.ProductionAPKFile != "speakup-v"+receipt.Version+"-production-arm64.apk" || !validNonzeroSHA256(receipt.ProductionAPKSHA256) || !validNonzeroSHA256(receipt.APKCertificateSHA256) || !validNonzeroHex(receipt.PortalContainerID, containerIDPattern) || !validNonzeroHex(receipt.ServerContainerID, containerIDPattern) || !validNonzeroHex(receipt.PostgresContainerID, containerIDPattern) || !validNonzeroSHA256(receipt.ProductionEngineReceiptSHA256) || !validUTCTimestamp(receipt.RecordedAtUTC) {
+		return auditReceipt{}, failure("state_invalid")
+	}
+	if receipt.Operation == "baseline" {
+		if receipt.CandidateRunID != nil || receipt.StagingRunID != nil || receipt.StagingRunAttempt != nil || receipt.StagingReceiptSHA256 != nil || receipt.DeploymentRunID != nil || receipt.DeploymentRunAttempt != nil || receipt.PreviousReceiptSHA256 != nil || receipt.ProductionEnginePreviousReceiptSHA256 != nil {
+			return auditReceipt{}, failure("state_invalid")
+		}
+	} else if receipt.CandidateRunID == nil || receipt.StagingRunID == nil || receipt.StagingRunAttempt == nil || receipt.StagingReceiptSHA256 == nil || receipt.DeploymentRunID == nil || receipt.DeploymentRunAttempt == nil || receipt.PreviousReceiptSHA256 == nil || receipt.ProductionEnginePreviousReceiptSHA256 == nil || receipt.PostgresBackupID == nil || receipt.PortalBackupID == nil || receipt.AndroidBundleManifestSHA256 == nil || !validNonzeroSHA256(*receipt.StagingReceiptSHA256) || !validNonzeroSHA256(*receipt.PreviousReceiptSHA256) || !validNonzeroSHA256(*receipt.ProductionEnginePreviousReceiptSHA256) {
+		return auditReceipt{}, failure("state_invalid")
+	}
+	return receipt, nil
+}
+
+type brokerLock struct{ file *os.File }
+
+func acquireLock(ctx context.Context, path string, ownerUID uint32) (*brokerLock, error) {
+	descriptor, err := syscall.Open(path, syscall.O_CREAT|syscall.O_RDWR|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(descriptor), path)
+	if file == nil {
+		syscall.Close(descriptor)
+		return nil, syscall.EBADF
+	}
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || !ownedByUID(info, ownerUID) {
+		file.Close()
+		return nil, syscall.EPERM
+	}
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		err = syscall.Flock(descriptor, syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return &brokerLock{file: file}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) && !errors.Is(err, syscall.EINTR) {
+			file.Close()
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			file.Close()
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (lock *brokerLock) close() {
+	if lock == nil || lock.file == nil {
+		return
+	}
+	_ = syscall.Flock(int(lock.file.Fd()), syscall.LOCK_UN)
+	_ = lock.file.Close()
+}
+
+func readSecureFile(path string, mode os.FileMode, limit int64, ownerUID uint32) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != mode || !ownedByUID(info, ownerUID) || info.Size() <= 0 || info.Size() > limit {
+		return nil, syscall.EPERM
+	}
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	contents, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil || int64(len(contents)) != info.Size() {
+		return nil, syscall.EIO
+	}
+	return contents, nil
+}
+
+func readExternalReceipt(path string, ownerUID uint32) ([]byte, error) {
+	if !safeAbsolutePath(path) {
+		return nil, syscall.EINVAL
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o444 || !ownedByUID(info, ownerUID) || info.Size() <= 0 || info.Size() > metadataLimit {
+		return nil, syscall.EPERM
+	}
+	return os.ReadFile(path)
+}
+
+func writeNoClobber(path string, contents []byte, mode os.FileMode) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, mode)
+	if err != nil {
+		return err
+	}
+	ok := false
+	defer func() {
+		if !ok {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.Write(contents); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func ownedByUID(info os.FileInfo, ownerUID uint32) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == ownerUID
+}
+
+func decodeStrictJSON(contents []byte) (any, error) {
+	if !utf8.Valid(contents) {
+		return nil, failure("invalid_json")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.UseNumber()
+	value, err := decodeJSONValue(decoder, 0)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return nil, failure("invalid_json")
+		}
+		return nil, err
+	}
+	return value, nil
+}
+
+func decodeJSONValue(decoder *json.Decoder, depth int) (any, error) {
+	if depth > maxJSONDepth {
+		return nil, failure("invalid_json")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	delimiter, isDelimiter := token.(json.Delim)
+	if !isDelimiter {
+		return token, nil
+	}
+	switch delimiter {
+	case '{':
+		object := make(map[string]any)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return nil, err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return nil, failure("invalid_json")
+			}
+			if _, duplicate := object[key]; duplicate {
+				return nil, failure("duplicate_key")
+			}
+			value, err := decodeJSONValue(decoder, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			object[key] = value
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return nil, failure("invalid_json")
+		}
+		return object, nil
+	case '[':
+		array := make([]any, 0)
+		for decoder.More() {
+			value, err := decodeJSONValue(decoder, depth+1)
+			if err != nil {
+				return nil, err
+			}
+			array = append(array, value)
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return nil, failure("invalid_json")
+		}
+		return array, nil
+	default:
+		return nil, failure("invalid_json")
+	}
+}
+
+func hasExactKeys(object map[string]any, keys ...string) bool {
+	if len(object) != len(keys) {
+		return false
+	}
+	for _, key := range keys {
+		if _, ok := object[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func integerValue(value any) (int64, bool) {
+	number, ok := value.(json.Number)
+	if !ok || number.String() == "" || strings.ContainsAny(number.String(), ".eE+") {
+		return 0, false
+	}
+	integer, err := strconv.ParseInt(number.String(), 10, 64)
+	return integer, err == nil
+}
+
+func positiveSafeInteger(value any) (int64, bool) {
+	integer, ok := integerValue(value)
+	return integer, ok && integer >= 1 && integer <= maxSafeInteger
+}
+
+func validNonzeroSHA256(value string) bool { return validNonzeroHex(value, sha256Pattern) }
+func stringIsNonzeroSHA256(value any) bool {
+	text, ok := value.(string)
+	return ok && validNonzeroSHA256(text)
+}
+func validNonzeroHex(value string, pattern *regexp.Regexp) bool {
+	if !pattern.MatchString(value) {
+		return false
+	}
+	return strings.Trim(value, "0") != ""
+}
+func validDigest(value string) bool {
+	return digestPattern.MatchString(value) && validNonzeroSHA256(strings.TrimPrefix(value, "sha256:"))
+}
+func validContainerValue(value any) bool {
+	text, ok := value.(string)
+	return ok && validNonzeroHex(text, containerIDPattern)
+}
+func validOptionalSHA(value any) bool { return value == nil || stringIsNonzeroSHA256(value) }
+func optionalSHAValue(value any) (*string, bool) {
+	if value == nil {
+		return nil, true
+	}
+	text, ok := value.(string)
+	if !ok || !validNonzeroSHA256(text) {
+		return nil, false
+	}
+	return &text, true
+}
+func optionalString(value any) (*string, bool) {
+	if value == nil {
+		return nil, true
+	}
+	text, ok := value.(string)
+	if !ok || text == "" || strings.ContainsAny(text, "\r\n") {
+		return nil, false
+	}
+	return &text, true
+}
+func validTimestampValue(value any) bool {
+	text, ok := value.(string)
+	return ok && validUTCTimestamp(text)
+}
+func validUTCTimestamp(value string) bool {
+	parsed, err := time.Parse("2006-01-02T15:04:05Z", value)
+	return err == nil && parsed.UTC().Format("2006-01-02T15:04:05Z") == value
+}
+func sha256Bytes(contents []byte) string {
+	sum := sha256.Sum256(contents)
+	return hex.EncodeToString(sum[:])
+}
+
+func sha256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/server/cmd/production-broker/main_test.go
+++ b/server/cmd/production-broker/main_test.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type recordingRunner struct {
+	calls [][]string
+}
+
+func (runner *recordingRunner) run(_ context.Context, _ string, arguments []string, _ []string) error {
+	runner.calls = append(runner.calls, append([]string(nil), arguments...))
+	manifestPath := argumentValue(arguments, "--manifest")
+	currentPath := argumentValue(arguments, "--current-receipt")
+	receiptPath := argumentValue(arguments, "--receipt")
+	bundlePath := argumentValue(arguments, "--bundle")
+	manifestContents, _ := os.ReadFile(manifestPath)
+	manifest, _ := parseReleaseManifest(manifestContents, 124)
+	currentContents, _ := os.ReadFile(currentPath)
+	bundleContents, _ := os.ReadFile(filepath.Join(bundlePath, "bundle-manifest.json"))
+	contents := engineReceiptJSON(manifest, "deploy", sha256Bytes(currentContents), sha256Bytes(bundleContents))
+	if err := os.WriteFile(receiptPath, contents, 0o444); err != nil {
+		return err
+	}
+	return os.Chmod(receiptPath, 0o444)
+}
+
+func argumentValue(arguments []string, name string) string {
+	for index := 0; index+1 < len(arguments); index++ {
+		if arguments[index] == name {
+			return arguments[index+1]
+		}
+	}
+	return ""
+}
+
+func newTestConfig(t *testing.T, runner *recordingRunner) Config {
+	t.Helper()
+	root := t.TempDir()
+	lockDir := filepath.Join(root, "lock")
+	if err := os.Mkdir(lockDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return Config{
+		Repository:     officialRepository,
+		ManagePath:     filepath.Join(root, "fixed", "manage.sh"),
+		Environment:    filepath.Join(root, "fixed", "production.env"),
+		StateDir:       filepath.Join(root, "state"),
+		LockFile:       filepath.Join(lockDir, "broker.lock"),
+		PATH:           productionPATH,
+		RequestTimeout: time.Second,
+		DeployTimeout:  time.Second,
+		Now:            func() time.Time { return time.Date(2026, 8, 26, 9, 10, 11, 0, time.UTC) },
+		RunCommand:     runner.run,
+		OwnerUID:       uint32(os.Geteuid()),
+	}
+}
+
+func manifestJSON(version string, versionCode int64, candidateRunID int64) []byte {
+	value := map[string]any{
+		"manifest_version":          1,
+		"version":                   version,
+		"git_sha":                   strings.Repeat("c", 40),
+		"version_code":              versionCode,
+		"portal_image":              "ghcr.io/1024xengineer/xe3-esl-portal",
+		"portal_image_digest":       "sha256:" + strings.Repeat("a", 64),
+		"server_image":              "ghcr.io/1024xengineer/xe3-esl-server",
+		"server_image_digest":       "sha256:" + strings.Repeat("b", 64),
+		"staging_apk_file":          "speakup-v" + version + "-staging-arm64.apk",
+		"staging_apk_sha256":        strings.Repeat("d", 64),
+		"production_apk_file":       "speakup-v" + version + "-production-arm64.apk",
+		"production_apk_size_bytes": int64(len("signed-production-apk\n")),
+		"production_apk_sha256":     sha256Bytes([]byte("signed-production-apk\n")),
+		"application_id":            "com.xengineer.speakup",
+		"minimum_android_api":       24,
+		"abis":                      []string{"arm64-v8a"},
+		"apk_certificate_sha256":    strings.Repeat("f", 64),
+		"database_schema_version":   9,
+		"quality_run_url":           "https://github.com/1024XEngineer/XE3-ESL/actions/runs/" + strconv.FormatInt(candidateRunID, 10),
+	}
+	contents, _ := json.Marshal(value)
+	return contents
+}
+
+func engineReceiptJSON(manifest releaseManifest, operation string, previous string, bundle string) []byte {
+	nginx := "server { listen 443 ssl; }\n"
+	value := map[string]any{
+		"receipt_version": 1, "environment": "production", "operation": operation,
+		"manifest_sha256": manifest.SHA256, "version": manifest.Version, "version_code": manifest.VersionCode,
+		"git_sha": manifest.GitSHA, "database_schema_version": manifest.DatabaseSchemaVersion,
+		"portal_image_digest": manifest.PortalImageDigest, "server_image_digest": manifest.ServerImageDigest,
+		"production_apk_file": manifest.ProductionAPKFile, "production_apk_size_bytes": manifest.ProductionAPKSize,
+		"production_apk_sha256": manifest.ProductionAPKSHA256, "apk_certificate_sha256": manifest.APKCertificateSHA256,
+		"portal_container_id": strings.Repeat("1", 64), "server_container_id": strings.Repeat("2", 64),
+		"postgres_container_id": strings.Repeat("3", 64), "nginx_config_sha256": sha256Bytes([]byte(nginx)), "nginx_config": nginx,
+		"postgres_backup_id": nil, "portal_backup_id": nil, "android_bundle_manifest_sha256": nil,
+		"previous_receipt_sha256": nil, "rollback_target_receipt_sha256": nil,
+		"recorded_at_utc": "2026-08-26T09:10:10Z",
+	}
+	if operation == "deploy" {
+		value["postgres_backup_id"] = "20260826T091000Z-predeploy"
+		value["portal_backup_id"] = "20260826T091000000Z"
+		value["android_bundle_manifest_sha256"] = bundle
+		value["previous_receipt_sha256"] = previous
+	}
+	contents, _ := json.Marshal(value)
+	return contents
+}
+
+func initializeTestState(t *testing.T, config Config) {
+	t.Helper()
+	manifestContents := manifestJSON("0.1.7", 8, 123)
+	manifest, err := parseReleaseManifest(manifestContents, 123)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Dir(config.StateDir)
+	manifestPath := filepath.Join(root, "baseline-manifest.json")
+	receiptPath := filepath.Join(root, "baseline-receipt.json")
+	if err := os.WriteFile(manifestPath, manifestContents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(receiptPath, engineReceiptJSON(manifest, "baseline", "", ""), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(receiptPath, 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := initializeState(config, manifestPath, receiptPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func stagingResponseJSON(manifest releaseManifest, candidateRunID, stagingRunID int64) []byte {
+	receipt := map[string]any{
+		"receipt_version": 2, "environment": "staging", "operation": "deploy", "repository": officialRepository,
+		"manifest_sha256": manifest.SHA256, "version": manifest.Version, "version_code": manifest.VersionCode,
+		"git_sha": manifest.GitSHA, "database_schema_version": manifest.DatabaseSchemaVersion,
+		"portal_image_digest": manifest.PortalImageDigest, "server_image_digest": manifest.ServerImageDigest,
+		"portal_container_id": strings.Repeat("4", 64), "server_container_id": strings.Repeat("5", 64),
+		"postgres_container_id": strings.Repeat("6", 64), "candidate_run_id": candidateRunID,
+		"deployment_run_id": stagingRunID, "deployment_run_attempt": 1,
+		"previous_receipt_sha256": strings.Repeat("7", 64), "rollback_target_receipt_sha256": nil,
+		"recorded_at_utc": "2026-08-26T09:00:00Z",
+	}
+	receiptContents, _ := json.Marshal(receipt)
+	value := map[string]any{"protocol_version": 1, "ok": true, "action": "deploy", "receipt_sha256": sha256Bytes(receiptContents), "receipt": receipt}
+	contents, _ := json.Marshal(value)
+	return contents
+}
+
+func deploymentPayload(t *testing.T, currentSHA string, mutateStaging bool) []byte {
+	t.Helper()
+	manifestContents := manifestJSON("0.1.8", 9, 124)
+	manifest, err := parseReleaseManifest(manifestContents, 124)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stagingCandidate := int64(124)
+	if mutateStaging {
+		stagingCandidate = 999
+	}
+	stagingContents := stagingResponseJSON(manifest, stagingCandidate, 700)
+	apk := []byte("signed-production-apk\n")
+	published := "2026-08-26T09:05:00Z"
+	prefix := "downloads/android/v" + manifest.Version + "/"
+	apkPath := prefix + manifest.ProductionAPKFile
+	metadata := map[string]any{
+		"metadata_version": 1, "version": manifest.Version, "version_code": manifest.VersionCode, "published_at": published,
+		"file_name": manifest.ProductionAPKFile, "download_path": "/" + apkPath, "size_bytes": int64(len(apk)),
+		"minimum_android_api": 24, "abis": []string{"arm64-v8a"}, "apk_sha256": manifest.ProductionAPKSHA256,
+		"apk_certificate_sha256": manifest.APKCertificateSHA256,
+	}
+	metadataContents, _ := json.Marshal(metadata)
+	checksum := []byte(manifest.ProductionAPKSHA256 + "  " + manifest.ProductionAPKFile + "\n")
+	files := map[string][]byte{
+		apkPath:                 apk,
+		apkPath + ".sha256":     checksum,
+		prefix + "release.json": metadataContents,
+	}
+	entries := make([]map[string]any, 0, 3)
+	for _, name := range []string{apkPath, apkPath + ".sha256", prefix + "release.json"} {
+		entries = append(entries, map[string]any{"path": name, "size_bytes": len(files[name]), "sha256": sha256Bytes(files[name])})
+	}
+	bundleManifest, _ := json.Marshal(map[string]any{"bundle_version": 1, "version": manifest.Version, "published_at": published, "release_manifest_sha256": manifest.SHA256, "files": entries})
+	requestContents, _ := json.Marshal(map[string]any{
+		"protocol_version": 1, "action": "deploy", "repository": officialRepository, "candidate_run_id": 124,
+		"staging_run_id": 700, "staging_run_attempt": 1, "deployment_run_id": 800, "deployment_run_attempt": 1,
+		"expected_current_receipt_sha256": currentSHA, "manifest_sha256": manifest.SHA256,
+		"staging_receipt_sha256": sha256Bytes(stagingContents), "bundle_manifest_sha256": sha256Bytes(bundleManifest),
+	})
+	archiveFiles := map[string][]byte{
+		"request.json": requestContents, "release-manifest.json": manifestContents, "staging-receipt.json": stagingContents,
+		"bundle/bundle-manifest.json": bundleManifest,
+	}
+	for name, contents := range files {
+		archiveFiles["bundle/"+name] = contents
+	}
+	return tarPayload(t, archiveFiles)
+}
+
+func tarPayload(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := tar.NewWriter(&buffer)
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	for _, name := range names {
+		contents := files[name]
+		if err := writer.WriteHeader(&tar.Header{Name: name, Mode: 0600, Size: int64(len(contents)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write(contents); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func inspectPayload(t *testing.T) []byte {
+	return tarPayload(t, map[string][]byte{"request.json": []byte(`{"protocol_version":1,"action":"inspect"}`)})
+}
+
+func TestInspectAndDeploySameCandidateEvidence(t *testing.T) {
+	runner := &recordingRunner{}
+	config := newTestConfig(t, runner)
+	initializeTestState(t, config)
+	initial, err := execute(context.Background(), bytes.NewReader(inspectPayload(t)), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initial.Action != "inspect" || initial.Receipt.Operation != "baseline" {
+		t.Fatalf("initial response = %#v", initial)
+	}
+	deployed, err := execute(context.Background(), bytes.NewReader(deploymentPayload(t, initial.CurrentReceiptSHA256, false)), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deployed.Action != "deploy" || deployed.Receipt.CandidateRunID == nil || *deployed.Receipt.CandidateRunID != 124 || deployed.Receipt.StagingRunID == nil || *deployed.Receipt.StagingRunID != 700 || deployed.Receipt.PreviousReceiptSHA256 == nil || *deployed.Receipt.PreviousReceiptSHA256 != initial.CurrentReceiptSHA256 {
+		t.Fatalf("deploy response = %#v", deployed)
+	}
+	receiptContents, err := json.Marshal(deployed.Receipt)
+	if err != nil || sha256Bytes(receiptContents) != deployed.CurrentReceiptSHA256 {
+		t.Fatal("response does not expose the immutable audit receipt hash")
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("runner calls = %d", len(runner.calls))
+	}
+	expected := []string{"deploy", "--manifest", "--env-file", "--bundle", "--current-receipt", "--receipt"}
+	for _, token := range expected {
+		if !contains(runner.calls[0], token) {
+			t.Fatalf("missing fixed manage argument %q in %#v", token, runner.calls[0])
+		}
+	}
+}
+
+func TestRejectsMismatchedStagingReceiptBeforeManage(t *testing.T) {
+	runner := &recordingRunner{}
+	config := newTestConfig(t, runner)
+	initializeTestState(t, config)
+	initial, _ := execute(context.Background(), bytes.NewReader(inspectPayload(t)), config)
+	_, err := execute(context.Background(), bytes.NewReader(deploymentPayload(t, initial.CurrentReceiptSHA256, true)), config)
+	if err == nil || errorCode(err) != "invalid_request" {
+		t.Fatalf("error = %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatal("manage ran for mismatched Staging evidence")
+	}
+}
+
+func TestForcedInvocationRejectsCommandsAndArguments(t *testing.T) {
+	config := newTestConfig(t, &recordingRunner{})
+	for _, test := range []struct {
+		args    []string
+		command string
+	}{
+		{[]string{"broker", "unexpected"}, ""},
+		{[]string{"broker"}, "scp -t /tmp/file"},
+	} {
+		var output bytes.Buffer
+		if runCLI(test.args, test.command, bytes.NewReader(nil), &output, config) == 0 || !strings.Contains(output.String(), "invalid_invocation") {
+			t.Fatalf("output = %q", output.String())
+		}
+	}
+}
+
+func TestRejectsNonRegularArchiveEntry(t *testing.T) {
+	config := newTestConfig(t, &recordingRunner{})
+	initializeTestState(t, config)
+	var buffer bytes.Buffer
+	writer := tar.NewWriter(&buffer)
+	_ = writer.WriteHeader(&tar.Header{Name: "request.json", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd"})
+	_ = writer.Close()
+	_, err := execute(context.Background(), bytes.NewReader(buffer.Bytes()), config)
+	if err == nil || errorCode(err) != "invalid_request" {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/production-deploy/production-deploy.test.mjs
+++ b/tools/production-deploy/production-deploy.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const workflow = readFileSync(
+  fileURLToPath(
+    new URL("../../.github/workflows/production-deploy.yml", import.meta.url),
+  ),
+  "utf8",
+);
+
+test("Production deploy is gated by the successful official Staging workflow", () => {
+  assert.match(
+    workflow,
+    /workflow_run:\n\s+workflows:\n\s+- Deploy Staging Candidate/,
+  );
+  assert.match(workflow, /github\.event\.workflow_run\.conclusion == 'success'/);
+  assert.match(workflow, /STAGING_HEAD_REPOSITORY.*head_repository\.full_name/);
+  assert.match(workflow, /STAGING_PATH" != "\.github\/workflows\/staging-deploy\.yml"/);
+  assert.match(workflow, /STAGING_EVENT" != "workflow_run"/);
+  assert.match(workflow, /STAGING_HEAD_BRANCH" != "main"/);
+  assert.match(workflow, /1024XEngineer\/XE3-ESL/);
+  assert.match(workflow, /receipt_version == 2/);
+  assert.match(workflow, /deployment_run_id == \$run_id/);
+  assert.match(workflow, /deployment_run_attempt == \$run_attempt/);
+});
+
+test("Production deploy consumes one matching Candidate without rebuilding it", () => {
+  assert.match(workflow, /getWorkflowRun/);
+  assert.match(workflow, /run\.name !== "Release Candidate"/);
+  assert.match(workflow, /run\.event !== "push"/);
+  assert.match(workflow, /run\.head_branch !== "main"/);
+  assert.match(workflow, /run\.head_sha !== process\.env\.CANDIDATE_SHA/);
+  assert.match(workflow, /speakup-v\$\{process\.env\.VERSION\}-release-manifest/);
+  assert.match(workflow, /speakup-v\$\{process\.env\.VERSION\}-android/);
+  assert.match(workflow, /Candidate run \$\{runId\} has \$\{selected\.length\}/);
+  assert.match(workflow, /run-id:.*candidate_run_id/);
+  assert.match(workflow, /tools\/android-download\/bundle\.mjs/);
+  assert.match(workflow, /production_apk_sha256/);
+  assert.match(workflow, /staging_receipt_sha256/);
+  assert.doesNotMatch(workflow, /flutter build|build-android|docker\/build-push-action/);
+});
+
+test("Production mutation waits for Environment approval and uses only the broker", () => {
+  assert.match(workflow, /environment:\n\s+name: production/);
+  assert.match(
+    workflow,
+    /group: production-deployment\n\s+cancel-in-progress: false/,
+  );
+  assert.match(workflow, /DEPLOY_USER" == "speakup-production-ci"/);
+  assert.match(workflow, /StrictHostKeyChecking=yes/);
+  assert.match(workflow, /tar --format=ustar --no-recursion/);
+  assert.match(workflow, /action:\s*"inspect"/);
+  assert.match(workflow, /action:\s*"deploy"/);
+  assert.match(workflow, /expected_current_receipt_sha256/);
+  assert.match(workflow, /production_engine_previous_receipt_sha256/);
+  assert.doesNotMatch(workflow, /deploy\/production\/manage\.sh/);
+  assert.doesNotMatch(workflow, /contents:\s*write|packages:\s*write/);
+});
+
+test("Production deploy preserves auditable evidence and performs public smoke", () => {
+  assert.match(workflow, /https:\/\/speak-up\.top\//);
+  assert.match(workflow, /https:\/\/api\.speak-up\.top\/health/);
+  assert.match(
+    workflow,
+    /production-deployment-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}/,
+  );
+  assert.match(workflow, /retention-days: 90/);
+  assert.match(workflow, /Remove the Production SSH identity/);
+});
+
+test("Every external action is pinned to a full commit", () => {
+  const references = [...workflow.matchAll(/uses:\s+([^\s#]+)/g)].map(
+    ([, reference]) => reference,
+  );
+  assert.ok(references.length >= 7);
+  for (const reference of references) {
+    assert.match(reference, /@[0-9a-f]{40}$/, reference);
+  }
+});


### PR DESCRIPTION
## 功能描述

- 在官方 Staging 部署成功后启动 Production 部署流程，并在 GitHub `production` Environment 等待人工批准。
- 复用同一个已经校验的 Release Candidate：Portal/Server 镜像和正式签名 APK 均不在 Production 阶段重新构建。
- 通过受限 SSH broker 调用现有 Production 部署引擎，保留部署前备份、失败状态、审计记录和回滚依据。
- 本 PR 不创建正式 Tag/GitHub Release，也不切换官网 APK 下载指针；这些由 Production 成功后的发布收口步骤负责。

## 实现思路

- 校验官方 `main` 上成功的 Release Candidate 与 Staging v2 部署回执，锁定 commit、manifest、镜像 digest、APK SHA-256 和签名证书。
- Production job 绑定 `production` Environment；Secrets 只有审批后才会进入 job。
- CI 仅能通过 forced-command SSH key 调用固定 broker，无远程 shell、SCP/SFTP、TTY、端口转发或 Docker 权限。
- broker 对输入包、当前基线和目标候选版本做严格校验，再调用现有 `deploy/production/manage.sh`，并保存审计回执。
- 提供 Production 主机一次性 bootstrap、校验脚本和最小权限配置说明。

## 可复现测试

```bash
make check-production-deploy
git diff --check upstream/dev...HEAD
```

已通过：

- Production Workflow 合约测试：5/5
- `go test -count=1 ./cmd/production-broker`
- Production 主机访问权限测试
- 现有 Production 部署合约测试

## 合并后的配置

- 创建 GitHub `production` Environment，配置 Required reviewer、禁止自审、仅允许 `main`。
- 配置 `PRODUCTION_DEPLOY_HOST`、`PRODUCTION_DEPLOY_PORT`、`PRODUCTION_DEPLOY_USER`。
- 配置 `PRODUCTION_DEPLOY_KNOWN_HOSTS`、`PRODUCTION_DEPLOY_SSH_PRIVATE_KEY`。
- 在生产服务器安装受限 broker，并用当前 v0.1.7 部署回执初始化基线。

Closes #1037
