### PR TITLE
ops(release): Production 成功后原子收口正式版本

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -535,6 +535,14 @@ jobs:
           curl --fail --silent --show-error --max-time 20 \
             https://api.speak-up.top/health >/dev/null
 
+      - name: Upload the Production deployment receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: production-deployment-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.deploy.outputs.response }}
+          if-no-files-found: error
+          retention-days: 90
+
       - name: Prepare the complete GitHub Release draft
         id: release
         env:
@@ -765,14 +773,6 @@ jobs:
           jq -e --arg sha "$CANDIDATE_SHA" \
             '.ref == ("refs/tags/" + env.TAG) and .object.type == "commit" and .object.sha == $sha' \
             <<<"$tag_ref" >/dev/null
-
-      - name: Upload the Production deployment receipt
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: production-deployment-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.deploy.outputs.response }}
-          if-no-files-found: error
-          retention-days: 90
 
       - name: Record the Production deployment
         env:

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -199,6 +199,9 @@ jobs:
   deploy:
     name: Approve and deploy the immutable Candidate
     needs: authorize
+    permissions:
+      actions: read
+      contents: write
     environment:
       name: production
       url: https://speak-up.top
@@ -318,21 +321,40 @@ jobs:
           printf 'production_apk=%s\n' "$ANDROID_DIRECTORY/$production_apk" >> "$GITHUB_OUTPUT"
           printf 'staging_receipt=%s\n' "$staging_receipt" >> "$GITHUB_OUTPUT"
 
+      - name: Validate and render the official release notes
+        id: notes
+        env:
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          notes="portal/public/release-notes/android/v$VERSION.zh-CN.json"
+          index="portal/public/release-notes/android/index.zh-CN.json"
+          body="$RUNNER_TEMP/release-notes.md"
+          published_at="$(node tools/release-finalize/notes.mjs \
+            --version "$VERSION" \
+            --notes "$notes" \
+            --index "$index" \
+            --output "$body")"
+          [[ "$published_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+          printf 'body=%s\n' "$body" >> "$GITHUB_OUTPUT"
+          printf 'file=%s\n' "$notes" >> "$GITHUB_OUTPUT"
+          printf 'published_at=%s\n' "$published_at" >> "$GITHUB_OUTPUT"
+
       - name: Build the immutable Android download payload
         id: bundle
         env:
           MANIFEST_FILE: ${{ steps.artifacts.outputs.manifest }}
           PRODUCTION_APK: ${{ steps.artifacts.outputs.production_apk }}
+          PUBLISHED_AT: ${{ steps.notes.outputs.published_at }}
           STAGING_RECEIPT: ${{ steps.artifacts.outputs.staging_receipt }}
         run: |
           set -euo pipefail
           payload="$RUNNER_TEMP/production-payload"
           install -d -m 700 "$payload"
-          published_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           node tools/android-download/bundle.mjs \
             --manifest "$MANIFEST_FILE" \
             --production-apk "$PRODUCTION_APK" \
-            --published-at "$published_at" \
+            --published-at "$PUBLISHED_AT" \
             --output "$payload/bundle"
           install -m 600 "$MANIFEST_FILE" "$payload/release-manifest.json"
           install -m 600 \
@@ -485,9 +507,14 @@ jobs:
               .receipt.staging_run_attempt == $staging_run_attempt and
               .receipt.staging_receipt_sha256 == $staging_receipt_sha256 and
               .receipt.deployment_run_id == $deployment_run_id and
-              .receipt.deployment_run_attempt == $deployment_run_attempt and
-              .receipt.previous_receipt_sha256 == $expected_current and
-              .receipt.production_engine_previous_receipt_sha256 == $expected_engine and
+              (.receipt.deployment_run_attempt | type == "number" and . >= 1 and
+                . <= $deployment_run_attempt and . == floor) and
+              ((.current_receipt_sha256 == $expected_current and
+                  .receipt.production_engine_receipt_sha256 == $expected_engine) or
+                (.current_receipt_sha256 != $expected_current and
+                  .receipt.deployment_run_attempt == $deployment_run_attempt and
+                  .receipt.previous_receipt_sha256 == $expected_current and
+                  .receipt.production_engine_previous_receipt_sha256 == $expected_engine)) and
               (.receipt.production_engine_receipt_sha256 | test("^[0-9a-f]{64}$")) and
               (.receipt.portal_container_id | test("^[0-9a-f]{12,64}$")) and
               (.receipt.server_container_id | test("^[0-9a-f]{12,64}$")) and
@@ -508,6 +535,237 @@ jobs:
           curl --fail --silent --show-error --max-time 20 \
             https://api.speak-up.top/health >/dev/null
 
+      - name: Prepare the complete GitHub Release draft
+        id: release
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          DEPLOY_RESPONSE: ${{ steps.deploy.outputs.response }}
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_FILE: ${{ steps.artifacts.outputs.manifest }}
+          NOTES_BODY: ${{ steps.notes.outputs.body }}
+          NOTES_FILE: ${{ steps.notes.outputs.file }}
+          PAYLOAD_DIRECTORY: ${{ steps.bundle.outputs.directory }}
+          PRODUCTION_APK: ${{ steps.artifacts.outputs.production_apk }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="v$VERSION"
+          title="SpeakUp Android v$VERSION"
+          assets="$RUNNER_TEMP/release-assets"
+          install -d -m 700 "$assets"
+          apk="speakup-v$VERSION-production-arm64.apk"
+          install -m 600 "$PRODUCTION_APK" "$assets/$apk"
+          install -m 600 \
+            "$PAYLOAD_DIRECTORY/bundle/downloads/android/v$VERSION/$apk.sha256" \
+            "$assets/$apk.sha256"
+          install -m 600 "$MANIFEST_FILE" "$assets/release-manifest.json"
+          install -m 600 "$DEPLOY_RESPONSE" "$assets/production-deployment-receipt.json"
+          install -m 600 "$NOTES_FILE" "$assets/release-notes.zh-CN.json"
+          install -m 600 \
+            "$PAYLOAD_DIRECTORY/bundle/downloads/android/v$VERSION/release.json" \
+            "$assets/android-release.json"
+
+          releases="$(gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100")"
+          matches="$(jq -c --arg tag "$tag" '[.[][] | select(.tag_name == $tag)]' <<<"$releases")"
+          [[ "$(jq 'length' <<<"$matches")" -le 1 ]]
+          if [[ "$(jq 'length' <<<"$matches")" == 0 ]]; then
+            if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag" >/dev/null 2>&1; then
+              echo "Stable tag already exists without the expected Release." >&2
+              exit 1
+            fi
+            body="$(<"$NOTES_BODY")"
+            release="$(jq -cn \
+              --arg tag "$tag" \
+              --arg target "$CANDIDATE_SHA" \
+              --arg name "$title" \
+              --arg body "$body" \
+              '{tag_name:$tag,target_commitish:$target,name:$name,body:$body,draft:true,prerelease:false,make_latest:"false"}' | \
+              gh api --method POST "repos/$GITHUB_REPOSITORY/releases" --input -)"
+          else
+            release="$(jq -c '.[0]' <<<"$matches")"
+          fi
+
+          body="$(<"$NOTES_BODY")"
+          jq -e \
+            --arg tag "$tag" \
+            --arg target "$CANDIDATE_SHA" \
+            --arg name "$title" \
+            --arg body "$body" '
+              .tag_name == $tag and .target_commitish == $target and
+              .name == $name and .body == $body and .prerelease == false and
+              ((.draft == true and .immutable == false) or
+                (.draft == false and .immutable == true)) and
+              (.id | type == "number" and . >= 1)
+            ' <<<"$release" >/dev/null
+          release_id="$(jq -er '.id' <<<"$release")"
+          already_published="$(jq -er '(.draft | not)' <<<"$release")"
+
+          expected_assets="$(printf '%s\n' \
+            android-release.json \
+            "$apk" \
+            "$apk.sha256" \
+            production-deployment-receipt.json \
+            release-manifest.json \
+            release-notes.zh-CN.json | sort)"
+          if [[ "$already_published" == false ]]; then
+            while read -r asset_id; do
+              [[ -z "$asset_id" ]] || gh api --method DELETE \
+                "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
+            done < <(gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \
+              --jq '.[].id')
+            gh release upload "$tag" \
+              "$assets/android-release.json" \
+              "$assets/$apk" \
+              "$assets/$apk.sha256" \
+              "$assets/production-deployment-receipt.json" \
+              "$assets/release-manifest.json" \
+              "$assets/release-notes.zh-CN.json"
+          fi
+          actual_assets="$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \
+            --jq '.[].name' | sort)"
+          [[ "$actual_assets" == "$expected_assets" ]]
+          asset_metadata="$RUNNER_TEMP/release-asset-metadata.json"
+          gh api --paginate --slurp \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \
+            > "$asset_metadata"
+          for file in "$assets"/*; do
+            name="$(basename "$file")"
+            size="$(stat -c '%s' "$file")"
+            digest="sha256:$(sha256sum "$file" | cut -d ' ' -f 1)"
+            jq -e \
+              --arg name "$name" \
+              --arg digest "$digest" \
+              --argjson size "$size" '
+                [.[][] | select(.name == $name and .size == $size and .digest == $digest)] |
+                length == 1
+              ' "$asset_metadata" >/dev/null
+          done
+          printf 'already_published=%s\n' "$already_published" >> "$GITHUB_OUTPUT"
+          printf 'assets=%s\n' "$assets" >> "$GITHUB_OUTPUT"
+          printf 'id=%s\n' "$release_id" >> "$GITHUB_OUTPUT"
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Activate the approved APK through the restricted broker
+        env:
+          BUNDLE_MANIFEST_SHA256: ${{ steps.bundle.outputs.manifest_sha256 }}
+          DEPLOY_HOST: ${{ vars.PRODUCTION_DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ vars.PRODUCTION_DEPLOY_PORT }}
+          DEPLOY_RESPONSE: ${{ steps.deploy.outputs.response }}
+          DEPLOY_USER: ${{ vars.PRODUCTION_DEPLOY_USER }}
+          MANIFEST_SHA256: ${{ steps.artifacts.outputs.manifest_sha256 }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          ssh_options=(
+            -i "$RUNNER_TEMP/production-ssh/id_ed25519"
+            -o BatchMode=yes
+            -o IdentitiesOnly=yes
+            -o StrictHostKeyChecking=yes
+            -o "UserKnownHostsFile=$RUNNER_TEMP/production-ssh/known_hosts"
+            -o ConnectTimeout=15
+            -p "$DEPLOY_PORT"
+          )
+          request_directory="$RUNNER_TEMP/production-release"
+          response="$RUNNER_TEMP/production-release-response.json"
+          install -d -m 700 "$request_directory"
+          current_receipt="$(jq -er '.current_receipt_sha256' "$DEPLOY_RESPONSE")"
+          jq -cn \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson deployment_run_id "$GITHUB_RUN_ID" \
+            --argjson deployment_run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg expected_current_receipt_sha256 "$current_receipt" \
+            --arg manifest_sha256 "$MANIFEST_SHA256" \
+            --arg bundle_manifest_sha256 "$BUNDLE_MANIFEST_SHA256" \
+            --arg version "$VERSION" \
+            '{
+              protocol_version: 1,
+              action: "release",
+              repository: $repository,
+              deployment_run_id: $deployment_run_id,
+              deployment_run_attempt: $deployment_run_attempt,
+              expected_current_receipt_sha256: $expected_current_receipt_sha256,
+              manifest_sha256: $manifest_sha256,
+              bundle_manifest_sha256: $bundle_manifest_sha256,
+              version: $version
+            }' > "$request_directory/request.json"
+          tar --format=ustar --no-recursion -C "$request_directory" \
+            -cf - request.json | \
+            ssh "${ssh_options[@]}" "$DEPLOY_USER@$DEPLOY_HOST" > "$response"
+          jq -e \
+            --arg current_receipt "$current_receipt" \
+            --arg manifest_sha256 "$MANIFEST_SHA256" \
+            --arg version "$VERSION" '
+              type == "object" and
+              keys == ["action", "current_receipt_sha256", "ok", "protocol_version", "receipt"] and
+              .protocol_version == 1 and .ok == true and .action == "release" and
+              .current_receipt_sha256 == $current_receipt and
+              .receipt.operation == "deploy" and
+              .receipt.manifest_sha256 == $manifest_sha256 and
+              .receipt.version == $version
+            ' "$response" >/dev/null
+
+      - name: Verify the public APK and changelog contract
+        env:
+          NOTES_FILE: ${{ steps.notes.outputs.file }}
+          PAYLOAD_DIRECTORY: ${{ steps.bundle.outputs.directory }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          apk="speakup-v$VERSION-production-arm64.apk"
+          expected="$PAYLOAD_DIRECTORY/bundle/downloads/android/v$VERSION/release.json"
+          actual="$RUNNER_TEMP/public-android-release.json"
+          downloaded="$RUNNER_TEMP/$apk"
+          curl --fail --silent --show-error --max-time 20 \
+            https://speak-up.top/downloads/android/release.json -o "$actual"
+          cmp --silent "$expected" "$actual"
+          curl --fail --silent --show-error --location --max-time 120 \
+            "https://speak-up.top/downloads/android/v$VERSION/$apk" -o "$downloaded"
+          [[ "$(sha256sum "$downloaded" | cut -d ' ' -f 1)" == \
+            "$(jq -er '.apk_sha256' "$actual")" ]]
+          curl --fail --silent --show-error --max-time 20 \
+            "https://speak-up.top/release-notes/android/v$VERSION.zh-CN.json" \
+            -o "$RUNNER_TEMP/public-release-notes.json"
+          cmp --silent "$NOTES_FILE" "$RUNNER_TEMP/public-release-notes.json"
+          curl --fail --silent --show-error --max-time 20 \
+            https://speak-up.top/changelog >/dev/null
+
+      - name: Publish and verify the immutable GitHub Release
+        env:
+          ALREADY_PUBLISHED: ${{ steps.release.outputs.already_published }}
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.release.outputs.id }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$ALREADY_PUBLISHED" == false ]]; then
+            jq -cn '{draft:false,make_latest:"true"}' | \
+              gh api --method PATCH \
+                "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" --input - >/dev/null
+          fi
+          for attempt in {1..10}; do
+            release="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+            if jq -e '.draft == false and .immutable == true' <<<"$release" >/dev/null; then
+              break
+            fi
+            if [[ "$attempt" == 10 ]]; then
+              echo "GitHub Release did not become immutable." >&2
+              exit 1
+            fi
+            sleep 3
+          done
+          jq -e --arg tag "$TAG" '
+            .tag_name == $tag and .draft == false and .prerelease == false and
+            .immutable == true
+          ' <<<"$release" >/dev/null
+          tag_ref="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG")"
+          jq -e --arg sha "$CANDIDATE_SHA" \
+            '.ref == ("refs/tags/" + env.TAG) and .object.type == "commit" and .object.sha == $sha' \
+            <<<"$tag_ref" >/dev/null
+
       - name: Upload the Production deployment receipt
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -520,6 +778,7 @@ jobs:
         env:
           CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
           RECEIPT_SHA256: ${{ steps.deploy.outputs.receipt_sha256 }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
           VERSION: ${{ needs.authorize.outputs.version }}
         run: |
           {
@@ -529,6 +788,8 @@ jobs:
             printf -- '- Receipt: `%s`\n' "$RECEIPT_SHA256"
             printf -- '- Portal: https://speak-up.top\n'
             printf -- '- API: https://api.speak-up.top/health\n'
+            printf -- '- Release: https://github.com/%s/releases/tag/%s\n' \
+              "$GITHUB_REPOSITORY" "$RELEASE_TAG"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove the Production SSH identity

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -91,7 +91,7 @@ jobs:
                   set_all_checks
                   android_release=true
                   ;;
-                .github/workflows/production-probe.yml|.github/workflows/production-deploy.yml|tools/production-deploy/*)
+                .github/workflows/production-probe.yml|.github/workflows/production-deploy.yml|tools/production-deploy/*|tools/release-finalize/*)
                   deploy=true
                   ;;
                 .github/workflows/database.yml|.github/workflows/coverage-comment.yml|tools/release-candidate/*)

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,7 @@ check-observability:
 
 check-production-deploy:
 	node --test tools/production-deploy/*.test.mjs
+	node --test tools/release-finalize/*.test.mjs
 	cd server && go test -count=1 ./cmd/production-broker
 	./deploy/production/test-host-access.sh
 	./deploy/production/test.sh

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -674,8 +674,9 @@ immutable Release is verified, never rewritten.
 The deploy job needs job-scoped `actions: read` and `contents: write`. Those
 permissions and all Production Secrets remain behind the `production`
 Environment approval. Enable repository immutable releases before the first
-real run. Protect `v*.*.*` tags from update and deletion; allow GitHub Actions
-to create a new stable tag, but never to update or delete one.
+real run. Protect `v*.*.*` tags from update and deletion. The Production job's
+Environment-gated `contents: write` permission creates the new stable tag when
+the Release is published; it cannot move or delete a published tag.
 
 If `manage.sh` fails, the broker leaves the previous current pointer unchanged
 and retains `pending.json` plus any engine receipt as recovery evidence. Later

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -592,8 +592,11 @@ does not rebuild an image or APK. The deploy job then enters the GitHub
 `production` Environment; its Secrets are unavailable until a required
 reviewer approves the deployment.
 
-Configure that Environment with a required reviewer, disallow self-approval,
-and allow only `main`. Add these Environment values:
+Configure that Environment with a required reviewer and allow only `main`.
+The current single-operator setup permits the named reviewer to approve their
+own initiated deployment, but an explicit approval is still mandatory; enable
+GitHub's prevent-self-review option when a second release owner is available.
+Add these Environment values:
 
 | Kind | Name | Value |
 | --- | --- | --- |
@@ -650,10 +653,29 @@ Each approved run streams only `request.json`, the Candidate manifest, the
 Staging receipt, and the versioned Android download bundle. The broker checks
 their hashes and cross-links before `manage.sh` performs its existing backup
 gates and digest-only deployment. Success stores content-addressed engine and
-audit receipts, atomically advances the current pointer, verifies the public
-Portal and API, and uploads the broker response as a 90-day Actions artifact.
-It publishes the versioned APK files but deliberately does not activate the
-public APK pointer and does not create a stable Tag or GitHub Release.
+audit receipts, atomically advances the current pointer, and verifies the
+public Portal and API. The workflow then creates or reuses a GitHub Release
+draft for the exact Candidate SHA and uploads the signed APK, checksum, release
+manifest, Production receipt, public metadata, and Chinese release notes. Only
+after all draft assets match does the broker atomically activate the public APK
+pointer. The workflow verifies the public metadata, APK digest, release notes,
+and changelog before publishing the `vX.Y.Z` Release. Repository immutable
+releases and Tag rulesets then prevent the published Release or stable Tag from
+being changed.
+
+If a later step fails after deployment, rerun the **same** Production workflow
+run. A higher run attempt with the same Candidate, Staging receipt, manifest,
+bundle, and deployment run ID performs `manage.sh verify` and reuses the prior
+immutable receipt; it does not repeat backups, migrations, or container
+restarts. A different workflow run or Candidate cannot claim that deployment.
+Draft asset preparation and APK activation are idempotent. A fully published
+immutable Release is verified, never rewritten.
+
+The deploy job needs job-scoped `actions: read` and `contents: write`. Those
+permissions and all Production Secrets remain behind the `production`
+Environment approval. Enable repository immutable releases before the first
+real run. Protect `v*.*.*` tags from update and deletion; allow GitHub Actions
+to create a new stable tag, but never to update or delete one.
 
 If `manage.sh` fails, the broker leaves the previous current pointer unchanged
 and retains `pending.json` plus any engine receipt as recovery evidence. Later
@@ -689,6 +711,8 @@ the four pull policies, and fail-closed behavior without contacting Production.
 - [Linux `flock`](https://man7.org/linux/man-pages/man1/flock.1.html)
 - [GitHub workflow API](https://docs.github.com/en/rest/actions/workflows#get-a-workflow)
 - [GitHub workflow run API](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)
+- [GitHub deployment environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)
+- [GitHub immutable releases](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/establish-provenance-and-integrity/prevent-release-changes)
 - [Nginx command-line parameters](https://nginx.org/en/docs/switches.html)
 - [Nginx proxy module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html)
 - [PostgreSQL SQL dump backup](https://www.postgresql.org/docs/18/backup-dump.html)

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -1,7 +1,7 @@
 # SpeakUp Android 发布与服务器部署方案
 
-> 状态：实施基线（PR Review 前）
-> 更新时间：2026-08-21
+> 状态：实施基线
+> 更新时间：2026-08-27
 > 关联 Issue：[#819](https://github.com/1024XEngineer/XE3-ESL/issues/819)
 > 目标 Milestone：MS4
 
@@ -146,15 +146,15 @@ GitHub Release 已发布；发布 GitHub Release 也不表示 Production 已完�
   -> 全量测试并构建完整、可追溯制品
   -> 成功后由独立 Staging Workflow 自动部署同一 Candidate
   -> 自动冒烟 + 真人验收
-  -> 批准正式发布并创建不可变 vX.Y.Z Stable Tag
-  -> 基于同一制品创建 GitHub Release 草稿
   -> 等待 Production 人工批准
   -> 生产数据备份与 migration
   -> 部署同一版本的 Portal/后端制品
   -> 上传正式 APK，但暂不更新公开入口
   -> 生产冒烟
+  -> 基于同一制品创建 GitHub Release 草稿并上传完整资产
   -> 原子更新 Portal APK 下载入口
-  -> 发布 GitHub Release 与部署记录
+  -> 校验公开 APK、更新日志与同一发布时间
+  -> 发布不可变 vX.Y.Z Tag、GitHub Release 与部署记录
 ```
 
 任一自动化检查失败时流程停止。没有人工批准时，生产环境不发生变化。
@@ -245,9 +245,9 @@ Candidate 不创建、模拟或要求 `vX.Y.Z` Stable Tag。
 镜像可使用语义版本标签方便识别，但部署必须引用 digest，不能引用可变
 `latest`。
 
-当前 #999 对应 PR 只构建并上传上述制品，不创建 Stable Tag 或 GitHub Release，
-不部署 Staging 或 Production，也不更新公开 changelog 或 Production 当前版本
-指针。Staging 验收、正式发布和 Production 提升属于后续独立任务。
+Release Candidate 只构建并上传上述制品，不提前创建 Stable Tag 或 GitHub
+Release。独立 Staging Workflow 自动部署同一 Candidate；Production Workflow 在
+Staging 成功后进入 Environment 人工审批，批准后才取得生产凭证并继续正式发布。
 
 Android 正式签名采用以下已确认边界：
 
@@ -283,9 +283,10 @@ Tag；保留的 Stable Tag 校验会继续检查运行时本地/远端集合、T
 
 ### 7.3 Staging 与 Production Deploy
 
-Release Candidate Workflow 本身不调用 Staging 或 Production 部署入口。独立的
-Staging Workflow 仅在由官方 `main` 的 `push` 触发的 Candidate 成功后自动部署
-同一制品；Production 仍由后续独立流程和人工批准控制。
+Release Candidate Workflow 本身不直接执行部署。独立的 Staging Workflow 仅在
+由官方 `main` 的 `push` 触发的 Candidate 成功后自动部署同一制品；成功后独立
+Production Workflow 校验 Candidate 与 Staging 回执，并停在 GitHub Environment
+等待人工批准。
 
 Deploy Workflow 接收确定的 `version` 和 `environment`，读取 Release manifest
 后部署现有制品，不重新构建。
@@ -328,10 +329,21 @@ Release manifest 指向的同一 Production APK 完成安装、启动与生产 A
 Production 使用 GitHub Environment：
 
 - 必须由指定发布负责人批准。
-- 禁止部署发起人自行批准。
+- 当前单人发布阶段允许指定负责人批准自己发起的部署，但不能跳过显式批准；增加
+  第二位发布负责人后启用禁止自审。
 - 审批前不释放生产环境 SSH 凭证和 Secret。
 - 同一时间只允许一个生产部署。
-- 只允许正式版本 Tag 部署。
+- 只允许官方 `main` 的已验证 Candidate 部署；Stable Tag 只在 Production 成功、
+  APK 公开入口校验完成后由 Workflow 创建。
+
+Production 部署成功后的发布顺序固定为：创建或复用 Release 草稿、上传并校验全部
+正式资产、通过受限 broker 激活 APK 指针、公网校验 APK 和 changelog、最后发布
+GitHub Release。仓库启用 immutable releases，`v*.*.*` Tag ruleset 禁止更新和
+删除。GitHub Actions 只获准创建新 Tag，不能修改历史 Tag。
+
+同一 Production workflow run 的后续 attempt 可以复用已成功的相同部署回执，
+只执行只读 verify，不重复备份、migration 或容器重启。不同 workflow run、不同
+Candidate、不同 Staging 回执或不同 bundle 均 fail closed。
 
 ### 7.4 备份任务
 
@@ -546,7 +558,7 @@ Portal 报名和访问事件继续使用独立 SQLite。它与产品核心业务
 - [ ] PR Gate 全绿。
 - [ ] Candidate 来自官方 `main` 精确 SHA，version、versionCode、SHA 和 run ID
       已记录。
-- [ ] 进入正式发布阶段后，Stable Tag、commit 和版本一致。
+- [ ] Production 成功后，Stable Tag、commit 和版本一致且不可修改。
 - [ ] Portal/后端镜像 digest 已记录。
 - [ ] APK 签名、版本、架构和 SHA-256 正确。
 - [ ] Staging migration、健康检查和真实供应商冒烟通过。

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -339,7 +339,8 @@ Production 使用 GitHub Environment：
 Production 部署成功后的发布顺序固定为：创建或复用 Release 草稿、上传并校验全部
 正式资产、通过受限 broker 激活 APK 指针、公网校验 APK 和 changelog、最后发布
 GitHub Release。仓库启用 immutable releases，`v*.*.*` Tag ruleset 禁止更新和
-删除。GitHub Actions 只获准创建新 Tag，不能修改历史 Tag。
+删除。Production job 仅在 Environment 批准后取得 `contents: write` 并创建新
+Tag；已发布的历史 Tag 不能移动或删除。
 
 同一 Production workflow run 的后续 attempt 可以复用已成功的相同部署回执，
 只执行只读 verify，不重复备份、migration 或容器重启。不同 workflow run、不同

--- a/docs/android-release-deployment-plan.md
+++ b/docs/android-release-deployment-plan.md
@@ -252,8 +252,8 @@ Staging 成功后进入 Environment 人工审批，批准后才取得生产凭�
 Android 正式签名采用以下已确认边界：
 
 - GitHub Environment 固定为 `android-release-signing`。
-- Required reviewer 为 `Lq0412`；当前单人发布阶段允许本人审核，未来增加独立
-  发布负责人后再启用禁止自审。
+- 不设置 Required reviewer，避免在 Candidate 构建阶段提前暂停；唯一人工发布
+  审批保留在后续 `production` Environment。
 - 正式签名证书 Owner 为 `Lq0412`。
 - 证书与密码均保存两份：团队密码管理器一份、离线加密备份一份，不能只保存在
   GitHub Secret。
@@ -261,9 +261,8 @@ Android 正式签名采用以下已确认边界：
   Runner；构建结束后删除，不进入 Artifact、日志或仓库。
 
 首次运行前，管理员必须先创建该 Environment，将 Deployment branches and tags
-设为 Selected branches and tags，并至少允许 Branch pattern `main`，同时配置
-Required reviewer；随后才能添加以下 Environment Secrets。后续正式 Tag 流程仍可
-保留 Tag pattern `v*.*.*`：
+设为 Selected branches and tags，并且只允许 Branch pattern `main`；随后才能添加
+以下 Environment Secrets。Candidate 的正式签名不需要 Tag pattern：
 
 - `SPEAKUP_ANDROID_KEYSTORE_BASE64`
 - `SPEAKUP_ANDROID_KEY_ALIAS`
@@ -271,10 +270,9 @@ Required reviewer；随后才能添加以下 Environment Secrets。后续正式 
 - `SPEAKUP_ANDROID_KEY_PASSWORD`
 - `SPEAKUP_ANDROID_CERT_SHA256`
 
-如果 `android-release-signing` 仍只允许 Tag pattern `v*.*.*`，由 `main` 的
-`push` 触发的 Candidate 将无法进入签名 job 或取得 Environment Secrets。本 PR
-不修改 Environment 保护规则；实际运行前必须由管理员确认 `main` 已获准，不能
-通过移出 Environment 或复制 Secrets 绕过该门禁。
+如果 `android-release-signing` 没有允许 `main`，由 `main` 的 `push` 触发的
+Candidate 将无法进入签名 job 或取得 Environment Secrets。不能通过移出
+Environment 或复制 Secrets 绕过该边界。
 
 正式 Tag 还需要单独的 Tag ruleset 禁止更新和删除。Candidate Workflow 不创建
 Tag；保留的 Stable Tag 校验会继续检查运行时本地/远端集合、Tag 格式、commit、

--- a/server/cmd/production-broker/main.go
+++ b/server/cmd/production-broker/main.go
@@ -27,7 +27,9 @@ const (
 	protocolVersion      = 1
 	officialRepository   = "1024XEngineer/XE3-ESL"
 	productionManagePath = "/opt/xe3-speakup-production-control/current/deploy/production/manage.sh"
+	androidManagePath    = "/opt/xe3-speakup-production-control/current/deploy/android-download/manage.sh"
 	productionEnvFile    = "/etc/speakup/production.env"
+	productionPublicRoot = "/var/www/speakup-production-public"
 	productionStateDir   = "/var/lib/speakup/production-broker"
 	productionLockFile   = "/run/lock/xe3-speakup-production-broker/broker.lock"
 	productionPATH       = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -53,7 +55,9 @@ type commandRunner func(context.Context, string, []string, []string) error
 type Config struct {
 	Repository     string
 	ManagePath     string
+	AndroidPath    string
 	Environment    string
+	PublicRoot     string
 	StateDir       string
 	LockFile       string
 	PATH           string
@@ -89,6 +93,7 @@ type request struct {
 	ManifestSHA256               string
 	StagingReceiptSHA256         string
 	BundleManifestSHA256         string
+	Version                      string
 }
 
 type releaseManifest struct {
@@ -215,7 +220,9 @@ func productionConfig() (Config, error) {
 	return Config{
 		Repository:     officialRepository,
 		ManagePath:     productionManagePath,
+		AndroidPath:    androidManagePath,
 		Environment:    productionEnvFile,
+		PublicRoot:     productionPublicRoot,
 		StateDir:       productionStateDir,
 		LockFile:       productionLockFile,
 		PATH:           productionPATH,
@@ -285,10 +292,17 @@ func execute(ctx context.Context, input io.Reader, config Config) (response, err
 		}
 		return response{ProtocolVersion: protocolVersion, OK: true, Action: "inspect", CurrentReceiptSHA256: currentSHA, Receipt: *current}, nil
 	}
-	if req.Action != "deploy" || req.Repository != config.Repository {
+	if req.Repository != config.Repository {
 		return response{}, failure("invalid_request")
 	}
-	return deploy(ctx, store, config, payload, req, *current, currentSHA)
+	switch req.Action {
+	case "deploy":
+		return deploy(ctx, store, config, payload, req, *current, currentSHA)
+	case "release":
+		return release(ctx, store, config, payload, req, *current, currentSHA)
+	default:
+		return response{}, failure("invalid_request")
+	}
 }
 
 func deploy(ctx context.Context, store *stateStore, config Config, payload extractedPayload, req request, current auditReceipt, currentSHA string) (response, error) {
@@ -326,6 +340,16 @@ func deploy(ctx context.Context, store *stateStore, config Config, payload extra
 	currentEnginePath, currentEngine, err := store.loadEngine(current.ProductionEngineReceiptSHA256)
 	if err != nil || !engineMatchesAudit(currentEngine, current) {
 		return response{}, failure("state_invalid")
+	}
+	if deploymentAlreadySucceeded(current, manifest, req) {
+		verifyContext, cancel := context.WithTimeout(ctx, config.RequestTimeout)
+		defer cancel()
+		arguments := []string{"verify", "--manifest", manifestPath, "--env-file", config.Environment}
+		environment := []string{"HOME=/root", "PATH=" + config.PATH}
+		if err := config.RunCommand(verifyContext, config.ManagePath, arguments, environment); err != nil {
+			return response{}, failure("operation_failed")
+		}
+		return response{ProtocolVersion: protocolVersion, OK: true, Action: "deploy", CurrentReceiptSHA256: currentSHA, Receipt: current}, nil
 	}
 	if req.CandidateRunID == valueOrZero(current.CandidateRunID) || manifest.VersionCode <= current.VersionCode {
 		return response{}, failure("release_not_newer")
@@ -393,6 +417,86 @@ func deploy(ctx context.Context, store *stateStore, config Config, payload extra
 		return response{}, failure("state_invalid")
 	}
 	return response{ProtocolVersion: protocolVersion, OK: true, Action: "deploy", CurrentReceiptSHA256: newSHA, Receipt: newReceipt}, nil
+}
+
+func deploymentAlreadySucceeded(current auditReceipt, manifest releaseManifest, req request) bool {
+	return current.Operation == "deploy" &&
+		current.CandidateRunID != nil && *current.CandidateRunID == req.CandidateRunID &&
+		current.StagingRunID != nil && *current.StagingRunID == req.StagingRunID &&
+		current.StagingRunAttempt != nil && *current.StagingRunAttempt == req.StagingRunAttempt &&
+		current.StagingReceiptSHA256 != nil && *current.StagingReceiptSHA256 == req.StagingReceiptSHA256 &&
+		current.DeploymentRunID != nil && *current.DeploymentRunID == req.DeploymentRunID &&
+		current.DeploymentRunAttempt != nil && *current.DeploymentRunAttempt <= req.DeploymentRunAttempt &&
+		current.ManifestSHA256 == manifest.SHA256 && current.Version == manifest.Version &&
+		current.VersionCode == manifest.VersionCode && current.GitSHA == manifest.GitSHA &&
+		current.DatabaseSchemaVersion == manifest.DatabaseSchemaVersion &&
+		current.PortalImageDigest == manifest.PortalImageDigest &&
+		current.ServerImageDigest == manifest.ServerImageDigest &&
+		current.ProductionAPKFile == manifest.ProductionAPKFile &&
+		current.ProductionAPKSHA256 == manifest.ProductionAPKSHA256 &&
+		current.APKCertificateSHA256 == manifest.APKCertificateSHA256 &&
+		current.AndroidBundleManifestSHA256 != nil &&
+		*current.AndroidBundleManifestSHA256 == req.BundleManifestSHA256
+}
+
+func release(ctx context.Context, store *stateStore, config Config, payload extractedPayload, req request, current auditReceipt, currentSHA string) (response, error) {
+	if len(payload.files) != 1 || payload.files["request.json"] == "" ||
+		req.ExpectedCurrentReceiptSHA256 == nil || *req.ExpectedCurrentReceiptSHA256 != currentSHA {
+		return response{}, failure("state_conflict")
+	}
+	if err := store.requireNoPending(); err != nil {
+		return response{}, err
+	}
+	if current.Operation != "deploy" || current.DeploymentRunID == nil ||
+		*current.DeploymentRunID != req.DeploymentRunID || current.DeploymentRunAttempt == nil ||
+		*current.DeploymentRunAttempt > req.DeploymentRunAttempt ||
+		current.ManifestSHA256 != req.ManifestSHA256 || current.Version != req.Version ||
+		current.AndroidBundleManifestSHA256 == nil ||
+		*current.AndroidBundleManifestSHA256 != req.BundleManifestSHA256 {
+		return response{}, failure("invalid_request")
+	}
+	releaseContext, cancel := context.WithTimeout(ctx, config.RequestTimeout)
+	defer cancel()
+	arguments := []string{"activate", "--root", config.PublicRoot, "--version", current.Version}
+	environment := []string{"HOME=/root", "PATH=" + config.PATH}
+	if err := config.RunCommand(releaseContext, config.AndroidPath, arguments, environment); err != nil {
+		return response{}, failure("operation_failed")
+	}
+	metadataPath := filepath.Join(config.PublicRoot, "downloads", "android", "release.json")
+	metadataContents, err := readSecureFile(metadataPath, 0o644, metadataLimit, config.OwnerUID)
+	if err != nil || !publicReleaseMatchesAudit(metadataContents, current) {
+		return response{}, failure("operation_failed")
+	}
+	return response{ProtocolVersion: protocolVersion, OK: true, Action: "release", CurrentReceiptSHA256: currentSHA, Receipt: current}, nil
+}
+
+func publicReleaseMatchesAudit(contents []byte, current auditReceipt) bool {
+	value, err := decodeStrictJSON(contents)
+	if err != nil {
+		return false
+	}
+	object, ok := value.(map[string]any)
+	if !ok || !hasExactKeys(object,
+		"metadata_version", "version", "version_code", "published_at", "file_name",
+		"download_path", "size_bytes", "minimum_android_api", "abis", "apk_sha256",
+		"apk_certificate_sha256") {
+		return false
+	}
+	version, versionOK := object["version"].(string)
+	versionCode, codeOK := positiveSafeInteger(object["version_code"])
+	fileName, fileOK := object["file_name"].(string)
+	downloadPath, pathOK := object["download_path"].(string)
+	_, sizeOK := positiveSafeInteger(object["size_bytes"])
+	apkSHA, apkOK := object["apk_sha256"].(string)
+	certificate, certificateOK := object["apk_certificate_sha256"].(string)
+	abis, abisOK := object["abis"].([]any)
+	return object["metadata_version"] == json.Number("1") && versionOK && version == current.Version &&
+		codeOK && versionCode == current.VersionCode && validTimestampValue(object["published_at"]) &&
+		fileOK && fileName == current.ProductionAPKFile && pathOK &&
+		downloadPath == "/downloads/android/v"+current.Version+"/"+current.ProductionAPKFile &&
+		sizeOK && object["minimum_android_api"] == json.Number("24") &&
+		abisOK && len(abis) == 1 && abis[0] == "arm64-v8a" && apkOK &&
+		apkSHA == current.ProductionAPKSHA256 && certificateOK && certificate == current.APKCertificateSHA256
 }
 
 func deploymentAudit(config Config, req request, manifest releaseManifest, engine engineReceipt, previous string, engineSHA string) auditReceipt {
@@ -487,10 +591,10 @@ func runCommand(ctx context.Context, name string, arguments []string, environmen
 }
 
 func validateConfig(config Config) error {
-	if config.Repository != officialRepository || config.ManagePath == "" || config.Environment == "" || config.StateDir == "" || config.LockFile == "" || config.PATH == "" || config.Now == nil || config.RunCommand == nil || config.RequestTimeout <= 0 || config.DeployTimeout <= 0 {
+	if config.Repository != officialRepository || config.ManagePath == "" || config.AndroidPath == "" || config.Environment == "" || config.PublicRoot == "" || config.StateDir == "" || config.LockFile == "" || config.PATH == "" || config.Now == nil || config.RunCommand == nil || config.RequestTimeout <= 0 || config.DeployTimeout <= 0 {
 		return failure("invalid_configuration")
 	}
-	for _, value := range []string{config.ManagePath, config.Environment, config.StateDir, config.LockFile} {
+	for _, value := range []string{config.ManagePath, config.AndroidPath, config.Environment, config.PublicRoot, config.StateDir, config.LockFile} {
 		if !safeAbsolutePath(value) {
 			return failure("invalid_configuration")
 		}
@@ -629,6 +733,41 @@ func parseRequest(contents []byte) (request, error) {
 		if !hasExactKeys(object, "protocol_version", "action") {
 			return request{}, failure("invalid_request")
 		}
+		return parsed, nil
+	}
+	if action == "release" {
+		if !hasExactKeys(object,
+			"protocol_version", "action", "repository", "deployment_run_id",
+			"deployment_run_attempt", "expected_current_receipt_sha256",
+			"manifest_sha256", "bundle_manifest_sha256", "version") {
+			return request{}, failure("invalid_request")
+		}
+		parsed.Repository, ok = object["repository"].(string)
+		if !ok || parsed.Repository != officialRepository {
+			return request{}, failure("invalid_request")
+		}
+		parsed.DeploymentRunID, ok = positiveSafeInteger(object["deployment_run_id"])
+		if !ok {
+			return request{}, failure("invalid_request")
+		}
+		parsed.DeploymentRunAttempt, ok = positiveSafeInteger(object["deployment_run_attempt"])
+		if !ok {
+			return request{}, failure("invalid_request")
+		}
+		expected, expectedOK := object["expected_current_receipt_sha256"].(string)
+		manifestSHA, manifestOK := object["manifest_sha256"].(string)
+		bundleSHA, bundleOK := object["bundle_manifest_sha256"].(string)
+		version, versionOK := object["version"].(string)
+		if !expectedOK || !validNonzeroSHA256(expected) ||
+			!manifestOK || !validNonzeroSHA256(manifestSHA) ||
+			!bundleOK || !validNonzeroSHA256(bundleSHA) ||
+			!versionOK || !versionPattern.MatchString(version) {
+			return request{}, failure("invalid_request")
+		}
+		parsed.ExpectedCurrentReceiptSHA256 = &expected
+		parsed.ManifestSHA256 = manifestSHA
+		parsed.BundleManifestSHA256 = bundleSHA
+		parsed.Version = version
 		return parsed, nil
 	}
 	if action != "deploy" || !hasExactKeys(object,

--- a/server/cmd/production-broker/main_test.go
+++ b/server/cmd/production-broker/main_test.go
@@ -14,11 +14,26 @@ import (
 )
 
 type recordingRunner struct {
-	calls [][]string
+	calls           [][]string
+	releaseMetadata []byte
 }
 
 func (runner *recordingRunner) run(_ context.Context, _ string, arguments []string, _ []string) error {
 	runner.calls = append(runner.calls, append([]string(nil), arguments...))
+	if len(arguments) == 0 {
+		return nil
+	}
+	switch arguments[0] {
+	case "verify":
+		return nil
+	case "activate":
+		root := argumentValue(arguments, "--root")
+		metadataPath := filepath.Join(root, "downloads", "android", "release.json")
+		if err := os.MkdirAll(filepath.Dir(metadataPath), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(metadataPath, runner.releaseMetadata, 0o644)
+	}
 	manifestPath := argumentValue(arguments, "--manifest")
 	currentPath := argumentValue(arguments, "--current-receipt")
 	receiptPath := argumentValue(arguments, "--receipt")
@@ -53,7 +68,9 @@ func newTestConfig(t *testing.T, runner *recordingRunner) Config {
 	return Config{
 		Repository:     officialRepository,
 		ManagePath:     filepath.Join(root, "fixed", "manage.sh"),
+		AndroidPath:    filepath.Join(root, "fixed", "android-manage.sh"),
 		Environment:    filepath.Join(root, "fixed", "production.env"),
+		PublicRoot:     filepath.Join(root, "public"),
 		StateDir:       filepath.Join(root, "state"),
 		LockFile:       filepath.Join(lockDir, "broker.lock"),
 		PATH:           productionPATH,
@@ -158,8 +175,14 @@ func stagingResponseJSON(manifest releaseManifest, candidateRunID, stagingRunID 
 	return contents
 }
 
-func deploymentPayload(t *testing.T, currentSHA string, mutateStaging bool) []byte {
+func deploymentPayload(t *testing.T, currentSHA string, mutateStaging bool, attempts ...int64) []byte {
 	t.Helper()
+	attempt := int64(1)
+	if len(attempts) == 1 {
+		attempt = attempts[0]
+	} else if len(attempts) > 1 {
+		t.Fatal("deploymentPayload accepts at most one attempt")
+	}
 	manifestContents := manifestJSON("0.1.8", 9, 124)
 	manifest, err := parseReleaseManifest(manifestContents, 124)
 	if err != nil {
@@ -194,7 +217,7 @@ func deploymentPayload(t *testing.T, currentSHA string, mutateStaging bool) []by
 	bundleManifest, _ := json.Marshal(map[string]any{"bundle_version": 1, "version": manifest.Version, "published_at": published, "release_manifest_sha256": manifest.SHA256, "files": entries})
 	requestContents, _ := json.Marshal(map[string]any{
 		"protocol_version": 1, "action": "deploy", "repository": officialRepository, "candidate_run_id": 124,
-		"staging_run_id": 700, "staging_run_attempt": 1, "deployment_run_id": 800, "deployment_run_attempt": 1,
+		"staging_run_id": 700, "staging_run_attempt": 1, "deployment_run_id": 800, "deployment_run_attempt": attempt,
 		"expected_current_receipt_sha256": currentSHA, "manifest_sha256": manifest.SHA256,
 		"staging_receipt_sha256": sha256Bytes(stagingContents), "bundle_manifest_sha256": sha256Bytes(bundleManifest),
 	})
@@ -233,6 +256,35 @@ func tarPayload(t *testing.T, files map[string][]byte) []byte {
 
 func inspectPayload(t *testing.T) []byte {
 	return tarPayload(t, map[string][]byte{"request.json": []byte(`{"protocol_version":1,"action":"inspect"}`)})
+}
+
+func releasePayload(t *testing.T, deployed response, attempt int64) []byte {
+	t.Helper()
+	requestContents, err := json.Marshal(map[string]any{
+		"protocol_version": 1, "action": "release", "repository": officialRepository,
+		"deployment_run_id": 800, "deployment_run_attempt": attempt,
+		"expected_current_receipt_sha256": deployed.CurrentReceiptSHA256,
+		"manifest_sha256":                 deployed.Receipt.ManifestSHA256,
+		"bundle_manifest_sha256":          *deployed.Receipt.AndroidBundleManifestSHA256,
+		"version":                         deployed.Receipt.Version,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tarPayload(t, map[string][]byte{"request.json": requestContents})
+}
+
+func releaseMetadata(receipt auditReceipt) []byte {
+	value := map[string]any{
+		"metadata_version": 1, "version": receipt.Version, "version_code": receipt.VersionCode,
+		"published_at": "2026-08-26T09:05:00Z", "file_name": receipt.ProductionAPKFile,
+		"download_path": "/downloads/android/v" + receipt.Version + "/" + receipt.ProductionAPKFile,
+		"size_bytes":    int64(len("signed-production-apk\n")), "minimum_android_api": 24,
+		"abis": []string{"arm64-v8a"}, "apk_sha256": receipt.ProductionAPKSHA256,
+		"apk_certificate_sha256": receipt.APKCertificateSHA256,
+	}
+	contents, _ := json.Marshal(value)
+	return contents
 }
 
 func TestInspectAndDeploySameCandidateEvidence(t *testing.T) {
@@ -279,6 +331,65 @@ func TestRejectsMismatchedStagingReceiptBeforeManage(t *testing.T) {
 	}
 	if len(runner.calls) != 0 {
 		t.Fatal("manage ran for mismatched Staging evidence")
+	}
+}
+
+func TestRetryReturnsExistingDeploymentWithoutRedeploying(t *testing.T) {
+	runner := &recordingRunner{}
+	config := newTestConfig(t, runner)
+	initializeTestState(t, config)
+	initial, _ := execute(context.Background(), bytes.NewReader(inspectPayload(t)), config)
+	deployed, err := execute(context.Background(), bytes.NewReader(deploymentPayload(t, initial.CurrentReceiptSHA256, false)), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retried, err := execute(context.Background(), bytes.NewReader(deploymentPayload(t, deployed.CurrentReceiptSHA256, false, 2)), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retried.CurrentReceiptSHA256 != deployed.CurrentReceiptSHA256 || len(runner.calls) != 2 || runner.calls[1][0] != "verify" {
+		t.Fatalf("retry response = %#v, calls = %#v", retried, runner.calls)
+	}
+}
+
+func TestReleaseActivatesOnlyTheDeployedAPK(t *testing.T) {
+	runner := &recordingRunner{}
+	config := newTestConfig(t, runner)
+	initializeTestState(t, config)
+	initial, _ := execute(context.Background(), bytes.NewReader(inspectPayload(t)), config)
+	deployed, err := execute(context.Background(), bytes.NewReader(deploymentPayload(t, initial.CurrentReceiptSHA256, false)), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.releaseMetadata = releaseMetadata(deployed.Receipt)
+	released, err := execute(context.Background(), bytes.NewReader(releasePayload(t, deployed, 1)), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released.Action != "release" || released.CurrentReceiptSHA256 != deployed.CurrentReceiptSHA256 || len(runner.calls) != 2 || runner.calls[1][0] != "activate" {
+		t.Fatalf("release response = %#v, calls = %#v", released, runner.calls)
+	}
+
+	if _, err := execute(context.Background(), bytes.NewReader(releasePayload(t, deployed, 2)), config); err != nil {
+		t.Fatalf("idempotent release failed: %v", err)
+	}
+	if len(runner.calls) != 3 || runner.calls[2][0] != "activate" {
+		t.Fatalf("release retry calls = %#v", runner.calls)
+	}
+}
+
+func TestReleaseRejectsMismatchedPublicMetadata(t *testing.T) {
+	runner := &recordingRunner{releaseMetadata: []byte(`{"metadata_version":1}`)}
+	config := newTestConfig(t, runner)
+	initializeTestState(t, config)
+	initial, _ := execute(context.Background(), bytes.NewReader(inspectPayload(t)), config)
+	deployed, err := execute(context.Background(), bytes.NewReader(deploymentPayload(t, initial.CurrentReceiptSHA256, false)), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = execute(context.Background(), bytes.NewReader(releasePayload(t, deployed, 1)), config)
+	if err == nil || errorCode(err) != "operation_failed" {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/tools/production-deploy/production-deploy.test.mjs
+++ b/tools/production-deploy/production-deploy.test.mjs
@@ -53,10 +53,12 @@ test("Production mutation waits for Environment approval and uses only the broke
   assert.match(workflow, /tar --format=ustar --no-recursion/);
   assert.match(workflow, /action:\s*"inspect"/);
   assert.match(workflow, /action:\s*"deploy"/);
+  assert.match(workflow, /action:\s*"release"/);
   assert.match(workflow, /expected_current_receipt_sha256/);
   assert.match(workflow, /production_engine_previous_receipt_sha256/);
   assert.doesNotMatch(workflow, /deploy\/production\/manage\.sh/);
-  assert.doesNotMatch(workflow, /contents:\s*write|packages:\s*write/);
+  assert.match(workflow, /permissions:\n\s+actions: read\n\s+contents: write/);
+  assert.doesNotMatch(workflow, /packages:\s*write/);
 });
 
 test("Production deploy preserves auditable evidence and performs public smoke", () => {
@@ -68,6 +70,23 @@ test("Production deploy preserves auditable evidence and performs public smoke",
   );
   assert.match(workflow, /retention-days: 90/);
   assert.match(workflow, /Remove the Production SSH identity/);
+});
+
+test("Production finalization is ordered, complete, immutable, and retryable", () => {
+  assert.match(workflow, /tools\/release-finalize\/notes\.mjs/);
+  assert.match(workflow, /--published-at "\$PUBLISHED_AT"/);
+  assert.match(workflow, /Prepare the complete GitHub Release draft/);
+  assert.match(workflow, /gh release upload "\$tag"/);
+  assert.match(workflow, /Activate the approved APK through the restricted broker/);
+  assert.match(workflow, /Verify the public APK and changelog contract/);
+  assert.match(workflow, /Publish and verify the immutable GitHub Release/);
+  assert.match(workflow, /\.immutable == true/);
+  assert.match(workflow, /\.receipt\.deployment_run_attempt[\s\S]*<= \$deployment_run_attempt/);
+
+  const draft = workflow.indexOf("Prepare the complete GitHub Release draft");
+  const activate = workflow.indexOf("Activate the approved APK");
+  const publish = workflow.indexOf("Publish and verify the immutable GitHub Release");
+  assert.ok(draft > 0 && draft < activate && activate < publish);
 });
 
 test("Every external action is pinned to a full commit", () => {

--- a/tools/release-finalize/notes.mjs
+++ b/tools/release-finalize/notes.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { lstatSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  parseAndroidReleaseNotes,
+  parseAndroidReleaseNotesIndex,
+} from "../../portal/lib/android-release-notes.mjs";
+
+const headings = new Map([
+  ["feature", "新功能"],
+  ["improvement", "体验优化"],
+  ["fix", "问题修复"],
+  ["compatibility", "兼容性"],
+  ["known_limitation", "已知限制"],
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readJson(file, name) {
+  let status;
+  try {
+    status = lstatSync(file);
+  } catch {
+    fail(`${name} does not exist`);
+  }
+  if (status.isSymbolicLink() || !status.isFile() || status.size < 1) {
+    fail(`${name} must be a non-empty regular file`);
+  }
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    fail(`${name} is not valid JSON`);
+  }
+}
+
+export function finalizeReleaseNotes({ version, notes, index }) {
+  const parsedNotes = parseAndroidReleaseNotes(notes);
+  const parsedIndex = parseAndroidReleaseNotesIndex(index);
+  if (parsedNotes.version !== version || parsedIndex.versions[0] !== version) {
+    fail("current Android release notes do not match the Candidate version");
+  }
+
+  const changes = new Map();
+  for (const change of parsedNotes.changes) {
+    if (!changes.has(change.type)) changes.set(change.type, []);
+    changes.get(change.type).push(change.text);
+  }
+
+  const lines = [
+    `# SpeakUp Android v${version}`,
+    "",
+    `发布时间：${parsedNotes.published_at}`,
+  ];
+  for (const [type, heading] of headings) {
+    const entries = changes.get(type);
+    if (!entries) continue;
+    lines.push("", `## ${heading}`, "", ...entries.map((text) => `- ${text}`));
+  }
+  lines.push("", "## 下载校验", "", "本 Release 附带正式签名 APK、SHA-256 校验文件和发布审计制品。", "");
+  return { body: lines.join("\n"), publishedAt: parsedNotes.published_at };
+}
+
+function parseArguments(arguments_) {
+  const values = new Map();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const name = arguments_[index];
+    const value = arguments_[index + 1];
+    if (!name?.startsWith("--") || value === undefined || values.has(name)) {
+      fail("invalid arguments");
+    }
+    values.set(name, value);
+  }
+  const expected = ["--index", "--notes", "--output", "--version"];
+  if (
+    values.size !== expected.length ||
+    expected.some((name) => !values.has(name))
+  ) {
+    fail("required arguments: --version --notes --index --output");
+  }
+  return values;
+}
+
+function main() {
+  const values = parseArguments(process.argv.slice(2));
+  const result = finalizeReleaseNotes({
+    version: values.get("--version"),
+    notes: readJson(values.get("--notes"), "release notes"),
+    index: readJson(values.get("--index"), "release notes index"),
+  });
+  writeFileSync(values.get("--output"), result.body, { flag: "wx", mode: 0o600 });
+  process.stdout.write(`${result.publishedAt}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tools/release-finalize/notes.test.mjs
+++ b/tools/release-finalize/notes.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { finalizeReleaseNotes } from "./notes.mjs";
+
+const notes = {
+  release_notes_version: 1,
+  locale: "zh-CN",
+  version: "0.1.8",
+  published_at: "2026-08-27T10:00:00Z",
+  changes: [
+    { type: "fix", text: "修复报告生成失败的问题。" },
+    { type: "improvement", text: "缩短报告等待时间。" },
+  ],
+};
+const index = {
+  release_notes_index_version: 1,
+  locale: "zh-CN",
+  versions: ["0.1.8", "0.1.7"],
+};
+
+test("renders deterministic release notes for the current indexed version", () => {
+  const result = finalizeReleaseNotes({ version: "0.1.8", notes, index });
+  assert.equal(result.publishedAt, notes.published_at);
+  assert.match(result.body, /^# SpeakUp Android v0\.1\.8/m);
+  assert.match(result.body, /## 体验优化\n\n- 缩短报告等待时间。/);
+  assert.match(result.body, /## 问题修复\n\n- 修复报告生成失败的问题。/);
+  assert.ok(result.body.indexOf("体验优化") < result.body.indexOf("问题修复"));
+});
+
+test("rejects notes that are not the current indexed version", () => {
+  assert.throws(
+    () =>
+      finalizeReleaseNotes({
+        version: "0.1.8",
+        notes,
+        index: { ...index, versions: ["0.1.9", "0.1.8"] },
+      }),
+    /do not match the Candidate version/,
+  );
+});


### PR DESCRIPTION
## 功能描述

完成 Production 部署成功后的正式发布收口，并保持所有生产变更位于 `production` Environment 人工审批之后：

- 同一 Production workflow run 重跑时复用已成功部署，不重复备份、迁移或重启。
- 严格校验当前版本中文更新说明，并让 APK 元数据与 GitHub Release 使用同一发布时间。
- Production 冒烟后创建/复用 Release 草稿，上传并校验正式 APK、SHA-256、manifest、Production 回执、公开元数据和更新说明。
- 通过受限 broker 原子激活官网下载指针，公网校验通过后才发布不可变 Tag/Release。
- 补充发布顺序、重试和权限合同文档。

## 实现思路

1. Production broker 新增固定 `release` 动作，只接受当前部署回执绑定的 version、manifest、bundle 和 workflow run，并调用快照内 Android 发布脚本。
2. 相同部署的更高 run attempt 只执行 `manage.sh verify`，返回原不可变回执。
3. Workflow 从 Candidate commit 读取 `release-notes/android`，生成确定性的中文 Release 正文与发布时间。
4. Release 草稿资产完整且 SHA-256/大小匹配后，才激活公开 APK；公开 APK、元数据、更新日志验证后，最后发布 Release 并验证 Tag 精确指向 Candidate SHA 且 Release 已 immutable。
5. `contents: write` 仅授予进入 `production` Environment 后的 deploy job；不会重建 APK 或镜像。

## 可复现测试

```sh
make check-production-deploy
cd server && go vet ./cmd/production-broker
git diff --check
```

已本地通过：

- Production workflow 合同 6/6
- Release notes 合同 2/2
- Production broker Go 单测与 go vet
- Production host access 合同
- Production 完整隔离部署合同
- Workflow YAML 与全部内嵌 Bash 语法检查

## 关联 Issue

Closes #1040
