### PR TITLE
chore(release): 准备 v0.1.8 候选版本

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.7+8
+version: 0.1.8+9
 
 environment:
   sdk: ^3.12.2

--- a/portal/public/release-notes/android/index.zh-CN.json
+++ b/portal/public/release-notes/android/index.zh-CN.json
@@ -1,5 +1,5 @@
 {
   "release_notes_index_version": 1,
   "locale": "zh-CN",
-  "versions": ["0.1.7", "0.1.4"]
+  "versions": ["0.1.8", "0.1.7", "0.1.4"]
 }

--- a/portal/public/release-notes/android/v0.1.8.zh-CN.json
+++ b/portal/public/release-notes/android/v0.1.8.zh-CN.json
@@ -1,0 +1,24 @@
+{
+  "release_notes_version": 1,
+  "locale": "zh-CN",
+  "version": "0.1.8",
+  "published_at": "2026-08-26T17:43:38Z",
+  "changes": [
+    {
+      "type": "feature",
+      "text": "在日常、职场、面试和 IELTS 练习中增加逐句纠错、润色与原声播放。"
+    },
+    {
+      "type": "fix",
+      "text": "修复 IELTS Speaking Part 2 说明阶段提前播放题目或出现双路语音的问题。"
+    },
+    {
+      "type": "fix",
+      "text": "修复未录到声音后重新录音可能无法发送或取消的问题。"
+    },
+    {
+      "type": "improvement",
+      "text": "优化 Android 底部导航选中状态、首页快捷入口布局和用户消息样式。"
+    }
+  ]
+}

--- a/portal/tests/android-release-notes.test.mjs
+++ b/portal/tests/android-release-notes.test.mjs
@@ -97,9 +97,34 @@ test("publishes an honest Android release history", () => {
   );
 
   assert.equal(parseAndroidReleaseNotesIndex(index), index);
-  assert.deepEqual(index.versions, ["0.1.7", "0.1.4"]);
-  assert.deepEqual(matchAndroidReleaseNotesHistory(release, index, notes), notes);
+  assert.deepEqual(index.versions, ["0.1.8", "0.1.7", "0.1.4"]);
+  const currentRelease = {
+    version: notes[0].version,
+    published_at: notes[0].published_at,
+  };
+  assert.deepEqual(
+    matchAndroidReleaseNotesHistory(currentRelease, index, notes),
+    notes,
+  );
   assert.deepEqual(notes[0].changes, [
+    {
+      type: "feature",
+      text: "在日常、职场、面试和 IELTS 练习中增加逐句纠错、润色与原声播放。",
+    },
+    {
+      type: "fix",
+      text: "修复 IELTS Speaking Part 2 说明阶段提前播放题目或出现双路语音的问题。",
+    },
+    {
+      type: "fix",
+      text: "修复未录到声音后重新录音可能无法发送或取消的问题。",
+    },
+    {
+      type: "improvement",
+      text: "优化 Android 底部导航选中状态、首页快捷入口布局和用户消息样式。",
+    },
+  ]);
+  assert.deepEqual(notes[1].changes, [
     {
       type: "fix",
       text: "修复断网后实时语音无法再次录音的问题。",
@@ -117,7 +142,7 @@ test("publishes an honest Android release history", () => {
       text: "修复进入历史练习时可能自动触发新回复的问题。",
     },
   ]);
-  assert.deepEqual(notes[1], validLegacyNotes());
+  assert.deepEqual(notes[2], validLegacyNotes());
 });
 
 test("parses strict Android release notes and their ordered index", () => {


### PR DESCRIPTION
## 功能描述

为下一次真实自动发布演练准备 Android `v0.1.8+9` 候选版本：更新 Flutter 版本号，并补充可供 GitHub Release、官网 APK 元数据与更新日志共同使用的中文发布说明。

## 实现思路

- 将移动端版本更新为 `0.1.8+9`。
- 新增 `v0.1.8.zh-CN.json`，记录本版本已经合入 `dev` 的用户可见功能与修复。
- 将 `v0.1.8` 放到发布说明索引首位。
- 更新发布说明契约测试，确保索引、版本、时间和内容一致。

本 PR 只准备候选版本，不部署 Staging 或 Production。合入 `dev` 后将另行创建 `dev → main` Release PR；只有该 Release PR 合入 `main` 才会触发自动构建和 Staging 部署。

## 可复现测试

```bash
node --test portal/tests/android-release-notes.test.mjs
make check-release-candidate
git diff --check
```

本地结果：发布说明测试 8/8 通过；Release Candidate 契约测试全部通过。

Closes #1042
