### PR TITLE
fix(release): 通过 Release ID 上传正式发布资产

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -608,6 +608,9 @@ jobs:
             ' <<<"$release" >/dev/null
           release_id="$(jq -er '.id' <<<"$release")"
           already_published="$(jq -er '(.draft | not)' <<<"$release")"
+          upload_url="$(jq -er '.upload_url | sub("\\{\\?name,label\\}$"; "")' <<<"$release")"
+          [[ "$upload_url" == \
+            "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id/assets" ]]
 
           expected_assets="$(printf '%s\n' \
             android-release.json \
@@ -623,13 +626,20 @@ jobs:
             done < <(gh api --paginate \
               "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \
               --jq '.[].id')
-            gh release upload "$tag" \
-              "$assets/android-release.json" \
-              "$assets/$apk" \
-              "$assets/$apk.sha256" \
-              "$assets/production-deployment-receipt.json" \
-              "$assets/release-manifest.json" \
-              "$assets/release-notes.zh-CN.json"
+            for file in "$assets"/*; do
+              name="$(basename "$file")"
+              curl \
+                --fail \
+                --silent \
+                --show-error \
+                --request POST \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer $GH_TOKEN" \
+                --header "Content-Type: application/octet-stream" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                --data-binary "@$file" \
+                "$upload_url?name=$name" >/dev/null
+            done
           fi
           actual_assets="$(gh api --paginate \
             "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \

--- a/tools/production-deploy/production-deploy.test.mjs
+++ b/tools/production-deploy/production-deploy.test.mjs
@@ -76,7 +76,13 @@ test("Production finalization is ordered, complete, immutable, and retryable", (
   assert.match(workflow, /tools\/release-finalize\/notes\.mjs/);
   assert.match(workflow, /--published-at "\$PUBLISHED_AT"/);
   assert.match(workflow, /Prepare the complete GitHub Release draft/);
-  assert.match(workflow, /gh release upload "\$tag"/);
+  assert.match(workflow, /\.upload_url \| sub/);
+  assert.match(
+    workflow,
+    /https:\/\/uploads\.github\.com\/repos\/\$GITHUB_REPOSITORY\/releases\/\$release_id\/assets/,
+  );
+  assert.match(workflow, /--data-binary "@\$file"/);
+  assert.doesNotMatch(workflow, /gh release upload/);
   assert.match(workflow, /Activate the approved APK through the restricted broker/);
   assert.match(workflow, /Verify the public APK and changelog contract/);
   assert.match(workflow, /Publish and verify the immutable GitHub Release/);


### PR DESCRIPTION
## 功能描述

- 修复 Production 工作流无法向尚未创建 Stable Tag 的草稿 Release 上传资产的问题。
- 通过创建 Release 返回并严格校验的 `upload_url` 与 `release_id` 上传六个不可变资产。
- 保持完整资产校验通过后才激活 APK、发布 Tag/Release 的 fail-closed 顺序。

## 实现思路

GitHub 官方 Upload a release asset API 以 `release_id` 为定位依据。工作流不再通过尚不存在的 `vX.Y.Z` Tag 二次查找草稿，而是校验 `upload_url` 必须精确属于当前仓库和当前 Release ID，再逐个上传已准备的固定资产。

## 可复现测试

```bash
node --test tools/production-deploy/production-deploy.test.mjs
git diff --check
```

- 结果：6/6 通过。

Closes #1046
