### PR TITLE
release: 合入 v0.1.8 正式发布资产上传修复

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -608,6 +608,9 @@ jobs:
             ' <<<"$release" >/dev/null
           release_id="$(jq -er '.id' <<<"$release")"
           already_published="$(jq -er '(.draft | not)' <<<"$release")"
+          upload_url="$(jq -er '.upload_url | sub("\\{\\?name,label\\}$"; "")' <<<"$release")"
+          [[ "$upload_url" == \
+            "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id/assets" ]]
 
           expected_assets="$(printf '%s\n' \
             android-release.json \
@@ -623,13 +626,20 @@ jobs:
             done < <(gh api --paginate \
               "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \
               --jq '.[].id')
-            gh release upload "$tag" \
-              "$assets/android-release.json" \
-              "$assets/$apk" \
-              "$assets/$apk.sha256" \
-              "$assets/production-deployment-receipt.json" \
-              "$assets/release-manifest.json" \
-              "$assets/release-notes.zh-CN.json"
+            for file in "$assets"/*; do
+              name="$(basename "$file")"
+              curl \
+                --fail \
+                --silent \
+                --show-error \
+                --request POST \
+                --header "Accept: application/vnd.github+json" \
+                --header "Authorization: Bearer $GH_TOKEN" \
+                --header "Content-Type: application/octet-stream" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                --data-binary "@$file" \
+                "$upload_url?name=$name" >/dev/null
+            done
           fi
           actual_assets="$(gh api --paginate \
             "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \

--- a/tools/production-deploy/production-deploy.test.mjs
+++ b/tools/production-deploy/production-deploy.test.mjs
@@ -76,7 +76,13 @@ test("Production finalization is ordered, complete, immutable, and retryable", (
   assert.match(workflow, /tools\/release-finalize\/notes\.mjs/);
   assert.match(workflow, /--published-at "\$PUBLISHED_AT"/);
   assert.match(workflow, /Prepare the complete GitHub Release draft/);
-  assert.match(workflow, /gh release upload "\$tag"/);
+  assert.match(workflow, /\.upload_url \| sub/);
+  assert.match(
+    workflow,
+    /https:\/\/uploads\.github\.com\/repos\/\$GITHUB_REPOSITORY\/releases\/\$release_id\/assets/,
+  );
+  assert.match(workflow, /--data-binary "@\$file"/);
+  assert.doesNotMatch(workflow, /gh release upload/);
   assert.match(workflow, /Activate the approved APK through the restricted broker/);
   assert.match(workflow, /Verify the public APK and changelog contract/);
   assert.match(workflow, /Publish and verify the immutable GitHub Release/);


### PR DESCRIPTION
## 功能描述

- 将已经审核通过的 v0.1.8 Production Release 资产上传修复从 `dev` 发布到 `main`。
- 修复草稿 Release 在 Stable Tag 创建前无法通过 Tag 路径上传资产的问题。

## 实现思路

- 使用 GitHub Create Release 返回并严格验证的 `upload_url`/`release_id`。
- 六个固定资产全部上传并按名称、大小、SHA-256 复核后，才允许激活 APK、发布 Tag 和冻结 Release。
- 保持 Staging 成功与 Production 人工审批门禁不变。

## 可复现测试

- PR #1047 Deployment contracts：通过。
- Quality gate：通过。
- 人工 Review：等待至少一位合格 Reviewer 批准。
- AI Review：无可操作问题。

Closes #1046