### PR TITLE
ops(experiment): 验证国内后端延迟与快速切换能力

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -416,6 +416,12 @@ jobs:
             quay.io/prometheus/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893 \
             check config /etc/prometheus/prometheus.yml
           docker run --rm \
+            --volume "$PWD/deploy/experiments/cn-backend/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
+            --volume "$PWD/deploy/experiments/cn-backend/observability/rules.yml:/etc/prometheus/rules.yml:ro" \
+            --entrypoint promtool \
+            quay.io/prometheus/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893 \
+            check config /etc/prometheus/prometheus.yml
+          docker run --rm \
             --volume "$PWD/deploy/observability/alertmanager.example.yml:/etc/alertmanager/alertmanager.yml:ro" \
             --entrypoint amtool \
             quay.io/prometheus/alertmanager:v0.34.0@sha256:690c7b525f4367aa91f73e2f91c632206d32e97c6384bdbf2fb7a861b420340d \
@@ -431,12 +437,17 @@ jobs:
           sudo install -D -m 0755 \
             deploy/observability/xe3-speakup-export-metrics \
             /usr/local/sbin/xe3-speakup-export-metrics
+          sudo install -D -m 0755 \
+            deploy/experiments/cn-backend/observability/export-host-metrics.sh \
+            /usr/local/sbin/xe3-speakup-cn-experiment-export-metrics
           sudo install -D -m 0600 \
             deploy/observability/observability-metrics.env.example \
             /etc/speakup/observability-metrics.env
           systemd-analyze verify \
             deploy/observability/xe3-speakup-observability-metrics.service \
-            deploy/observability/xe3-speakup-observability-metrics.timer
+            deploy/observability/xe3-speakup-observability-metrics.timer \
+            deploy/experiments/cn-backend/observability/xe3-speakup-cn-experiment-metrics.service \
+            deploy/experiments/cn-backend/observability/xe3-speakup-cn-experiment-metrics.timer
           sudo logrotate --debug \
             deploy/observability/xe3-speakup-nginx.logrotate
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -446,6 +446,9 @@ jobs:
       - name: Validate Production deployment contract
         run: make check-production-deploy
 
+      - name: Validate China backend experiment contract
+        run: make check-cn-backend-experiment
+
       - name: Validate Production PostgreSQL systemd units
         run: |
           sudo install -D -m 0755 \

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ SHELL := /bin/bash
 	check-observability \
 	check-production-deploy \
 	check-production-nginx \
+	check-cn-backend-experiment \
 	check-staging-deploy \
 	check-staging-host-access \
 	check-staging-nginx \
@@ -67,6 +68,7 @@ help:
 		'  make check-observability  Validate monitoring, alert, and log rotation contracts' \
 		'  make check-production-deploy  Validate the immutable Production contract' \
 		'  make check-production-nginx  Run nginx -t against the Production template' \
+		'  make check-cn-backend-experiment  Validate the isolated China backend experiment contract' \
 		'  make check-staging-deploy  Validate Staging runtime-env, schema, lock, and receipt contracts' \
 		'  make check-staging-host-access  Validate restricted Staging SSH and rootless host access' \
 		'  make check-staging-nginx  Validate the Staging edge-env and rendered Nginx contract' \
@@ -353,6 +355,9 @@ check-production-deploy:
 
 check-production-nginx:
 	./deploy/production/test-nginx.sh
+
+check-cn-backend-experiment:
+	./deploy/experiments/cn-backend/test.sh
 
 check-staging-deploy:
 	node --test deploy/staging/uat.test.mjs

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -159,15 +159,63 @@ destroyed after its results have been recorded.
 
 ## Regional provider switch
 
-Keep a mode-`0600` copy of the working Singapore baseline before changing the
-active `server.env`. A complete China candidate changes these groups together:
+This work starts only after the current Singapore release has completed its
+existing Release Candidate, Staging approval, Production, Tag, APK, and
+changelog path. Missing China-provider values do not block that Singapore
+release. Conversely, a file containing only some China values is not a
+deployable candidate and must not receive Production traffic.
 
-- `QIANWEN_BASE_URL`, `QIANWEN_ASR_BASE_URL`, `QIANWEN_TTS_BASE_URL`, and
-  `DASHSCOPE_API_KEY`;
-- `OSS_REGION`, `OSS_ENDPOINT`, `OSS_BUCKET`, and the selected OSS credential
-  provider values;
-- `XFYUN_ISE_ENDPOINT`, `APPID`, `APIKey`, and `APISecret`;
-- any explicitly regional avatar or OCR endpoint that remains enabled.
+Keep a mode-`0600` copy of the working Singapore baseline before changing the
+active `server.env`. Record the Singapore and China values, resource region,
+credential owner, and environment-file SHA-256 in private evidence. A complete
+China candidate changes and validates these groups together:
+
+- Qianwen text generation:
+  - `TEXT_GENERATION_PROVIDER=qianwen` and `DASHSCOPE_API_KEY`;
+  - `QIANWEN_BASE_URL`, `QIANWEN_MODEL`, `QIANWEN_EVALUATION_MODEL`,
+    `QIANWEN_SPEECH_FEEDBACK_MODEL`, `QIANWEN_TIMEOUT`, and
+    `QIANWEN_MAX_OUTPUT_TOKENS`.
+- Qianwen speech recognition:
+  - `SPEECH_RECOGNITION_PROVIDER=qianwen`;
+  - `QIANWEN_ASR_BASE_URL`, `QIANWEN_ASR_MODEL`, `QIANWEN_ASR_TIMEOUT`,
+    `QIANWEN_ASR_RECORDED_MODEL`, and `QIANWEN_ASR_RECORDED_TIMEOUT`.
+    The current Server requires `fun-asr-realtime` with a timeout of at least
+    `150s`, and `fun-asr-flash-2026-06-15` for recorded audio.
+- Qianwen speech synthesis:
+  - `SPEECH_SYNTHESIS_PROVIDER=qianwen`;
+  - `QIANWEN_TTS_BASE_URL`, `QIANWEN_TTS_MODEL`, `QIANWEN_TTS_VOICE`,
+    `QIANWEN_TTS_LANGUAGE`, `QIANWEN_TTS_TIMEOUT`, and
+    `QIANWEN_TTS_TEMP_DIRECTORY`.
+- Aliyun OSS:
+  - `OSS_ENABLED=1`, `OBJECT_STORAGE_PROVIDER=aliyun_oss`, `OSS_REGION`,
+    `OSS_ENDPOINT`, `OSS_BUCKET`, `OSS_AUDIO_PREFIX`, `OSS_IMAGE_PREFIX`,
+    `OSS_RESUME_PREFIX`, and `OSS_SIGNED_URL_TTL`; the current namespaces are
+    `audio/v1`, `image/v1`, and `resume/v1`, and signed URLs may live for at
+    most two minutes;
+  - `OSS_CREDENTIALS_PROVIDER=environment` requires
+    `OSS_ACCESS_KEY_ID`, `OSS_ACCESS_KEY_SECRET`, and an optional
+    `OSS_SESSION_TOKEN`, with `OSS_RAM_ROLE_NAME` empty;
+  - `OSS_CREDENTIALS_PROVIDER=ecs_role` requires a verified Alibaba ECS role
+    credential source and may set `OSS_RAM_ROLE_NAME`; do not select it merely
+    because the bucket is in Alibaba Cloud.
+- XFYun ISE: `XFYUN_ISE_ENDPOINT`, `XFYUN_ISE_TIMEOUT`, `APPID`, `APIKey`, and
+  `APISecret` from the same domestic application and service entitlement.
+
+Copy non-regional limits such as `AGENT_CONTEXT_MAX_CHARACTERS`,
+`AGENT_RUN_LOOP_TIMEOUT`, and the `VOICE_*` budgets unchanged from the tested
+baseline unless a separately reviewed change requires otherwise. Classify each
+optional regional integration explicitly as `china`, `unchanged`, or
+`disabled`:
+
+- avatar: `SPATIUS_ENABLED`, `SPATIUS_REGION`,
+  `SPATIUS_CONSOLE_BASE_URL`, `SPATIUS_APP_ID`, `SPATIUS_AVATAR_ID`,
+  `SPATIUS_API_KEY`, `SPATIUS_TOKEN_TTL`, and `SPATIUS_TIMEOUT`;
+- resume OCR: `RESUME_OCR_ENABLED`, `PADDLEOCR_ACCESS_TOKEN`,
+  `PADDLEOCR_BASE_URL`, and `RESUME_OCR_TIMEOUT`.
+
+An integration classified as `unchanged` still requires a latency and success
+check from the China host. An integration classified as `disabled` must be
+disabled explicitly in the candidate rather than omitted accidentally.
 
 Do not mix a China credential with a Singapore endpoint or reuse the Production
 database. After replacing the active environment file, recreate only the

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -1,0 +1,86 @@
+# China backend latency experiment
+
+This Compose stack runs only the SpeakUp Server and an isolated PostgreSQL
+database. It exists to compare a China-hosted backend with the current
+Singapore Staging backend before any Production traffic or data is moved.
+
+The stack deliberately uses its own Compose project, volume, port, deployment
+directory, runtime file, and Server environment file. It must not reuse a
+Staging or Production database volume. The Server image digest must come from
+the same successful Release Candidate manifest used by the comparison APK.
+
+The public mapping is an external provider responsibility. This stack binds
+the container API to private instance port `18083`; it never publishes
+PostgreSQL or metrics. A public high-port mapping is suitable only for the
+short internal experiment and must not be treated as the final Production
+HTTPS endpoint.
+
+## Host files
+
+- Compose file: `/opt/speakup-cn-experiment/compose.yaml`
+- Runtime configuration: `/etc/speakup-cn-experiment/runtime.env`
+- Provider configuration: `/etc/speakup-cn-experiment/server.env`
+
+Both environment files must be owned by root with mode `0600`. The Server
+environment must not define `DATABASE_URL`, `SERVER_HOST`, or `SERVER_PORT`;
+Compose owns those values.
+
+Both images use `pull_policy: never`. Load the exact Server and PostgreSQL
+digests recorded by the selected Release Candidate before starting the stack.
+An offline PostgreSQL import may retain only the image ID; verify that ID is
+`sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108`
+before applying the local `postgres:18-bookworm` tag. This keeps the experiment
+reproducible when the China host cannot reach Docker Hub and prevents an
+unreviewed registry mirror from changing the image.
+
+## Start and verify
+
+```sh
+docker compose \
+  --env-file /etc/speakup-cn-experiment/runtime.env \
+  --file /opt/speakup-cn-experiment/compose.yaml \
+  up --detach postgres
+
+docker compose \
+  --env-file /etc/speakup-cn-experiment/runtime.env \
+  --file /opt/speakup-cn-experiment/compose.yaml \
+  --profile migration run --rm migrate
+
+docker compose \
+  --env-file /etc/speakup-cn-experiment/runtime.env \
+  --file /opt/speakup-cn-experiment/compose.yaml \
+  up --detach --wait postgres server
+
+curl --fail http://10.222.1.17:18083/health
+curl --fail http://10.222.1.17:18083/readyz
+```
+
+## Stop without deleting experiment data
+
+```sh
+docker compose \
+  --env-file /etc/speakup-cn-experiment/runtime.env \
+  --file /opt/speakup-cn-experiment/compose.yaml \
+  down
+```
+
+Do not add `--volumes` unless the experiment database is intentionally being
+destroyed after its results have been recorded.
+
+## Regional provider switch
+
+Keep a mode-`0600` copy of the working Singapore baseline before changing the
+active `server.env`. A complete China candidate changes these groups together:
+
+- `QIANWEN_BASE_URL`, `QIANWEN_ASR_BASE_URL`, `QIANWEN_TTS_BASE_URL`, and
+  `DASHSCOPE_API_KEY`;
+- `OSS_REGION`, `OSS_ENDPOINT`, `OSS_BUCKET`, and the selected OSS credential
+  provider values;
+- `XFYUN_ISE_ENDPOINT`, `APPID`, `APIKey`, and `APISecret`;
+- any explicitly regional avatar or OCR endpoint that remains enabled.
+
+Do not mix a China credential with a Singapore endpoint or reuse the Production
+database. After replacing the active environment file, recreate only the
+Server container and run the same readiness and real-provider smoke checks.
+Rollback restores the known-good baseline environment file and recreates the
+Server container; PostgreSQL is unchanged.

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -9,11 +9,19 @@ directory, runtime file, and Server environment file. It must not reuse a
 Staging or Production database volume. The Server image digest must come from
 the same successful Release Candidate manifest used by the comparison APK.
 
-The public mapping is an external provider responsibility. This stack binds
-the container API to private instance port `18083`; it never publishes
-PostgreSQL or metrics. A public high-port mapping is suitable only for the
-short internal experiment and must not be treated as the final Production
-HTTPS endpoint.
+This stack binds the container API only to host loopback port `28083`; it never
+publishes PostgreSQL or metrics. Do not point the APK at a public plaintext
+mapping. Until a trusted TLS edge exists, connect a debug APK through USB and
+an encrypted SSH local forward:
+
+```sh
+ssh -N -L 18083:127.0.0.1:28083 -p "$CN_EXPERIMENT_SSH_PORT" \
+  "$CN_EXPERIMENT_SSH_TARGET"
+adb reverse tcp:18083 tcp:18083
+```
+
+The debug APK then uses `http://127.0.0.1:18083`; plaintext exists only across
+the local USB forwarding boundary and the Internet leg is protected by SSH.
 
 ## Host files
 
@@ -24,6 +32,17 @@ HTTPS endpoint.
 Both environment files must be owned by root with mode `0600`. The Server
 environment must not define `DATABASE_URL`, `SERVER_HOST`, or `SERVER_PORT`;
 Compose owns those values.
+
+Run `./validate-runtime.sh /etc/speakup-cn-experiment/runtime.env` before every
+Compose operation. The validator requires lowercase PostgreSQL identifiers and
+a 24-to-128-character URL-safe password because Compose inserts these values
+directly into a PostgreSQL URL.
+
+Generate a unique experiment password rather than copying a placeholder:
+
+```sh
+openssl rand -hex 24
+```
 
 Both images use `pull_policy: never`. Load the exact Server and PostgreSQL
 digests recorded by the selected Release Candidate before starting the stack.
@@ -36,6 +55,8 @@ unreviewed registry mirror from changing the image.
 ## Start and verify
 
 ```sh
+./validate-runtime.sh /etc/speakup-cn-experiment/runtime.env
+
 docker compose \
   --env-file /etc/speakup-cn-experiment/runtime.env \
   --file /opt/speakup-cn-experiment/compose.yaml \
@@ -51,13 +72,15 @@ docker compose \
   --file /opt/speakup-cn-experiment/compose.yaml \
   up --detach --wait postgres server
 
-curl --fail http://10.222.1.17:18083/health
-curl --fail http://10.222.1.17:18083/readyz
+curl --fail http://127.0.0.1:28083/health
+curl --fail http://127.0.0.1:28083/readyz
 ```
 
 ## Stop without deleting experiment data
 
 ```sh
+./validate-runtime.sh /etc/speakup-cn-experiment/runtime.env
+
 docker compose \
   --env-file /etc/speakup-cn-experiment/runtime.env \
   --file /opt/speakup-cn-experiment/compose.yaml \

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -95,6 +95,54 @@ The account remains only in the isolated experiment database so repeated runs
 are auditable. ASR, WebSocket voice streaming, and report generation still
 require the comparison APK and a real-device session.
 
+## Private experiment metrics
+
+The optional monitoring overlay runs only Prometheus and a textfile-only
+node_exporter. It does not install Grafana, Alertmanager, Nginx, blackbox probes,
+or a Docker socket mount. Prometheus is available only on host loopback port
+`29091`; Server metrics remain unpublished and are reachable only through the
+internal `monitor` Docker network. Prometheus alone also joins an otherwise
+empty bridge network so Docker can publish its UI to host loopback; neither the
+Server nor node_exporter joins that bridge.
+
+Install the fixed host exporter and timer, then start the overlay with the base
+Compose file so it shares the same private network:
+
+```sh
+install -d -o root -g root -m 0755 /var/lib/speakup-cn-experiment/metrics
+install -m 0755 observability/export-host-metrics.sh \
+  /usr/local/sbin/xe3-speakup-cn-experiment-export-metrics
+install -m 0644 observability/xe3-speakup-cn-experiment-metrics.service \
+  observability/xe3-speakup-cn-experiment-metrics.timer \
+  /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now xe3-speakup-cn-experiment-metrics.timer
+systemctl start xe3-speakup-cn-experiment-metrics.service
+
+docker compose \
+  --env-file /etc/speakup-cn-experiment/runtime.env \
+  --file /opt/speakup-cn-experiment/compose.yaml \
+  --file /opt/speakup-cn-experiment/compose.observability.yaml \
+  up --detach --wait server prometheus node-exporter
+```
+
+Inspect Prometheus through an encrypted local forward rather than a public
+port:
+
+```sh
+ssh -N -L 29091:127.0.0.1:29091 -p "$CN_EXPERIMENT_SSH_PORT" \
+  "$CN_EXPERIMENT_SSH_TARGET"
+curl --fail http://127.0.0.1:29091/-/ready
+```
+
+The host exporter records local health/readiness, exact experiment container
+state and restart counts, plus root filesystem bytes and inodes. Application
+metrics provide real provider calls, failures, duration, and usage. The smoke
+test is deliberately not scheduled because it consumes paid providers and
+creates accounts. This private stack cannot detect a complete host outage and
+has no notification delivery path; those remain formal HTTPS and Alertmanager
+cutover prerequisites.
+
 ## Stop without deleting experiment data
 
 ```sh

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -4,6 +4,10 @@ This Compose stack runs only the SpeakUp Server and an isolated PostgreSQL
 database. It exists to compare a China-hosted backend with the current
 Singapore Staging backend before any Production traffic or data is moved.
 
+Formal migration evidence and approval are tracked with
+[`cutover-checklist-v1.md`](./cutover-checklist-v1.md). An incomplete checklist
+means this stack must remain isolated from Production traffic.
+
 The stack deliberately uses its own Compose project, volume, port, deployment
 directory, runtime file, and Server environment file. It must not reuse a
 Staging or Production database volume. The Server image digest must come from
@@ -75,6 +79,21 @@ docker compose \
 curl --fail http://127.0.0.1:28083/health
 curl --fail http://127.0.0.1:28083/readyz
 ```
+
+## Current-provider smoke
+
+Run the smoke only on the experiment host after readiness succeeds:
+
+```sh
+./smoke-current-providers.sh
+```
+
+It creates an isolated test account, verifies registration, login, current
+user lookup, the IELTS question bank, one real answer-generation request, one
+real TTS request, and logout. It never prints credentials or response bodies.
+The account remains only in the isolated experiment database so repeated runs
+are auditable. ASR, WebSocket voice streaming, and report generation still
+require the comparison APK and a real-device session.
 
 ## Stop without deleting experiment data
 

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -143,6 +143,29 @@ creates accounts. This private stack cannot detect a complete host outage and
 has no notification delivery path; those remain formal HTTPS and Alertmanager
 cutover prerequisites.
 
+## Scheduled PostgreSQL backups
+
+Install and enable the experiment-only daily backup and weekly isolated
+restore check after PostgreSQL is healthy:
+
+```sh
+install -m 0755 backup/xe3-speakup-cn-experiment-postgres-backup \
+  /usr/local/sbin/xe3-speakup-cn-experiment-postgres-backup
+install -m 0644 backup/*.service backup/*.timer /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now \
+  xe3-speakup-cn-experiment-postgres-backup.timer \
+  xe3-speakup-cn-experiment-postgres-restore-check.timer
+systemctl start xe3-speakup-cn-experiment-postgres-backup.service
+systemctl start xe3-speakup-cn-experiment-postgres-restore-check.service
+systemctl list-timers 'xe3-speakup-cn-experiment-postgres-*'
+```
+
+Backups remain under
+`/var/lib/speakup-cn-experiment/postgres-backups`. To uninstall the schedule,
+disable both timers and remove only the installed units and command; do not
+remove that backup directory or the experiment PostgreSQL volume.
+
 ## Stop without deleting experiment data
 
 ```sh

--- a/deploy/experiments/cn-backend/backup/test.sh
+++ b/deploy/experiments/cn-backend/backup/test.sh
@@ -231,6 +231,10 @@ existing_containers="$(docker container ls --all --quiet \
 [[ -z "$existing_containers" ]] || fail 'refusing to run beside an existing experiment PostgreSQL container'
 ! docker volume inspect "$source_volume" >/dev/null 2>&1 || fail 'source test volume already exists'
 ! docker network inspect "$database_network" >/dev/null 2>&1 || fail 'database test network already exists'
+if ! docker image inspect "$postgres_image" >/dev/null 2>&1; then
+  docker image pull "$postgres_image" >/dev/null ||
+    fail 'cannot pull the audited PostgreSQL image'
+fi
 [[ "$(docker image inspect --format '{{.Id}}' "$postgres_image")" == "$postgres_image_id" ]] ||
   fail 'audited PostgreSQL image is not available locally'
 

--- a/deploy/experiments/cn-backend/backup/test.sh
+++ b/deploy/experiments/cn-backend/backup/test.sh
@@ -103,6 +103,13 @@ assert_unit_contracts() {
   for service in "$backup_service" "$restore_service"; do
     assert_unit_directive "$service" Service TimeoutStartSec 1h
     assert_unit_directive "$service" Service StateDirectoryMode 0700
+    assert_unit_directive \
+      "$service" Service RuntimeDirectory \
+      xe3-speakup-cn-experiment-postgres-backup
+    assert_unit_directive "$service" Service RuntimeDirectoryMode 0700
+    assert_unit_directive \
+      "$service" Service Environment \
+      DOCKER_CONFIG=/run/xe3-speakup-cn-experiment-postgres-backup
     assert_unit_directive "$service" Service UMask 0077
     assert_unit_directive "$service" Service PrivateNetwork true
     assert_unit_directive "$service" Service RestrictAddressFamilies AF_UNIX

--- a/deploy/experiments/cn-backend/backup/test.sh
+++ b/deploy/experiments/cn-backend/backup/test.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly backup_command="$directory/xe3-speakup-cn-experiment-postgres-backup"
+readonly backup_service="$directory/xe3-speakup-cn-experiment-postgres-backup.service"
+readonly backup_timer="$directory/xe3-speakup-cn-experiment-postgres-backup.timer"
+readonly restore_service="$directory/xe3-speakup-cn-experiment-postgres-restore-check.service"
+readonly restore_timer="$directory/xe3-speakup-cn-experiment-postgres-restore-check.timer"
+readonly postgres_image="postgres@sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
+readonly postgres_image_id="sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
+readonly test_id="$(printf '%08x%08x' "$$" "$RANDOM")"
+readonly compose_project="xe3-speakup-cn-backup-test-$test_id"
+readonly compose_service="postgres"
+readonly database_network="${compose_project}_database"
+readonly source_volume="${compose_project}_postgres_data"
+readonly database_name="speakup_cn_backup_$test_id"
+readonly database_user="$database_name"
+readonly database_password="cn-backup-test-only-0123456789"
+readonly identity_label_key="com.xengineer.speakup.cn-experiment-identity"
+readonly identity_label="$identity_label_key=$test_id"
+readonly test_label="com.xengineer.speakup.cn-backup-test=$test_id"
+readonly source_container="${compose_project}-postgres"
+readonly temporary_directory="$(mktemp -d)"
+readonly backup_root="$temporary_directory/$compose_project/postgres-backups"
+readonly docker_wrapper_directory="$temporary_directory/docker-wrapper"
+readonly docker_wrapper_state="$temporary_directory/docker-wrapper-armed"
+readonly real_docker="$(command -v docker)"
+
+failure_number=0
+
+fail() {
+  printf 'China experiment backup contract test: %s\n' "$*" >&2
+  exit 1
+}
+
+remove_owned_container() {
+  local name=$1
+  if ! docker container inspect "$name" >/dev/null 2>&1; then
+    return 0
+  fi
+  docker container inspect "$name" | jq --exit-status --arg label "$test_label" '
+    length == 1 and
+    ((.[0].Config.Labels | to_entries | map(.key + "=" + .value)) | index($label)) != null
+  ' >/dev/null || return 1
+  docker container rm --force "$name" >/dev/null
+}
+
+remove_owned_volume() {
+  local name=$1
+  if ! docker volume inspect "$name" >/dev/null 2>&1; then
+    return 0
+  fi
+  docker volume inspect "$name" | jq --exit-status --arg label "$test_label" '
+    length == 1 and
+    ((.[0].Labels | to_entries | map(.key + "=" + .value)) | index($label)) != null
+  ' >/dev/null || return 1
+  docker volume rm "$name" >/dev/null
+}
+
+remove_owned_network() {
+  local name=$1
+  if ! docker network inspect "$name" >/dev/null 2>&1; then
+    return 0
+  fi
+  docker network inspect "$name" | jq --exit-status --arg label "$test_label" '
+    length == 1 and
+    ((.[0].Labels | to_entries | map(.key + "=" + .value)) | index($label)) != null
+  ' >/dev/null || return 1
+  docker network rm "$name" >/dev/null
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT
+  set +e
+  remove_owned_container "$source_container" || status=1
+  remove_owned_volume "$source_volume" || status=1
+  remove_owned_network "$database_network" || status=1
+  rm -rf -- "$temporary_directory"
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT HUP TERM
+
+assert_unit_directive() {
+  local file=$1 section=$2 directive=$3 expected=$4 actual
+  actual="$(awk -v section="[$section]" -v directive="$directive" '
+    /^\[[^]]+\]$/ { current = $0; next }
+    current == section && substr($0, 1, length(directive) + 1) == directive "=" {
+      print substr($0, length(directive) + 2)
+    }
+  ' "$file")"
+  [[ "$actual" == "$expected" ]] ||
+    fail "$file must set [$section] $directive=$expected exactly once"
+}
+
+assert_unit_contracts() {
+  local service
+  for service in "$backup_service" "$restore_service"; do
+    assert_unit_directive "$service" Service TimeoutStartSec 1h
+    assert_unit_directive "$service" Service StateDirectoryMode 0700
+    assert_unit_directive "$service" Service UMask 0077
+    assert_unit_directive "$service" Service PrivateNetwork true
+    assert_unit_directive "$service" Service RestrictAddressFamilies AF_UNIX
+    assert_unit_directive "$service" Service ProtectSystem strict
+    assert_unit_directive "$service" Service NoNewPrivileges true
+  done
+  assert_unit_directive \
+    "$backup_service" Service StateDirectory \
+    speakup-cn-experiment/postgres-backups
+  assert_unit_directive \
+    "$backup_service" Service ExecStart \
+    '/usr/bin/flock --wait 900 /run/lock/xe3-speakup-cn-experiment-postgres-backup.lock /usr/bin/env EXPERIMENT_POSTGRES_BACKUP_ROOT=/var/lib/speakup-cn-experiment/postgres-backups /usr/local/sbin/xe3-speakup-cn-experiment-postgres-backup backup'
+  assert_unit_directive \
+    "$restore_service" Service StateDirectory \
+    'speakup-cn-experiment/postgres-backups speakup-cn-experiment/backup-checks'
+  assert_unit_directive \
+    "$restore_service" Service ExecStart \
+    '/usr/bin/flock --wait 900 /run/lock/xe3-speakup-cn-experiment-postgres-backup.lock /usr/bin/env EXPERIMENT_POSTGRES_BACKUP_ROOT=/var/lib/speakup-cn-experiment/postgres-backups /usr/local/sbin/xe3-speakup-cn-experiment-postgres-backup restore-check'
+  assert_unit_directive \
+    "$restore_service" Unit Requires \
+    'docker.service xe3-speakup-cn-experiment-postgres-backup.service'
+  assert_unit_directive \
+    "$restore_service" Unit After \
+    'docker.service xe3-speakup-cn-experiment-postgres-backup.service'
+  assert_unit_directive \
+    "$restore_service" Service ExecStartPre \
+    '/usr/bin/rm --force -- /var/lib/speakup-cn-experiment/backup-checks/latest-restore.success'
+  assert_unit_directive \
+    "$restore_service" Service ExecStartPost \
+    '/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup-cn-experiment/backup-checks/latest-restore.success'
+  assert_unit_directive "$backup_timer" Timer OnCalendar '*-*-* 18:30:00 UTC'
+  assert_unit_directive "$backup_timer" Timer RandomizedDelaySec 15m
+  assert_unit_directive "$backup_timer" Timer Persistent true
+  assert_unit_directive \
+    "$backup_timer" Timer Unit xe3-speakup-cn-experiment-postgres-backup.service
+  assert_unit_directive "$restore_timer" Timer OnCalendar 'Sun *-*-* 19:30:00 UTC'
+  assert_unit_directive "$restore_timer" Timer RandomizedDelaySec 30m
+  assert_unit_directive "$restore_timer" Timer Persistent true
+  assert_unit_directive \
+    "$restore_timer" Timer Unit xe3-speakup-cn-experiment-postgres-restore-check.service
+}
+
+wait_for_source() {
+  local deadline=$((SECONDS + 90)) state process
+  while ((SECONDS < deadline)); do
+    state="$(docker container inspect --format \
+      '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+      "$source_container" 2>/dev/null || true)"
+    process="$(docker container exec "$source_container" cat /proc/1/comm 2>/dev/null || true)"
+    [[ "$state" == "healthy" && "$process" == "postgres" ]] && return 0
+    [[ "$state" == "exited" || "$state" == "dead" ]] && fail 'source PostgreSQL exited early'
+    sleep 1
+  done
+  fail 'source PostgreSQL did not become healthy'
+}
+
+run_backup_command() {
+  EXPERIMENT_POSTGRES_BACKUP_TEST_MODE=1 \
+    EXPERIMENT_POSTGRES_BACKUP_TEST_ID="$test_id" \
+    EXPERIMENT_POSTGRES_BACKUP_ROOT="$backup_root" \
+    "$backup_command" "$@"
+}
+
+run_backup_command_with_docker_wrapper() {
+  PATH="$docker_wrapper_directory:$PATH" \
+    CN_BACKUP_TEST_REAL_DOCKER="$real_docker" \
+    CN_BACKUP_TEST_WRAPPER_STATE="$docker_wrapper_state" \
+    CN_BACKUP_TEST_COMPOSE_PROJECT="$compose_project" \
+    EXPERIMENT_POSTGRES_BACKUP_TEST_MODE=1 \
+    EXPERIMENT_POSTGRES_BACKUP_TEST_ID="$test_id" \
+    EXPERIMENT_POSTGRES_BACKUP_ROOT="$backup_root" \
+    "$backup_command" "$@"
+}
+
+expect_failure() {
+  local description=$1
+  shift
+  failure_number=$((failure_number + 1))
+  local output="$temporary_directory/failure-$failure_number.log"
+  if "$@" >"$output" 2>&1; then
+    fail "$description unexpectedly succeeded"
+  fi
+  ! grep -Fq "$database_password" "$output" || fail "$description exposed the database password"
+}
+
+assert_no_restore_resources() {
+  [[ -z "$(docker container ls --all --quiet --filter "label=$identity_label_key=$compose_project")" ]] ||
+    fail 'restore-check left a temporary container'
+  [[ -z "$(docker volume ls --quiet --filter "label=$identity_label_key=$compose_project")" ]] ||
+    fail 'restore-check left a temporary volume'
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+for command_name in docker jq awk cmp date stat sync; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "$command_name is required"
+done
+
+bash -n "$backup_command"
+assert_unit_contracts
+grep -Fq 'readonly retention_days=7' "$backup_command" || fail 'retention must remain fixed at seven days'
+grep -Fq -- '--network none' "$backup_command" || fail 'restore-check must remain network-isolated'
+grep -Fq 'readonly production_source_volume="xe3-speakup-cn-experiment_postgres_data"' "$backup_command" ||
+  fail 'production source volume identity must remain fixed'
+grep -Fq "readonly postgres_image_id=\"$postgres_image_id\"" "$backup_command" ||
+  fail 'PostgreSQL image ID must remain immutable'
+grep -Fq 'EXPERIMENT_POSTGRES_BACKUP_TEST_MODE' "$backup_command" ||
+  fail 'test identity override must require explicit test mode'
+
+existing_containers="$(docker container ls --all --quiet \
+  --filter "label=com.docker.compose.project=$compose_project" \
+  --filter "label=com.docker.compose.service=$compose_service")"
+[[ -z "$existing_containers" ]] || fail 'refusing to run beside an existing experiment PostgreSQL container'
+! docker volume inspect "$source_volume" >/dev/null 2>&1 || fail 'source test volume already exists'
+! docker network inspect "$database_network" >/dev/null 2>&1 || fail 'database test network already exists'
+[[ "$(docker image inspect --format '{{.Id}}' "$postgres_image")" == "$postgres_image_id" ]] ||
+  fail 'audited PostgreSQL image is not available locally'
+
+mkdir -p "$backup_root"
+chmod 700 "$temporary_directory/$compose_project" "$backup_root"
+mkdir -m 700 "$docker_wrapper_directory"
+cat >"$docker_wrapper_directory/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly real_docker="${CN_BACKUP_TEST_REAL_DOCKER:?}"
+readonly state="${CN_BACKUP_TEST_WRAPPER_STATE:?}"
+readonly project="${CN_BACKUP_TEST_COMPOSE_PROJECT:?}"
+
+if [[ "${1:-}" == "container" && "${2:-}" == "inspect" &&
+  -f "$state" && ! -e "$state.failed" ]]; then
+  mv "$state" "$state.failed"
+  printf 'simulated transient container inspect failure\n' >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "container" && "${2:-}" == "run" ]]; then
+  name=""
+  previous=""
+  for argument in "$@"; do
+    if [[ "$previous" == "--name" ]]; then
+      name=$argument
+      break
+    fi
+    previous=$argument
+  done
+  "$real_docker" "$@"
+  status=$?
+  if [[ $status == 0 && "$name" == "$project-restore-"* ]]; then
+    : >"$state"
+  fi
+  exit "$status"
+fi
+
+exec "$real_docker" "$@"
+EOF
+chmod 700 "$docker_wrapper_directory/docker"
+expect_failure 'test root override without explicit test mode' \
+  env EXPERIMENT_POSTGRES_BACKUP_ROOT="$backup_root" "$backup_command" verify
+expect_failure 'test mode without a unique test ID' \
+  env EXPERIMENT_POSTGRES_BACKUP_TEST_MODE=1 \
+  EXPERIMENT_POSTGRES_BACKUP_ROOT="$backup_root" "$backup_command" verify
+expect_failure 'test mode with an invalid test ID' \
+  env EXPERIMENT_POSTGRES_BACKUP_TEST_MODE=1 \
+  EXPERIMENT_POSTGRES_BACKUP_TEST_ID='not-unique' \
+  EXPERIMENT_POSTGRES_BACKUP_ROOT="$backup_root" "$backup_command" verify
+docker network create --internal --label "$test_label" "$database_network" >/dev/null
+docker volume create --label "$test_label" "$source_volume" >/dev/null
+docker container run --detach \
+  --name "$source_container" \
+  --label "$test_label" \
+  --label "$identity_label" \
+  --label "com.docker.compose.project=$compose_project" \
+  --label "com.docker.compose.service=$compose_service" \
+  --network "$database_network" \
+  --mount "type=volume,src=$source_volume,dst=/var/lib/postgresql,volume-nocopy" \
+  --env "POSTGRES_DB=$database_name" \
+  --env "POSTGRES_USER=$database_user" \
+  --env "POSTGRES_PASSWORD=$database_password" \
+  --health-cmd "pg_isready --username=$database_user --dbname=$database_name" \
+  --health-interval 1s \
+  --health-timeout 5s \
+  --health-retries 30 \
+  --health-start-period 5s \
+  "$postgres_image" >/dev/null
+wait_for_source
+
+docker container exec "$source_container" psql \
+  --set ON_ERROR_STOP=1 \
+  --username "$database_user" \
+  --dbname "$database_name" \
+  --command 'CREATE TABLE public.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL);' \
+  --command 'INSERT INTO public.schema_migrations (version, dirty) VALUES (9, false);' \
+  --command 'CREATE TABLE public.users (id bigint PRIMARY KEY, canonical_email text NOT NULL);' \
+  --command "INSERT INTO public.users (id, canonical_email) VALUES (1, 'backup-test@example.com');" \
+  >/dev/null
+
+backup_output="$(run_backup_command backup 2>&1)"
+! grep -Fq "$database_password" <<<"$backup_output" || fail 'backup exposed the database password'
+[[ "$backup_output" =~ ^backup_id=([0-9]{8}T[0-9]{6}Z-daily)\ checksum=verified$ ]] ||
+  fail 'backup did not return verified evidence'
+first_backup_id=${BASH_REMATCH[1]}
+first_backup="$backup_root/$first_backup_id"
+
+jq --exit-status \
+  --arg backup_id "$first_backup_id" \
+  --arg image "$postgres_image_id" '
+    .backup_id == $backup_id and
+    .postgres_image_id == $image and
+    .schema_version == 9 and
+    .schema_dirty == false and
+    .user_count == 1 and
+    .retention_days == 7
+  ' "$first_backup/metadata.json" >/dev/null || fail 'backup metadata evidence is incomplete'
+
+verify_output="$(run_backup_command verify 2>&1)"
+[[ "$verify_output" == "backup_id=$first_backup_id checksum=verified" ]] ||
+  fail 'latest backup verification failed'
+
+restore_output="$(run_backup_command restore-check 2>&1)"
+[[ "$restore_output" == "backup_id=$first_backup_id restore=verified" ]] ||
+  fail 'isolated restore-check failed'
+assert_no_restore_resources
+docker volume inspect "$source_volume" >/dev/null || fail 'restore-check removed the source volume'
+
+old_backup_id='20000101T000000Z-daily'
+old_backup="$backup_root/$old_backup_id"
+cp -R "$first_backup" "$old_backup"
+chmod 700 "$old_backup"
+chmod 600 "$old_backup"/*
+jq --arg id "$old_backup_id" --arg created_at '2000-01-01T00:00:00Z' \
+  '.backup_id = $id | .created_at = $created_at' \
+  "$old_backup/metadata.json" >"$temporary_directory/old-metadata.json"
+mv "$temporary_directory/old-metadata.json" "$old_backup/metadata.json"
+chmod 600 "$old_backup/metadata.json"
+
+sleep 1
+second_output="$(run_backup_command backup 2>&1)"
+[[ "$second_output" =~ ^backup_id=([0-9]{8}T[0-9]{6}Z-daily)\ checksum=verified$ ]] ||
+  fail 'second backup did not return verified evidence'
+second_backup_id=${BASH_REMATCH[1]}
+[[ "$second_backup_id" != "$first_backup_id" ]] || fail 'backup IDs must be unique'
+[[ ! -e "$old_backup" ]] || fail 'expired backup was not pruned'
+[[ -d "$first_backup" && -d "$backup_root/$second_backup_id" ]] ||
+  fail 'retention pruned a non-expired backup'
+
+second_dump="$backup_root/$second_backup_id/database.dump"
+cp "$second_dump" "$temporary_directory/original.dump"
+printf '%s\n' 'tamper' >>"$second_dump"
+expect_failure 'tampered latest backup' run_backup_command verify "$second_backup_id"
+cp "$temporary_directory/original.dump" "$second_dump"
+chmod 600 "$second_dump"
+verify_output="$(run_backup_command verify "$second_backup_id")"
+[[ "$verify_output" == "backup_id=$second_backup_id checksum=verified" ]] ||
+  fail 'valid backup did not recover after tamper test'
+
+second_checksum="$backup_root/$second_backup_id/database.dump.sha256"
+second_metadata="$backup_root/$second_backup_id/metadata.json"
+cp "$second_dump" "$temporary_directory/restore-original.dump"
+cp "$second_checksum" "$temporary_directory/restore-original.sha256"
+cp "$second_metadata" "$temporary_directory/restore-original-metadata.json"
+printf '%s\n' 'PGDMP-invalid-restore-test-payload' >"$second_dump"
+corrupt_sha="$(sha256_file "$second_dump")"
+corrupt_size="$(wc -c <"$second_dump" | tr -d '[:space:]')"
+printf '%s  database.dump\n' "$corrupt_sha" >"$second_checksum"
+jq --arg sha256 "$corrupt_sha" --argjson size_bytes "$corrupt_size" \
+  '.sha256 = $sha256 | .size_bytes = $size_bytes' \
+  "$temporary_directory/restore-original-metadata.json" >"$second_metadata"
+chmod 600 "$second_dump" "$second_checksum" "$second_metadata"
+expect_failure 'forced isolated restore failure' \
+  run_backup_command restore-check "$second_backup_id"
+assert_no_restore_resources
+cp "$temporary_directory/restore-original.dump" "$second_dump"
+cp "$temporary_directory/restore-original.sha256" "$second_checksum"
+cp "$temporary_directory/restore-original-metadata.json" "$second_metadata"
+chmod 600 "$second_dump" "$second_checksum" "$second_metadata"
+verify_output="$(run_backup_command verify "$second_backup_id")"
+[[ "$verify_output" == "backup_id=$second_backup_id checksum=verified" ]] ||
+  fail 'valid backup did not recover after forced restore failure'
+
+rm -f -- "$docker_wrapper_state" "$docker_wrapper_state.failed"
+transient_output="$temporary_directory/transient-inspect.log"
+if run_backup_command_with_docker_wrapper restore-check "$second_backup_id" \
+  >"$transient_output" 2>&1; then
+  fail 'transient cleanup inspect failure unexpectedly succeeded'
+fi
+[[ -f "$docker_wrapper_state.failed" ]] ||
+  fail 'transient cleanup inspect failure was not exercised'
+! grep -Fq 'restore=verified' "$transient_output" ||
+  fail 'cleanup failure incorrectly reported a verified restore'
+! grep -Fq "$database_password" "$transient_output" ||
+  fail 'cleanup failure exposed the database password'
+assert_no_restore_resources
+
+source_state="$(docker container exec "$source_container" psql \
+  --tuples-only --no-align --set ON_ERROR_STOP=1 \
+  --username "$database_user" --dbname "$database_name" \
+  --command "SELECT version::text || '|' || dirty::text || '|' || (SELECT count(*)::text FROM public.users) FROM public.schema_migrations;")"
+[[ "$source_state" == '9|false|1' ]] || fail 'backup workflow modified source data'
+assert_no_restore_resources
+
+printf 'China experiment PostgreSQL backup contract tests passed\n'

--- a/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup
+++ b/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup
@@ -1,0 +1,697 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+readonly compose_service="postgres"
+readonly production_compose_project="xe3-speakup-cn-experiment"
+readonly production_database_network="xe3-speakup-cn-experiment_database"
+readonly production_source_volume="xe3-speakup-cn-experiment_postgres_data"
+readonly production_database_name="speakup_cn_experiment"
+readonly test_mode="${EXPERIMENT_POSTGRES_BACKUP_TEST_MODE:-0}"
+readonly test_id="${EXPERIMENT_POSTGRES_BACKUP_TEST_ID:-}"
+readonly postgres_image_id="sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108"
+readonly retention_days=7
+readonly maximum_age_seconds=129600
+readonly restore_label="com.xengineer.speakup.cn-experiment-restore"
+readonly restore_backup_label="com.xengineer.speakup.cn-experiment-backup-id"
+readonly restore_run_label="com.xengineer.speakup.cn-experiment-restore-run"
+readonly identity_label="com.xengineer.speakup.cn-experiment-identity"
+readonly dump_name="database.dump"
+readonly checksum_name="database.dump.sha256"
+readonly metadata_name="metadata.json"
+
+case "$test_mode" in
+  0)
+    [[ -z "$test_id" ]] || {
+      printf 'China experiment PostgreSQL backup error: test ID requires test mode\n' >&2
+      exit 1
+    }
+    compose_project=$production_compose_project
+    database_network=$production_database_network
+    source_volume=$production_source_volume
+    database_name=$production_database_name
+    database_user=$production_database_name
+    backup_root="${EXPERIMENT_POSTGRES_BACKUP_ROOT:-/var/lib/speakup-cn-experiment/postgres-backups}"
+    ;;
+  1)
+    [[ "$test_id" =~ ^[a-f0-9]{16}$ ]] || {
+      printf 'China experiment PostgreSQL backup error: test ID must be 16 lowercase hexadecimal characters\n' >&2
+      exit 1
+    }
+    compose_project="xe3-speakup-cn-backup-test-$test_id"
+    database_network="${compose_project}_database"
+    source_volume="${compose_project}_postgres_data"
+    database_name="speakup_cn_backup_$test_id"
+    database_user=$database_name
+    backup_root="${EXPERIMENT_POSTGRES_BACKUP_ROOT:-}"
+    ;;
+  *)
+    printf 'China experiment PostgreSQL backup error: test mode must be 0 or 1\n' >&2
+    exit 1
+    ;;
+esac
+readonly compose_project database_network source_volume database_name database_user backup_root
+
+active_partial_directory=""
+restore_container_id=""
+restore_container_name=""
+restore_volume=""
+restore_backup_id=""
+restore_run_id=""
+
+usage() {
+  printf '%s\n' \
+    'Usage:' \
+    '  xe3-speakup-cn-experiment-postgres-backup backup' \
+    '  xe3-speakup-cn-experiment-postgres-backup verify [BACKUP_ID]' \
+    '  xe3-speakup-cn-experiment-postgres-backup restore-check [BACKUP_ID]' >&2
+}
+
+fail() {
+  printf 'China experiment PostgreSQL backup error: %s\n' "$*" >&2
+  exit 1
+}
+
+file_mode() {
+  local value
+  if value="$(stat -c '%a' "$1" 2>/dev/null)"; then
+    :
+  elif value="$(stat -f '%Lp' "$1" 2>/dev/null)"; then
+    :
+  else
+    fail 'cannot inspect path permissions'
+  fi
+  printf '%s\n' "$value"
+}
+
+file_owner() {
+  local value
+  if value="$(stat -c '%u' "$1" 2>/dev/null)"; then
+    :
+  elif value="$(stat -f '%u' "$1" 2>/dev/null)"; then
+    :
+  else
+    fail 'cannot inspect path ownership'
+  fi
+  printf '%s\n' "$value"
+}
+
+file_size() {
+  local value
+  if value="$(stat -c '%s' "$1" 2>/dev/null)"; then
+    :
+  elif value="$(stat -f '%z' "$1" 2>/dev/null)"; then
+    :
+  else
+    fail 'cannot inspect backup size'
+  fi
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail 'backup dump must not be empty'
+  printf '%s\n' "$value"
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+valid_backup_id() {
+  [[ "$1" =~ ^[0-9]{8}T[0-9]{6}Z-daily$ ]]
+}
+
+validate_backup_root() {
+  [[ "$backup_root" =~ ^/[A-Za-z0-9._/-]+/postgres-backups$ ]] ||
+    fail 'backup root must be a safe absolute postgres-backups path'
+  [[ -d "$backup_root" && ! -L "$backup_root" ]] ||
+    fail 'backup root must already exist as a real directory'
+  [[ "$(file_mode "$backup_root")" == "700" ]] ||
+    fail 'backup root must have mode 0700'
+  [[ "$(file_owner "$backup_root")" == "$EUID" ]] ||
+    fail 'backup root must be owned by the service user'
+  if [[ "$test_mode" == "0" ]]; then
+    [[ "$backup_root" == "/var/lib/speakup-cn-experiment/postgres-backups" ]] ||
+      fail 'non-test backup root must use the fixed experiment path'
+  else
+    [[ "$backup_root" == */"$compose_project"/postgres-backups ]] ||
+      fail 'test backup root must include its unique Compose identity'
+  fi
+}
+
+cleanup_partial_directory() {
+  local entry name
+  local -a entries
+
+  [[ -n "$active_partial_directory" ]] || return 0
+  [[ "${active_partial_directory%/*}" == "$backup_root" &&
+    "${active_partial_directory##*/}" == .partial-* &&
+    -d "$active_partial_directory" && ! -L "$active_partial_directory" ]] || return 1
+  shopt -s nullglob dotglob
+  entries=("$active_partial_directory"/*)
+  shopt -u nullglob dotglob
+  for entry in "${entries[@]}"; do
+    name=${entry##*/}
+    case "$name" in
+      "$dump_name" | "$checksum_name" | "$metadata_name") ;;
+      *) return 1 ;;
+    esac
+    [[ -f "$entry" && ! -L "$entry" ]] || return 1
+  done
+  for entry in "${entries[@]}"; do
+    rm -- "$entry" || return 1
+  done
+  rmdir -- "$active_partial_directory" || return 1
+  active_partial_directory=""
+}
+
+container_confirmed_absent() {
+  local id=$1 name=$2 listing
+
+  listing="$(docker container ls --all --no-trunc --format '{{.ID}}\t{{.Names}}')" || return 1
+  if [[ -n "$id" ]]; then
+    ! awk -v expected="$id" '$1 == expected { found = 1 } END { exit(found ? 0 : 1) }' \
+      <<<"$listing"
+  else
+    ! awk -v expected="$name" '$2 == expected { found = 1 } END { exit(found ? 0 : 1) }' \
+      <<<"$listing"
+  fi
+}
+
+volume_confirmed_absent() {
+  local name=$1 listing
+
+  listing="$(docker volume ls --format '{{.Name}}')" || return 1
+  ! grep -Fqx -- "$name" <<<"$listing"
+}
+
+cleanup_restore_resources() {
+  local inspect_json target
+  local failed=0
+
+  if [[ -n "$restore_container_id" || -n "$restore_container_name" ]]; then
+    target=${restore_container_id:-$restore_container_name}
+    if inspect_json="$(docker container inspect "$target" 2>/dev/null)"; then
+      if jq --exit-status \
+        --arg id "$restore_container_id" \
+        --arg name "/$restore_container_name" \
+        --arg identity "$compose_project" \
+        --arg backup_id "$restore_backup_id" \
+        --arg run_id "$restore_run_id" \
+        --arg identity_label "$identity_label" \
+        --arg restore_label "$restore_label" \
+        --arg backup_label "$restore_backup_label" \
+        --arg run_label "$restore_run_label" '
+          length == 1 and
+          ($id == "" or .[0].Id == $id) and
+          .[0].Name == $name and
+          .[0].Config.Labels[$identity_label] == $identity and
+          .[0].Config.Labels[$restore_label] == "true" and
+          .[0].Config.Labels[$backup_label] == $backup_id and
+          .[0].Config.Labels[$run_label] == $run_id
+        ' <<<"$inspect_json" >/dev/null &&
+        docker container rm --force "$target" >/dev/null; then
+        restore_container_id=""
+        restore_container_name=""
+      else
+        failed=1
+      fi
+    elif container_confirmed_absent "$restore_container_id" "$restore_container_name"; then
+      restore_container_id=""
+      restore_container_name=""
+    else
+      failed=1
+    fi
+  fi
+
+  if [[ -n "$restore_volume" ]]; then
+    if [[ "$restore_volume" == "$source_volume" ]]; then
+      failed=1
+    elif inspect_json="$(docker volume inspect "$restore_volume" 2>/dev/null)"; then
+      if jq --exit-status \
+        --arg volume "$restore_volume" \
+        --arg identity "$compose_project" \
+        --arg backup_id "$restore_backup_id" \
+        --arg run_id "$restore_run_id" \
+        --arg identity_label "$identity_label" \
+        --arg restore_label "$restore_label" \
+        --arg backup_label "$restore_backup_label" \
+        --arg run_label "$restore_run_label" '
+          length == 1 and
+          .[0].Name == $volume and
+          .[0].Labels[$identity_label] == $identity and
+          .[0].Labels[$restore_label] == "true" and
+          .[0].Labels[$backup_label] == $backup_id and
+          .[0].Labels[$run_label] == $run_id
+        ' <<<"$inspect_json" >/dev/null &&
+        docker volume rm "$restore_volume" >/dev/null; then
+        restore_volume=""
+      else
+        failed=1
+      fi
+    elif volume_confirmed_absent "$restore_volume"; then
+      restore_volume=""
+    else
+      failed=1
+    fi
+  fi
+
+  if [[ -z "$restore_container_id" && -z "$restore_container_name" && -z "$restore_volume" ]]; then
+    restore_backup_id=""
+    restore_run_id=""
+  fi
+  ((failed == 0))
+}
+
+cleanup_on_exit() {
+  local status=$?
+  trap - EXIT
+  set +e
+  cleanup_restore_resources || status=1
+  cleanup_partial_directory || status=1
+  exit "$status"
+}
+
+trap cleanup_on_exit EXIT
+trap 'exit 130' INT HUP TERM
+
+source_container() {
+  local ids count
+  ids="$(docker container ls --quiet \
+    --filter "label=com.docker.compose.project=$compose_project" \
+    --filter "label=com.docker.compose.service=$compose_service")" ||
+    fail 'cannot inspect the experiment PostgreSQL container'
+  count="$(awk 'NF { count += 1 } END { print count + 0 }' <<<"$ids")"
+  [[ "$count" == "1" ]] || fail 'exactly one experiment PostgreSQL container is required'
+  printf '%s\n' "$ids"
+}
+
+validate_source_container() {
+  local container=$1
+  local state
+  state="$(docker container inspect --format \
+    '{{.State.Running}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}|{{.Image}}' \
+    "$container")" || fail 'cannot inspect the experiment PostgreSQL state'
+  [[ "$state" == "true|healthy|$postgres_image_id" ]] ||
+    fail 'experiment PostgreSQL must be healthy and use the audited image ID'
+  docker volume inspect "$source_volume" >/dev/null || fail 'source volume does not exist'
+  docker network inspect "$database_network" | jq --exit-status '
+    length == 1 and .[0].Internal == true
+  ' >/dev/null || fail 'database network must remain internal'
+  docker container inspect "$container" | jq --exit-status \
+    --arg network "$database_network" \
+    --arg volume "$source_volume" '
+      length == 1 and
+      ((.[0].HostConfig.PortBindings // {}) == {}) and
+      ((.[0].NetworkSettings.Networks | keys) == [$network]) and
+      ([.[0].Mounts[] |
+        select(.Type == "volume" and
+               .Name == $volume and
+               .Destination == "/var/lib/postgresql" and
+               .RW == true)] | length) == 1
+    ' >/dev/null || fail 'source PostgreSQL isolation or volume identity is invalid'
+  if [[ "$test_mode" == "1" ]]; then
+    docker container inspect "$container" | jq --exit-status \
+      --arg label "$identity_label" \
+      --arg test_id "$test_id" '
+        length == 1 and .[0].Config.Labels[$label] == $test_id
+      ' >/dev/null || fail 'test source container does not carry its unique identity label'
+  fi
+}
+
+database_query() {
+  docker container exec --user postgres "$1" psql \
+    --no-psqlrc \
+    --set ON_ERROR_STOP=1 \
+    --tuples-only \
+    --no-align \
+    --quiet \
+    --username "$database_user" \
+    --dbname "$database_name" \
+    --command "$2"
+}
+
+schema_state() {
+  local value
+  value="$(database_query "$1" \
+    "SELECT version::text || '|' || dirty::text FROM public.schema_migrations;")" ||
+    fail 'cannot read database schema state'
+  [[ "$value" =~ ^([1-9][0-9]*)\|false$ ]] ||
+    fail 'database schema must contain one clean positive version'
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+user_count() {
+  local value
+  value="$(database_query "$1" 'SELECT count(*)::text FROM public.users;')" ||
+    fail 'cannot read database user count'
+  [[ "$value" =~ ^[0-9]+$ ]] || fail 'database user count is invalid'
+  printf '%s\n' "$value"
+}
+
+postgres_version() {
+  local value
+  value="$(database_query "$1" 'SHOW server_version;')" ||
+    fail 'cannot read PostgreSQL version'
+  [[ "$value" =~ ^[1-9][0-9]*\. && ${#value} -le 128 ]] ||
+    fail 'PostgreSQL version is invalid'
+  [[ "$value" != *$'\n'* && "$value" != *$'\r'* && "$value" != *$'\t'* ]] ||
+    fail 'PostgreSQL version contains control characters'
+  printf '%s\n' "$value"
+}
+
+write_metadata() {
+  local file=$1 backup_id=$2 created_at=$3 version=$4 schema_version=$5 users=$6 size=$7 checksum=$8
+  jq --null-input --sort-keys \
+    --arg backup_id "$backup_id" \
+    --arg created_at "$created_at" \
+    --arg database_name "$database_name" \
+    --arg database_user "$database_user" \
+    --arg postgres_image_id "$postgres_image_id" \
+    --arg postgres_version "$version" \
+    --arg sha256 "$checksum" \
+    --arg source_compose_project "$compose_project" \
+    --arg source_compose_service "$compose_service" \
+    --arg source_volume "$source_volume" \
+    --argjson retention_days "$retention_days" \
+    --argjson schema_version "$schema_version" \
+    --argjson size_bytes "$size" \
+    --argjson user_count "$users" '
+      {
+        format_version: 1,
+        backup_id: $backup_id,
+        backup_type: "daily",
+        created_at: $created_at,
+        retention_days: $retention_days,
+        source_compose_project: $source_compose_project,
+        source_compose_service: $source_compose_service,
+        source_volume: $source_volume,
+        postgres_image_id: $postgres_image_id,
+        postgres_version: $postgres_version,
+        database_name: $database_name,
+        database_user: $database_user,
+        schema_version: $schema_version,
+        schema_dirty: false,
+        user_count: $user_count,
+        size_bytes: $size_bytes,
+        sha256: $sha256
+      }
+    ' >"$file"
+}
+
+validate_metadata() {
+  local metadata=$1 backup_id=$2
+  jq --exit-status \
+    --arg backup_id "$backup_id" \
+    --arg database_name "$database_name" \
+    --arg database_user "$database_user" \
+    --arg postgres_image_id "$postgres_image_id" \
+    --arg source_compose_project "$compose_project" \
+    --arg source_compose_service "$compose_service" \
+    --arg source_volume "$source_volume" \
+    --argjson retention_days "$retention_days" '
+      type == "object" and
+      keys == [
+        "backup_id", "backup_type", "created_at", "database_name", "database_user",
+        "format_version", "postgres_image_id", "postgres_version", "retention_days",
+        "schema_dirty", "schema_version", "sha256", "size_bytes",
+        "source_compose_project", "source_compose_service", "source_volume", "user_count"
+      ] and
+      .format_version == 1 and
+      .backup_id == $backup_id and
+      .backup_type == "daily" and
+      (.created_at | type == "string" and
+        test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$") and
+        (fromdateiso8601 | type == "number")) and
+      ((.created_at | gsub("[-:]"; "")) + "-daily" == .backup_id) and
+      .retention_days == $retention_days and
+      .source_compose_project == $source_compose_project and
+      .source_compose_service == $source_compose_service and
+      .source_volume == $source_volume and
+      .postgres_image_id == $postgres_image_id and
+      (.postgres_version | type == "string" and test("^[1-9][0-9]*\\.") and length <= 128) and
+      .database_name == $database_name and
+      .database_user == $database_user and
+      (.schema_version | type == "number" and floor == . and . > 0) and
+      .schema_dirty == false and
+      (.user_count | type == "number" and floor == . and . >= 0) and
+      (.size_bytes | type == "number" and floor == . and . > 0) and
+      (.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
+    ' "$metadata" >/dev/null || fail 'backup metadata is invalid'
+}
+
+verify_backup_files() {
+  local directory=$1 backup_id=$2 require_freshness=$3
+  local metadata="$directory/$metadata_name" dump="$directory/$dump_name"
+  local checksum_file="$directory/$checksum_name" expected_sha expected_size
+  local actual_sha actual_size entry name
+  local -a entries
+
+  valid_backup_id "$backup_id" || fail 'backup ID is invalid'
+  [[ -d "$directory" && ! -L "$directory" ]] || fail 'backup directory is unsafe'
+  shopt -s nullglob dotglob
+  entries=("$directory"/*)
+  shopt -u nullglob dotglob
+  [[ ${#entries[@]} == 3 ]] || fail 'backup directory must contain exactly three files'
+  for entry in "${entries[@]}"; do
+    name=${entry##*/}
+    case "$name" in
+      "$dump_name" | "$checksum_name" | "$metadata_name") ;;
+      *) fail 'backup directory contains an unexpected file' ;;
+    esac
+    [[ -f "$entry" && ! -L "$entry" ]] || fail 'backup entries must be regular files'
+    [[ "$(file_mode "$entry")" == "600" ]] || fail 'backup files must have mode 0600'
+  done
+  [[ "$(file_mode "$directory")" == "700" ]] || fail 'backup directory must have mode 0700'
+  validate_metadata "$metadata" "$backup_id"
+  expected_sha="$(jq --raw-output '.sha256' "$metadata")"
+  expected_size="$(jq --raw-output '.size_bytes' "$metadata")"
+  actual_sha="$(sha256_file "$dump")"
+  actual_size="$(file_size "$dump")"
+  [[ "$actual_sha" == "$expected_sha" ]] || fail 'backup SHA-256 does not match metadata'
+  [[ "$actual_size" == "$expected_size" ]] || fail 'backup size does not match metadata'
+  printf '%s  %s\n' "$expected_sha" "$dump_name" |
+    cmp -s - "$checksum_file" || fail 'checksum file does not match metadata'
+  if [[ "$require_freshness" == "true" ]]; then
+    jq --exit-status --argjson maximum_age "$maximum_age_seconds" '
+      (.created_at | fromdateiso8601) as $created |
+      now as $current |
+      $created <= $current and ($current - $created) <= $maximum_age
+    ' "$metadata" >/dev/null || fail 'latest backup is stale or from the future'
+  fi
+}
+
+backup_entries() {
+  local -a entries
+  shopt -s nullglob dotglob
+  entries=("$backup_root"/*)
+  shopt -u nullglob dotglob
+  printf '%s\n' "${entries[@]}"
+}
+
+latest_backup_id() {
+  local entry name latest=""
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    name=${entry##*/}
+    if [[ "$name" == .partial-* ]]; then
+      [[ -d "$entry" && ! -L "$entry" ]] || fail 'partial backup entry is unsafe'
+      continue
+    fi
+    valid_backup_id "$name" || fail 'backup root contains an unexpected entry'
+    [[ -d "$entry" && ! -L "$entry" ]] || fail 'final backup entry is unsafe'
+    [[ -z "$latest" || "$name" > "$latest" ]] && latest=$name
+  done < <(backup_entries)
+  [[ -n "$latest" ]] || fail 'no finalized backup exists'
+  printf '%s\n' "$latest"
+}
+
+prune_expired_backups() {
+  local keep=$1 entry name
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    name=${entry##*/}
+    [[ "$name" == .partial-* || "$name" == "$keep" ]] && continue
+    valid_backup_id "$name" || fail 'backup root contains an unexpected entry'
+    verify_backup_files "$entry" "$name" false
+    if jq --exit-status --argjson days "$retention_days" '
+      (now - (.created_at | fromdateiso8601)) > ($days * 86400)
+    ' "$entry/$metadata_name" >/dev/null; then
+      [[ "${entry%/*}" == "$backup_root" ]] || fail 'refusing to prune outside backup root'
+      rm -- "$entry/$dump_name" "$entry/$checksum_name" "$entry/$metadata_name" ||
+        fail 'cannot remove expired backup files'
+      rmdir -- "$entry" || fail 'cannot remove expired backup directory'
+    fi
+  done < <(backup_entries)
+}
+
+run_backup() {
+  local container schema_before schema_after users_before users_after version
+  local timestamp backup_id created_at partial final dump size checksum
+
+  validate_backup_root
+  container="$(source_container)"
+  validate_source_container "$container"
+  schema_before="$(schema_state "$container")"
+  users_before="$(user_count "$container")"
+  version="$(postgres_version "$container")"
+  timestamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+  backup_id="$timestamp-daily"
+  created_at="${timestamp:0:4}-${timestamp:4:2}-${timestamp:6:2}T${timestamp:9:2}:${timestamp:11:2}:${timestamp:13:2}Z"
+  partial="$backup_root/.partial-$backup_id-$$-$RANDOM"
+  final="$backup_root/$backup_id"
+  [[ ! -e "$partial" && ! -e "$final" ]] || fail 'backup ID already exists'
+  mkdir -m 700 "$partial"
+  active_partial_directory=$partial
+  dump="$partial/$dump_name"
+  docker container exec --user postgres "$container" pg_dump \
+    --format=custom \
+    --lock-wait-timeout=30s \
+    --no-owner \
+    --no-privileges \
+    --username "$database_user" \
+    --dbname "$database_name" >"$dump" || fail 'pg_dump failed'
+  docker container exec --interactive --user postgres "$container" pg_restore --list <"$dump" >/dev/null ||
+    fail 'pg_dump output is not a valid custom-format archive'
+  schema_after="$(schema_state "$container")"
+  users_after="$(user_count "$container")"
+  [[ "$schema_after" == "$schema_before" && "$users_after" == "$users_before" ]] ||
+    fail 'source schema or user count changed during backup'
+  chmod 600 "$dump"
+  size="$(file_size "$dump")"
+  checksum="$(sha256_file "$dump")"
+  [[ "$checksum" =~ ^[a-f0-9]{64}$ ]] || fail 'cannot calculate backup SHA-256'
+  printf '%s  %s\n' "$checksum" "$dump_name" >"$partial/$checksum_name"
+  write_metadata "$partial/$metadata_name" "$backup_id" "$created_at" \
+    "$version" "$schema_before" "$users_before" "$size" "$checksum"
+  chmod 600 "$partial/$checksum_name" "$partial/$metadata_name"
+  verify_backup_files "$partial" "$backup_id" true
+  sync
+  mv "$partial" "$final" || fail 'cannot atomically finalize backup'
+  active_partial_directory=""
+  sync
+  verify_backup_files "$final" "$backup_id" true
+  prune_expired_backups "$backup_id"
+  printf 'backup_id=%s checksum=verified\n' "$backup_id"
+}
+
+wait_for_restore() {
+  local attempt process
+  for ((attempt = 1; attempt <= 60; attempt += 1)); do
+    process="$(docker container exec "$restore_container_id" cat /proc/1/comm 2>/dev/null || true)"
+    if [[ "$process" == "postgres" ]] &&
+      docker container exec --user postgres "$restore_container_id" pg_isready \
+        --username "$database_user" --dbname "$database_name" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  fail 'isolated restore database did not become ready'
+}
+
+run_isolated_restore() {
+  local backup_id=$1 directory="$backup_root/$1" suffix expected_schema expected_users expected_version
+  local actual_schema actual_users actual_version container_name
+
+  verify_backup_files "$directory" "$backup_id" true
+  expected_schema="$(jq --raw-output '.schema_version' "$directory/$metadata_name")"
+  expected_users="$(jq --raw-output '.user_count' "$directory/$metadata_name")"
+  expected_version="$(jq --raw-output '.postgres_version' "$directory/$metadata_name")"
+  suffix="${backup_id//[^A-Za-z0-9_.-]/-}-$$-$RANDOM"
+  container_name="$compose_project-restore-$suffix"
+  restore_container_name=$container_name
+  restore_volume="$compose_project-restore-$suffix"
+  restore_backup_id=$backup_id
+  restore_run_id="$$-$RANDOM-$RANDOM"
+  [[ "$restore_volume" != "$source_volume" ]] || fail 'restore volume must differ from source volume'
+  ! docker volume inspect "$restore_volume" >/dev/null 2>&1 || fail 'restore volume already exists'
+  ! docker container inspect "$container_name" >/dev/null 2>&1 || fail 'restore container already exists'
+  [[ "$(docker volume create \
+    --label "$identity_label=$compose_project" \
+    --label "$restore_label=true" \
+    --label "$restore_backup_label=$backup_id" \
+    --label "$restore_run_label=$restore_run_id" \
+    "$restore_volume")" == "$restore_volume" ]] || fail 'cannot create isolated restore volume'
+  restore_container_id="$(docker container run \
+    --detach \
+    --pull never \
+    --name "$container_name" \
+    --network none \
+    --memory 2g \
+    --cpus 1 \
+    --pids-limit 128 \
+    --log-driver none \
+    --label "$identity_label=$compose_project" \
+    --label "$restore_label=true" \
+    --label "$restore_backup_label=$backup_id" \
+    --label "$restore_run_label=$restore_run_id" \
+    --mount "type=volume,src=$restore_volume,dst=/var/lib/postgresql,volume-nocopy" \
+    --env "POSTGRES_DB=$database_name" \
+    --env "POSTGRES_USER=$database_user" \
+    --env POSTGRES_HOST_AUTH_METHOD=trust \
+    "$postgres_image_id")" || fail 'cannot start isolated restore database'
+  [[ "$restore_container_id" =~ ^[a-f0-9]{64}$ ]] || fail 'restore container ID is invalid'
+  wait_for_restore
+  docker container exec --interactive --user postgres "$restore_container_id" pg_restore \
+    --single-transaction \
+    --exit-on-error \
+    --no-owner \
+    --no-privileges \
+    --username "$database_user" \
+    --dbname "$database_name" <"$directory/$dump_name" || fail 'isolated pg_restore failed'
+  actual_schema="$(schema_state "$restore_container_id")"
+  actual_users="$(user_count "$restore_container_id")"
+  actual_version="$(postgres_version "$restore_container_id")"
+  [[ "$actual_schema" == "$expected_schema" ]] || fail 'restored schema does not match metadata'
+  [[ "$actual_users" == "$expected_users" ]] || fail 'restored user count does not match metadata'
+  [[ "$actual_version" == "$expected_version" ]] || fail 'restored PostgreSQL version does not match metadata'
+  cleanup_restore_resources || fail 'cannot remove isolated restore resources'
+  printf 'backup_id=%s restore=verified\n' "$backup_id"
+}
+
+selected_backup_id() {
+  local requested=${1:-}
+  if [[ -n "$requested" ]]; then
+    valid_backup_id "$requested" || fail 'requested backup ID is invalid'
+    printf '%s\n' "$requested"
+  else
+    latest_backup_id
+  fi
+}
+
+main() {
+  local command_name=${1:-} backup_id
+  for command_name_required in docker jq awk cmp date stat sync; do
+    command -v "$command_name_required" >/dev/null 2>&1 ||
+      fail "$command_name_required is required"
+  done
+  if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    fail 'sha256sum or shasum is required'
+  fi
+  case "$command_name" in
+    backup)
+      [[ $# == 1 ]] || { usage; exit 1; }
+      run_backup
+      ;;
+    verify)
+      [[ $# == 1 || $# == 2 ]] || { usage; exit 1; }
+      validate_backup_root
+      backup_id="$(selected_backup_id "${2:-}")"
+      verify_backup_files "$backup_root/$backup_id" "$backup_id" true
+      printf 'backup_id=%s checksum=verified\n' "$backup_id"
+      ;;
+    restore-check)
+      [[ $# == 1 || $# == 2 ]] || { usage; exit 1; }
+      validate_backup_root
+      backup_id="$(selected_backup_id "${2:-}")"
+      run_isolated_restore "$backup_id"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup.service
+++ b/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Create and verify a SpeakUp China experiment PostgreSQL logical backup
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+TimeoutStartSec=1h
+StateDirectory=speakup-cn-experiment/postgres-backups
+StateDirectoryMode=0700
+UMask=0077
+ExecStart=/usr/bin/flock --wait 900 /run/lock/xe3-speakup-cn-experiment-postgres-backup.lock /usr/bin/env EXPERIMENT_POSTGRES_BACKUP_ROOT=/var/lib/speakup-cn-experiment/postgres-backups /usr/local/sbin/xe3-speakup-cn-experiment-postgres-backup backup
+PrivateTmp=true
+PrivateDevices=true
+PrivateNetwork=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/run/lock
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_UNIX
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true

--- a/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup.service
+++ b/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup.service
@@ -8,6 +8,9 @@ Type=oneshot
 TimeoutStartSec=1h
 StateDirectory=speakup-cn-experiment/postgres-backups
 StateDirectoryMode=0700
+RuntimeDirectory=xe3-speakup-cn-experiment-postgres-backup
+RuntimeDirectoryMode=0700
+Environment=DOCKER_CONFIG=/run/xe3-speakup-cn-experiment-postgres-backup
 UMask=0077
 ExecStart=/usr/bin/flock --wait 900 /run/lock/xe3-speakup-cn-experiment-postgres-backup.lock /usr/bin/env EXPERIMENT_POSTGRES_BACKUP_ROOT=/var/lib/speakup-cn-experiment/postgres-backups /usr/local/sbin/xe3-speakup-cn-experiment-postgres-backup backup
 PrivateTmp=true

--- a/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup.timer
+++ b/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the SpeakUp China experiment PostgreSQL backup daily
+
+[Timer]
+OnCalendar=*-*-* 18:30:00 UTC
+RandomizedDelaySec=15m
+Persistent=true
+Unit=xe3-speakup-cn-experiment-postgres-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-restore-check.service
+++ b/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-restore-check.service
@@ -8,6 +8,9 @@ Type=oneshot
 TimeoutStartSec=1h
 StateDirectory=speakup-cn-experiment/postgres-backups speakup-cn-experiment/backup-checks
 StateDirectoryMode=0700
+RuntimeDirectory=xe3-speakup-cn-experiment-postgres-backup
+RuntimeDirectoryMode=0700
+Environment=DOCKER_CONFIG=/run/xe3-speakup-cn-experiment-postgres-backup
 UMask=0077
 ExecStartPre=/usr/bin/rm --force -- /var/lib/speakup-cn-experiment/backup-checks/latest-restore.success
 ExecStart=/usr/bin/flock --wait 900 /run/lock/xe3-speakup-cn-experiment-postgres-backup.lock /usr/bin/env EXPERIMENT_POSTGRES_BACKUP_ROOT=/var/lib/speakup-cn-experiment/postgres-backups /usr/local/sbin/xe3-speakup-cn-experiment-postgres-backup restore-check

--- a/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-restore-check.service
+++ b/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-restore-check.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Restore-check the latest SpeakUp China experiment PostgreSQL backup
+Requires=docker.service xe3-speakup-cn-experiment-postgres-backup.service
+After=docker.service xe3-speakup-cn-experiment-postgres-backup.service
+
+[Service]
+Type=oneshot
+TimeoutStartSec=1h
+StateDirectory=speakup-cn-experiment/postgres-backups speakup-cn-experiment/backup-checks
+StateDirectoryMode=0700
+UMask=0077
+ExecStartPre=/usr/bin/rm --force -- /var/lib/speakup-cn-experiment/backup-checks/latest-restore.success
+ExecStart=/usr/bin/flock --wait 900 /run/lock/xe3-speakup-cn-experiment-postgres-backup.lock /usr/bin/env EXPERIMENT_POSTGRES_BACKUP_ROOT=/var/lib/speakup-cn-experiment/postgres-backups /usr/local/sbin/xe3-speakup-cn-experiment-postgres-backup restore-check
+ExecStartPost=/usr/bin/install --no-target-directory --owner=root --group=root --mode=0600 /dev/null /var/lib/speakup-cn-experiment/backup-checks/latest-restore.success
+PrivateTmp=true
+PrivateDevices=true
+PrivateNetwork=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/run/lock
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_UNIX
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true

--- a/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-restore-check.timer
+++ b/deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-restore-check.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Restore-check the SpeakUp China experiment PostgreSQL backup weekly
+
+[Timer]
+OnCalendar=Sun *-*-* 19:30:00 UTC
+RandomizedDelaySec=30m
+Persistent=true
+Unit=xe3-speakup-cn-experiment-postgres-restore-check.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/experiments/cn-backend/compose.observability.yaml
+++ b/deploy/experiments/cn-backend/compose.observability.yaml
@@ -1,0 +1,73 @@
+name: xe3-speakup-cn-experiment
+
+x-observability-security: &observability-security
+  read_only: true
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+  restart: unless-stopped
+  logging:
+    driver: json-file
+    options:
+      max-size: "5m"
+      max-file: "3"
+
+services:
+  prometheus:
+    <<: *observability-security
+    image: quay.io/prometheus/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
+    pull_policy: never
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.retention.size=512MB
+    ports:
+      - "127.0.0.1:29091:9090"
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/rules.yml:/etc/prometheus/rules.yml:ro
+      - prometheus_data:/prometheus
+    tmpfs:
+      - /tmp:size=16m,mode=1777
+    networks:
+      - monitor
+      - monitor_ui
+    mem_limit: 256m
+    cpus: 0.25
+    pids_limit: 64
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:9090/-/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  node-exporter:
+    <<: *observability-security
+    image: quay.io/prometheus/node-exporter:v1.12.1@sha256:1b4e4438faca4dd7e001dd445d161a4a2091b0fededa84093b3a8dfeae1f1be0
+    pull_policy: never
+    command:
+      - --collector.disable-defaults
+      - --collector.textfile
+      - --collector.textfile.directory=/textfile
+    volumes:
+      - /var/lib/speakup-cn-experiment/metrics:/textfile:ro
+    networks:
+      - monitor
+    mem_limit: 64m
+    cpus: 0.10
+    pids_limit: 32
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:9100/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+volumes:
+  prometheus_data:
+
+networks:
+  monitor_ui:

--- a/deploy/experiments/cn-backend/compose.yaml
+++ b/deploy/experiments/cn-backend/compose.yaml
@@ -1,0 +1,97 @@
+name: xe3-speakup-cn-experiment
+
+x-speakup-logging: &speakup-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+services:
+  postgres:
+    image: postgres:18-bookworm
+    # Docker Hub is not reliably reachable from the experiment host. Load this
+    # exact digest through the audited offline path before starting the stack.
+    pull_policy: never
+    restart: unless-stopped
+    logging: *speakup-logging
+    environment:
+      POSTGRES_DB: ${EXPERIMENT_POSTGRES_DB:?EXPERIMENT_POSTGRES_DB is required}
+      POSTGRES_USER: ${EXPERIMENT_POSTGRES_USER:?EXPERIMENT_POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${EXPERIMENT_POSTGRES_PASSWORD:?EXPERIMENT_POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql
+    networks:
+      - database
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'pg_isready --username="$${POSTGRES_USER}" --dbname="$${POSTGRES_DB}"',
+        ]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+      start_period: 5s
+
+  migrate:
+    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    pull_policy: never
+    profiles:
+      - migration
+    restart: "no"
+    logging: *speakup-logging
+    command:
+      - /usr/local/bin/speakup-migrate
+      - up
+    environment:
+      DATABASE_URL: postgres://${EXPERIMENT_POSTGRES_USER:?EXPERIMENT_POSTGRES_USER is required}:${EXPERIMENT_POSTGRES_PASSWORD:?EXPERIMENT_POSTGRES_PASSWORD is required}@postgres:5432/${EXPERIMENT_POSTGRES_DB:?EXPERIMENT_POSTGRES_DB is required}?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - database
+
+  server:
+    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    pull_policy: never
+    restart: unless-stopped
+    init: true
+    logging: *speakup-logging
+    env_file:
+      - ${EXPERIMENT_SERVER_ENV_FILE:?EXPERIMENT_SERVER_ENV_FILE is required}
+    environment:
+      DATABASE_URL: postgres://${EXPERIMENT_POSTGRES_USER:?EXPERIMENT_POSTGRES_USER is required}:${EXPERIMENT_POSTGRES_PASSWORD:?EXPERIMENT_POSTGRES_PASSWORD is required}@postgres:5432/${EXPERIMENT_POSTGRES_DB:?EXPERIMENT_POSTGRES_DB is required}?sslmode=disable
+      SERVER_HOST: 0.0.0.0
+      SERVER_PORT: "8080"
+      METRICS_HOST: 127.0.0.1
+    ports:
+      - "${EXPERIMENT_BIND_ADDRESS:?EXPERIMENT_BIND_ADDRESS is required}:18083:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - server_egress
+      - database
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "-q",
+          "-T",
+          "2",
+          "--spider",
+          "http://127.0.0.1:8080/readyz",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+
+networks:
+  server_egress:
+  database:
+    internal: true
+
+volumes:
+  postgres_data:

--- a/deploy/experiments/cn-backend/compose.yaml
+++ b/deploy/experiments/cn-backend/compose.yaml
@@ -65,7 +65,7 @@ services:
       SERVER_PORT: "8080"
       METRICS_HOST: 127.0.0.1
     ports:
-      - "${EXPERIMENT_BIND_ADDRESS:?EXPERIMENT_BIND_ADDRESS is required}:18083:8080"
+      - "127.0.0.1:28083:8080"
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/experiments/cn-backend/compose.yaml
+++ b/deploy/experiments/cn-backend/compose.yaml
@@ -63,7 +63,7 @@ services:
       DATABASE_URL: postgres://${EXPERIMENT_POSTGRES_USER:?EXPERIMENT_POSTGRES_USER is required}:${EXPERIMENT_POSTGRES_PASSWORD:?EXPERIMENT_POSTGRES_PASSWORD is required}@postgres:5432/${EXPERIMENT_POSTGRES_DB:?EXPERIMENT_POSTGRES_DB is required}?sslmode=disable
       SERVER_HOST: 0.0.0.0
       SERVER_PORT: "8080"
-      METRICS_HOST: 127.0.0.1
+      METRICS_HOST: 0.0.0.0
     ports:
       - "127.0.0.1:28083:8080"
     depends_on:
@@ -72,6 +72,7 @@ services:
     networks:
       - server_egress
       - database
+      - monitor
     healthcheck:
       test:
         [
@@ -91,6 +92,8 @@ services:
 networks:
   server_egress:
   database:
+    internal: true
+  monitor:
     internal: true
 
 volumes:

--- a/deploy/experiments/cn-backend/compose.yaml
+++ b/deploy/experiments/cn-backend/compose.yaml
@@ -14,6 +14,9 @@ services:
     pull_policy: never
     restart: unless-stopped
     logging: *speakup-logging
+    mem_limit: 2g
+    cpus: 1.0
+    pids_limit: 128
     environment:
       POSTGRES_DB: ${EXPERIMENT_POSTGRES_DB:?EXPERIMENT_POSTGRES_DB is required}
       POSTGRES_USER: ${EXPERIMENT_POSTGRES_USER:?EXPERIMENT_POSTGRES_USER is required}
@@ -57,6 +60,9 @@ services:
     restart: unless-stopped
     init: true
     logging: *speakup-logging
+    mem_limit: 3g
+    cpus: 2.0
+    pids_limit: 256
     env_file:
       - ${EXPERIMENT_SERVER_ENV_FILE:?EXPERIMENT_SERVER_ENV_FILE is required}
     environment:

--- a/deploy/experiments/cn-backend/cutover-checklist-v1.md
+++ b/deploy/experiments/cn-backend/cutover-checklist-v1.md
@@ -25,6 +25,8 @@ SHA-256 values.
 
 - [ ] The current Singapore release completed through immutable Tag, GitHub
   Release, public APK, and changelog verification before this cutover started.
+- [ ] China-provider preparation did not change or block the current Singapore
+  release path; this checklist governs only the later China cutover.
 - [ ] Candidate `release_version`, Git SHA, Server digest, PostgreSQL digest,
   and schema version match the reviewed Release Candidate manifest.
 - [ ] China Qianwen, OSS, and XFYun resources are Production-owned and use
@@ -36,11 +38,46 @@ SHA-256 values.
 
 Required provider groups change together:
 
-- Qianwen: `QIANWEN_BASE_URL`, `QIANWEN_ASR_BASE_URL`,
-  `QIANWEN_TTS_BASE_URL`, `DASHSCOPE_API_KEY`;
-- OSS: `OSS_REGION`, `OSS_ENDPOINT`, `OSS_BUCKET`, and its credential provider;
-- XFYun ISE: endpoint, APPID, API key, and API secret;
-- explicitly enabled regional avatar and OCR endpoints.
+- Qianwen text generation: `TEXT_GENERATION_PROVIDER`,
+  `DASHSCOPE_API_KEY`, `QIANWEN_BASE_URL`, `QIANWEN_MODEL`,
+  `QIANWEN_EVALUATION_MODEL`, `QIANWEN_SPEECH_FEEDBACK_MODEL`,
+  `QIANWEN_TIMEOUT`, and `QIANWEN_MAX_OUTPUT_TOKENS`;
+- Qianwen ASR: `SPEECH_RECOGNITION_PROVIDER`, `QIANWEN_ASR_BASE_URL`,
+  `QIANWEN_ASR_MODEL`, `QIANWEN_ASR_TIMEOUT`,
+  `QIANWEN_ASR_RECORDED_MODEL`, and `QIANWEN_ASR_RECORDED_TIMEOUT`;
+- Qianwen TTS: `SPEECH_SYNTHESIS_PROVIDER`, `QIANWEN_TTS_BASE_URL`,
+  `QIANWEN_TTS_MODEL`, `QIANWEN_TTS_VOICE`, `QIANWEN_TTS_LANGUAGE`,
+  `QIANWEN_TTS_TIMEOUT`, and `QIANWEN_TTS_TEMP_DIRECTORY`;
+- Aliyun OSS: `OSS_ENABLED`, `OBJECT_STORAGE_PROVIDER`, `OSS_REGION`,
+  `OSS_ENDPOINT`, `OSS_BUCKET`, `OSS_AUDIO_PREFIX`, `OSS_IMAGE_PREFIX`,
+  `OSS_RESUME_PREFIX`, `OSS_SIGNED_URL_TTL`, and
+  `OSS_CREDENTIALS_PROVIDER`;
+- OSS environment credentials: `OSS_ACCESS_KEY_ID`,
+  `OSS_ACCESS_KEY_SECRET`, and optional `OSS_SESSION_TOKEN`, with
+  `OSS_RAM_ROLE_NAME` empty; or a verified Alibaba ECS role source with the
+  environment credentials absent and `OSS_RAM_ROLE_NAME` recorded;
+- XFYun ISE: `XFYUN_ISE_ENDPOINT`, `XFYUN_ISE_TIMEOUT`, `APPID`, `APIKey`, and
+  `APISecret` from one domestic application and service entitlement.
+
+- [ ] The private provider matrix records, for every field above, the Singapore
+  baseline, China candidate, resource region and owner, secret classification,
+  validation receipt, and rollback value or environment hash.
+- [ ] `TEXT_GENERATION_PROVIDER`, `SPEECH_RECOGNITION_PROVIDER`, and
+  `SPEECH_SYNTHESIS_PROVIDER` are all `qianwen`; `OSS_ENABLED=1` and
+  `OBJECT_STORAGE_PROVIDER=aliyun_oss`.
+- [ ] `AGENT_CONTEXT_MAX_CHARACTERS`, `AGENT_RUN_LOOP_TIMEOUT`, all `VOICE_*`
+  limits, and other non-regional runtime values either match the tested
+  Singapore baseline or have a separately reviewed reason to change.
+- [ ] Avatar fields (`SPATIUS_ENABLED`, `SPATIUS_REGION`,
+  `SPATIUS_CONSOLE_BASE_URL`, `SPATIUS_APP_ID`, `SPATIUS_AVATAR_ID`,
+  `SPATIUS_API_KEY`, `SPATIUS_TOKEN_TTL`, `SPATIUS_TIMEOUT`) and OCR fields
+  (`RESUME_OCR_ENABLED`, `PADDLEOCR_ACCESS_TOKEN`, `PADDLEOCR_BASE_URL`,
+  `RESUME_OCR_TIMEOUT`) are each classified as `china`, `unchanged`, or
+  `disabled`; enabled unchanged services passed China-host latency checks.
+- [ ] No partial candidate file is accepted: a missing selector, model,
+  timeout, endpoint, resource identifier, or required credential rejects the
+  candidate from approval and keeps the China stack isolated from Production
+  traffic; successful Server startup alone does not complete this matrix.
 
 ## 2. HTTPS, WSS, and App entry
 

--- a/deploy/experiments/cn-backend/cutover-checklist-v1.md
+++ b/deploy/experiments/cn-backend/cutover-checklist-v1.md
@@ -1,0 +1,153 @@
+# China backend cutover checklist v1
+
+This is a fail-closed template. A blank item means the China backend is not
+approved to receive Production traffic. Never put credentials or raw
+environment files in this document or in Git.
+
+```text
+plan_version: 1
+release_version:
+git_sha:
+server_image_digest:
+database_schema_version:
+generated_at_utc:
+change_owner:
+approver:
+private_receipt_root:
+```
+
+Private evidence belongs under
+`/var/lib/speakup-cn-experiment/receipts/<version>/<timestamp>/` with directory
+mode `0700` and file mode `0600`. This checklist records only receipt names and
+SHA-256 values.
+
+## 1. Release and resource boundary
+
+- [ ] The current Singapore release completed through immutable Tag, GitHub
+  Release, public APK, and changelog verification before this cutover started.
+- [ ] Candidate `release_version`, Git SHA, Server digest, PostgreSQL digest,
+  and schema version match the reviewed Release Candidate manifest.
+- [ ] China Qianwen, OSS, and XFYun resources are Production-owned and use
+  China endpoints. Enabled avatar or OCR providers were classified explicitly.
+- [ ] The active China `server.env` contains no Singapore endpoint mixed with a
+  China credential, and its SHA-256 is recorded without exposing values.
+- [ ] The known-good Singapore `server.env` SHA-256 and Server image digest are
+  recorded as rollback inputs.
+
+Required provider groups change together:
+
+- Qianwen: `QIANWEN_BASE_URL`, `QIANWEN_ASR_BASE_URL`,
+  `QIANWEN_TTS_BASE_URL`, `DASHSCOPE_API_KEY`;
+- OSS: `OSS_REGION`, `OSS_ENDPOINT`, `OSS_BUCKET`, and its credential provider;
+- XFYun ISE: endpoint, APPID, API key, and API secret;
+- explicitly enabled regional avatar and OCR endpoints.
+
+## 2. HTTPS, WSS, and App entry
+
+- [ ] A trusted HTTPS edge terminates a valid certificate and proxies HTTP plus
+  WebSocket upgrades to the loopback-only Server API.
+- [ ] `/health` and `/readyz` pass through the intended public edge without
+  exposing `/metrics`, PostgreSQL, or a container port.
+- [ ] DNS TTL and the old `api.speak-up.top` origin are recorded before change.
+- [ ] External probes confirm the China edge from at least two networks.
+
+The Android Production flavor is compiled for `https://api.speak-up.top` and
+rejects non-loopback HTTP/WS. Keeping that hostname allows an origin/DNS switch
+without a new APK. Changing the API hostname requires a separately reviewed,
+signed, higher-version APK. A public IP and plaintext high port are never a
+Production entry.
+
+## 3. Data and OSS migration
+
+- [ ] A maintenance window and an explicit write-stop point are approved;
+  there is no dual-write or replication contract today.
+- [ ] Singapore PostgreSQL produced a final consistency backup with backup ID,
+  metadata, size, and SHA-256.
+- [ ] The final backup passed an isolated restore check before transfer.
+- [ ] The encrypted transfer completed and the China restore passed schema,
+  row-count, ownership, and application-readiness checks.
+- [ ] Singapore OSS objects were copied to the China bucket and an inventory
+  compared object keys, sizes, and checksums or ETags where their semantics are
+  equivalent.
+- [ ] The Singapore database and bucket remain intact and read-only throughout
+  the rollback window.
+
+Record `backup.json` and its SHA-256. Do not treat “the dump file exists” as a
+restore test.
+
+## 4. Acceptance matrix
+
+- [ ] Five or more comparable runs cover login, authenticated HTTP, WebSocket,
+  text response, voice upload, ASR, LLM, TTS, XFYun ISE, OSS upload and signed
+  download, and Part 1/2/3/full report generation.
+- [ ] Each scenario records attempts, successes, failure categories, P50, P95,
+  and maximum duration for Singapore and China under the same client method.
+- [ ] Android real-device testing used the reviewed APK; the SSH-tunnel debug
+  APK was used only before the trusted HTTPS edge existed.
+- [ ] `uat.json` names the release, endpoint, device build, provider region,
+  and receipt SHA-256 without including user content or tokens.
+
+## 5. Monitoring, alerting, and backups
+
+- [ ] Local metrics are collected without public exposure; external probes
+  monitor the public API independently of the China host.
+- [ ] Dashboards cover HTTP success/5xx/P95, report success and duration,
+  Qianwen/ASR/TTS/ISE/OSS calls and errors, container health, CPU, memory, disk,
+  inode, PostgreSQL readiness, and certificate expiry.
+- [ ] An alert drill reached the intended recipient and its evidence is
+  recorded.
+- [ ] Daily PostgreSQL backup, pre-cutover backup, retention, off-host copy,
+  freshness check, and scheduled isolated restore are active.
+- [ ] Docker and edge logs rotate within a measured disk budget.
+
+## 6. GitHub and host control plane
+
+- [ ] A dedicated protected GitHub Environment holds only China deployment
+  credentials and requires the chosen human approval policy.
+- [ ] The Environment permits only reviewed official `main` artifacts and pins
+  SSH known-host identity.
+- [ ] A non-root deployment user can invoke only the reviewed deployment entry;
+  routine deployment does not use root password authentication.
+- [ ] Deployment is locked to one operation and writes a content-addressed
+  receipt. Re-running the same receipt is idempotent.
+
+These controls are not required to finish the current Singapore release, but
+they are required before repeatable China Production deployment.
+
+## 7. Cutover
+
+- [ ] `preflight.json`, `backup.json`, and `uat.json` all exist and their hashes
+  match this plan.
+- [ ] Writes are stopped at the recorded timestamp and the final database/OSS
+  delta is zero.
+- [ ] China Server starts from the pinned digest and candidate `server.env`;
+  migrations and readiness succeed before traffic changes.
+- [ ] The HTTPS origin or DNS changes to China and external health, login,
+  WebSocket, voice, report, and download checks pass.
+- [ ] Writes are re-enabled only after those checks pass.
+- [ ] `cutover.json` records the approver, timestamps, old/new origin, digests,
+  backup ID, checks, and final result.
+
+## 8. Rollback
+
+Rollback trigger examples must be assigned measured thresholds before cutover:
+health/readiness failure, elevated 5xx or P95, provider failure, report failure,
+or data-integrity mismatch.
+
+- [ ] Stop new writes and preserve China logs, receipts, and the current
+  database before changing traffic.
+- [ ] If China accepted **no writes**, restore the recorded Singapore origin and
+  verify the preserved Singapore database and provider configuration.
+- [ ] If China accepted **any writes**, do not point traffic at the stale
+  Singapore database. First back up China, restore or reconcile that state into
+  the selected rollback database, verify it in isolation, and only then switch
+  traffic.
+- [ ] Restore the previous Server digest, environment hash, edge origin, and
+  DNS value as one reviewed rollback operation.
+- [ ] Re-run external health, login, WebSocket, voice, report, and object access
+  checks before reopening writes.
+- [ ] `rollback.json` records trigger, data boundary, target backup/digest,
+  approver, checks, and result; its SHA-256 is attached to the incident record.
+
+Until both the no-write and post-write rollback paths have been rehearsed, the
+China stack remains an experiment and must not take Production traffic.

--- a/deploy/experiments/cn-backend/observability/export-host-metrics.sh
+++ b/deploy/experiments/cn-backend/observability/export-host-metrics.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 022
+
+readonly metrics_directory="/var/lib/speakup-cn-experiment/metrics"
+readonly metrics_file="$metrics_directory/speakup-cn-experiment.prom"
+readonly api_origin="http://127.0.0.1:28083"
+
+fail() {
+  printf 'China experiment metrics export error: %s\n' "$*" >&2
+  exit 1
+}
+
+for command in chmod curl df docker install jq mktemp mv rm stat tail; do
+  command -v "$command" >/dev/null 2>&1 || fail "$command is required"
+done
+
+[[ -d "$metrics_directory" && ! -L "$metrics_directory" ]] ||
+  fail "$metrics_directory must be a real directory"
+[[ "$(stat --format='%U:%G:%a' "$metrics_directory")" == "root:root:755" ]] ||
+  fail "$metrics_directory must be root:root mode 0755"
+
+temporary_file="$(mktemp "$metrics_directory/.speakup-cn-experiment.XXXXXX")"
+ready_body="$(mktemp)"
+trap 'rm -f -- "$temporary_file" "$ready_body"' EXIT
+
+health_up=0
+health_duration=0
+if measured="$(curl --fail --silent --show-error --max-time 3 \
+  --output /dev/null --write-out '%{time_total}' "$api_origin/health")"; then
+  health_up=1
+  health_duration="$measured"
+fi
+
+ready_up=0
+ready_duration=0
+if measured="$(curl --fail --silent --show-error --max-time 3 \
+  --output "$ready_body" --write-out '%{time_total}' "$api_origin/readyz")"; then
+  ready_duration="$measured"
+  if jq --exit-status \
+    '.status == "ready" and .checks.database == "ready"' \
+    "$ready_body" >/dev/null; then
+    ready_up=1
+  fi
+fi
+
+read -r filesystem_size filesystem_available < <(
+  df --block-size=1 --output=size,avail / | tail -n 1
+)
+read -r filesystem_files filesystem_files_free < <(
+  df --output=itotal,iavail / | tail -n 1
+)
+for value in "$filesystem_size" "$filesystem_available" \
+  "$filesystem_files" "$filesystem_files_free"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "df returned an invalid value"
+done
+
+{
+  printf '# HELP speakup_cn_experiment_api_up Whether the local API endpoint is healthy.\n'
+  printf '# TYPE speakup_cn_experiment_api_up gauge\n'
+  printf 'speakup_cn_experiment_api_up{endpoint="health"} %s\n' "$health_up"
+  printf 'speakup_cn_experiment_api_up{endpoint="readyz"} %s\n' "$ready_up"
+  printf '# HELP speakup_cn_experiment_api_probe_duration_seconds Local API probe duration.\n'
+  printf '# TYPE speakup_cn_experiment_api_probe_duration_seconds gauge\n'
+  printf 'speakup_cn_experiment_api_probe_duration_seconds{endpoint="health"} %s\n' "$health_duration"
+  printf 'speakup_cn_experiment_api_probe_duration_seconds{endpoint="readyz"} %s\n' "$ready_duration"
+
+  for service in server postgres; do
+    container="xe3-speakup-cn-experiment-${service}-1"
+    running=0
+    healthy=0
+    restarts=0
+    if state="$(docker container inspect "$container" 2>/dev/null)"; then
+      if jq --exit-status 'length == 1 and .[0].State.Status == "running"' \
+        <<<"$state" >/dev/null; then
+        running=1
+      fi
+      if jq --exit-status 'length == 1 and .[0].State.Health.Status == "healthy"' \
+        <<<"$state" >/dev/null; then
+        healthy=1
+      fi
+      restarts="$(jq --raw-output '.[0].RestartCount' <<<"$state")"
+      [[ "$restarts" =~ ^[0-9]+$ ]] || fail "Docker returned an invalid restart count"
+    fi
+    printf 'speakup_cn_experiment_container_running{service="%s"} %s\n' \
+      "$service" "$running"
+    printf 'speakup_cn_experiment_container_healthy{service="%s"} %s\n' \
+      "$service" "$healthy"
+    printf 'speakup_cn_experiment_container_restart_count{service="%s"} %s\n' \
+      "$service" "$restarts"
+  done
+
+  printf '# HELP speakup_cn_experiment_filesystem_size_bytes Root filesystem size.\n'
+  printf '# TYPE speakup_cn_experiment_filesystem_size_bytes gauge\n'
+  printf 'speakup_cn_experiment_filesystem_size_bytes %s\n' "$filesystem_size"
+  printf '# HELP speakup_cn_experiment_filesystem_available_bytes Root filesystem available bytes.\n'
+  printf '# TYPE speakup_cn_experiment_filesystem_available_bytes gauge\n'
+  printf 'speakup_cn_experiment_filesystem_available_bytes %s\n' "$filesystem_available"
+  printf '# HELP speakup_cn_experiment_filesystem_files Root filesystem inode count.\n'
+  printf '# TYPE speakup_cn_experiment_filesystem_files gauge\n'
+  printf 'speakup_cn_experiment_filesystem_files %s\n' "$filesystem_files"
+  printf '# HELP speakup_cn_experiment_filesystem_files_free Root filesystem free inodes.\n'
+  printf '# TYPE speakup_cn_experiment_filesystem_files_free gauge\n'
+  printf 'speakup_cn_experiment_filesystem_files_free %s\n' "$filesystem_files_free"
+} >"$temporary_file"
+
+chmod 0644 "$temporary_file"
+mv -- "$temporary_file" "$metrics_file"
+trap 'rm -f -- "$ready_body"' EXIT

--- a/deploy/experiments/cn-backend/observability/prometheus.yml
+++ b/deploy/experiments/cn-backend/observability/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    product: speakup
+    environment: cn-experiment
+
+rule_files:
+  - /etc/prometheus/rules.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - prometheus:9090
+
+  - job_name: speakup-cn-experiment-api
+    static_configs:
+      - targets:
+          - server:9090
+
+  - job_name: speakup-cn-experiment-host
+    static_configs:
+      - targets:
+          - node-exporter:9100

--- a/deploy/experiments/cn-backend/observability/rules.yml
+++ b/deploy/experiments/cn-backend/observability/rules.yml
@@ -1,0 +1,77 @@
+groups:
+  - name: speakup-cn-experiment
+    rules:
+      - alert: SpeakUpChinaExperimentScrapeDown
+        expr: up{job=~"speakup-cn-experiment-api|speakup-cn-experiment-host"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "China experiment metrics scrape is down"
+
+      - alert: SpeakUpChinaExperimentAPIUnavailable
+        expr: speakup_cn_experiment_api_up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "China experiment API health or readiness failed"
+
+      - alert: SpeakUpChinaExperimentContainerUnavailable
+        expr: speakup_cn_experiment_container_running == 0 or speakup_cn_experiment_container_healthy == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "China experiment container is unavailable"
+
+      - alert: SpeakUpChinaExperimentHostMetricsStale
+        expr: |
+          absent(node_textfile_mtime_seconds{file=~".*speakup-cn-experiment[.]prom"})
+          or
+          time()
+          - max(node_textfile_mtime_seconds{file=~".*speakup-cn-experiment[.]prom"})
+          > 180
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "China experiment host metrics are stale"
+
+      - alert: SpeakUpChinaExperimentDiskLow
+        expr: speakup_cn_experiment_filesystem_available_bytes / speakup_cn_experiment_filesystem_size_bytes < 0.15
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "China experiment root disk has less than 15% free"
+
+      - alert: SpeakUpChinaExperimentInodesLow
+        expr: speakup_cn_experiment_filesystem_files_free / speakup_cn_experiment_filesystem_files < 0.15
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "China experiment root filesystem has less than 15% free inodes"
+
+      - alert: SpeakUpChinaExperimentProviderFailureRateHigh
+        expr: |
+          sum by (provider, capability) (
+            increase(speakup_provider_calls_total{outcome!="success"}[10m])
+          ) >= 5
+          and
+          sum by (provider, capability) (
+            increase(speakup_provider_calls_total{outcome!="success"}[10m])
+          )
+          /
+          clamp_min(
+            sum by (provider, capability) (
+              increase(speakup_provider_calls_total[10m])
+            ),
+            1
+          ) > 0.20
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "China experiment provider failures exceed 20%"

--- a/deploy/experiments/cn-backend/observability/xe3-speakup-cn-experiment-metrics.service
+++ b/deploy/experiments/cn-backend/observability/xe3-speakup-cn-experiment-metrics.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Export private host metrics for the SpeakUp China experiment
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+UMask=0022
+StateDirectory=speakup-cn-experiment/metrics
+StateDirectoryMode=0755
+ExecStart=/usr/local/sbin/xe3-speakup-cn-experiment-export-metrics
+PrivateTmp=true
+PrivateDevices=true
+ProtectHome=true
+ProtectSystem=strict
+NoNewPrivileges=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true

--- a/deploy/experiments/cn-backend/observability/xe3-speakup-cn-experiment-metrics.timer
+++ b/deploy/experiments/cn-backend/observability/xe3-speakup-cn-experiment-metrics.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Refresh private host metrics for the SpeakUp China experiment
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=10s
+Persistent=true
+Unit=xe3-speakup-cn-experiment-metrics.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
+++ b/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
@@ -1,0 +1,48 @@
+# 2026-08-27 China backend baseline
+
+## Scope
+
+- Release Candidate: `v0.1.8`, git SHA
+  `0d89b071682131651178d2adf6cdfee0fb6391b8`.
+- Server image digest:
+  `sha256:77718703587e0ad027c7b4d15856dbddfb40554946a935de26dc4ac6500428c5`.
+- China experiment host: Qiniu LAS, China (Changzhou 2), 4 vCPU, 8 GiB RAM.
+- Database: isolated PostgreSQL 18 volume with schema migration 9 applied.
+- Provider environment: current Singapore Staging configuration; no Production
+  database or Production traffic was used.
+
+## Client-to-API health probe
+
+Twenty sequential `/health` requests were made from the operator network. The
+China endpoints used HTTP high-port mappings while Singapore Staging used
+HTTPS, so this is a directional latency signal rather than a final protocol-
+equivalent benchmark.
+
+| Endpoint | Success | Minimum | P50 | P95 | Maximum |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| China Mobile mapping | 20/20 | 59 ms | 62 ms | 66 ms | 80 ms |
+| China Unicom mapping | 20/20 | 121 ms | 133 ms | 151 ms | 154 ms |
+| Singapore Staging HTTPS | 20/20 | 215 ms | 227 ms | 744 ms | 756 ms |
+
+## Backend-to-provider TLS probe
+
+Each cell is the median total time from ten HTTPS requests. The requests
+measured DNS/TCP/TLS/routing only and did not invoke a paid model operation.
+
+| Backend location | Qianwen Singapore | OSS Singapore | XFYun Singapore |
+| --- | ---: | ---: | ---: |
+| China experiment | 660 ms | 1,358 ms | 297 ms |
+| Singapore Staging | 33 ms | 32 ms | 30 ms |
+
+| Backend location | Qianwen China | OSS China (Shanghai endpoint) | XFYun China |
+| --- | ---: | ---: | ---: |
+| China experiment | 84 ms | 167 ms | 86 ms |
+| Singapore Staging | 1,233 ms | 859 ms | 842 ms |
+
+## Initial conclusion
+
+Moving only the Go backend to China lowers the client-to-API leg but introduces
+large cross-border latency to the current Singapore providers. The meaningful
+candidate is a coordinated China backend, Qianwen, OSS, and XFYun environment.
+Provider credentials and buckets must be provisioned before the paid, end-to-
+end voice and report comparison.

--- a/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
+++ b/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
@@ -45,22 +45,24 @@ measured DNS/TCP/TLS/routing only and did not invoke a paid model operation.
 
 ## Real current-provider smoke
 
-The reusable smoke ran on the China host against the loopback API while the
-Server used the current Singapore Staging provider configuration. It created
-only an isolated experiment account and did not access Production data.
+The reusable smoke ran five times on the China host against the loopback API
+while the Server used the current Singapore Staging provider configuration. It
+created only isolated experiment accounts and did not access Production data.
+P95 uses nearest-rank selection; with five samples it is the maximum, so these
+numbers are an initial distribution rather than a capacity result.
 
-| Operation | HTTP | Total time | Result |
-| --- | ---: | ---: | --- |
-| Register | 201 | 331 ms | Passed |
-| Login | 200 | 400 ms | Passed |
-| Current user | 200 | 5 ms | Passed |
-| Question bank | 200 | 4 ms | Passed |
-| Qianwen answer generation | 200 | 4.930 s | Valid answer and speech text |
-| Question TTS | 200 | 1.863 s | 140,684-byte WAV |
-| Logout | 204 | 7 ms | Passed |
+| Operation | Success | P50 | P95 | Result |
+| --- | ---: | ---: | ---: | --- |
+| Register | 5/5 | 247 ms | 339 ms | HTTP 201 |
+| Login | 5/5 | 229 ms | 400 ms | HTTP 200 |
+| Current user | 5/5 | 3 ms | 5 ms | HTTP 200 |
+| Question bank | 5/5 | 3 ms | 4 ms | HTTP 200 |
+| Qianwen answer generation | 5/5 | 4.823 s | 5.265 s | Valid answer and speech text |
+| Question TTS | 5/5 | 1.909 s | 2.100 s | Valid WAV, 140,684–148,364 bytes |
+| Logout | 5/5 | 8 ms | 8 ms | HTTP 204 |
 
-This is one functional smoke, not a latency distribution. ASR, WebSocket voice
-streaming, and report generation remain real-device acceptance items.
+ASR, WebSocket voice streaming, and report generation remain real-device
+acceptance items.
 
 ## Initial conclusion
 

--- a/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
+++ b/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
@@ -18,6 +18,10 @@ China endpoints used HTTP high-port mappings while Singapore Staging used
 HTTPS, so this is a directional latency signal rather than a final protocol-
 equivalent benchmark.
 
+Only the unauthenticated `/health` endpoint was probed. After recording this
+baseline, the experiment API was restricted to host loopback; application
+traffic must use the documented SSH tunnel until a trusted TLS edge is ready.
+
 | Endpoint | Success | Minimum | P50 | P95 | Maximum |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | China Mobile mapping | 20/20 | 59 ms | 62 ms | 66 ms | 80 ms |

--- a/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
+++ b/deploy/experiments/cn-backend/results/2026-08-27-baseline.md
@@ -43,6 +43,25 @@ measured DNS/TCP/TLS/routing only and did not invoke a paid model operation.
 | China experiment | 84 ms | 167 ms | 86 ms |
 | Singapore Staging | 1,233 ms | 859 ms | 842 ms |
 
+## Real current-provider smoke
+
+The reusable smoke ran on the China host against the loopback API while the
+Server used the current Singapore Staging provider configuration. It created
+only an isolated experiment account and did not access Production data.
+
+| Operation | HTTP | Total time | Result |
+| --- | ---: | ---: | --- |
+| Register | 201 | 331 ms | Passed |
+| Login | 200 | 400 ms | Passed |
+| Current user | 200 | 5 ms | Passed |
+| Question bank | 200 | 4 ms | Passed |
+| Qianwen answer generation | 200 | 4.930 s | Valid answer and speech text |
+| Question TTS | 200 | 1.863 s | 140,684-byte WAV |
+| Logout | 204 | 7 ms | Passed |
+
+This is one functional smoke, not a latency distribution. ASR, WebSocket voice
+streaming, and report generation remain real-device acceptance items.
+
 ## Initial conclusion
 
 Moving only the Go backend to China lowers the client-to-API leg but introduces

--- a/deploy/experiments/cn-backend/runtime.env.example
+++ b/deploy/experiments/cn-backend/runtime.env.example
@@ -1,0 +1,6 @@
+SERVER_IMAGE_DIGEST=sha256:replace-with-release-manifest-digest
+EXPERIMENT_BIND_ADDRESS=replace-with-private-instance-ip
+EXPERIMENT_POSTGRES_DB=speakup_cn_experiment
+EXPERIMENT_POSTGRES_USER=speakup_cn_experiment
+EXPERIMENT_POSTGRES_PASSWORD=
+EXPERIMENT_SERVER_ENV_FILE=/etc/speakup-cn-experiment/server.env

--- a/deploy/experiments/cn-backend/runtime.env.example
+++ b/deploy/experiments/cn-backend/runtime.env.example
@@ -1,6 +1,6 @@
 SERVER_IMAGE_DIGEST=sha256:replace-with-release-manifest-digest
-EXPERIMENT_BIND_ADDRESS=replace-with-private-instance-ip
 EXPERIMENT_POSTGRES_DB=speakup_cn_experiment
 EXPERIMENT_POSTGRES_USER=speakup_cn_experiment
+# Generate a unique value, for example: openssl rand -hex 24
 EXPERIMENT_POSTGRES_PASSWORD=
 EXPERIMENT_SERVER_ENV_FILE=/etc/speakup-cn-experiment/server.env

--- a/deploy/experiments/cn-backend/smoke-current-providers.sh
+++ b/deploy/experiments/cn-backend/smoke-current-providers.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly base_url="http://127.0.0.1:28083"
+session_token=""
+
+cleanup() {
+  if [[ -n "$session_token" ]]; then
+    curl --silent --show-error --max-time 10 \
+      --request POST \
+      --header "Authorization: Bearer $session_token" \
+      "$base_url/v1/auth/logout" >/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+for command in curl jq openssl; do
+  command -v "$command" >/dev/null 2>&1 || {
+    printf '%s is required\n' "$command" >&2
+    exit 1
+  }
+done
+
+request_body=""
+request_code=""
+request_seconds=""
+
+request_json() {
+  local method="$1"
+  local path="$2"
+  local payload="${3:-}"
+  local token="${4:-}"
+  local result metrics
+  local -a arguments=(
+    --silent
+    --show-error
+    --max-time 180
+    --request "$method"
+    --write-out $'\n%{http_code} %{time_total}'
+  )
+
+  if [[ -n "$payload" ]]; then
+    arguments+=(--header 'Content-Type: application/json' --data "$payload")
+  fi
+  if [[ -n "$token" ]]; then
+    arguments+=(--header "Authorization: Bearer $token")
+  fi
+
+  result="$(curl "${arguments[@]}" "$base_url$path")"
+  metrics="${result##*$'\n'}"
+  request_body="${result%$'\n'*}"
+  read -r request_code request_seconds <<<"$metrics"
+}
+
+require_code() {
+  local operation="$1"
+  local expected="$2"
+  if [[ "$request_code" != "$expected" ]]; then
+    printf '%s returned HTTP %s, expected %s\n' \
+      "$operation" "$request_code" "$expected" >&2
+    exit 1
+  fi
+  printf '%s http=%s seconds=%s\n' \
+    "$operation" "$request_code" "$request_seconds"
+}
+
+email="cn-experiment-$(date +%s)-$(openssl rand -hex 4)@example.com"
+password="$(openssl rand -hex 18)"
+register_payload="$(jq -cn \
+  --arg email "$email" \
+  --arg password "$password" \
+  '{email: $email, password: $password, display_name: "CN Experiment"}')"
+
+request_json POST /v1/auth/register "$register_payload"
+require_code register 201
+
+login_payload="$(jq -cn \
+  --arg email "$email" \
+  --arg password "$password" \
+  '{email: $email, password: $password}')"
+request_json POST /v1/auth/login "$login_payload"
+require_code login 200
+session_token="$(jq -er '.session_token' <<<"$request_body")"
+
+request_json GET /v1/me '' "$session_token"
+require_code current_user 200
+
+request_json GET /v1/ielts-speaking/question-bank
+require_code question_bank 200
+bank_id="$(jq -er '.bank_id' <<<"$request_body")"
+source_id="$(jq -er '.part1_topics[0].id' <<<"$request_body")"
+bank_path="$(jq -nr --arg value "$bank_id" '$value | @uri')"
+source_path="$(jq -nr --arg value "$source_id" '$value | @uri')"
+
+answer_payload="$(jq -cn \
+  --arg bank "$bank_id" \
+  --arg source "$source_id" \
+  '{
+    question: {
+      bank_id: $bank,
+      part: "PART_1",
+      source_id: $source,
+      question_position: 1
+    },
+    personal_points: [],
+    target_band: 6.5
+  }')"
+request_json POST /v1/ielts-speaking/answers:generate \
+  "$answer_payload" "$session_token"
+require_code answer_generation 200
+jq -e '
+  (.answer | type == "string" and length > 0) and
+  (.speech_text | type == "string" and length > 0)
+' <<<"$request_body" >/dev/null
+
+tts_metrics="$(curl \
+  --silent \
+  --show-error \
+  --max-time 90 \
+  --output /dev/null \
+  --write-out '%{http_code} %{time_total} %{size_download} %{content_type}' \
+  --header "Authorization: Bearer $session_token" \
+  "$base_url/v1/ielts-speaking/question-banks/$bank_path/PART_1/$source_path/questions/1/speech")"
+read -r tts_code tts_seconds tts_bytes tts_content_type <<<"$tts_metrics"
+if [[ "$tts_code" != 200 || "$tts_bytes" -le 44 ||
+      "$tts_content_type" != audio/wav* ]]; then
+  printf 'question_speech response is invalid: %s\n' "$tts_metrics" >&2
+  exit 1
+fi
+printf 'question_speech http=%s seconds=%s bytes=%s content_type=%s\n' \
+  "$tts_code" "$tts_seconds" "$tts_bytes" "$tts_content_type"
+
+request_json POST /v1/auth/logout '' "$session_token"
+require_code logout 204
+session_token=""
+
+printf 'Current-provider smoke passed; the test account remains only in the isolated experiment database.\n'

--- a/deploy/experiments/cn-backend/test.sh
+++ b/deploy/experiments/cn-backend/test.sh
@@ -5,6 +5,8 @@ directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 temporary_directory="$(mktemp -d)"
 trap 'rm -rf "$temporary_directory"' EXIT
 
+bash -n "$directory/smoke-current-providers.sh"
+
 if [[ "$(grep -Ec '^[[:space:]]+ports:$' "$directory/compose.yaml")" -ne 1 ]] ||
   ! grep -Fqx '      - "127.0.0.1:28083:8080"' "$directory/compose.yaml"; then
   printf 'Server API must have exactly one loopback-only host port mapping\n' >&2

--- a/deploy/experiments/cn-backend/test.sh
+++ b/deploy/experiments/cn-backend/test.sh
@@ -7,6 +7,8 @@ trap 'rm -rf "$temporary_directory"' EXIT
 
 bash -n "$directory/smoke-current-providers.sh"
 bash -n "$directory/observability/export-host-metrics.sh"
+bash -n "$directory/backup/xe3-speakup-cn-experiment-postgres-backup"
+bash -n "$directory/backup/test.sh"
 
 if [[ "$(grep -Ec '^[[:space:]]+ports:$' "$directory/compose.yaml")" -ne 1 ]] ||
   ! grep -Fqx '      - "127.0.0.1:28083:8080"' "$directory/compose.yaml"; then
@@ -102,5 +104,7 @@ if grep -R --fixed-strings '/var/run/docker.sock' \
   printf 'observability stack must not mount the Docker socket\n' >&2
   exit 1
 fi
+
+"$directory/backup/test.sh"
 
 printf 'China backend experiment contract tests passed\n'

--- a/deploy/experiments/cn-backend/test.sh
+++ b/deploy/experiments/cn-backend/test.sh
@@ -6,6 +6,7 @@ temporary_directory="$(mktemp -d)"
 trap 'rm -rf "$temporary_directory"' EXIT
 
 bash -n "$directory/smoke-current-providers.sh"
+bash -n "$directory/observability/export-host-metrics.sh"
 
 if [[ "$(grep -Ec '^[[:space:]]+ports:$' "$directory/compose.yaml")" -ne 1 ]] ||
   ! grep -Fqx '      - "127.0.0.1:28083:8080"' "$directory/compose.yaml"; then
@@ -52,6 +53,47 @@ printf '%s\n' 'DATABASE_URL=postgres://forbidden' >>"$server_env"
 write_runtime '0123456789abcdef_ABCDEF-'
 if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
   printf 'validator accepted a Compose-owned server key\n' >&2
+  exit 1
+fi
+
+printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$server_env"
+write_runtime '0123456789abcdef_ABCDEF-'
+rendered="$temporary_directory/rendered.json"
+docker compose \
+  --env-file "$runtime_env" \
+  --file "$directory/compose.yaml" \
+  --file "$directory/compose.observability.yaml" \
+  config --format json >"$rendered"
+
+jq --exit-status '
+  .networks.monitor.internal == true and
+  (.networks.monitor_ui | has("internal") | not) and
+  .services.server.environment.METRICS_HOST == "0.0.0.0" and
+  (.services.server.ports | length) == 1 and
+  .services.server.ports[0].host_ip == "127.0.0.1" and
+  (.services.server.ports[0].published | tostring) == "28083" and
+  (.services.prometheus.ports | length) == 1 and
+  .services.prometheus.ports[0].host_ip == "127.0.0.1" and
+  (.services.prometheus.ports[0].published | tostring) == "29091" and
+  (.services.prometheus.networks | has("monitor")) and
+  (.services.prometheus.networks | has("monitor_ui")) and
+  (.services["node-exporter"].networks | keys) == ["monitor"] and
+  (.services["node-exporter"] | has("ports") | not) and
+  .services.prometheus.read_only == true and
+  .services["node-exporter"].read_only == true and
+  .services.prometheus.pull_policy == "never" and
+  .services["node-exporter"].pull_policy == "never" and
+  .services.prometheus.pids_limit == 64 and
+  .services["node-exporter"].pids_limit == 32 and
+  ([.services[] | .volumes[]? | .source] | any(. == "/var/run/docker.sock") | not)
+' "$rendered" >/dev/null || {
+  printf 'observability stack violates the private runtime contract\n' >&2
+  exit 1
+}
+
+if grep -R --fixed-strings '/var/run/docker.sock' \
+  "$directory/compose.yaml" "$directory/compose.observability.yaml" >/dev/null; then
+  printf 'observability stack must not mount the Docker socket\n' >&2
   exit 1
 fi
 

--- a/deploy/experiments/cn-backend/test.sh
+++ b/deploy/experiments/cn-backend/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+temporary_directory="$(mktemp -d)"
+trap 'rm -rf "$temporary_directory"' EXIT
+
+if [[ "$(grep -Ec '^[[:space:]]+ports:$' "$directory/compose.yaml")" -ne 1 ]] ||
+  ! grep -Fqx '      - "127.0.0.1:28083:8080"' "$directory/compose.yaml"; then
+  printf 'Server API must have exactly one loopback-only host port mapping\n' >&2
+  exit 1
+fi
+
+server_env="$temporary_directory/server.env"
+runtime_env="$temporary_directory/runtime.env"
+printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$server_env"
+
+write_runtime() {
+  local password="$1"
+  printf '%s\n' \
+    'SERVER_IMAGE_DIGEST=sha256:77718703587e0ad027c7b4d15856dbddfb40554946a935de26dc4ac6500428c5' \
+    'EXPERIMENT_POSTGRES_DB=speakup_cn_experiment' \
+    'EXPERIMENT_POSTGRES_USER=speakup_cn_experiment' \
+    "EXPERIMENT_POSTGRES_PASSWORD=$password" \
+    "EXPERIMENT_SERVER_ENV_FILE=$server_env" >"$runtime_env"
+}
+
+write_runtime '0123456789abcdef_ABCDEF-'
+"$directory/validate-runtime.sh" "$runtime_env" >/dev/null
+
+write_runtime 'contains-url-unsafe-@-delimiter'
+if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
+  printf 'validator accepted a URL-unsafe password\n' >&2
+  exit 1
+fi
+
+write_runtime 'too-short'
+if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
+  printf 'validator accepted a short password\n' >&2
+  exit 1
+fi
+
+write_runtime 'replace-with-at-least-24-url-safe-characters'
+if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
+  printf 'validator accepted the documented placeholder password\n' >&2
+  exit 1
+fi
+
+printf '%s\n' 'DATABASE_URL=postgres://forbidden' >>"$server_env"
+write_runtime '0123456789abcdef_ABCDEF-'
+if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
+  printf 'validator accepted a Compose-owned server key\n' >&2
+  exit 1
+fi
+
+printf 'China backend experiment contract tests passed\n'

--- a/deploy/experiments/cn-backend/test.sh
+++ b/deploy/experiments/cn-backend/test.sh
@@ -68,6 +68,12 @@ docker compose \
 jq --exit-status '
   .networks.monitor.internal == true and
   (.networks.monitor_ui | has("internal") | not) and
+  .services.postgres.mem_limit == "2147483648" and
+  .services.postgres.cpus == 1 and
+  .services.postgres.pids_limit == 128 and
+  .services.server.mem_limit == "3221225472" and
+  .services.server.cpus == 2 and
+  .services.server.pids_limit == 256 and
   .services.server.environment.METRICS_HOST == "0.0.0.0" and
   (.services.server.ports | length) == 1 and
   .services.server.ports[0].host_ip == "127.0.0.1" and

--- a/deploy/experiments/cn-backend/validate-runtime.sh
+++ b/deploy/experiments/cn-backend/validate-runtime.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_env="${1:-}"
+if [[ -z "$runtime_env" || "$#" -ne 1 ]]; then
+  printf 'usage: %s RUNTIME_ENV\n' "$0" >&2
+  exit 64
+fi
+if [[ ! -f "$runtime_env" || -L "$runtime_env" ]]; then
+  printf 'runtime environment must be a regular file\n' >&2
+  exit 1
+fi
+
+read_value() {
+  local key="$1"
+  local value
+  local count
+  count="$(awk -F= -v key="$key" '$1 == key {count++} END {print count+0}' "$runtime_env")"
+  if [[ "$count" -ne 1 ]]; then
+    printf '%s must occur exactly once\n' "$key" >&2
+    exit 1
+  fi
+  value="$(awk -F= -v key="$key" '$1 == key {sub(/^[^=]*=/, ""); print}' "$runtime_env")"
+  if [[ -z "$value" ]]; then
+    printf '%s must not be empty\n' "$key" >&2
+    exit 1
+  fi
+  printf '%s' "$value"
+}
+
+server_digest="$(read_value SERVER_IMAGE_DIGEST)"
+postgres_database="$(read_value EXPERIMENT_POSTGRES_DB)"
+postgres_user="$(read_value EXPERIMENT_POSTGRES_USER)"
+postgres_password="$(read_value EXPERIMENT_POSTGRES_PASSWORD)"
+server_env="$(read_value EXPERIMENT_SERVER_ENV_FILE)"
+
+if [[ ! "$server_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  printf 'SERVER_IMAGE_DIGEST must be a sha256 digest\n' >&2
+  exit 1
+fi
+for identifier in "$postgres_database" "$postgres_user"; do
+  if [[ ! "$identifier" =~ ^[a-z][a-z0-9_]{0,62}$ ]]; then
+    printf 'PostgreSQL identifiers must be lowercase and URL-safe\n' >&2
+    exit 1
+  fi
+done
+if [[ "$postgres_password" == "replace-with-at-least-24-url-safe-characters" ||
+      ${#postgres_password} -lt 24 || ${#postgres_password} -gt 128 ||
+      ! "$postgres_password" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  printf 'EXPERIMENT_POSTGRES_PASSWORD must contain 24-128 URL-safe characters\n' >&2
+  exit 1
+fi
+if [[ "$server_env" != /* || ! -f "$server_env" || -L "$server_env" ]]; then
+  printf 'EXPERIMENT_SERVER_ENV_FILE must be an absolute regular file\n' >&2
+  exit 1
+fi
+if grep -Eq '^(DATABASE_URL|SERVER_HOST|SERVER_PORT)=' "$server_env"; then
+  printf 'server environment contains a Compose-owned key\n' >&2
+  exit 1
+fi
+
+printf 'runtime environment is valid\n'


### PR DESCRIPTION
## 功能描述

新增一个与 Staging、Production 完全隔离的国内后端实验栈，用于验证小规模团队测试下的国内 API 延迟，并为后续只通过服务端环境文件整体切换千问、OSS、讯飞国内资源准备可复用底座。

## 实现思路

- 只部署 Server 与独立 PostgreSQL，不部署 Portal，也不接管 Production 流量。
- 复用 Release Candidate 的不可变 Server 镜像摘要。
- 使用独立 Compose project、数据卷、部署目录、loopback 端口和环境文件。
- PostgreSQL、API、应用 metrics 和 Prometheus 均不暴露公网；API 仅绑定 `127.0.0.1:28083`，Prometheus 仅绑定 `127.0.0.1:29091`。
- 真机实验通过 SSH local forward + adb reverse 加密传输，等待可信 TLS edge 后再考虑公网入口。
- 运行前 fail-closed 校验镜像摘要、数据库标识、24–128 位 URL-safe 随机密码和 `server.env` 所有权边界。
- 提供不输出凭证的真实 Provider smoke，以及 fail-closed 的数据、入口、监控、备份和回滚清单。
- 增加资源受限的私有 Prometheus、textfile-only node_exporter 和宿主采集 timer；不挂 Docker socket，不安装 Grafana、Alertmanager、Nginx 或黑盒公网探针。
- 增加实验专属的每日 PostgreSQL 逻辑备份与每周 `network=none` 隔离恢复检查：固定镜像/源卷身份、原子 dump + SHA-256 + 严格元数据、7 天保留、共享有界锁、失败清理与源卷保护。
- 支持保留新加坡 Provider 基线，再通过服务端环境文件整体切换国内 Provider。

## 可复现测试

```sh
bash -n deploy/experiments/cn-backend/validate-runtime.sh
bash -n deploy/experiments/cn-backend/test.sh
bash -n deploy/experiments/cn-backend/smoke-current-providers.sh
bash -n deploy/experiments/cn-backend/observability/export-host-metrics.sh
bash -n deploy/experiments/cn-backend/backup/xe3-speakup-cn-experiment-postgres-backup
bash -n deploy/experiments/cn-backend/backup/test.sh
make check-cn-backend-experiment

docker run --rm \
  --volume "$PWD/deploy/experiments/cn-backend/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro" \
  --volume "$PWD/deploy/experiments/cn-backend/observability/rules.yml:/etc/prometheus/rules.yml:ro" \
  --entrypoint promtool \
  quay.io/prometheus/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893 \
  check config /etc/prometheus/prometheus.yml

git diff --check
```

实机已验证：PostgreSQL 迁移成功、Server `/health` 与 `/readyz` 正常、Docker 重启后自动恢复、API 仅监听 host loopback、SSH 隧道健康检查成功；原公网高端口映射当前无法直达 API，未连接或迁移 Production 数据。

当前新加坡 Staging Provider 配置真实 smoke 共 6 轮且全部成功：前 5 轮千问答案生成 P50 4.823s / P95 5.265s，TTS P50 1.909s / P95 2.100s；第 6 轮用于监控验收，千问 4.572s、TTS 1.850s。Prometheus 三个 targets 均为 up，7 条本地告警规则已加载且当前均未触发；公网无法访问 `29091`。

备份合同测试会真实启动独立 PostgreSQL，覆盖 daily backup、SHA/元数据、latest verify、`network=none` 隔离恢复、7 天保留、篡改失败关闭、瞬时 Docker inspect 故障不误报、源卷/源数据不变与临时资源零残留。

ASR/WebSocket/ISE/OSS/报告仍明确留作国内资源与真机验收；同机监控、通知送达和异地备份也不在本 PR 中伪报完成。

Related #1049
Related #1048
