### PR TITLE
chore(release): 准备 v0.1.9 候选版本

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.8+9
+version: 0.1.9+10
 
 environment:
   sdk: ^3.12.2

--- a/portal/public/release-notes/android/index.zh-CN.json
+++ b/portal/public/release-notes/android/index.zh-CN.json
@@ -1,5 +1,5 @@
 {
   "release_notes_index_version": 1,
   "locale": "zh-CN",
-  "versions": ["0.1.8", "0.1.7", "0.1.4"]
+  "versions": ["0.1.9", "0.1.8", "0.1.7", "0.1.4"]
 }

--- a/portal/public/release-notes/android/v0.1.9.zh-CN.json
+++ b/portal/public/release-notes/android/v0.1.9.zh-CN.json
@@ -1,0 +1,20 @@
+{
+  "release_notes_version": 1,
+  "locale": "zh-CN",
+  "version": "0.1.9",
+  "published_at": "2026-08-27T05:35:51Z",
+  "changes": [
+    {
+      "type": "feature",
+      "text": "新增“关于 SpeakUp”页面，可查看当前安装版本、检查更新、访问产品官网和开源许可。"
+    },
+    {
+      "type": "improvement",
+      "text": "精简个人页入口与视觉层级，让记忆、能力、关于和退出登录更容易辨认。"
+    },
+    {
+      "type": "improvement",
+      "text": "优化产品官网首页展示，直接呈现练习与复盘流程，并简化客户端下载入口。"
+    }
+  ]
+}

--- a/portal/tests/android-release-notes.test.mjs
+++ b/portal/tests/android-release-notes.test.mjs
@@ -97,7 +97,7 @@ test("publishes an honest Android release history", () => {
   );
 
   assert.equal(parseAndroidReleaseNotesIndex(index), index);
-  assert.deepEqual(index.versions, ["0.1.8", "0.1.7", "0.1.4"]);
+  assert.deepEqual(index.versions, ["0.1.9", "0.1.8", "0.1.7", "0.1.4"]);
   const currentRelease = {
     version: notes[0].version,
     published_at: notes[0].published_at,
@@ -107,6 +107,20 @@ test("publishes an honest Android release history", () => {
     notes,
   );
   assert.deepEqual(notes[0].changes, [
+    {
+      type: "feature",
+      text: "新增“关于 SpeakUp”页面，可查看当前安装版本、检查更新、访问产品官网和开源许可。",
+    },
+    {
+      type: "improvement",
+      text: "精简个人页入口与视觉层级，让记忆、能力、关于和退出登录更容易辨认。",
+    },
+    {
+      type: "improvement",
+      text: "优化产品官网首页展示，直接呈现练习与复盘流程，并简化客户端下载入口。",
+    },
+  ]);
+  assert.deepEqual(notes[1].changes, [
     {
       type: "feature",
       text: "在日常、职场、面试和 IELTS 练习中增加逐句纠错、润色与原声播放。",
@@ -124,7 +138,7 @@ test("publishes an honest Android release history", () => {
       text: "优化 Android 底部导航选中状态、首页快捷入口布局和用户消息样式。",
     },
   ]);
-  assert.deepEqual(notes[1].changes, [
+  assert.deepEqual(notes[2].changes, [
     {
       type: "fix",
       text: "修复断网后实时语音无法再次录音的问题。",
@@ -142,7 +156,7 @@ test("publishes an honest Android release history", () => {
       text: "修复进入历史练习时可能自动触发新回复的问题。",
     },
   ]);
-  assert.deepEqual(notes[2], validLegacyNotes());
+  assert.deepEqual(notes[3], validLegacyNotes());
 });
 
 test("parses strict Android release notes and their ordered index", () => {


### PR DESCRIPTION
## 功能描述

- 将 Flutter/Android 唯一版本来源从 `0.1.8+9` 推进到 `0.1.9+10`。
- 新增 v0.1.9 中文更新日志，说明“关于 SpeakUp”页面、个人页优化和 Portal 首页优化。
- 将 v0.1.9 加入公开更新日志索引首位。

## 实现思路

- 保持 versionName 与 Android versionCode 单调递增，避免 `main` 上的 Release Candidate 与既有 `v0.1.8` Tag 冲突。
- 更新日志继续使用严格 JSON 协议；候选版本可提前进入索引，但只有正式 APK 激活后才会对用户展示。
- 不创建 Tag、GitHub Release，也不触发 Staging 或 Production 部署。

## 可复现测试

- `node --test portal/tests/android-release-notes.test.mjs tools/release-finalize/notes.test.mjs`
- `node --test --test-name-pattern='rejects Candidate version and versionCode regressions|accepts an increased versionCode' tools/release-candidate/release-candidate.test.mjs`
- `git diff --check`

以上测试共 12 项通过。

Closes #1057

## 提交前检查

- [x] 单一发布准备范围，不包含产品功能改动
- [x] 分支来自最新 `upstream/dev`
- [x] 未提交密钥、环境文件或构建产物
- [x] Commit 符合 Conventional Commits
