### PR TITLE
[缺陷] 修复 Tips 展开后自动滚动到底部

### DIFF
--- a/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
+++ b/mobile/lib/features/coaching/ielts/ielts_mock_practice.dart
@@ -17,6 +17,7 @@ import 'package:speakup/features/coaching/practice/practice_prompt_speaker.dart'
 import 'package:speakup/features/coaching/ielts/ielts_mock_progress_store.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_completion_sheet.dart';
+import 'package:speakup/features/coaching/practice/practice_conversation_scroll.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
@@ -581,24 +582,17 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
   }
 
   void _jumpToLatestMessage() {
-    if (!mounted || !_conversationScrollController.hasClients) {
-      return;
-    }
-    _conversationScrollController.jumpTo(
-      _conversationScrollController.position.maxScrollExtent,
+    schedulePracticeConversationScrollToBottom(
+      controller: _conversationScrollController,
+      isMounted: () => mounted,
+      animated: false,
     );
   }
 
   void _scrollToLatestMessage() {
-    if (!mounted || !_conversationScrollController.hasClients) {
-      return;
-    }
-    unawaited(
-      _conversationScrollController.animateTo(
-        _conversationScrollController.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 220),
-        curve: Curves.easeOutCubic,
-      ),
+    schedulePracticeConversationScrollToBottom(
+      controller: _conversationScrollController,
+      isMounted: () => mounted,
     );
   }
 
@@ -778,6 +772,7 @@ class _IeltsSpeakingMockPageState extends State<IeltsSpeakingMockPage> {
       return;
     }
     setState(() => _visibleTipQuestionId = tip.questionId);
+    _scrollToLatestMessage();
   }
 
   Future<void> _speakQuestionTip() async {

--- a/mobile/lib/features/coaching/interview/interview_practice.dart
+++ b/mobile/lib/features/coaching/interview/interview_practice.dart
@@ -15,6 +15,7 @@ import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_recordings.dart';
 import 'package:speakup/features/coaching/practice/practice_completion_sheet.dart';
+import 'package:speakup/features/coaching/practice/practice_conversation_scroll.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
 
@@ -390,23 +391,13 @@ class _InterviewPracticePageState extends State<InterviewPracticePage>
   }
 
   void _scheduleScrollToLatest({bool animated = true}) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_messageScrollController.hasClients) {
-        return;
-      }
-      final target = _messageScrollController.position.maxScrollExtent;
-      if (animated) {
-        unawaited(
-          _messageScrollController.animateTo(
-            target,
-            duration: const Duration(milliseconds: 180),
-            curve: Curves.easeOut,
-          ),
-        );
-      } else {
-        _messageScrollController.jumpTo(target);
-      }
-    });
+    schedulePracticeConversationScrollToBottom(
+      controller: _messageScrollController,
+      isMounted: () => mounted,
+      animated: animated,
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOut,
+    );
   }
 
   void _syncRecordingTimer() {

--- a/mobile/lib/features/coaching/practice/practice_conversation_scroll.dart
+++ b/mobile/lib/features/coaching/practice/practice_conversation_scroll.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+void schedulePracticeConversationScrollToBottom({
+  required ScrollController controller,
+  required bool Function() isMounted,
+  bool animated = true,
+  Duration duration = const Duration(milliseconds: 220),
+  Curve curve = Curves.easeOutCubic,
+}) {
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (!isMounted() || !controller.hasClients) {
+      return;
+    }
+    final position = controller.position;
+    if (!position.hasContentDimensions) {
+      return;
+    }
+    final target = position.maxScrollExtent;
+    if (!animated) {
+      controller.jumpTo(target);
+      return;
+    }
+    unawaited(controller.animateTo(target, duration: duration, curve: curve));
+  });
+}

--- a/mobile/lib/features/coaching/scenario/scenario_practice.dart
+++ b/mobile/lib/features/coaching/scenario/scenario_practice.dart
@@ -11,6 +11,7 @@ import 'package:speakup/features/coaching/practice/question_tip_sheet.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_message_bubble.dart';
 import 'package:speakup/features/coaching/practice/practice_completion_sheet.dart';
+import 'package:speakup/features/coaching/practice/practice_conversation_scroll.dart';
 import 'package:speakup/features/coaching/practice/practice_stage.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback.dart';
 import 'package:speakup/features/coaching/evaluation/turn_feedback_controller.dart';
@@ -365,23 +366,11 @@ class _ScenarioPracticePageState extends State<ScenarioPracticePage> {
   }
 
   void _scheduleConversationScrollToBottom({bool animated = true}) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_conversationScrollController.hasClients) {
-        return;
-      }
-      final target = _conversationScrollController.position.maxScrollExtent;
-      if (!animated) {
-        _conversationScrollController.jumpTo(target);
-        return;
-      }
-      unawaited(
-        _conversationScrollController.animateTo(
-          target,
-          duration: const Duration(milliseconds: 220),
-          curve: Curves.easeOutCubic,
-        ),
-      );
-    });
+    schedulePracticeConversationScrollToBottom(
+      controller: _conversationScrollController,
+      isMounted: () => mounted,
+      animated: animated,
+    );
   }
 
   void _syncSpeechFeedbackSources() {

--- a/mobile/test/coaching/practice/ielts_mock_practice_test.dart
+++ b/mobile/test/coaching/practice/ielts_mock_practice_test.dart
@@ -24,6 +24,74 @@ import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
 
 void main() {
+  for (final mode in <PracticeMode>[PracticeMode.part1, PracticeMode.part3]) {
+    testWidgets('${mode.name} scrolls to the expanded Tips card', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(390, 640);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      const capabilities = PracticeCapabilities(
+        retryAllowed: false,
+        questionTranslationAllowed: false,
+        questionTipsAllowed: true,
+        speechFeedbackAllowed: false,
+      );
+      final practice = _IeltsPracticeClient(
+        initialCompleted: 0,
+        turnLimit: 2,
+        capabilities: capabilities,
+      );
+      final controller = PracticeController(
+        client: practice,
+        recorder: _Recorder(),
+      );
+      addTearDown(controller.dispose);
+      await _activatePractice(controller, practice, _ieltsScene, mode: mode);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: IeltsSpeakingMockPage(
+            controller: controller,
+            progressStore: _MemoryProgressStore(),
+            examinerSpeaker: _ImmediateExaminerSpeaker(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      final tipButton = find.byKey(
+        const ValueKey('ielts-question-tip-question-1'),
+      );
+      await tester.ensureVisible(tipButton);
+      await tester.pump();
+      final conversation = tester.widget<ListView>(
+        find.byKey(const Key('ielts-mock-conversation')),
+      );
+      final scrollController = conversation.controller!;
+      final maxScrollExtentBeforeTip =
+          scrollController.position.maxScrollExtent;
+
+      await tester.tap(tipButton);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('practice-question-tip-card')),
+        findsOneWidget,
+      );
+      expect(
+        scrollController.position.maxScrollExtent,
+        greaterThan(maxScrollExtentBeforeTip),
+      );
+      expect(
+        scrollController.offset,
+        moreOrLessEquals(scrollController.position.maxScrollExtent),
+      );
+      expect(tester.takeException(), isNull);
+    });
+  }
+
   testWidgets('Part 1 keeps Tips visible while recording', (tester) async {
     const capabilities = PracticeCapabilities(
       retryAllowed: false,

--- a/mobile/test/coaching/practice/scenario_practice_test.dart
+++ b/mobile/test/coaching/practice/scenario_practice_test.dart
@@ -340,54 +340,58 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('shows capability-gated Tips without blocking the composer', (
-    tester,
-  ) async {
-    tester.view.physicalSize = const Size(390, 844);
-    tester.view.devicePixelRatio = 1;
-    addTearDown(tester.view.reset);
-    final controller = await _scenarioController(
-      practiceClient: _TranslationPracticeClient(),
-    );
-    addTearDown(controller.dispose);
-    await controller.submitPracticeText('I have a reservation under Chen.');
+  testWidgets(
+    'interview Tips scroll to the new bottom without blocking the composer',
+    (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final controller = await _scenarioController(
+        practiceClient: _TranslationPracticeClient(),
+      );
+      addTearDown(controller.dispose);
+      await controller.submitPracticeText('I have a reservation under Chen.');
 
-    await tester.pumpWidget(
-      MaterialApp(home: ScenarioPracticePage(practiceController: controller)),
-    );
-    await tester.pump();
+      await tester.pumpWidget(
+        MaterialApp(home: ScenarioPracticePage(practiceController: controller)),
+      );
+      await tester.pump();
 
-    final questionId = controller.currentQuestion!.id;
-    final tipButton = find.byKey(Key('scenario-question-tip-$questionId'));
-    final conversation = tester.widget<ListView>(
-      find.byKey(const Key('scenario-conversation-history')),
-    );
-    final scrollController = conversation.controller!;
-    final offsetBeforeTip = scrollController.offset;
-    expect(tipButton, findsOneWidget);
-    await tester.tap(tipButton);
-    await tester.pumpAndSettle();
+      final questionId = controller.currentQuestion!.id;
+      final tipButton = find.byKey(Key('scenario-question-tip-$questionId'));
+      final conversation = tester.widget<ListView>(
+        find.byKey(const Key('scenario-conversation-history')),
+      );
+      final scrollController = conversation.controller!;
+      final offsetBeforeTip = scrollController.offset;
+      expect(tipButton, findsOneWidget);
+      await tester.tap(tipButton);
+      await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('practice-question-tip-card')), findsOneWidget);
-    expect(
-      scrollController.position.maxScrollExtent,
-      greaterThan(offsetBeforeTip),
-    );
-    expect(
-      scrollController.offset,
-      moreOrLessEquals(scrollController.position.maxScrollExtent),
-    );
-    expect(
-      find.text('I would describe the situation and my specific role.'),
-      findsOneWidget,
-    );
-    expect(find.text('我会描述当时的情况以及我的具体职责。'), findsOneWidget);
-    expect(
-      find.byKey(const Key('scenario-record')).hitTestable(),
-      findsOneWidget,
-    );
-    expect(tester.takeException(), isNull);
-  });
+      expect(
+        find.byKey(const Key('practice-question-tip-card')),
+        findsOneWidget,
+      );
+      expect(
+        scrollController.position.maxScrollExtent,
+        greaterThan(offsetBeforeTip),
+      );
+      expect(
+        scrollController.offset,
+        moreOrLessEquals(scrollController.position.maxScrollExtent),
+      );
+      expect(
+        find.text('I would describe the situation and my specific role.'),
+        findsOneWidget,
+      );
+      expect(find.text('我会描述当时的情况以及我的具体职责。'), findsOneWidget);
+      expect(
+        find.byKey(const Key('scenario-record')).hitTestable(),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets('keeps the existing typed-answer flow in the scenario shell', (
     tester,


### PR DESCRIPTION
## 功能描述

修复 IELTS Part 1 / Part 3 及当前面试练习中，内联 Tips 展开后未滚动到对话列表新底部的问题，避免参考答案被底部输入区遮挡。

Closes #961

## 实现思路

- 新增练习对话共用的 post-frame 滚底方法，在布局完成后读取最新 `maxScrollExtent`。
- 公共方法统一处理页面销毁、ScrollController 未挂载和内容尺寸尚不可用的情况。
- IELTS 在 Tips 成功展开后触发滚底。
- 场景/面试练习及旧面试页复用同一公共滚动逻辑，移除重复实现。
- 保持 Tips 请求、缓存、关闭、朗读和错误处理语义不变。

## 可复现测试

- `flutter test --no-pub test/coaching/practice/ielts_mock_practice_test.dart test/coaching/practice/scenario_practice_test.dart`
  - 63 tests passed
  - 覆盖 IELTS Part 1、Part 3 和面试 Tips 展开后的最终滚动位置
- 对 6 个修改文件逐一执行 `dart analyze`
  - No issues found
- Android 真机 ANA AN00（Android 12）staging debug
  - 最新分支热重启成功
  - 后端 `/health` 与 `/readyz` 正常