### PR TITLE
fix(release): 统一 Staging 重跑 attempt 契约

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -582,9 +582,25 @@ jobs:
             "bundle/downloads/android/v$VERSION/$apk.sha256"
           )
           deploy_response="$RUNNER_TEMP/production-deploy-response.json"
-          tar --format=ustar --no-recursion -C "$PAYLOAD_DIRECTORY" \
+          if ! tar --format=ustar --no-recursion -C "$PAYLOAD_DIRECTORY" \
             -cf - "${payload_files[@]}" | \
-            ssh "${ssh_options[@]}" "$DEPLOY_USER@$DEPLOY_HOST" > "$deploy_response"
+            ssh "${ssh_options[@]}" "$DEPLOY_USER@$DEPLOY_HOST" > "$deploy_response"; then
+            broker_error="$(jq -er '
+              if type == "object" and
+                keys == ["error", "ok", "protocol_version"] and
+                .protocol_version == 1 and .ok == false and
+                (.error | type == "string" and length > 0)
+              then .error
+              else empty
+              end
+            ' "$deploy_response" 2>/dev/null || true)"
+            if [[ -n "$broker_error" ]]; then
+              echo "Production broker rejected the deployment: $broker_error" >&2
+            else
+              echo "Production broker deployment failed without a valid error response." >&2
+            fi
+            exit 1
+          fi
           jq -e \
             --arg bundle_manifest_sha256 "$BUNDLE_MANIFEST_SHA256" \
             --arg expected_current "$expected_current" \

--- a/server/cmd/production-broker/main.go
+++ b/server/cmd/production-broker/main.go
@@ -911,7 +911,7 @@ func parseStagingReceipt(contents []byte) (stagingReceipt, error) {
 }
 
 func stagingMatches(staging stagingReceipt, manifest releaseManifest, req request) bool {
-	return staging.ManifestSHA256 == manifest.SHA256 && staging.Version == manifest.Version && staging.VersionCode == manifest.VersionCode && staging.GitSHA == manifest.GitSHA && staging.DatabaseSchemaVersion == manifest.DatabaseSchemaVersion && staging.PortalImageDigest == manifest.PortalImageDigest && staging.ServerImageDigest == manifest.ServerImageDigest && staging.CandidateRunID == req.CandidateRunID && staging.DeploymentRunID == req.StagingRunID && staging.DeploymentRunAttempt == req.StagingRunAttempt
+	return staging.ManifestSHA256 == manifest.SHA256 && staging.Version == manifest.Version && staging.VersionCode == manifest.VersionCode && staging.GitSHA == manifest.GitSHA && staging.DatabaseSchemaVersion == manifest.DatabaseSchemaVersion && staging.PortalImageDigest == manifest.PortalImageDigest && staging.ServerImageDigest == manifest.ServerImageDigest && staging.CandidateRunID == req.CandidateRunID && staging.DeploymentRunID == req.StagingRunID && staging.DeploymentRunAttempt <= req.StagingRunAttempt
 }
 
 func validateBundle(root string, files map[string]string, manifest releaseManifest, expectedManifestSHA string) error {

--- a/server/cmd/production-broker/main_test.go
+++ b/server/cmd/production-broker/main_test.go
@@ -157,7 +157,7 @@ func initializeTestState(t *testing.T, config Config) {
 	}
 }
 
-func stagingResponseJSON(manifest releaseManifest, candidateRunID, stagingRunID int64) []byte {
+func stagingResponseJSON(manifest releaseManifest, candidateRunID, stagingRunID, deploymentRunAttempt int64) []byte {
 	receipt := map[string]any{
 		"receipt_version": 2, "environment": "staging", "operation": "deploy", "repository": officialRepository,
 		"manifest_sha256": manifest.SHA256, "version": manifest.Version, "version_code": manifest.VersionCode,
@@ -165,7 +165,7 @@ func stagingResponseJSON(manifest releaseManifest, candidateRunID, stagingRunID 
 		"portal_image_digest": manifest.PortalImageDigest, "server_image_digest": manifest.ServerImageDigest,
 		"portal_container_id": strings.Repeat("4", 64), "server_container_id": strings.Repeat("5", 64),
 		"postgres_container_id": strings.Repeat("6", 64), "candidate_run_id": candidateRunID,
-		"deployment_run_id": stagingRunID, "deployment_run_attempt": 1,
+		"deployment_run_id": stagingRunID, "deployment_run_attempt": deploymentRunAttempt,
 		"previous_receipt_sha256": strings.Repeat("7", 64), "rollback_target_receipt_sha256": nil,
 		"recorded_at_utc": "2026-08-26T09:00:00Z",
 	}
@@ -192,7 +192,7 @@ func deploymentPayload(t *testing.T, currentSHA string, mutateStaging bool, atte
 	if mutateStaging {
 		stagingCandidate = 999
 	}
-	stagingContents := stagingResponseJSON(manifest, stagingCandidate, 700)
+	stagingContents := stagingResponseJSON(manifest, stagingCandidate, 700, 1)
 	apk := []byte("signed-production-apk\n")
 	published := "2026-08-26T09:05:00Z"
 	prefix := "downloads/android/v" + manifest.Version + "/"
@@ -331,6 +331,40 @@ func TestRejectsMismatchedStagingReceiptBeforeManage(t *testing.T) {
 	}
 	if len(runner.calls) != 0 {
 		t.Fatal("manage ran for mismatched Staging evidence")
+	}
+}
+
+func TestStagingReceiptAttemptMatchesWorkflowRerun(t *testing.T) {
+	manifestContents := manifestJSON("0.1.8", 9, 124)
+	manifest, err := parseReleaseManifest(manifestContents, 124)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name            string
+		receiptAttempt  int64
+		workflowAttempt int64
+		want            bool
+	}{
+		{name: "same attempt", receiptAttempt: 1, workflowAttempt: 1, want: true},
+		{name: "earlier successful deployment reused by rerun", receiptAttempt: 1, workflowAttempt: 2, want: true},
+		{name: "future receipt", receiptAttempt: 2, workflowAttempt: 1, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			contents := stagingResponseJSON(manifest, 124, 700, test.receiptAttempt)
+			staging, err := parseStagingReceipt(contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req := request{
+				CandidateRunID:    124,
+				StagingRunID:      700,
+				StagingRunAttempt: test.workflowAttempt,
+			}
+			if got := stagingMatches(staging, manifest, req); got != test.want {
+				t.Fatalf("stagingMatches() = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 功能描述

修复 `Deploy Production Candidate #4` 在 Staging workflow 重跑后被 Production broker 错误拒绝的问题。

Staging 第 1 次实际部署成功，第 2 次重跑只重新发布 artifact，因此第 2 次 artifact 内绑定的运行时回执仍为 `deployment_run_attempt = 1`。Production workflow 已允许该回执 attempt 小于等于当前 workflow attempt，但 broker 仍要求严格相等，最终返回 `invalid_request`。

## 实现思路

- broker 在候选、run ID、manifest、镜像摘要和回执 SHA 全部保持严格绑定的前提下，允许 `receipt_attempt <= workflow_attempt`。
- 明确拒绝来自未来 attempt 的回执。
- broker 返回结构化错误时，Production workflow 将错误码写入日志，避免 SSH 非零退出后诊断信息被吞掉。

## 可复现测试

- `make check-production-deploy`
  - Production workflow 契约测试：6/6 通过
  - Release finalize 测试：2/2 通过
  - Production broker Go 测试：通过
  - Host access 与 Production contract 测试：通过
- 新增用例覆盖：相同 attempt、早期成功回执被重跑复用、未来 attempt 拒绝。
- `git diff --check`

## 关联 Issue

Closes #1063
