### PR TITLE
fix(release): 正确处理草稿 Release 状态

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -721,7 +721,7 @@ jobs:
               (.id | type == "number" and . >= 1)
             ' <<<"$release" >/dev/null
           release_id="$(jq -er '.id' <<<"$release")"
-          already_published="$(jq -er '(.draft | not)' <<<"$release")"
+          already_published="$(jq -r '(.draft | not)' <<<"$release")"
           upload_url="$(jq -er '.upload_url | sub("\\{\\?name,label\\}$"; "")' <<<"$release")"
           [[ "$upload_url" == \
             "https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id/assets" ]]

--- a/tools/production-deploy/production-deploy.test.mjs
+++ b/tools/production-deploy/production-deploy.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -108,6 +109,14 @@ test("Production finalization is ordered, complete, immutable, and retryable", (
   );
   assert.match(workflow, /--data-binary "@\$file"/);
   assert.doesNotMatch(workflow, /gh release upload/);
+  assert.match(
+    workflow,
+    /already_published="\$\(jq -r '\(\.draft \| not\)' <<<"\$release"\)"/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /already_published="\$\(jq -er '\(\.draft \| not\)'/,
+  );
   assert.match(workflow, /Activate the approved APK through the restricted broker/);
   assert.match(workflow, /Verify the public APK and changelog contract/);
   assert.match(workflow, /Publish and verify the immutable GitHub Release/);
@@ -118,6 +127,27 @@ test("Production finalization is ordered, complete, immutable, and retryable", (
   const activate = workflow.indexOf("Activate the approved APK");
   const publish = workflow.indexOf("Publish and verify the immutable GitHub Release");
   assert.ok(draft > 0 && draft < activate && activate < publish);
+});
+
+test("Draft and published Release states are both valid shell values", () => {
+  const script = String.raw`
+    set -euo pipefail
+    release=$1
+    already_published="$(jq -r '(.draft | not)' <<<"$release")"
+    printf '%s\n' "$already_published"
+  `;
+  for (const [draft, expected] of [
+    [true, "false"],
+    [false, "true"],
+  ]) {
+    const result = spawnSync(
+      "bash",
+      ["-c", script, "bash", JSON.stringify({ draft })],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), expected);
+  }
 });
 
 test("Every external action is pinned to a full commit", () => {


### PR DESCRIPTION
## 功能描述

- 修复 Production 工作流读取草稿 Release 状态时，把合法的 false 值误判为命令失败的问题。
- 保留前置 Release 元数据与字段校验，不放宽发布信任边界。
- 补充草稿与已发布两种状态在 set -euo pipefail 下的回归测试。

## 实现思路

状态已经由前一段 jq -e 完整校验；实际读取布尔字符串时使用 jq -r，确保 false 和 true 都以退出码 0 返回。

## 可复现测试

- make check-production-deploy
- git diff --check
- 生产 Deploy Production Candidate #4 attempt 4 已全绿验证

Closes #1067