### PR TITLE
ops(experiment): 支持国内 ACR 不可变镜像

### DIFF
--- a/.github/workflows/cn-acr-mirror.yml
+++ b/.github/workflows/cn-acr-mirror.yml
@@ -1,0 +1,396 @@
+name: Mirror Release Candidate Server Image to CN ACR
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_run_id:
+        description: Successful official Release Candidate run ID
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+
+concurrency:
+  group: cn-acr-mirror
+  cancel-in-progress: false
+
+env:
+  OFFICIAL_REPOSITORY: 1024XEngineer/XE3-ESL
+  OFFICIAL_SERVER_IMAGE: ghcr.io/1024xengineer/xe3-esl-server
+  EXPECTED_CN_ACR_REGISTRY: crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com
+  EXPECTED_CN_ACR_SERVER_REPOSITORY: speakup/xe3-esl-server
+  EXPECTED_CN_ACR_SERVER_IMAGE: crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com/speakup/xe3-esl-server
+
+jobs:
+  authorize:
+    name: Validate official Candidate and manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      candidate_run_id: ${{ steps.candidate.outputs.run_id }}
+      candidate_sha: ${{ steps.candidate.outputs.sha }}
+      version: ${{ steps.manifest.outputs.version }}
+      source_image: ${{ steps.manifest.outputs.source_image }}
+      source_index_digest: ${{ steps.manifest.outputs.source_index_digest }}
+      manifest_sha256: ${{ steps.manifest.outputs.manifest_sha256 }}
+    steps:
+      - name: Select one successful official Release Candidate
+        id: candidate
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          OFFICIAL_REPOSITORY: ${{ env.OFFICIAL_REPOSITORY }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const input = process.env.CANDIDATE_RUN_ID;
+            if (!/^[1-9][0-9]*$/.test(input)) {
+              core.setFailed("candidate_run_id must be a positive integer.");
+              return;
+            }
+            const runId = Number(input);
+            if (!Number.isSafeInteger(runId)) {
+              core.setFailed("candidate_run_id is outside the safe integer range.");
+              return;
+            }
+            const run = (
+              await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              })
+            ).data;
+            const headRepository = run.head_repository?.full_name;
+            if (
+              context.repo.owner + "/" + context.repo.repo !==
+                process.env.OFFICIAL_REPOSITORY ||
+              run.name !== "Release Candidate" ||
+              run.path !== ".github/workflows/release-candidate.yml" ||
+              run.event !== "push" ||
+              run.head_branch !== "main" ||
+              headRepository !== process.env.OFFICIAL_REPOSITORY ||
+              run.status !== "completed" ||
+              run.conclusion !== "success" ||
+              !/^[0-9a-f]{40}$/.test(run.head_sha)
+            ) {
+              core.setFailed(
+                `Run ${runId} is not a successful official main Release Candidate.`,
+              );
+              return;
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100,
+              },
+            );
+            const manifests = artifacts.filter(
+              (artifact) =>
+                !artifact.expired &&
+                artifact.size_in_bytes > 0 &&
+                /^speakup-v[0-9]+\.[0-9]+\.[0-9]+-release-manifest$/.test(
+                  artifact.name,
+                ),
+            );
+            if (manifests.length !== 1) {
+              core.setFailed(
+                `Candidate run ${runId} has ${manifests.length} valid release manifest artifacts.`,
+              );
+              return;
+            }
+            core.setOutput("run_id", String(runId));
+            core.setOutput("sha", run.head_sha);
+            core.setOutput("manifest_artifact", manifests[0].name);
+
+      - name: Download only the Candidate release manifest
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: ${{ steps.candidate.outputs.manifest_artifact }}
+          path: ${{ runner.temp }}/candidate-manifest
+          run-id: ${{ steps.candidate.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate immutable server image identity
+        id: manifest
+        env:
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run_id }}
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
+          MANIFEST_DIRECTORY: ${{ runner.temp }}/candidate-manifest
+          OFFICIAL_SERVER_IMAGE: ${{ env.OFFICIAL_SERVER_IMAGE }}
+        run: |
+          set -euo pipefail
+          manifest="$MANIFEST_DIRECTORY/release-manifest.json"
+          [[ ! -L "$manifest" && -f "$manifest" && -s "$manifest" ]]
+          [[ "$(find "$MANIFEST_DIRECTORY" -mindepth 1 -maxdepth 1 | wc -l)" == 1 ]]
+          jq -e \
+            --arg run_url "https://github.com/1024XEngineer/XE3-ESL/actions/runs/$CANDIDATE_RUN_ID" \
+            --arg server_image "$OFFICIAL_SERVER_IMAGE" \
+            --arg sha "$CANDIDATE_SHA" '
+              .git_sha == $sha and
+              .quality_run_url == $run_url and
+              .server_image == $server_image and
+              (.server_image_digest | type == "string" and
+                test("^sha256:[0-9a-f]{64}$")) and
+              (.version | type == "string" and
+                test("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"))
+            ' "$manifest" >/dev/null
+          printf 'version=%s\n' "$(jq -er '.version' "$manifest")" >> "$GITHUB_OUTPUT"
+          printf 'source_image=%s\n' "$(jq -er '.server_image' "$manifest")" >> "$GITHUB_OUTPUT"
+          printf 'source_index_digest=%s\n' \
+            "$(jq -er '.server_image_digest' "$manifest")" >> "$GITHUB_OUTPUT"
+          printf 'manifest_sha256=%s\n' \
+            "$(sha256sum "$manifest" | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+
+  mirror:
+    name: Mirror immutable linux/amd64 Server image
+    needs: authorize
+    environment:
+      name: cn-acr-mirror
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    env:
+      CN_ACR_REGISTRY: ${{ vars.CN_ACR_REGISTRY }}
+      CN_ACR_SERVER_REPOSITORY: ${{ vars.CN_ACR_SERVER_REPOSITORY }}
+      CN_ACR_SERVER_IMAGE: ${{ format('{0}/{1}', vars.CN_ACR_REGISTRY, vars.CN_ACR_SERVER_REPOSITORY) }}
+    steps:
+      - name: Validate protected ACR identity
+        run: |
+          set -euo pipefail
+          [[ "$CN_ACR_REGISTRY" == "$EXPECTED_CN_ACR_REGISTRY" ]]
+          [[ "$CN_ACR_SERVER_REPOSITORY" == \
+            "$EXPECTED_CN_ACR_SERVER_REPOSITORY" ]]
+          [[ "$CN_ACR_SERVER_IMAGE" == "$EXPECTED_CN_ACR_SERVER_IMAGE" ]]
+          [[ "$CN_ACR_SERVER_IMAGE" == \
+            "$CN_ACR_REGISTRY/$CN_ACR_SERVER_REPOSITORY" ]]
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Sign in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Sign in to protected CN ACR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.CN_ACR_REGISTRY }}
+          username: ${{ secrets.CN_ACR_USERNAME }}
+          password: ${{ secrets.CN_ACR_PASSWORD }}
+
+      - name: Copy only the immutable linux/amd64 application manifest
+        id: mirror
+        env:
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          SOURCE_IMAGE: ${{ needs.authorize.outputs.source_image }}
+          SOURCE_INDEX_DIGEST: ${{ needs.authorize.outputs.source_index_digest }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/cn-acr-mirror"
+          install -d -m 700 "$work"
+          source_index="$work/source-index.json"
+          source_manifest="$work/source-manifest.json"
+          docker buildx imagetools inspect --raw \
+            "$SOURCE_IMAGE@$SOURCE_INDEX_DIGEST" > "$source_index"
+          platform_digest="$(
+            jq -er '
+              [.manifests[] |
+                select(
+                  .platform.os == "linux" and
+                  .platform.architecture == "amd64" and
+                  ((.platform.variant // "") == "")
+                ) |
+                .digest] |
+              if length == 1 then .[0]
+              else error("Candidate must contain exactly one linux/amd64 manifest")
+              end
+            ' "$source_index"
+          )"
+          [[ "$platform_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          docker buildx imagetools inspect --raw \
+            "$SOURCE_IMAGE@$platform_digest" > "$source_manifest"
+          [[ "sha256:$(sha256sum "$source_manifest" | cut -d ' ' -f 1)" == \
+            "$platform_digest" ]]
+          jq -e '
+            .schemaVersion == 2 and
+            (.config.digest | test("^sha256:[0-9a-f]{64}$")) and
+            (.layers | type == "array" and length > 0) and
+            all(.layers[]; .digest | test("^sha256:[0-9a-f]{64}$"))
+          ' "$source_manifest" >/dev/null
+
+          inspect_index() {
+            local reference=$1
+            local raw_file=$2
+            local error_file=$3
+            if docker buildx imagetools inspect --raw "$reference" \
+              > "$raw_file" 2> "$error_file"; then
+              local platform_digest
+              if ! platform_digest="$(
+                jq -er '
+                  if (.manifests | type) != "array" or
+                    (.manifests | length) != 1 then
+                    error("Destination tag must be a single-platform index")
+                  else
+                    .manifests[0] |
+                    if .platform.os == "linux" and
+                      .platform.architecture == "amd64" and
+                      ((.platform.variant // "") == "") and
+                      (.digest | test("^sha256:[0-9a-f]{64}$")) then
+                      .digest
+                    else
+                      error("Destination index must contain only linux/amd64")
+                    end
+                  end
+                ' "$raw_file"
+              )"; then
+                printf '%s must be a valid single-platform linux/amd64 index.\n' \
+                  "$reference" >&2
+                return 2
+              fi
+              printf 'sha256:%s\t%s\n' \
+                "$(sha256sum "$raw_file" | cut -d ' ' -f 1)" \
+                "$platform_digest"
+              return 0
+            fi
+            if grep -Eqi 'manifest unknown|not found|(^|[^0-9])404([^0-9]|$)' \
+              "$error_file"; then
+              return 1
+            fi
+            cat "$error_file" >&2
+            return 2
+          }
+
+          mirror_tag() {
+            local tag=$1
+            local reference="$CN_ACR_SERVER_IMAGE:$tag"
+            local safe_tag="${tag//[^A-Za-z0-9_.-]/_}"
+            local existing_raw="$work/existing-$safe_tag.json"
+            local existing_error="$work/existing-$safe_tag.err"
+            local existing_identity
+            local status=0
+            existing_identity="$(
+              inspect_index "$reference" "$existing_raw" "$existing_error"
+            )" || status=$?
+            case "$status" in
+              0)
+                local existing_platform_digest="${existing_identity#*$'\t'}"
+                if [[ "$existing_platform_digest" != "$platform_digest" ]]; then
+                  printf 'Refusing to overwrite %s (%s != %s).\n' \
+                    "$reference" "$existing_platform_digest" "$platform_digest" >&2
+                  return 1
+                fi
+                ;;
+              1)
+                docker buildx imagetools create \
+                  --tag "$reference" \
+                  "$SOURCE_IMAGE@$platform_digest" >&2
+                ;;
+              *)
+                return "$status"
+                ;;
+            esac
+            local verified_identity
+            verified_identity="$(
+              inspect_index \
+                "$reference" \
+                "$work/verified-$safe_tag.json" \
+                "$work/verified-$safe_tag.err"
+            )"
+            local mirrored_index_digest="${verified_identity%%$'\t'*}"
+            local mirrored_platform_digest="${verified_identity#*$'\t'}"
+            if [[ "$mirrored_platform_digest" != "$platform_digest" ]]; then
+              printf 'Mirrored platform digest for %s is %s, expected %s.\n' \
+                "$reference" "$mirrored_platform_digest" "$platform_digest" >&2
+              return 1
+            fi
+            printf '%s\n' "$mirrored_index_digest"
+          }
+
+          version_index_digest="$(mirror_tag "$VERSION")"
+          sha_index_digest="$(mirror_tag "$CANDIDATE_SHA")"
+          if [[ "$version_index_digest" != "$sha_index_digest" ]]; then
+            printf 'ACR tags resolve to different indexes (%s != %s).\n' \
+              "$version_index_digest" "$sha_index_digest" >&2
+            exit 1
+          fi
+          printf 'destination_index_digest=%s\n' \
+            "$version_index_digest" >> "$GITHUB_OUTPUT"
+          printf 'platform_digest=%s\n' "$platform_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Write non-secret mirror receipt
+        id: receipt
+        env:
+          CANDIDATE_RUN_ID: ${{ needs.authorize.outputs.candidate_run_id }}
+          CANDIDATE_SHA: ${{ needs.authorize.outputs.candidate_sha }}
+          DESTINATION_INDEX_DIGEST: ${{ steps.mirror.outputs.destination_index_digest }}
+          MANIFEST_SHA256: ${{ needs.authorize.outputs.manifest_sha256 }}
+          PLATFORM_DIGEST: ${{ steps.mirror.outputs.platform_digest }}
+          SOURCE_IMAGE: ${{ needs.authorize.outputs.source_image }}
+          SOURCE_INDEX_DIGEST: ${{ needs.authorize.outputs.source_index_digest }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+        run: |
+          set -euo pipefail
+          receipt="$RUNNER_TEMP/cn-acr-mirror-receipt.json"
+          jq -n \
+            --arg destination_image "$CN_ACR_SERVER_IMAGE" \
+            --arg destination_index_digest "$DESTINATION_INDEX_DIGEST" \
+            --arg git_sha "$CANDIDATE_SHA" \
+            --arg manifest_sha256 "$MANIFEST_SHA256" \
+            --arg platform_digest "$PLATFORM_DIGEST" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg source_image "$SOURCE_IMAGE" \
+            --arg source_index_digest "$SOURCE_INDEX_DIGEST" \
+            --arg version "$VERSION" \
+            --arg workflow_run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --argjson candidate_run_id "$CANDIDATE_RUN_ID" '{
+              receipt_version: 1,
+              repository: $repository,
+              candidate_run_id: $candidate_run_id,
+              version: $version,
+              git_sha: $git_sha,
+              release_manifest_sha256: $manifest_sha256,
+              platform: "linux/amd64",
+              source: {
+                image: $source_image,
+                index_digest: $source_index_digest,
+                platform_digest: $platform_digest
+              },
+              destination: {
+                image: $destination_image,
+                version_tag: $version,
+                git_sha_tag: $git_sha,
+                index_digest: $destination_index_digest,
+                platform_digest: $platform_digest
+              },
+              workflow_run_url: $workflow_run_url
+            }' > "$receipt"
+          printf 'file=%s\n' "$receipt" >> "$GITHUB_OUTPUT"
+          {
+            printf '## CN ACR mirror\n\n'
+            printf -- '- Candidate: `%s` (`%s`)\n' "$VERSION" "$CANDIDATE_SHA"
+            printf -- '- Source index: `%s@%s`\n' "$SOURCE_IMAGE" "$SOURCE_INDEX_DIGEST"
+            printf -- '- ACR index: `%s@%s`\n' \
+              "$CN_ACR_SERVER_IMAGE" "$DESTINATION_INDEX_DIGEST"
+            printf -- '- Mirrored platform: `linux/amd64@%s`\n' "$PLATFORM_DIGEST"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mirror receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: speakup-v${{ needs.authorize.outputs.version }}-cn-acr-mirror-${{ github.run_id }}
+          path: ${{ steps.receipt.outputs.file }}
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/cn-acr-mirror.yml
+++ b/.github/workflows/cn-acr-mirror.yml
@@ -273,7 +273,7 @@ jobs:
             return 2
           }
 
-          mirror_tag() {
+          preflight_tag() {
             local tag=$1
             local reference="$CN_ACR_SERVER_IMAGE:$tag"
             local safe_tag="${tag//[^A-Za-z0-9_.-]/_}"
@@ -292,16 +292,27 @@ jobs:
                     "$reference" "$existing_platform_digest" "$platform_digest" >&2
                   return 1
                 fi
+                printf 'existing\n'
                 ;;
               1)
-                docker buildx imagetools create \
-                  --tag "$reference" \
-                  "$SOURCE_IMAGE@$platform_digest" >&2
+                printf 'missing\n'
                 ;;
               *)
                 return "$status"
                 ;;
             esac
+          }
+
+          mirror_tag() {
+            local tag=$1
+            local state=$2
+            local reference="$CN_ACR_SERVER_IMAGE:$tag"
+            local safe_tag="${tag//[^A-Za-z0-9_.-]/_}"
+            if [[ "$state" == "missing" ]]; then
+              docker buildx imagetools create \
+                --tag "$reference" \
+                "$SOURCE_IMAGE@$platform_digest" >&2
+            fi
             local verified_identity
             verified_identity="$(
               inspect_index \
@@ -319,8 +330,10 @@ jobs:
             printf '%s\n' "$mirrored_index_digest"
           }
 
-          version_index_digest="$(mirror_tag "$VERSION")"
-          sha_index_digest="$(mirror_tag "$CANDIDATE_SHA")"
+          version_state="$(preflight_tag "$VERSION")"
+          sha_state="$(preflight_tag "$CANDIDATE_SHA")"
+          version_index_digest="$(mirror_tag "$VERSION" "$version_state")"
+          sha_index_digest="$(mirror_tag "$CANDIDATE_SHA" "$sha_state")"
           if [[ "$version_index_digest" != "$sha_index_digest" ]]; then
             printf 'ACR tags resolve to different indexes (%s != %s).\n' \
               "$version_index_digest" "$sha_index_digest" >&2

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -10,8 +10,16 @@ means this stack must remain isolated from Production traffic.
 
 The stack deliberately uses its own Compose project, volume, port, deployment
 directory, runtime file, and Server environment file. It must not reuse a
-Staging or Production database volume. The Server image digest must come from
-the same successful Release Candidate manifest used by the comparison APK.
+Staging or Production database volume. `SERVER_IMAGE_REPOSITORY` must be either
+the official `ghcr.io/1024xengineer/xe3-esl-server` repository or the approved
+China mirror at
+`crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com/speakup/xe3-esl-server`.
+`SERVER_IMAGE_DIGEST` must be the immutable index digest for the selected
+repository. GHCR uses the canonical digest from the successful Release
+Candidate manifest. ACR uses the verified mirror index digest recorded beside
+that canonical digest and the matching `linux/amd64` platform digest. The two
+index digests may differ when provenance is removed during mirroring; tags are
+never accepted.
 
 This stack binds the container API only to host loopback port `28083`; it never
 publishes PostgreSQL or metrics. Do not point the APK at a public plaintext
@@ -48,8 +56,26 @@ Generate a unique experiment password rather than copying a placeholder:
 openssl rand -hex 24
 ```
 
-Both images use `pull_policy: never`. Load the exact Server and PostgreSQL
-digests recorded by the selected Release Candidate before starting the stack.
+Both images use `pull_policy: never`. Load the exact Server repository digest
+from the audited Release Candidate mirror mapping and the PostgreSQL digest
+recorded by the selected Release Candidate before starting the stack.
+For the approved private ACR mirror, authenticate without placing its password
+in either environment file, then pull the immutable reference recorded in the
+validated runtime file:
+
+```sh
+docker login --username "$ACR_USERNAME" \
+  crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com
+
+server_image_repository="$(awk -F= '$1 == "SERVER_IMAGE_REPOSITORY" {print $2}' \
+  /etc/speakup-cn-experiment/runtime.env)"
+server_image_digest="$(awk -F= '$1 == "SERVER_IMAGE_DIGEST" {print $2}' \
+  /etc/speakup-cn-experiment/runtime.env)"
+docker pull "${server_image_repository}@${server_image_digest}"
+```
+
+Enter the ACR access-credential password only at Docker's prompt. Never store
+it in `runtime.env`, `server.env`, the repository, or command-line arguments.
 An offline PostgreSQL import may retain only the image ID; verify that ID is
 `sha256:7d2695c3aa88e792e8b3b233e7e4adb296a20412c6c0ca361e3edaaacfada108`
 before applying the local `postgres:18-bookworm` tag. This keeps the experiment

--- a/deploy/experiments/cn-backend/compose.yaml
+++ b/deploy/experiments/cn-backend/compose.yaml
@@ -37,7 +37,7 @@ services:
       start_period: 5s
 
   migrate:
-    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    image: ${SERVER_IMAGE_REPOSITORY:?SERVER_IMAGE_REPOSITORY is required}@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
     pull_policy: never
     profiles:
       - migration
@@ -55,7 +55,7 @@ services:
       - database
 
   server:
-    image: ghcr.io/1024xengineer/xe3-esl-server@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
+    image: ${SERVER_IMAGE_REPOSITORY:?SERVER_IMAGE_REPOSITORY is required}@${SERVER_IMAGE_DIGEST:?SERVER_IMAGE_DIGEST is required}
     pull_policy: never
     restart: unless-stopped
     init: true

--- a/deploy/experiments/cn-backend/runtime.env.example
+++ b/deploy/experiments/cn-backend/runtime.env.example
@@ -1,4 +1,5 @@
-SERVER_IMAGE_DIGEST=sha256:replace-with-release-manifest-digest
+SERVER_IMAGE_REPOSITORY=crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com/speakup/xe3-esl-server
+SERVER_IMAGE_DIGEST=sha256:replace-with-verified-repository-index-digest
 EXPERIMENT_POSTGRES_DB=speakup_cn_experiment
 EXPERIMENT_POSTGRES_USER=speakup_cn_experiment
 # Generate a unique value, for example: openssl rand -hex 24

--- a/deploy/experiments/cn-backend/test.sh
+++ b/deploy/experiments/cn-backend/test.sh
@@ -5,6 +5,10 @@ directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 temporary_directory="$(mktemp -d)"
 trap 'rm -rf "$temporary_directory"' EXIT
 
+readonly ghcr_repository='ghcr.io/1024xengineer/xe3-esl-server'
+readonly acr_repository='crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com/speakup/xe3-esl-server'
+readonly server_digest='sha256:77718703587e0ad027c7b4d15856dbddfb40554946a935de26dc4ac6500428c5'
+
 bash -n "$directory/smoke-current-providers.sh"
 bash -n "$directory/observability/export-host-metrics.sh"
 bash -n "$directory/backup/xe3-speakup-cn-experiment-postgres-backup"
@@ -22,49 +26,78 @@ printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$server_env"
 
 write_runtime() {
   local password="$1"
+  local repository="$2"
+  local digest="$3"
   printf '%s\n' \
-    'SERVER_IMAGE_DIGEST=sha256:77718703587e0ad027c7b4d15856dbddfb40554946a935de26dc4ac6500428c5' \
+    "SERVER_IMAGE_REPOSITORY=$repository" \
+    "SERVER_IMAGE_DIGEST=$digest" \
     'EXPERIMENT_POSTGRES_DB=speakup_cn_experiment' \
     'EXPERIMENT_POSTGRES_USER=speakup_cn_experiment' \
     "EXPERIMENT_POSTGRES_PASSWORD=$password" \
     "EXPERIMENT_SERVER_ENV_FILE=$server_env" >"$runtime_env"
 }
 
-write_runtime '0123456789abcdef_ABCDEF-'
+write_runtime '0123456789abcdef_ABCDEF-' "$ghcr_repository" "$server_digest"
 "$directory/validate-runtime.sh" "$runtime_env" >/dev/null
 
-write_runtime 'contains-url-unsafe-@-delimiter'
+write_runtime '0123456789abcdef_ABCDEF-' "$acr_repository" "$server_digest"
+"$directory/validate-runtime.sh" "$runtime_env" >/dev/null
+
+write_runtime '0123456789abcdef_ABCDEF-' "$acr_repository" "$server_digest"
+awk '$0 !~ /^SERVER_IMAGE_REPOSITORY=/' "$runtime_env" >"$runtime_env.missing"
+mv "$runtime_env.missing" "$runtime_env"
+if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
+  printf 'validator accepted a missing Server repository\n' >&2
+  exit 1
+fi
+
+write_runtime '0123456789abcdef_ABCDEF-' \
+  'registry.example.com/speakup/xe3-esl-server' "$server_digest"
+if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
+  printf 'validator accepted an unapproved Server repository\n' >&2
+  exit 1
+fi
+
+write_runtime '0123456789abcdef_ABCDEF-' "$acr_repository" 'v0.1.9'
+if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
+  printf 'validator accepted a Server image tag instead of a digest\n' >&2
+  exit 1
+fi
+
+write_runtime 'contains-url-unsafe-@-delimiter' "$ghcr_repository" "$server_digest"
 if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
   printf 'validator accepted a URL-unsafe password\n' >&2
   exit 1
 fi
 
-write_runtime 'too-short'
+write_runtime 'too-short' "$ghcr_repository" "$server_digest"
 if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
   printf 'validator accepted a short password\n' >&2
   exit 1
 fi
 
-write_runtime 'replace-with-at-least-24-url-safe-characters'
+write_runtime 'replace-with-at-least-24-url-safe-characters' \
+  "$ghcr_repository" "$server_digest"
 if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
   printf 'validator accepted the documented placeholder password\n' >&2
   exit 1
 fi
 
 printf '%s\n' 'DATABASE_URL=postgres://forbidden' >>"$server_env"
-write_runtime '0123456789abcdef_ABCDEF-'
+write_runtime '0123456789abcdef_ABCDEF-' "$ghcr_repository" "$server_digest"
 if "$directory/validate-runtime.sh" "$runtime_env" >/dev/null 2>&1; then
   printf 'validator accepted a Compose-owned server key\n' >&2
   exit 1
 fi
 
 printf '%s\n' 'TEXT_GENERATION_PROVIDER=test-fixture' >"$server_env"
-write_runtime '0123456789abcdef_ABCDEF-'
+write_runtime '0123456789abcdef_ABCDEF-' "$acr_repository" "$server_digest"
 rendered="$temporary_directory/rendered.json"
 docker compose \
   --env-file "$runtime_env" \
   --file "$directory/compose.yaml" \
   --file "$directory/compose.observability.yaml" \
+  --profile migration \
   config --format json >"$rendered"
 
 jq --exit-status '
@@ -74,6 +107,9 @@ jq --exit-status '
   .services.postgres.cpus == 1 and
   .services.postgres.pids_limit == 128 and
   .services.server.mem_limit == "3221225472" and
+  .services.server.image ==
+    "crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com/speakup/xe3-esl-server@sha256:77718703587e0ad027c7b4d15856dbddfb40554946a935de26dc4ac6500428c5" and
+  .services.migrate.image == .services.server.image and
   .services.server.cpus == 2 and
   .services.server.pids_limit == 256 and
   .services.server.environment.METRICS_HOST == "0.0.0.0" and

--- a/deploy/experiments/cn-backend/validate-runtime.sh
+++ b/deploy/experiments/cn-backend/validate-runtime.sh
@@ -28,12 +28,21 @@ read_value() {
   printf '%s' "$value"
 }
 
+server_repository="$(read_value SERVER_IMAGE_REPOSITORY)"
 server_digest="$(read_value SERVER_IMAGE_DIGEST)"
 postgres_database="$(read_value EXPERIMENT_POSTGRES_DB)"
 postgres_user="$(read_value EXPERIMENT_POSTGRES_USER)"
 postgres_password="$(read_value EXPERIMENT_POSTGRES_PASSWORD)"
 server_env="$(read_value EXPERIMENT_SERVER_ENV_FILE)"
 
+case "$server_repository" in
+  ghcr.io/1024xengineer/xe3-esl-server) ;;
+  crpi-uzndbvgv3nza56mp.cn-beijing.personal.cr.aliyuncs.com/speakup/xe3-esl-server) ;;
+  *)
+    printf 'SERVER_IMAGE_REPOSITORY is not an approved Server repository\n' >&2
+    exit 1
+    ;;
+esac
 if [[ ! "$server_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
   printf 'SERVER_IMAGE_DIGEST must be a sha256 digest\n' >&2
   exit 1

--- a/tools/release-candidate/cn-acr-mirror.test.mjs
+++ b/tools/release-candidate/cn-acr-mirror.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const workflowFile = fileURLToPath(
+  new URL("../../.github/workflows/cn-acr-mirror.yml", import.meta.url),
+);
+
+test("CN ACR mirror is manual, Candidate-bound, immutable, and isolated", () => {
+  const workflow = readFileSync(workflowFile, "utf8");
+
+  assert.match(workflow, /workflow_dispatch:\n\s+inputs:\n\s+candidate_run_id:/);
+  assert.match(workflow, /getWorkflowRun/);
+  assert.match(workflow, /run\.name !== "Release Candidate"/);
+  assert.match(workflow, /run\.path !== "\.github\/workflows\/release-candidate\.yml"/);
+  assert.match(workflow, /run\.event !== "push"/);
+  assert.match(workflow, /run\.head_branch !== "main"/);
+  assert.match(workflow, /run\.conclusion !== "success"/);
+  assert.match(workflow, /manifests\.length !== 1/);
+  assert.match(workflow, /quality_run_url == \$run_url/);
+  assert.match(workflow, /server_image == \$server_image/);
+  assert.match(workflow, /environment:\n\s+name: cn-acr-mirror/);
+  assert.match(workflow, /vars\.CN_ACR_REGISTRY/);
+  assert.match(workflow, /vars\.CN_ACR_SERVER_REPOSITORY/);
+  assert.match(workflow, /secrets\.CN_ACR_USERNAME/);
+  assert.match(workflow, /secrets\.CN_ACR_PASSWORD/);
+  assert.match(workflow, /\.platform\.os == "linux"/);
+  assert.match(workflow, /\.platform\.architecture == "amd64"/);
+  assert.doesNotMatch(workflow, /--prefer-index=false/);
+  assert.match(workflow, /mirror_tag "\$VERSION"/);
+  assert.match(workflow, /mirror_tag "\$CANDIDATE_SHA"/);
+  assert.match(workflow, /Refusing to overwrite/);
+  assert.match(workflow, /"\$mirrored_platform_digest" != "\$platform_digest"/);
+  assert.match(workflow, /version_index_digest.*sha_index_digest/);
+  assert.match(workflow, /destination_index_digest/);
+  assert.match(workflow, /cn-acr-mirror-receipt\.json/);
+  assert.match(workflow, /release_manifest_sha256/);
+  assert.doesNotMatch(workflow, /:latest/);
+  assert.doesNotMatch(workflow, /staging-deploy\.yml|production-deploy\.yml/);
+});

--- a/tools/release-candidate/cn-acr-mirror.test.mjs
+++ b/tools/release-candidate/cn-acr-mirror.test.mjs
@@ -30,6 +30,12 @@ test("CN ACR mirror is manual, Candidate-bound, immutable, and isolated", () => 
   assert.doesNotMatch(workflow, /--prefer-index=false/);
   assert.match(workflow, /mirror_tag "\$VERSION"/);
   assert.match(workflow, /mirror_tag "\$CANDIDATE_SHA"/);
+  const versionPreflight = workflow.indexOf('preflight_tag "$VERSION"');
+  const shaPreflight = workflow.indexOf('preflight_tag "$CANDIDATE_SHA"');
+  const firstMirror = workflow.indexOf('mirror_tag "$VERSION"');
+  assert.ok(versionPreflight >= 0);
+  assert.ok(shaPreflight > versionPreflight);
+  assert.ok(firstMirror > shaPreflight);
   assert.match(workflow, /Refusing to overwrite/);
   assert.match(workflow, /"\$mirrored_platform_digest" != "\$platform_digest"/);
   assert.match(workflow, /version_index_digest.*sha_index_digest/);


### PR DESCRIPTION
## 功能描述

- 为国内隔离后端增加显式的 Server 镜像仓库配置，仅允许官方 GHCR 与指定北京 ACR。
- 新增手动 ACR 镜像同步 Workflow：从成功的官方 Release Candidate 复制唯一 `linux/amd64` 制品，生成版本号与完整 Git SHA 标签，并输出可审计回执。
- 国内运行时继续强制使用不可变 `sha256` 摘要；不修改新加坡 Staging/Production 发布链。

## 实现思路

- 先校验所选 Actions run 必须是官方仓 `main` 上成功的 `Release Candidate`，并验证唯一 release manifest。
- 仅复制 GHCR index 中的 `linux/amd64` 应用 manifest，避开 ACR 个人版不支持的 provenance manifest。
- 目标标签已存在时只允许平台摘要相同的幂等复用，禁止覆盖不同内容。
- ACR 凭据仅从 `cn-acr-mirror` Environment Secrets 读取，不进入仓库、日志或回执。
- 国内 Compose 使用 `SERVER_IMAGE_REPOSITORY@SERVER_IMAGE_DIGEST`，校验器对仓库地址和摘要 fail closed。

## 可复现测试

```sh
node --test tools/release-candidate/*.test.mjs
make check-cn-backend-experiment
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/cn-acr-mirror.yml', aliases: true)"
git diff --check upstream/dev...HEAD
```

结果：Release Candidate 测试 42/42 通过；国内实验合同测试与 PostgreSQL 备份合同测试通过。

## 实机验证

- v0.1.9 已同步到北京 ACR，版本标签与短 SHA 标签均解析到单平台 index。
- 国内隔离服务器已按 ACR digest 拉取并启动 v0.1.9。
- 数据库迁移结果为 `unchanged`，`/health`、`/readyz` 与容器健康检查均通过。
- 新加坡 Staging/Production 未修改。

Closes #1071
Related #1049
