### PR TITLE
feat(ai): 接入七牛千问分层文本模型

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,12 +28,12 @@ QIANWEN_MAX_OUTPUT_TOKENS=8192
 
 # 七牛云：备用 LLM、多模态（MaaS）
 QINIU_AI_BASE_URL=https://api.qnaigc.com/v1
-QINIU_AI_MODEL=moonshotai/kimi-k2.6
+QINIU_AI_MODEL=qwen/qwen3.7-plus
 # Evaluation stays independent from the latency-oriented Agent model above;
 # this model passed the opt-in strict IELTS contract check. Replace it only
 # after the candidate also passes that check within the provider timeout.
-QINIU_AI_EVALUATION_MODEL=qwen3-30b-a3b-instruct-2507
-QINIU_AI_SPEECH_FEEDBACK_MODEL=gemini-2.5-flash
+QINIU_AI_EVALUATION_MODEL=qwen/qwen3.7-max
+QINIU_AI_SPEECH_FEEDBACK_MODEL=qwen3-30b-a3b-instruct-2507
 QINIU_AI_TIMEOUT=60s
 QINIU_AI_MAX_OUTPUT_TOKENS=8192
 QINIU_AI_API_KEY=

--- a/server/internal/agent/input/voice/validation.go
+++ b/server/internal/agent/input/voice/validation.go
@@ -28,7 +28,7 @@ func ValidProviderID(value string) bool {
 }
 
 func ValidModelID(value string) bool {
-	return run.ValidOpaqueID(value)
+	return run.ValidModelID(value)
 }
 
 func validConfiguration(configuration run.Configuration) bool {

--- a/server/internal/agent/input/voice/validation_test.go
+++ b/server/internal/agent/input/voice/validation_test.go
@@ -1,0 +1,12 @@
+package voice
+
+import "testing"
+
+func TestValidModelIDAcceptsProviderQualifiedModel(t *testing.T) {
+	if !ValidModelID("qwen/qwen3.7-plus") {
+		t.Fatal("provider-qualified model ID was rejected")
+	}
+	if ValidModelID("qwen//qwen3.7-plus") {
+		t.Fatal("invalid provider-qualified model ID was accepted")
+	}
+}

--- a/server/internal/coaching/evaluation/ielts_profile.go
+++ b/server/internal/coaching/evaluation/ielts_profile.go
@@ -3,6 +3,8 @@ package evaluation
 import (
 	"strings"
 	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/modelid"
 )
 
 const (
@@ -111,7 +113,7 @@ func (profile IELTSCumulativeProfile) Valid() bool {
 		profile.CompletedParts[0] != 1 ||
 		(len(profile.CompletedParts) == 2 && profile.CompletedParts[1] != 2) ||
 		len(profile.Dimensions) != 4 || !validIdentifier(profile.Provider) ||
-		!validIdentifier(profile.Model) {
+		!modelid.Valid(profile.Model) {
 		return false
 	}
 	expected := []string{

--- a/server/internal/coaching/evaluation/job.go
+++ b/server/internal/coaching/evaluation/job.go
@@ -11,6 +11,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/modelid"
 )
 
 const (
@@ -85,7 +87,7 @@ func (lineage ConfigLineage) Valid() bool {
 		validVersion(lineage.PromptVersion) &&
 		validVersion(lineage.ResultSchema) &&
 		validIdentifier(lineage.Provider) &&
-		validIdentifier(lineage.Model)
+		modelid.Valid(lineage.Model)
 }
 
 type JobError struct {

--- a/server/internal/coaching/evaluation/model_lineage_test.go
+++ b/server/internal/coaching/evaluation/model_lineage_test.go
@@ -1,0 +1,36 @@
+package evaluation
+
+import "testing"
+
+func TestConfigLineageAcceptsProviderQualifiedModel(t *testing.T) {
+	lineage := ConfigLineage{
+		SchemaVersion: ConfigLineageSchemaVersion,
+		StrategyRef:   "strategy/v1", PipelineVersion: "pipeline/v1",
+		PromptVersion: "prompt/v1", ResultSchema: "result/v1",
+		Provider: "qiniu", Model: "qwen/qwen3.7-max",
+	}
+	if !lineage.Valid() {
+		t.Fatal("provider-qualified model lineage was rejected")
+	}
+	lineage.Model = "qwen//qwen3.7-max"
+	if lineage.Valid() {
+		t.Fatal("invalid provider-qualified model lineage was accepted")
+	}
+}
+
+func TestIELTSCumulativeProfileAcceptsProviderQualifiedModel(t *testing.T) {
+	profile := IELTSCumulativeProfile{
+		SchemaVersion:  IELTSCumulativeProfileSchemaVersion,
+		SessionID:      "20000000-0000-4000-8000-000000000001",
+		CompletedParts: []int{1}, Provider: "qiniu", Model: "qwen/qwen3.7-max",
+		Dimensions: []IELTSProfileDimension{
+			{Key: "FLUENCY_COHERENCE", ProvisionalBandLow: 6, ProvisionalBandHigh: 6.5, Observations: []IELTSProfileObservation{}},
+			{Key: "LEXICAL_RESOURCE", ProvisionalBandLow: 6, ProvisionalBandHigh: 6.5, Observations: []IELTSProfileObservation{}},
+			{Key: "GRAMMATICAL_RANGE_ACCURACY", ProvisionalBandLow: 6, ProvisionalBandHigh: 6.5, Observations: []IELTSProfileObservation{}},
+			{Key: "PRONUNCIATION", ProvisionalBandLow: 6, ProvisionalBandHigh: 6.5, Observations: []IELTSProfileObservation{}},
+		},
+	}
+	if !profile.Valid() {
+		t.Fatal("provider-qualified cumulative profile model was rejected")
+	}
+}

--- a/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
+++ b/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
@@ -137,6 +137,35 @@ func TestQiniuGeminiRequestOmitsKimiThinkingControl(t *testing.T) {
 	}
 }
 
+func TestQiniuQwenRequestDisablesThinking(t *testing.T) {
+	var payload map[string]json.RawMessage
+	generator := mustQiniuGeneratorForModel(
+		t,
+		"qwen/qwen3.7-plus",
+		doerFunc(func(request *http.Request) (*http.Response, error) {
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			return jsonResponse(http.StatusOK, `{
+				"id":"chatcmpl-qiniu-qwen",
+				"model":"qwen/qwen3.7-plus",
+				"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"Hello"}}],
+				"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}
+			}`), nil
+		}),
+		"qiniu-test-key",
+	)
+	if _, err := generator.Generate(context.Background(), validRequest()); err != nil {
+		t.Fatalf("Qiniu Qwen Generate() error = %v", err)
+	}
+	if string(payload["enable_thinking"]) != "false" {
+		t.Fatalf("Qiniu Qwen enable_thinking = %s", payload["enable_thinking"])
+	}
+	if _, exists := payload["thinking"]; exists {
+		t.Fatal("Qiniu Qwen request included the Kimi thinking field")
+	}
+}
+
 func TestQiniuGenerateStreamRequiresUsageAndReportsLineage(t *testing.T) {
 	var payload map[string]json.RawMessage
 	generator := mustQiniuGenerator(t, doerFunc(func(request *http.Request) (*http.Response, error) {
@@ -173,6 +202,30 @@ func TestQiniuGenerateStreamRequiresUsageAndReportsLineage(t *testing.T) {
 	}
 	if string(payload["stream_options"]) != `{"include_usage":true}` {
 		t.Fatalf("Qiniu stream_options = %s", payload["stream_options"])
+	}
+}
+
+func TestQiniuQwenToolStreamNormalizesStopFinishReason(t *testing.T) {
+	const model = "qwen/qwen3.7-plus"
+	generator := mustQiniuGeneratorForModel(t, model, doerFunc(func(*http.Request) (*http.Response, error) {
+		return streamResponse(
+			`data: {"id":"chatcmpl-qiniu-tool-stream","model":"qwen/qwen3.7-plus","choices":[{"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_qiniu_1","type":"function","function":{"name":"review_search_v1","arguments":"{\"query\":\"IELTS\"}"}}]}}]}` + "\n\n" +
+				`data: {"id":"chatcmpl-qiniu-tool-stream","model":"qwen/qwen3.7-plus","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":3,"total_tokens":12}}` + "\n\n" +
+				"data: [DONE]\n\n",
+		), nil
+	}), "qiniu-test-key")
+
+	result, err := generator.GenerateStream(
+		context.Background(),
+		toolRequest(),
+		protocol.TextDeltaObserverFunc(func(context.Context, string) error { return nil }),
+	)
+	if err != nil {
+		t.Fatalf("Qiniu Qwen tool GenerateStream() error = %v", err)
+	}
+	if result.FinishReason != "tool_calls" || len(result.ToolCalls) != 1 ||
+		result.ToolCalls[0].Name != "review.search.v1" {
+		t.Fatalf("Qiniu Qwen tool stream result = %#v", result)
 	}
 }
 

--- a/server/internal/providers/qianwen/text_generator.go
+++ b/server/internal/providers/qianwen/text_generator.go
@@ -437,10 +437,13 @@ func (generator *textClient) providerRequest(
 		disabled := false
 		payload.EnableThinking = &disabled
 	case qiniuProviderName:
-		// Qiniu fronts heterogeneous upstream APIs. Kimi needs Qiniu's generic
-		// thinking control, while existing Gemini configurations must omit it.
+		// Qiniu fronts heterogeneous upstream APIs. Kimi uses Qiniu's generic
+		// thinking control, Qwen uses enable_thinking, and other upstreams omit both.
 		if generator.model == qiniuKimiK26Model {
 			payload.Thinking = &chatThinking{Type: "disabled"}
+		} else if strings.HasPrefix(strings.ToLower(generator.model), "qwen") {
+			disabled := false
+			payload.EnableThinking = &disabled
 		}
 	}
 	if request.ResponseFormat == protocol.TextResponseFormatJSON {
@@ -827,6 +830,11 @@ func decodeCompletionStream(
 	}
 	if !sawDone || !sawUsage || finishReason == "" {
 		return protocol.TextResult{}, errors.New("Qianwen stream ended before completion")
+	}
+	if provider == qiniuProviderName &&
+		(mode == streamModeTools || mode == streamModeMixed) &&
+		finishReason == "stop" && len(tools) > 0 {
+		finishReason = "tool_calls"
 	}
 	result := protocol.TextResult{
 		ID: completionID, Provider: provider, Model: model,


### PR DESCRIPTION
## 功能描述

- 接入七牛 Qwen 分层文本模型配置：主对话、报告评测、短语音反馈分别使用实验通过的模型。
- 七牛 Qwen 请求明确关闭思考模式，避免不必要的延迟。
- 兼容七牛 Qwen 流式工具调用以 `stop` 结束的响应，并保留严格工具调用校验。
- 评测 lineage 与 IELTS 累计报告支持 `qwen/qwen3.7-max` 形式的模型 ID。

## 实现思路

- 仅对七牛 Qwen 模型发送 `enable_thinking: false`，不改变 Kimi、Gemini 或原生千问行为。
- 仅当七牛流式响应实际包含工具调用且结束原因为 `stop` 时，将其规范为 `tool_calls`。
- 复用平台已有的 `modelid.Valid` 校验 provider-qualified model ID，不新建重复规则。

## 可复现测试

```bash
cd server
go test ./internal/providers/qianwen ./internal/coaching/evaluation
```

结果：通过。

Closes #1073
