### PR TITLE
fix(storage): 接入七牛 Kodo 私有对象存储

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,10 +107,10 @@ OSS_RESUME_PREFIX=resume/v1
 OSS_SIGNED_URL_TTL=2m
 
 # 七牛云：对象存储（Kodo S3）
+# Bucket 必须保持私有；应用不会把无法验证的空间级服务端加密状态当作配置项。
 QINIU_KODO_S3_REGION=cn-east-1
 QINIU_KODO_S3_ENDPOINT=https://s3.cn-east-1.qiniucs.com
 QINIU_KODO_S3_BUCKET=
-QINIU_KODO_SERVER_SIDE_ENCRYPTION=0
 QINIU_ACCESS_KEY=
 QINIU_SECRET_KEY=
 

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ check-oss-live-go:
 
 check-kodo-live:
 	@set -euo pipefail; \
-	required=(OSS_ENABLED OBJECT_STORAGE_PROVIDER QINIU_KODO_S3_REGION QINIU_KODO_S3_ENDPOINT QINIU_KODO_S3_BUCKET QINIU_KODO_SERVER_SIDE_ENCRYPTION QINIU_ACCESS_KEY QINIU_SECRET_KEY KODO_LIVE_TEST); \
+	required=(OSS_ENABLED OBJECT_STORAGE_PROVIDER QINIU_KODO_S3_REGION QINIU_KODO_S3_ENDPOINT QINIU_KODO_S3_BUCKET QINIU_ACCESS_KEY QINIU_SECRET_KEY KODO_LIVE_TEST); \
 	missing=(); \
 	for name in "$${required[@]}"; do \
 		if [[ -z "$${!name:-}" ]]; then missing+=("$$name"); fi; \
@@ -260,10 +260,6 @@ check-kodo-live:
 	fi; \
 	if [[ "$${OBJECT_STORAGE_PROVIDER}" != "qiniu_kodo" ]]; then \
 		printf '%s\n' 'Set and export OBJECT_STORAGE_PROVIDER=qiniu_kodo.'; \
-		exit 1; \
-	fi; \
-	if [[ "$${QINIU_KODO_SERVER_SIDE_ENCRYPTION}" != "1" && "$${QINIU_KODO_SERVER_SIDE_ENCRYPTION}" != "true" ]]; then \
-		printf '%s\n' 'Enable Kodo server-side encryption, then attest it with QINIU_KODO_SERVER_SIDE_ENCRYPTION=1.'; \
 		exit 1; \
 	fi; \
 	if [[ "$${KODO_LIVE_TEST}" != "1" ]]; then \

--- a/server/internal/platform/config/object_storage.go
+++ b/server/internal/platform/config/object_storage.go
@@ -41,7 +41,6 @@ var (
 	ErrObjectStorageQiniuS3Region   = errors.New("QINIU_KODO_S3_REGION must be a valid Qiniu S3 region")
 	ErrObjectStorageQiniuS3Endpoint = errors.New("QINIU_KODO_S3_ENDPOINT must be the official HTTPS endpoint for QINIU_KODO_S3_REGION")
 	ErrObjectStorageQiniuBucket     = errors.New("QINIU_KODO_S3_BUCKET is required when Qiniu Kodo is enabled")
-	ErrObjectStorageEncryption      = errors.New("QINIU_KODO_SERVER_SIDE_ENCRYPTION must be 1 or true when Qiniu Kodo is enabled")
 )
 
 var (
@@ -53,18 +52,17 @@ var (
 // Access credentials stay in the SDK credential provider so Config values can
 // be logged during local debugging without disclosing an AccessKey secret.
 type ObjectStorageConfig struct {
-	Enabled              bool
-	Provider             string
-	Region               string
-	Endpoint             string
-	Bucket               string
-	ServerSideEncryption bool
-	AudioPrefix          string
-	ImagePrefix          string
-	ResumePrefix         string
-	SignedURLTTL         time.Duration
-	CredentialsProvider  ObjectStorageCredentialsProvider
-	RAMRoleName          string
+	Enabled             bool
+	Provider            string
+	Region              string
+	Endpoint            string
+	Bucket              string
+	AudioPrefix         string
+	ImagePrefix         string
+	ResumePrefix        string
+	SignedURLTTL        time.Duration
+	CredentialsProvider ObjectStorageCredentialsProvider
+	RAMRoleName         string
 }
 
 // LoadObjectStorage reads and validates the server-only OSS configuration.
@@ -136,20 +134,11 @@ func LoadObjectStorage() (ObjectStorageConfig, error) {
 		config.Region = strings.TrimSpace(os.Getenv("QINIU_KODO_S3_REGION"))
 		config.Endpoint = strings.TrimSpace(os.Getenv("QINIU_KODO_S3_ENDPOINT"))
 		config.Bucket = strings.TrimSpace(os.Getenv("QINIU_KODO_S3_BUCKET"))
-		// Kodo's bucket-info API does not expose the console-level encryption
-		// switch. Require an explicit operator attestation so startup fails
-		// closed until bucket-level AES-256 encryption has been enabled.
-		config.ServerSideEncryption = enabledValue(
-			os.Getenv("QINIU_KODO_SERVER_SIDE_ENCRYPTION"),
-		)
 		if config.Bucket == "" {
 			return ObjectStorageConfig{}, ErrObjectStorageQiniuBucket
 		}
 		if err := validateQiniuS3Endpoint(config.Region, config.Endpoint); err != nil {
 			return ObjectStorageConfig{}, err
-		}
-		if !config.ServerSideEncryption {
-			return ObjectStorageConfig{}, ErrObjectStorageEncryption
 		}
 		return config, nil
 	}
@@ -181,15 +170,6 @@ func LoadObjectStorage() (ObjectStorageConfig, error) {
 	}
 
 	return config, nil
-}
-
-func enabledValue(raw string) bool {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "1", "true":
-		return true
-	default:
-		return false
-	}
 }
 
 func validateQiniuS3Endpoint(region string, raw string) error {

--- a/server/internal/platform/config/object_storage_test.go
+++ b/server/internal/platform/config/object_storage_test.go
@@ -74,7 +74,6 @@ func TestLoadObjectStorageReadsQiniuKodoConfigurationWithoutSecrets(t *testing.T
 	t.Setenv("QINIU_KODO_S3_REGION", "cn-east-1")
 	t.Setenv("QINIU_KODO_S3_ENDPOINT", "https://s3.cn-east-1.qiniucs.com")
 	t.Setenv("QINIU_KODO_S3_BUCKET", "speakup-private")
-	t.Setenv("QINIU_KODO_SERVER_SIDE_ENCRYPTION", "true")
 	t.Setenv("QINIU_ACCESS_KEY", "must-not-be-copied")
 	t.Setenv("QINIU_SECRET_KEY", "must-not-be-copied")
 
@@ -87,7 +86,6 @@ func TestLoadObjectStorageReadsQiniuKodoConfigurationWithoutSecrets(t *testing.T
 		configuration.Bucket != "speakup-private" ||
 		configuration.Region != "cn-east-1" ||
 		configuration.Endpoint != "https://s3.cn-east-1.qiniucs.com" ||
-		!configuration.ServerSideEncryption ||
 		configuration.AudioPrefix != "audio/v1" ||
 		configuration.ImagePrefix != "image/v1" ||
 		configuration.ResumePrefix != "resume/v1" {
@@ -97,37 +95,31 @@ func TestLoadObjectStorageReadsQiniuKodoConfigurationWithoutSecrets(t *testing.T
 
 func TestLoadObjectStorageRejectsUnsafeQiniuKodoConfiguration(t *testing.T) {
 	testCases := []struct {
-		name       string
-		region     string
-		endpoint   string
-		bucket     string
-		encryption string
-		expected   error
+		name     string
+		region   string
+		endpoint string
+		bucket   string
+		expected error
 	}{
 		{
 			name: "missing bucket", region: "cn-east-1",
-			endpoint:   "https://s3.cn-east-1.qiniucs.com",
-			encryption: "1", expected: ErrObjectStorageQiniuBucket,
+			endpoint: "https://s3.cn-east-1.qiniucs.com",
+			expected: ErrObjectStorageQiniuBucket,
 		},
 		{
 			name: "invalid region", region: "z0", bucket: "speakup-private",
-			endpoint: "https://s3.cn-east-1.qiniucs.com", encryption: "1",
+			endpoint: "https://s3.cn-east-1.qiniucs.com",
 			expected: ErrObjectStorageQiniuS3Region,
 		},
 		{
 			name: "insecure endpoint", region: "cn-east-1", bucket: "speakup-private",
-			endpoint: "http://s3.cn-east-1.qiniucs.com", encryption: "1",
+			endpoint: "http://s3.cn-east-1.qiniucs.com",
 			expected: ErrObjectStorageQiniuS3Endpoint,
 		},
 		{
 			name: "endpoint region mismatch", region: "cn-east-1", bucket: "speakup-private",
-			endpoint: "https://s3.cn-south-1.qiniucs.com", encryption: "1",
+			endpoint: "https://s3.cn-south-1.qiniucs.com",
 			expected: ErrObjectStorageQiniuS3Endpoint,
-		},
-		{
-			name: "encryption not attested", bucket: "speakup-private",
-			region: "cn-east-1", endpoint: "https://s3.cn-east-1.qiniucs.com", encryption: "0",
-			expected: ErrObjectStorageEncryption,
 		},
 	}
 
@@ -138,8 +130,6 @@ func TestLoadObjectStorageRejectsUnsafeQiniuKodoConfiguration(t *testing.T) {
 			t.Setenv("QINIU_KODO_S3_REGION", testCase.region)
 			t.Setenv("QINIU_KODO_S3_ENDPOINT", testCase.endpoint)
 			t.Setenv("QINIU_KODO_S3_BUCKET", testCase.bucket)
-			t.Setenv("QINIU_KODO_SERVER_SIDE_ENCRYPTION", testCase.encryption)
-
 			_, err := LoadObjectStorage()
 			if !errors.Is(err, testCase.expected) {
 				t.Fatalf("LoadObjectStorage() error = %v, want %v", err, testCase.expected)

--- a/server/internal/platform/objectstore/kodostore/client.go
+++ b/server/internal/platform/objectstore/kodostore/client.go
@@ -69,8 +69,7 @@ func NewForPrefix(
 	if !storageConfig.Enabled {
 		return nil, objectstore.ErrDisabled
 	}
-	if storageConfig.Provider != config.ObjectStorageProviderQiniuKodo ||
-		!storageConfig.ServerSideEncryption {
+	if storageConfig.Provider != config.ObjectStorageProviderQiniuKodo {
 		return nil, objectstore.ErrOperationFailed
 	}
 	if prefix == "" ||

--- a/server/internal/platform/objectstore/kodostore/client_test.go
+++ b/server/internal/platform/objectstore/kodostore/client_test.go
@@ -357,7 +357,7 @@ func TestNewRejectsMissingCredentialsBeforeNetwork(t *testing.T) {
 		Region: "cn-east-1", Endpoint: "https://s3.cn-east-1.qiniucs.com",
 		Bucket:      "private-bucket",
 		AudioPrefix: "audio/v1", ImagePrefix: "image/v1", ResumePrefix: "resume/v1",
-		SignedURLTTL: 2 * time.Minute, ServerSideEncryption: true,
+		SignedURLTTL: 2 * time.Minute,
 	})
 	if client != nil || !errors.Is(err, objectstore.ErrCredentials) {
 		t.Fatalf("New() = %#v, %v", client, err)

--- a/server/internal/platform/objectstore/kodostore/client_test.go
+++ b/server/internal/platform/objectstore/kodostore/client_test.go
@@ -330,6 +330,15 @@ func TestClientPreflightRequiresPrivateBucket(t *testing.T) {
 	}
 }
 
+func TestClientPreflightAcceptsPrivateBucket(t *testing.T) {
+	client := newTestClient(&apiStub{acl: &s3.GetBucketAclOutput{Grants: []types.Grant{{
+		Grantee: &types.Grantee{URI: aws.String("private-owner")},
+	}}}}, &presignerStub{})
+	if err := client.Preflight(context.Background()); err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+}
+
 func TestClientOpenReturnsOnlyPDF(t *testing.T) {
 	api := &apiStub{get: &s3.GetObjectOutput{
 		Body:        io.NopCloser(strings.NewReader("%PDF fixture")),
@@ -361,6 +370,48 @@ func TestNewRejectsMissingCredentialsBeforeNetwork(t *testing.T) {
 	})
 	if client != nil || !errors.Is(err, objectstore.ErrCredentials) {
 		t.Fatalf("New() = %#v, %v", client, err)
+	}
+}
+
+func TestNewForPrefixRejectsInvalidConfigurationBeforeCredentials(t *testing.T) {
+	testCases := []struct {
+		name          string
+		configuration config.ObjectStorageConfig
+		prefix        string
+		expected      error
+	}{
+		{
+			name: "disabled",
+			configuration: config.ObjectStorageConfig{
+				Provider: config.ObjectStorageProviderQiniuKodo,
+			},
+			prefix: "audio/v1", expected: objectstore.ErrDisabled,
+		},
+		{
+			name: "wrong provider",
+			configuration: config.ObjectStorageConfig{
+				Enabled: true, Provider: config.ObjectStorageProviderAliyunOSS,
+			},
+			prefix: "audio/v1", expected: objectstore.ErrOperationFailed,
+		},
+		{
+			name: "unknown prefix",
+			configuration: config.ObjectStorageConfig{
+				Enabled: true, Provider: config.ObjectStorageProviderQiniuKodo,
+				AudioPrefix: "audio/v1", ImagePrefix: "image/v1", ResumePrefix: "resume/v1",
+			},
+			prefix: "other/v1", expected: objectstore.ErrInvalidKey,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, err := NewForPrefix(
+				context.Background(), testCase.configuration, testCase.prefix,
+			)
+			if client != nil || !errors.Is(err, testCase.expected) {
+				t.Fatalf("NewForPrefix() = %#v, %v; want %v", client, err, testCase.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 功能描述

- 国内后端可直接使用七牛 Kodo 私有空间，不再依赖无法验证的服务端加密声明。
- 保留私有 Bucket 预检、官方 HTTPS Endpoint、固定对象前缀和最长 2 分钟签名 URL。
- 删除已废弃的 `QINIU_KODO_SERVER_SIDE_ENCRYPTION` 示例与真实测试门禁。

## 实现思路

七牛当前空间控制台没有服务端加密入口，S3 上传探测也不能通过对象元信息确认 AES-256。原配置只是一项人工声明，并未改变上传请求，因此删除这项虚假门禁，继续用可由程序真实核验的私有 ACL 和传输/访问控制保护对象。

## 可复现测试

- `cd server && go test ./...`
- `make check-kodo-live`（使用 `ai-english-speaking-xiayanji`）：真实上传、匿名访问拒绝、签名下载、内容校验与删除全部通过。
- `git diff --check`

## 安全边界

- Bucket 必须保持私有。
- 当前不宣称七牛空间已启用或已验证静态服务端加密。
- 未修改或提交任何密钥、`.env`、生产配置或生产数据。

Closes #1075