### PR TITLE
feat(speech): 切换 Qwen-Audio 3.0 语音识别

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,9 @@ QIANWEN_LIVE_TEST=0
 # 阿里云：ASR（千问）
 SPEECH_RECOGNITION_PROVIDER=qianwen
 QIANWEN_ASR_BASE_URL=https://dashscope.aliyuncs.com/api/v1
-QIANWEN_ASR_MODEL=fun-asr-realtime
+QIANWEN_ASR_MODEL=qwen-audio-3.0-asr-flash-streaming
 QIANWEN_ASR_TIMEOUT=150s
-QIANWEN_ASR_RECORDED_MODEL=fun-asr-flash-2026-06-15
+QIANWEN_ASR_RECORDED_MODEL=qwen-audio-3.0-asr-flash
 QIANWEN_ASR_RECORDED_TIMEOUT=150s
 
 # 阿里云：TTS（千问）

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -163,9 +163,9 @@ jobs:
           QIANWEN_SPEECH_FEEDBACK_MODEL: qwen-ci-readiness-not-invoked
           SPEECH_RECOGNITION_PROVIDER: qianwen
           QIANWEN_ASR_BASE_URL: https://dashscope.aliyuncs.com/api/v1
-          QIANWEN_ASR_MODEL: fun-asr-realtime
+          QIANWEN_ASR_MODEL: qwen-audio-3.0-asr-flash-streaming
           QIANWEN_ASR_TIMEOUT: 150s
-          QIANWEN_ASR_RECORDED_MODEL: fun-asr-flash-2026-06-15
+          QIANWEN_ASR_RECORDED_MODEL: qwen-audio-3.0-asr-flash
           QIANWEN_ASR_RECORDED_TIMEOUT: 150s
           SPEECH_SYNTHESIS_PROVIDER: qianwen
           QIANWEN_TTS_BASE_URL: https://dashscope.aliyuncs.com/api/v1

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -202,8 +202,9 @@ China candidate changes and validates these groups together:
   - `SPEECH_RECOGNITION_PROVIDER=qianwen`;
   - `QIANWEN_ASR_BASE_URL`, `QIANWEN_ASR_MODEL`, `QIANWEN_ASR_TIMEOUT`,
     `QIANWEN_ASR_RECORDED_MODEL`, and `QIANWEN_ASR_RECORDED_TIMEOUT`.
-    The current Server requires `fun-asr-realtime` with a timeout of at least
-    `150s`, and `fun-asr-flash-2026-06-15` for recorded audio.
+    The current Server requires `qwen-audio-3.0-asr-flash-streaming` with a
+    timeout of at least `150s`, and `qwen-audio-3.0-asr-flash` for recorded
+    audio.
 - Qianwen speech synthesis:
   - `SPEECH_SYNTHESIS_PROVIDER=qianwen`;
   - `QIANWEN_TTS_BASE_URL`, `QIANWEN_TTS_MODEL`, `QIANWEN_TTS_VOICE`,

--- a/server/internal/platform/config/speech.go
+++ b/server/internal/platform/config/speech.go
@@ -11,8 +11,8 @@ import (
 const (
 	SpeechProviderQianwen = "qianwen"
 
-	qianwenRealtimeASRModel = "fun-asr-realtime"
-	qianwenRecordedASRModel = "fun-asr-flash-2026-06-15"
+	qianwenRealtimeASRModel = "qwen-audio-3.0-asr-flash-streaming"
+	qianwenRecordedASRModel = "qwen-audio-3.0-asr-flash"
 
 	defaultASRTimeout         = 150 * time.Second
 	minimumRealtimeASRTimeout = 150 * time.Second

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -62,7 +62,7 @@ func NewAgentVoiceRecognizer(
 		return nil, err
 	}
 	agentRecognizer := &AgentVoiceRecognizer{recognizer: recognizer}
-	if recognizer.model == "fun-asr-realtime" {
+	if isRealtimeASRModel(recognizer.model) {
 		return &agentRealtimeVoiceRecognizer{
 			AgentVoiceRecognizer: agentRecognizer,
 		}, nil
@@ -151,7 +151,7 @@ func (recognizer *agentRealtimeVoiceRecognizer) TranscribePCMStream(
 ) (agentvoice.TranscriptionResult, error) {
 	if recognizer == nil || recognizer.AgentVoiceRecognizer == nil ||
 		recognizer.recognizer == nil || observer == nil ||
-		recognizer.recognizer.model != "fun-asr-realtime" {
+		!isRealtimeASRModel(recognizer.recognizer.model) {
 		return agentvoice.TranscriptionResult{}, agentvoice.NewSpeechError(
 			agentvoice.SpeechOperationTranscription,
 			agentvoice.ErrorConfiguration,

--- a/server/internal/providers/qianwen/practice_interaction.go
+++ b/server/internal/providers/qianwen/practice_interaction.go
@@ -33,9 +33,9 @@ func NewPracticeRecordedVoiceRecognizer(
 	if err != nil {
 		return nil, err
 	}
-	if model != "fun-asr-flash-2026-06-15" {
+	if model != recordedASRModel {
 		return nil, errors.New(
-			"Qianwen recorded Practice Voice requires fun-asr-flash-2026-06-15",
+			"Qianwen recorded Practice Voice requires " + recordedASRModel,
 		)
 	}
 	configuration.Model = model
@@ -90,7 +90,7 @@ func (recognizer *PracticeVoiceRecognizer) TranscribeStream(
 	observer practiceinteraction.TranscriptionObserver,
 ) (practiceinteraction.TranscriptionResult, error) {
 	if recognizer == nil || recognizer.recognizer == nil || observer == nil ||
-		recognizer.recognizer.model != "fun-asr-realtime" {
+		!isRealtimeASRModel(recognizer.recognizer.model) {
 		return practiceinteraction.TranscriptionResult{},
 			practiceinteraction.NewProviderError(
 				practiceinteraction.ProviderOperationTranscription,

--- a/server/internal/providers/qianwen/practice_interaction_test.go
+++ b/server/internal/providers/qianwen/practice_interaction_test.go
@@ -171,7 +171,7 @@ func TestPracticeVoiceObserverClassifiesCallbackFailureAsCancelled(t *testing.T)
 
 func TestPracticeVoiceStreamingRejectsNonRealtimeModel(t *testing.T) {
 	recognizer := &PracticeVoiceRecognizer{
-		recognizer: &speechRecognizer{model: "fun-asr-flash-2026-06-15"},
+		recognizer: &speechRecognizer{model: "qwen-audio-3.0-asr-flash"},
 	}
 	_, err := recognizer.TranscribeStream(
 		context.Background(),
@@ -187,20 +187,20 @@ func TestPracticeRecordedVoiceRecognizerRequiresFlashModel(t *testing.T) {
 	recorded, err := NewPracticeRecordedVoiceRecognizer(
 		ASRConfig{
 			BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-			Model:   "fun-asr-flash-2026-06-15",
+			Model:   "qwen-audio-3.0-asr-flash",
 			Timeout: time.Second,
 		},
 		"test-key",
 	)
 	if err != nil || recorded == nil || recorded.recognizer == nil ||
-		recorded.recognizer.model != "fun-asr-flash-2026-06-15" {
+		recorded.recognizer.model != "qwen-audio-3.0-asr-flash" {
 		t.Fatalf("recorded recognizer = %#v, %v", recorded, err)
 	}
 
 	_, err = NewPracticeRecordedVoiceRecognizer(
 		ASRConfig{
 			BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-			Model:   "fun-asr-realtime",
+			Model:   "qwen-audio-3.0-asr-flash-streaming",
 			Timeout: time.Second,
 		},
 		"test-key",

--- a/server/internal/providers/qianwen/speech_live_test.go
+++ b/server/internal/providers/qianwen/speech_live_test.go
@@ -61,6 +61,7 @@ func TestLiveSpeechRecognition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create Qianwen recognizer: %v", err)
 	}
+	startedAt := time.Now()
 	result, err := recognizer.Transcribe(
 		context.Background(),
 		protocol.TranscriptionRequest{Audio: audio},
@@ -75,7 +76,7 @@ func TestLiveSpeechRecognition(t *testing.T) {
 		"ASR success: provider=%s model=%s request_id=%s "+
 			"transcript_nonempty=%t transcript_characters=%d "+
 			"usage_audio_seconds=%d fixture_type=%s fixture_bytes=%d "+
-			"fixture_rate_hz=%d fixture_duration=%s",
+			"fixture_rate_hz=%d fixture_duration=%s total_latency=%s",
 		result.Provider,
 		result.Model,
 		result.ID,
@@ -86,6 +87,56 @@ func TestLiveSpeechRecognition(t *testing.T) {
 		audio.Size(),
 		audio.SampleRate(),
 		audio.Duration(),
+		time.Since(startedAt),
+	)
+}
+
+func TestLiveRecordedSpeechRecognition(t *testing.T) {
+	if os.Getenv("QIANWEN_ASR_LIVE_TEST") != "1" {
+		t.Skip(
+			"set QIANWEN_ASR_LIVE_TEST=1 and the ASR environment variables " +
+				"to run; the real request may incur charges",
+		)
+	}
+	audioPath := os.Getenv("QIANWEN_ASR_LIVE_TEST_AUDIO")
+	if audioPath == "" {
+		audioPath = defaultASRLiveFixture
+	}
+	audio := captureLiveASRFixture(t, audioPath)
+	defer audio.Close()
+
+	cfg, err := platformconfig.LoadSpeechRecognition()
+	if err != nil {
+		t.Fatalf("load speech recognition config: %v", err)
+	}
+	recognizer, err := newSpeechRecognizer(ASRConfig{
+		BaseURL: cfg.BaseURL,
+		Model:   cfg.RecordedModel,
+		Timeout: cfg.RecordedTimeout,
+	}, cfg.APIKey.Reveal())
+	if err != nil {
+		t.Fatalf("create recorded Qianwen recognizer: %v", err)
+	}
+	startedAt := time.Now()
+	result, err := recognizer.Transcribe(
+		context.Background(),
+		protocol.TranscriptionRequest{Audio: audio},
+	)
+	if err != nil {
+		t.Fatalf("live recorded Qianwen ASR failed: %s", safeLiveSpeechError(err))
+	}
+	if result.Transcript == "" {
+		t.Fatal("live recorded Qianwen ASR returned an empty transcript")
+	}
+	t.Logf(
+		"recorded ASR success: provider=%s model=%s request_id=%s "+
+			"transcript_characters=%d fixture_duration=%s total_latency=%s",
+		result.Provider,
+		result.Model,
+		result.ID,
+		utf8.RuneCountInString(result.Transcript),
+		audio.Duration(),
+		time.Since(startedAt),
 	)
 }
 

--- a/server/internal/providers/qianwen/speech_recognizer.go
+++ b/server/internal/providers/qianwen/speech_recognizer.go
@@ -20,6 +20,11 @@ import (
 
 const maxASRDataURLBytes = 10_000_000
 
+const (
+	realtimeASRModel = "qwen-audio-3.0-asr-flash-streaming"
+	recordedASRModel = "qwen-audio-3.0-asr-flash"
+)
+
 type ASRConfig struct {
 	BaseURL  string
 	Model    string
@@ -39,10 +44,10 @@ type speechRecognizer struct {
 
 func (recognizer *speechRecognizer) String() string {
 	if recognizer == nil {
-		return "FunASRRecognizer(<nil>)"
+		return "QianwenASRRecognizer(<nil>)"
 	}
 	return fmt.Sprintf(
-		"FunASRRecognizer(model=%q, timeout=%s, api_key=[REDACTED])",
+		"QianwenASRRecognizer(model=%q, timeout=%s, api_key=[REDACTED])",
 		recognizer.model,
 		recognizer.timeout,
 	)
@@ -80,10 +85,10 @@ func newRecognizerWithClient(
 		return nil, err
 	}
 	if config.Timeout <= 0 || config.Timeout > maxTimeout {
-		return nil, fmt.Errorf("Fun-ASR timeout must be greater than zero and at most %s", maxTimeout)
+		return nil, fmt.Errorf("Qianwen ASR timeout must be greater than zero and at most %s", maxTimeout)
 	}
 	if client == nil {
-		return nil, errors.New("Fun-ASR HTTP client is required")
+		return nil, errors.New("Qianwen ASR HTTP client is required")
 	}
 	return &speechRecognizer{
 		endpoint:   baseURL + multimodalGenerationPath,
@@ -100,7 +105,7 @@ func (recognizer *speechRecognizer) Transcribe(
 	ctx context.Context,
 	request protocol.TranscriptionRequest,
 ) (protocol.TranscriptionResult, error) {
-	if recognizer.model == "fun-asr-realtime" {
+	if isRealtimeASRModel(recognizer.model) {
 		return recognizer.transcribeRealtime(ctx, request, nil)
 	}
 	if ctx == nil {
@@ -143,7 +148,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			0,
 			"",
 			"",
-			errors.New("encoded audio exceeds the Fun-ASR input limit"),
+			errors.New("encoded audio exceeds the Qianwen ASR input limit"),
 		)
 	}
 
@@ -173,7 +178,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			0,
 			"",
 			"",
-			errors.New("encode Fun-ASR request"),
+			errors.New("encode Qianwen ASR request"),
 		)
 	}
 
@@ -192,7 +197,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			0,
 			"",
 			"",
-			errors.New("create Fun-ASR request"),
+			errors.New("create Qianwen ASR request"),
 		)
 	}
 	httpRequest.Header.Set(
@@ -216,7 +221,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			0,
 			"",
-			"Fun-ASR returned a nil HTTP response",
+			"Qianwen ASR returned a nil HTTP response",
 		)
 	}
 	if response.Body == nil {
@@ -224,7 +229,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			response.StatusCode,
 			response.Header.Get("X-Request-Id"),
-			"Fun-ASR returned an HTTP response without a body",
+			"Qianwen ASR returned an HTTP response without a body",
 		)
 	}
 	defer response.Body.Close()
@@ -240,7 +245,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			response.StatusCode,
 			response.Header.Get("X-Request-Id"),
-			"Fun-ASR response exceeds the accepted limit",
+			"Qianwen ASR response exceeds the accepted limit",
 		)
 	}
 	var completion asrResponse
@@ -249,7 +254,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			response.StatusCode,
 			response.Header.Get("X-Request-Id"),
-			"decode Fun-ASR response",
+			"decode Qianwen ASR response",
 		)
 	}
 	result, err := completion.result(recognizer.model)
@@ -269,7 +274,7 @@ func (recognizer *speechRecognizer) TranscribeStream(
 	request protocol.TranscriptionRequest,
 	observer protocol.TranscriptionObserver,
 ) (protocol.TranscriptionResult, error) {
-	if recognizer.model != "fun-asr-realtime" || observer == nil {
+	if !isRealtimeASRModel(recognizer.model) || observer == nil {
 		return recognizer.Transcribe(ctx, request)
 	}
 	return recognizer.transcribeRealtime(ctx, request, observer)
@@ -307,7 +312,12 @@ type asrParameters struct {
 type asrResponse struct {
 	RequestID string `json:"request_id"`
 	Output    struct {
-		Text     string `json:"text"`
+		Text   string `json:"text"`
+		Output struct {
+			Sentence struct {
+				Text string `json:"text"`
+			} `json:"sentence"`
+		} `json:"output"`
 		Sentence struct {
 			Text string `json:"text"`
 		} `json:"sentence"`
@@ -320,10 +330,10 @@ type asrResponse struct {
 func (response asrResponse) result(model string) (protocol.TranscriptionResult, error) {
 	requestID := sanitizeIdentifier(response.RequestID)
 	if requestID == "" {
-		return protocol.TranscriptionResult{}, errors.New("Fun-ASR response has no valid request ID")
+		return protocol.TranscriptionResult{}, errors.New("Qianwen ASR response has no valid request ID")
 	}
 	if response.Usage.Duration < 0 {
-		return protocol.TranscriptionResult{}, errors.New("Fun-ASR response has invalid audio usage")
+		return protocol.TranscriptionResult{}, errors.New("Qianwen ASR response has invalid audio usage")
 	}
 	text := strings.TrimSpace(response.Output.Text)
 	sentenceText := strings.TrimSpace(response.Output.Sentence.Text)
@@ -333,7 +343,10 @@ func (response asrResponse) result(model string) (protocol.TranscriptionResult, 
 		text = sentenceText
 	}
 	if text == "" {
-		return protocol.TranscriptionResult{}, errors.New("Fun-ASR response has no transcript")
+		text = strings.TrimSpace(response.Output.Output.Sentence.Text)
+	}
+	if text == "" {
+		return protocol.TranscriptionResult{}, errors.New("Qianwen ASR response has no transcript")
 	}
 	return protocol.TranscriptionResult{
 		ID:         requestID,
@@ -372,10 +385,18 @@ func readAudioSource(source platformmedia.AudioSource) ([]byte, error) {
 
 func normalizeASRModel(raw string) (string, error) {
 	model := strings.ToLower(strings.TrimSpace(raw))
-	if model != "fun-asr-realtime" && model != "fun-asr-flash-2026-06-15" {
-		return "", errors.New("Fun-ASR adapter only accepts fun-asr-realtime or fun-asr-flash-2026-06-15")
+	if model != realtimeASRModel && model != recordedASRModel {
+		return "", fmt.Errorf(
+			"Qianwen ASR adapter only accepts %s or %s",
+			realtimeASRModel,
+			recordedASRModel,
+		)
 	}
 	return model, nil
+}
+
+func isRealtimeASRModel(model string) bool {
+	return model == realtimeASRModel
 }
 
 func invalidSpeechResponse(

--- a/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
@@ -24,8 +24,8 @@ func TestAgentVoiceRecognizerExposesRealtimePCMCapabilityOnlyForRealtime(
 		model string
 		want  bool
 	}{
-		{model: "fun-asr-realtime", want: true},
-		{model: "fun-asr-flash-2026-06-15", want: false},
+		{model: "qwen-audio-3.0-asr-flash-streaming", want: true},
+		{model: "qwen-audio-3.0-asr-flash", want: false},
 	} {
 		t.Run(test.model, func(t *testing.T) {
 			recognizer, err := NewAgentVoiceRecognizer(ASRConfig{
@@ -86,7 +86,7 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 			return
 		}
 		if run.Header.Action != "run-task" ||
-			run.Payload.Model != "fun-asr-realtime" ||
+			run.Payload.Model != "qwen-audio-3.0-asr-flash-streaming" ||
 			run.Payload.Parameters.SampleRate != 16_000 {
 			t.Errorf("unexpected run-task: %#v", run)
 			return
@@ -177,7 +177,7 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 		t.Fatal("realtime recognition must not use HTTP generation")
 		return nil, nil
 	}), apiKey)
-	recognizer.model = "fun-asr-realtime"
+	recognizer.model = "qwen-audio-3.0-asr-flash-streaming"
 	recognizer.wsEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
 	observer := &recordingTranscriptionObserver{}
 	result, err := recognizer.TranscribeStream(
@@ -192,7 +192,7 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 		t.Fatalf("validated source format = %q, want wav", format)
 	}
 	if result.Transcript != "I practice English for interviews." ||
-		result.Model != "fun-asr-realtime" ||
+		result.Model != "qwen-audio-3.0-asr-flash-streaming" ||
 		result.Usage.AudioSeconds != 4 {
 		t.Fatalf("result = %#v", result)
 	}
@@ -282,7 +282,7 @@ func TestRealtimeTranscribeClosesProviderConnectionOnCancellation(t *testing.T) 
 		t.Fatal("realtime recognition must not use HTTP generation")
 		return nil, nil
 	}), "test-realtime-key")
-	recognizer.model = "fun-asr-realtime"
+	recognizer.model = "qwen-audio-3.0-asr-flash-streaming"
 	recognizer.wsEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
 	ctx, cancel := context.WithCancel(context.Background())
 	result := make(chan error, 1)

--- a/server/internal/providers/qianwen/speech_recognizer_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_test.go
@@ -17,7 +17,7 @@ import (
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
-func TestTranscribeUsesDocumentedFunASRFlashContract(t *testing.T) {
+func TestTranscribeUsesDocumentedQwenAudioASRFlashContract(t *testing.T) {
 	t.Parallel()
 
 	const apiKey = "test-api-key"
@@ -53,7 +53,7 @@ func TestTranscribeUsesDocumentedFunASRFlashContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transcribe: %v", err)
 	}
-	if received.Model != "fun-asr-flash-2026-06-15" ||
+	if received.Model != "qwen-audio-3.0-asr-flash" ||
 		received.Parameters.Format != "wav" ||
 		received.Parameters.SampleRate != "16000" ||
 		len(received.Input.Messages) != 1 ||
@@ -68,7 +68,7 @@ func TestTranscribeUsesDocumentedFunASRFlashContract(t *testing.T) {
 	expected := protocol.TranscriptionResult{
 		ID:         "fun-asr-safe-1",
 		Provider:   providerName,
-		Model:      "fun-asr-flash-2026-06-15",
+		Model:      "qwen-audio-3.0-asr-flash",
 		Transcript: "I am preparing for an interview.",
 		Usage: protocol.SpeechUsage{
 			AudioSeconds: 4,
@@ -86,6 +86,10 @@ func TestTranscribeAcceptsDocumentedTranscriptLocations(t *testing.T) {
 		"top-level output text": `{
 			"output":{"text":"Hello from the top level."},
 			"request_id":"fun-asr-top"
+		}`,
+		"documented nested sentence text": `{
+			"output":{"output":{"sentence":{"text":"Hello from the nested sentence."}}},
+			"request_id":"qwen-audio-asr-sentence"
 		}`,
 		"documented sentence text": `{
 			"output":{"sentence":{"text":"Hello from the sentence."}},
@@ -252,7 +256,7 @@ func TestRecognizerTimeoutAndFormattingAreSafe(t *testing.T) {
 	})
 	recognizer, err := newRecognizerWithClient(ASRConfig{
 		BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-		Model:   "fun-asr-flash-2026-06-15",
+		Model:   "qwen-audio-3.0-asr-flash",
 		Timeout: 10 * time.Millisecond,
 	}, apiKey, blocking)
 	if err != nil {
@@ -298,7 +302,7 @@ func TestNewRecognizerRejectsUnsupportedModelAndEndpoint(t *testing.T) {
 
 	valid := ASRConfig{
 		BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-		Model:   "fun-asr-flash-2026-06-15",
+		Model:   "qwen-audio-3.0-asr-flash",
 		Timeout: time.Second,
 	}
 	tests := []struct {
@@ -332,7 +336,7 @@ func mustRecognizer(t *testing.T, client httpDoer, apiKey string) *speechRecogni
 	t.Helper()
 	recognizer, err := newRecognizerWithClient(ASRConfig{
 		BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-		Model:   "fun-asr-flash-2026-06-15",
+		Model:   "qwen-audio-3.0-asr-flash",
 		Timeout: time.Second,
 	}, apiKey, client)
 	if err != nil {


### PR DESCRIPTION
## 功能描述

- 将实时语音识别从 Fun-ASR 切换到 `qwen-audio-3.0-asr-flash-streaming`。
- 将短录音识别切换到 `qwen-audio-3.0-asr-flash`。
- 按官方协议补充嵌套转写结果解析，并将适配器错误信息统一为 Qianwen ASR。
- 增加录音识别真实接口测试及端到端耗时记录。

## 实现思路

两个 Qwen-Audio 3.0 模型分别对应实时与录音场景，配置保持 fail closed，只接受这两个已审核的模型 ID。实时模型继续复用官方兼容的 WebSocket `run-task`/二进制音频/`finish-task` 协议；录音模型继续使用同步 multimodal-generation 端点。

## 可复现测试

```bash
cd server
go test ./internal/providers/qianwen ./internal/platform/config
```

国内百炼真实接口（需要本地环境变量，可能产生费用）：

```bash
cd server
QIANWEN_ASR_LIVE_TEST=1 go test ./internal/providers/qianwen \
  -run '^TestLive(SpeechRecognition|RecordedSpeechRecognition)$' -count=1 -v
```

本次实测同一段 3.506 秒 WAV：

- Streaming：成功，55 字符，总耗时约 1.04 秒。
- Recorded Flash：成功，55 字符，总耗时约 1.39 秒。

## 关联 Issue

Closes #1077
