### PR TITLE
fix(evaluation): 收紧报告生成契约

### DIFF
--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -234,7 +234,9 @@ func (evaluator *IELTSEvaluator) Evaluate(
 	var evidencePolicy *providerEvidencePolicy
 	if lineage.PromptVersion == ieltsPromptVersionV4 ||
 		lineage.PromptVersion == ieltsPromptVersionV5 {
-		payloadOverride, evidencePolicy, err = ieltsV4Payload(snapshot, dimensions)
+		payloadOverride, evidencePolicy, err = ieltsV4Payload(
+			snapshot, dimensions, lineage.PromptVersion == ieltsPromptVersionV5,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -334,12 +336,23 @@ func evaluate(
 	}
 	payloadSource := payloadOverride
 	if payloadSource == nil {
-		payloadSource = providerInput{
-			EvaluatedParticipantRole:                     "LEARNER",
-			EffectiveTurnsAreConfirmedEvaluatedResponses: true,
-			SceneType: sceneType, PracticeMode: snapshot.PracticeMode,
-			DimensionKeys: dimensionKeys, Questions: snapshot.Questions,
-			Turns: effectiveTurns,
+		if lineage.PromptVersion == interviewPromptVersionV3 ||
+			lineage.PromptVersion == generalPromptVersionV3 {
+			payloadSource = providerInputV3{
+				EvaluatedParticipantRole:                     "LEARNER",
+				EffectiveTurnsAreConfirmedEvaluatedResponses: true,
+				ConfirmedLearnerResponseCount:                len(effectiveTurns),
+				SceneType:                                    sceneType, PracticeMode: snapshot.PracticeMode,
+				DimensionKeys: dimensionKeys,
+				Questions:     referencedQuestions(snapshot.Questions, effectiveTurns),
+				Turns:         effectiveTurns,
+			}
+		} else {
+			payloadSource = providerInput{
+				SceneType: sceneType, PracticeMode: snapshot.PracticeMode,
+				DimensionKeys: dimensionKeys, Questions: snapshot.Questions,
+				Turns: effectiveTurns,
+			}
 		}
 	}
 	payload, err := json.Marshal(payloadSource)
@@ -415,8 +428,17 @@ func evaluate(
 }
 
 type providerInput struct {
+	SceneType     evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode  string                               `json:"practice_mode"`
+	DimensionKeys []string                             `json:"dimension_keys"`
+	Questions     []evaluation.SessionEvidenceQuestion `json:"questions"`
+	Turns         []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
+}
+
+type providerInputV3 struct {
 	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
 	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
+	ConfirmedLearnerResponseCount                int                                  `json:"confirmed_learner_response_count"`
 	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
 	PracticeMode                                 string                               `json:"practice_mode"`
 	DimensionKeys                                []string                             `json:"dimension_keys"`
@@ -425,19 +447,29 @@ type providerInput struct {
 }
 
 type incrementalIELTSProviderInput struct {
-	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
-	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
-	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
-	PracticeMode                                 string                               `json:"practice_mode"`
-	DimensionKeys                                []string                             `json:"dimension_keys"`
-	CumulativeProfile                            evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
-	Questions                                    []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
-	Turns                                        []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+	SceneType         evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode      string                               `json:"practice_mode"`
+	DimensionKeys     []string                             `json:"dimension_keys"`
+	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
+	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
+	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
 }
 
 type resolvedIELTSProviderInputV4 struct {
+	SchemaVersion     string                               `json:"schema_version"`
+	EvidenceMode      string                               `json:"evidence_mode"`
+	SceneType         evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode      string                               `json:"practice_mode"`
+	DimensionKeys     []string                             `json:"dimension_keys"`
+	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
+	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
+	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+}
+
+type resolvedIELTSProviderInputV5 struct {
 	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
 	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
+	ConfirmedLearnerResponseCount                int                                  `json:"confirmed_learner_response_count"`
 	SchemaVersion                                string                               `json:"schema_version"`
 	EvidenceMode                                 string                               `json:"evidence_mode"`
 	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
@@ -449,8 +481,19 @@ type resolvedIELTSProviderInputV4 struct {
 }
 
 type fallbackIELTSProviderInputV4 struct {
+	SchemaVersion string                               `json:"schema_version"`
+	EvidenceMode  string                               `json:"evidence_mode"`
+	SceneType     evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode  string                               `json:"practice_mode"`
+	DimensionKeys []string                             `json:"dimension_keys"`
+	Questions     []evaluation.SessionEvidenceQuestion `json:"questions"`
+	Turns         []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
+}
+
+type fallbackIELTSProviderInputV5 struct {
 	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
 	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
+	ConfirmedLearnerResponseCount                int                                  `json:"confirmed_learner_response_count"`
 	SchemaVersion                                string                               `json:"schema_version"`
 	EvidenceMode                                 string                               `json:"evidence_mode"`
 	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
@@ -463,6 +506,7 @@ type fallbackIELTSProviderInputV4 struct {
 func ieltsV4Payload(
 	snapshot evaluation.SessionInputSnapshot,
 	dimensionKeys []string,
+	includeLearnerSemantics bool,
 ) (any, *providerEvidencePolicy, error) {
 	switch snapshot.ProfileResolution {
 	case evaluation.IELTSFinalProfileResolved:
@@ -471,15 +515,30 @@ func ieltsV4Payload(
 			return nil, nil, err
 		}
 		policy := resolvedIELTSProviderEvidencePolicy(snapshot, incremental)
+		if includeLearnerSemantics {
+			return resolvedIELTSProviderInputV5{
+				EvaluatedParticipantRole:                     "LEARNER",
+				EffectiveTurnsAreConfirmedEvaluatedResponses: true,
+				ConfirmedLearnerResponseCount:                len(incremental.Turns),
+				SchemaVersion:                                ieltsInputSchemaVersionV4,
+				EvidenceMode:                                 ieltsInputCumulativeParts12PlusPart3,
+				SceneType:                                    incremental.SceneType,
+				PracticeMode:                                 incremental.PracticeMode,
+				DimensionKeys:                                incremental.DimensionKeys,
+				CumulativeProfile:                            incremental.CumulativeProfile,
+				Questions:                                    incremental.Questions,
+				Turns:                                        incremental.Turns,
+			}, &policy, nil
+		}
 		return resolvedIELTSProviderInputV4{
-			EvaluatedParticipantRole:                     "LEARNER",
-			EffectiveTurnsAreConfirmedEvaluatedResponses: true,
-			SchemaVersion:                                ieltsInputSchemaVersionV4,
-			EvidenceMode:                                 ieltsInputCumulativeParts12PlusPart3,
-			SceneType:                                    incremental.SceneType, PracticeMode: incremental.PracticeMode,
+			SchemaVersion:     ieltsInputSchemaVersionV4,
+			EvidenceMode:      ieltsInputCumulativeParts12PlusPart3,
+			SceneType:         incremental.SceneType,
+			PracticeMode:      incremental.PracticeMode,
 			DimensionKeys:     incremental.DimensionKeys,
 			CumulativeProfile: incremental.CumulativeProfile,
-			Questions:         incremental.Questions, Turns: incremental.Turns,
+			Questions:         incremental.Questions,
+			Turns:             incremental.Turns,
 		}, &policy, nil
 	case evaluation.IELTSFinalProfileFallback:
 		effectiveTurns := make([]evaluation.SessionEvidenceTurn, 0, len(snapshot.Turns))
@@ -488,14 +547,28 @@ func ieltsV4Payload(
 				effectiveTurns = append(effectiveTurns, turn)
 			}
 		}
+		if includeLearnerSemantics {
+			return fallbackIELTSProviderInputV5{
+				EvaluatedParticipantRole:                     "LEARNER",
+				EffectiveTurnsAreConfirmedEvaluatedResponses: true,
+				ConfirmedLearnerResponseCount:                len(effectiveTurns),
+				SchemaVersion:                                ieltsInputSchemaVersionV4,
+				EvidenceMode:                                 ieltsInputFullRawFallback,
+				SceneType:                                    evaluation.SceneIELTSSpeaking,
+				PracticeMode:                                 snapshot.PracticeMode,
+				DimensionKeys:                                dimensionKeys,
+				Questions:                                    referencedQuestions(snapshot.Questions, effectiveTurns),
+				Turns:                                        effectiveTurns,
+			}, nil, nil
+		}
 		return fallbackIELTSProviderInputV4{
-			EvaluatedParticipantRole:                     "LEARNER",
-			EffectiveTurnsAreConfirmedEvaluatedResponses: true,
-			SchemaVersion:                                ieltsInputSchemaVersionV4,
-			EvidenceMode:                                 ieltsInputFullRawFallback,
-			SceneType:                                    evaluation.SceneIELTSSpeaking,
-			PracticeMode:                                 snapshot.PracticeMode, DimensionKeys: dimensionKeys,
-			Questions: snapshot.Questions, Turns: effectiveTurns,
+			SchemaVersion: ieltsInputSchemaVersionV4,
+			EvidenceMode:  ieltsInputFullRawFallback,
+			SceneType:     evaluation.SceneIELTSSpeaking,
+			PracticeMode:  snapshot.PracticeMode,
+			DimensionKeys: dimensionKeys,
+			Questions:     snapshot.Questions,
+			Turns:         effectiveTurns,
 		}, nil, nil
 	default:
 		return nil, nil, evaluation.ErrInvalidRequest
@@ -547,14 +620,29 @@ func incrementalIELTSPayload(
 		}
 	}
 	return incrementalIELTSProviderInput{
-		EvaluatedParticipantRole:                     "LEARNER",
-		EffectiveTurnsAreConfirmedEvaluatedResponses: true,
 		SceneType:         evaluation.SceneIELTSSpeaking,
 		PracticeMode:      snapshot.PracticeMode,
 		DimensionKeys:     dimensionKeys,
 		CumulativeProfile: *snapshot.CumulativeProfile,
 		Questions:         questions, Turns: turns,
 	}, nil
+}
+
+func referencedQuestions(
+	questions []evaluation.SessionEvidenceQuestion,
+	turns []evaluation.SessionEvidenceTurn,
+) []evaluation.SessionEvidenceQuestion {
+	questionIDs := make(map[string]struct{}, len(turns))
+	for _, turn := range turns {
+		questionIDs[turn.QuestionID] = struct{}{}
+	}
+	result := make([]evaluation.SessionEvidenceQuestion, 0, len(questionIDs))
+	for _, question := range questions {
+		if _, exists := questionIDs[question.ID]; exists {
+			result = append(result, question)
+		}
+	}
+	return result
 }
 
 type providerReport struct {
@@ -1056,7 +1144,7 @@ const interviewSystemPromptV1 = `You are an evidence-bound job interview English
 
 const interviewSystemPromptV2 = `You are an evidence-bound job interview English evaluator. Score only the requested interview dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
 
-const evaluatedLearnerEvidenceInstruction = ` Every item in effective_turns or part_3_effective_turns is a confirmed response by the LEARNER being evaluated. Treat its transcript as the learner's answer. Questions are prompts; never use question speaker metadata to reassign response authorship or conclude that learner responses are absent.`
+const evaluatedLearnerEvidenceInstruction = ` Every item in effective_turns or part_3_effective_turns is a confirmed response by the LEARNER being evaluated. Treat its transcript as the learner's answer. confirmed_learner_response_count is authoritative: when it is greater than zero, never claim that learner responses are absent. This count alone does not guarantee sufficient evidence; judge scoreability from the substance of those transcripts. Questions are prompts; never use question speaker metadata to reassign response authorship.`
 
 const interviewSystemPromptV3 = interviewSystemPromptV2 + evaluatedLearnerEvidenceInstruction
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -319,9 +319,26 @@ func evaluate(
 	if err != nil {
 		return nil, evaluation.ErrInvalidRequest
 	}
+	var scoreMaximum float64
+	switch scale {
+	case report.ReportScalePercentage100:
+		scoreMaximum = 100
+	case report.ReportScaleIELTSBand:
+		scoreMaximum = 9
+	default:
+		return nil, evaluation.ErrInvalidRequest
+	}
+	contract := textgeneration.ReportContract{
+		DimensionKeys: slices.Clone(dimensionKeys),
+		ScoreMaximum:  scoreMaximum,
+	}
+	if !contract.Valid() {
+		return nil, evaluation.ErrInvalidRequest
+	}
 	generated, err := generator.Generate(ctx, textgeneration.Request{
 		SystemPrompt: systemPrompt,
 		UserPrompt:   string(payload),
+		Report:       contract,
 	})
 	if err != nil {
 		return nil, err
@@ -355,6 +372,7 @@ func evaluate(
 	repaired, err := generator.Generate(ctx, textgeneration.Request{
 		SystemPrompt: systemPrompt,
 		UserPrompt:   string(repairPayload),
+		Report:       contract,
 	})
 	if err != nil {
 		return nil, err

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator.go
@@ -27,12 +27,15 @@ const minimumPronunciationCoverage = 0.6
 const (
 	interviewPromptVersionV1 = "interview-report/v1"
 	interviewPromptVersionV2 = "interview-report/v2"
+	interviewPromptVersionV3 = "interview-report/v3"
 	ieltsPromptVersionV1     = "ielts-report/v1"
 	ieltsPromptVersionV2     = "ielts-report/v2"
 	ieltsPromptVersionV3     = "ielts-report/v3"
 	ieltsPromptVersionV4     = "ielts-report/v4"
+	ieltsPromptVersionV5     = "ielts-report/v5"
 	generalPromptVersionV1   = "general-report/v1"
 	generalPromptVersionV2   = "general-report/v2"
+	generalPromptVersionV3   = "general-report/v3"
 
 	ieltsInputSchemaVersionV4            = "ielts-report-input/v4"
 	ieltsInputCumulativeParts12PlusPart3 = "CUMULATIVE_PARTS_1_2_PLUS_PART_3"
@@ -48,7 +51,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.InterviewStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   interviewPromptVersionV2,
+			PromptVersion:   interviewPromptVersionV3,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -57,7 +60,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.IELTSStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   ieltsPromptVersionV4,
+			PromptVersion:   ieltsPromptVersionV5,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -75,7 +78,7 @@ func Lineages(
 			SchemaVersion:   evaluation.ConfigLineageSchemaVersion,
 			StrategyRef:     evaluation.GeneralStrategyRef,
 			PipelineVersion: pipelineVersion,
-			PromptVersion:   generalPromptVersionV2,
+			PromptVersion:   generalPromptVersionV3,
 			ResultSchema:    report.FormalReportSchemaVersion,
 			Provider:        provider,
 			Model:           model,
@@ -160,6 +163,13 @@ func (evaluator *InterviewEvaluator) Evaluate(
 		interviewPromptVersionV2,
 		interviewSystemPromptV2,
 	)
+	if lineage.PromptVersion == interviewPromptVersionV3 {
+		prompt = reportPrompt{
+			system:              interviewSystemPromptV3,
+			insufficientSummary: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		}
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -201,6 +211,13 @@ func (evaluator *IELTSEvaluator) Evaluate(
 		}
 		err = nil
 	}
+	if lineage.PromptVersion == ieltsPromptVersionV5 {
+		prompt = reportPrompt{
+			system:              ieltsSystemPromptV5,
+			insufficientSummary: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		}
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +232,8 @@ func (evaluator *IELTSEvaluator) Evaluate(
 	}
 	var payloadOverride any
 	var evidencePolicy *providerEvidencePolicy
-	if lineage.PromptVersion == ieltsPromptVersionV4 {
+	if lineage.PromptVersion == ieltsPromptVersionV4 ||
+		lineage.PromptVersion == ieltsPromptVersionV5 {
 		payloadOverride, evidencePolicy, err = ieltsV4Payload(snapshot, dimensions)
 		if err != nil {
 			return nil, err
@@ -244,6 +262,13 @@ func (evaluator *GeneralEvaluator) Evaluate(
 		generalPromptVersionV2,
 		generalSystemPromptV2,
 	)
+	if lineage.PromptVersion == generalPromptVersionV3 {
+		prompt = reportPrompt{
+			system:              generalSystemPromptV3,
+			insufficientSummary: "本次练习的有效证据不足，暂时无法形成可靠的评估结论。",
+		}
+		err = nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -310,6 +335,8 @@ func evaluate(
 	payloadSource := payloadOverride
 	if payloadSource == nil {
 		payloadSource = providerInput{
+			EvaluatedParticipantRole:                     "LEARNER",
+			EffectiveTurnsAreConfirmedEvaluatedResponses: true,
 			SceneType: sceneType, PracticeMode: snapshot.PracticeMode,
 			DimensionKeys: dimensionKeys, Questions: snapshot.Questions,
 			Turns: effectiveTurns,
@@ -388,41 +415,49 @@ func evaluate(
 }
 
 type providerInput struct {
-	SceneType     evaluation.SceneType                 `json:"scene_type"`
-	PracticeMode  string                               `json:"practice_mode"`
-	DimensionKeys []string                             `json:"dimension_keys"`
-	Questions     []evaluation.SessionEvidenceQuestion `json:"questions"`
-	Turns         []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
+	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
+	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
+	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode                                 string                               `json:"practice_mode"`
+	DimensionKeys                                []string                             `json:"dimension_keys"`
+	Questions                                    []evaluation.SessionEvidenceQuestion `json:"questions"`
+	Turns                                        []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
 }
 
 type incrementalIELTSProviderInput struct {
-	SceneType         evaluation.SceneType                 `json:"scene_type"`
-	PracticeMode      string                               `json:"practice_mode"`
-	DimensionKeys     []string                             `json:"dimension_keys"`
-	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
-	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
-	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
+	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
+	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode                                 string                               `json:"practice_mode"`
+	DimensionKeys                                []string                             `json:"dimension_keys"`
+	CumulativeProfile                            evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
+	Questions                                    []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
+	Turns                                        []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
 }
 
 type resolvedIELTSProviderInputV4 struct {
-	SchemaVersion     string                               `json:"schema_version"`
-	EvidenceMode      string                               `json:"evidence_mode"`
-	SceneType         evaluation.SceneType                 `json:"scene_type"`
-	PracticeMode      string                               `json:"practice_mode"`
-	DimensionKeys     []string                             `json:"dimension_keys"`
-	CumulativeProfile evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
-	Questions         []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
-	Turns             []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
+	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
+	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
+	SchemaVersion                                string                               `json:"schema_version"`
+	EvidenceMode                                 string                               `json:"evidence_mode"`
+	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode                                 string                               `json:"practice_mode"`
+	DimensionKeys                                []string                             `json:"dimension_keys"`
+	CumulativeProfile                            evaluation.IELTSCumulativeProfile    `json:"cumulative_profile"`
+	Questions                                    []evaluation.SessionEvidenceQuestion `json:"part_3_questions"`
+	Turns                                        []evaluation.SessionEvidenceTurn     `json:"part_3_effective_turns"`
 }
 
 type fallbackIELTSProviderInputV4 struct {
-	SchemaVersion string                               `json:"schema_version"`
-	EvidenceMode  string                               `json:"evidence_mode"`
-	SceneType     evaluation.SceneType                 `json:"scene_type"`
-	PracticeMode  string                               `json:"practice_mode"`
-	DimensionKeys []string                             `json:"dimension_keys"`
-	Questions     []evaluation.SessionEvidenceQuestion `json:"questions"`
-	Turns         []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
+	EvaluatedParticipantRole                     string                               `json:"evaluated_participant_role"`
+	EffectiveTurnsAreConfirmedEvaluatedResponses bool                                 `json:"effective_turns_are_confirmed_evaluated_responses"`
+	SchemaVersion                                string                               `json:"schema_version"`
+	EvidenceMode                                 string                               `json:"evidence_mode"`
+	SceneType                                    evaluation.SceneType                 `json:"scene_type"`
+	PracticeMode                                 string                               `json:"practice_mode"`
+	DimensionKeys                                []string                             `json:"dimension_keys"`
+	Questions                                    []evaluation.SessionEvidenceQuestion `json:"questions"`
+	Turns                                        []evaluation.SessionEvidenceTurn     `json:"effective_turns"`
 }
 
 func ieltsV4Payload(
@@ -437,9 +472,11 @@ func ieltsV4Payload(
 		}
 		policy := resolvedIELTSProviderEvidencePolicy(snapshot, incremental)
 		return resolvedIELTSProviderInputV4{
-			SchemaVersion: ieltsInputSchemaVersionV4,
-			EvidenceMode:  ieltsInputCumulativeParts12PlusPart3,
-			SceneType:     incremental.SceneType, PracticeMode: incremental.PracticeMode,
+			EvaluatedParticipantRole:                     "LEARNER",
+			EffectiveTurnsAreConfirmedEvaluatedResponses: true,
+			SchemaVersion:                                ieltsInputSchemaVersionV4,
+			EvidenceMode:                                 ieltsInputCumulativeParts12PlusPart3,
+			SceneType:                                    incremental.SceneType, PracticeMode: incremental.PracticeMode,
 			DimensionKeys:     incremental.DimensionKeys,
 			CumulativeProfile: incremental.CumulativeProfile,
 			Questions:         incremental.Questions, Turns: incremental.Turns,
@@ -452,10 +489,12 @@ func ieltsV4Payload(
 			}
 		}
 		return fallbackIELTSProviderInputV4{
-			SchemaVersion: ieltsInputSchemaVersionV4,
-			EvidenceMode:  ieltsInputFullRawFallback,
-			SceneType:     evaluation.SceneIELTSSpeaking,
-			PracticeMode:  snapshot.PracticeMode, DimensionKeys: dimensionKeys,
+			EvaluatedParticipantRole:                     "LEARNER",
+			EffectiveTurnsAreConfirmedEvaluatedResponses: true,
+			SchemaVersion:                                ieltsInputSchemaVersionV4,
+			EvidenceMode:                                 ieltsInputFullRawFallback,
+			SceneType:                                    evaluation.SceneIELTSSpeaking,
+			PracticeMode:                                 snapshot.PracticeMode, DimensionKeys: dimensionKeys,
 			Questions: snapshot.Questions, Turns: effectiveTurns,
 		}, nil, nil
 	default:
@@ -508,6 +547,8 @@ func incrementalIELTSPayload(
 		}
 	}
 	return incrementalIELTSProviderInput{
+		EvaluatedParticipantRole:                     "LEARNER",
+		EffectiveTurnsAreConfirmedEvaluatedResponses: true,
 		SceneType:         evaluation.SceneIELTSSpeaking,
 		PracticeMode:      snapshot.PracticeMode,
 		DimensionKeys:     dimensionKeys,
@@ -517,10 +558,10 @@ func incrementalIELTSPayload(
 }
 
 type providerReport struct {
-	ScoreabilityStatus report.ReportScoreability `json:"scoreability_status"`
-	Summary            string                    `json:"summary"`
-	Dimensions         []providerDimension       `json:"dimensions"`
-	PriorityActions    []providerPriorityAction  `json:"priority_actions"`
+	ScoreabilityStatus report.ReportScoreability    `json:"scoreability_status"`
+	Summary            string                       `json:"summary"`
+	Dimensions         map[string]providerDimension `json:"dimensions"`
+	PriorityActions    []providerPriorityAction     `json:"priority_actions"`
 }
 
 type providerDimension struct {
@@ -677,8 +718,8 @@ func normalizeProviderReport(
 	}
 	improvementIDs := make(map[string][]string, len(dimensionKeys))
 	for index, expectedKey := range dimensionKeys {
-		providedDimension := provided.Dimensions[index]
-		if providedDimension.Key != expectedKey {
+		providedDimension, exists := provided.Dimensions[providerDimensionSlot(index)]
+		if !exists || providedDimension.Key != expectedKey {
 			return report.FormalReport{}, providerResponseError(
 				normalizeReasonDimensionOrderInvalid,
 			)
@@ -805,6 +846,10 @@ func normalizeProviderReport(
 		)
 	}
 	return formal, nil
+}
+
+func providerDimensionSlot(index int) string {
+	return fmt.Sprintf("dimension_%d", index+1)
 }
 
 func reportQuestions(
@@ -1011,6 +1056,10 @@ const interviewSystemPromptV1 = `You are an evidence-bound job interview English
 
 const interviewSystemPromptV2 = `You are an evidence-bound job interview English evaluator. Score only the requested interview dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
 
+const evaluatedLearnerEvidenceInstruction = ` Every item in effective_turns or part_3_effective_turns is a confirmed response by the LEARNER being evaluated. Treat its transcript as the learner's answer. Questions are prompts; never use question speaker metadata to reassign response authorship or conclude that learner responses are absent.`
+
+const interviewSystemPromptV3 = interviewSystemPromptV2 + evaluatedLearnerEvidenceInstruction
+
 const ieltsSystemPromptV1 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
 
 const ieltsSystemPromptV2 = `You are an evidence-bound IELTS Speaking practice evaluator. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. PRONUNCIATION is requested only when assessed acoustic checkpoints are present on effective turns; base that dimension on those checkpoints and their coverage, never on transcript spelling.`
@@ -1019,9 +1068,13 @@ const ieltsSystemPromptV3 = `You are an evidence-bound IELTS Speaking practice e
 
 const ieltsSystemPromptV4 = `You are an evidence-bound IELTS Speaking practice evaluator. The input schema_version is ielts-report-input/v4 and evidence_mode is exactly one of CUMULATIVE_PARTS_1_2_PLUS_PART_3 or FULL_RAW_FALLBACK. For CUMULATIVE_PARTS_1_2_PLUS_PART_3, score the candidate's average performance across the whole test using the provisional cumulative_profile for Parts 1 and 2 plus only part_3_questions and part_3_effective_turns as raw evidence. Preserve exact profile quotes, then recalibrate every requested dimension using Part 3; never mechanically average Parts or copy provisional bands without reconsideration. For FULL_RAW_FALLBACK, use only questions and effective_turns as the complete raw evidence for all Parts. Never infer or combine fields from the other evidence mode. Score every requested dimension on IELTS_BAND_9 using half-band increments. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote present in the evidence allowed by evidence_mode, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Base PRONUNCIATION only on acoustic checkpoints and, in CUMULATIVE_PARTS_1_2_PLUS_PART_3 mode, the provisional pronunciation profile; never on transcript spelling.`
 
+const ieltsSystemPromptV5 = ieltsSystemPromptV4 + evaluatedLearnerEvidenceInstruction
+
 const generalSystemPromptV1 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Do not infer voice qualities from text.`
 
 const generalSystemPromptV2 = `You are an evidence-bound everyday or workplace English evaluator. Score only the requested communication dimensions on PERCENTAGE_100. Return one JSON object only, with exactly: scoreability_status, summary, dimensions, priority_actions. Use dimension_keys in the input in the same order. Each dimension must contain key, score, coverage, confidence, reason_codes, strengths, improvements, recommended_examples. Each finding must contain message, suggestion, evidence. Each evidence item must contain turn_id, an exact quote copied from that turn, and its 1-based occurrence. priority_actions contains dimension_key and 1-based improvement_index. Arrays must be present even when empty. Write summary and every finding message in Simplified Chinese. Write suggestions for strengths and improvements in Simplified Chinese. For each recommended_examples finding, write its message in Simplified Chinese and put only the directly reusable English expression in suggestion. Keep every question, answer, and evidence quote in its original language; never translate or rewrite them. Do not infer voice qualities from text.`
+
+const generalSystemPromptV3 = generalSystemPromptV2 + evaluatedLearnerEvidenceInstruction
 
 type normalizeReason string
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -690,6 +690,35 @@ func TestGeneralEvaluatorRejectsPolicyCategoryMismatch(t *testing.T) {
 	}
 }
 
+func TestGeneralEvaluatorPassesExactReportContract(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := sessionSnapshotFixture()
+	snapshot.EvaluationPolicyRef = evaluation.WorkplaceEvaluationPolicyRef
+	snapshot.PracticeExperience = "WORKPLACE"
+	snapshot.SceneCategory = "WORKPLACE_GENERAL"
+	snapshot.PracticeMode = "GUIDED"
+	if _, err := evaluators.EvaluateGeneral(
+		context.Background(), evaluation.Record{}, snapshot, lineages.General,
+	); err != nil {
+		t.Fatalf("EvaluateGeneral() error = %v", err)
+	}
+	want := []string{
+		"TASK_ACHIEVEMENT", "CLARITY_COHERENCE", "LANGUAGE_CONTROL", "INTERACTION",
+	}
+	if !slices.Equal(generator.last.Report.DimensionKeys, want) ||
+		generator.last.Report.ScoreMaximum != 100 {
+		t.Fatalf("report contract = %#v", generator.last.Report)
+	}
+}
+
 func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -296,11 +296,11 @@ func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T
 	); err != nil {
 		t.Fatalf("EvaluateIELTS() error = %v", err)
 	}
-	var payload resolvedIELTSProviderInputV4
+	var payload resolvedIELTSProviderInputV5
 	if err := evaluation.DecodeStrict(
 		json.RawMessage(generator.last.UserPrompt), &payload,
 	); err != nil {
-		t.Fatalf("decode resolved v4 payload: %v: %s", err, generator.last.UserPrompt)
+		t.Fatalf("decode resolved v5 payload: %v: %s", err, generator.last.UserPrompt)
 	}
 	if lineages.IELTS.PromptVersion != ieltsPromptVersionV5 ||
 		payload.SchemaVersion != ieltsInputSchemaVersionV4 ||
@@ -312,7 +312,7 @@ func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T
 		payload.Turns[0].Transcript != "PART_THREE_RAW_TRANSCRIPT" ||
 		strings.Contains(generator.last.UserPrompt, "PART_ONE_HIDDEN_RAW") ||
 		strings.Contains(generator.last.UserPrompt, "PART_TWO_RAW_TRANSCRIPT") {
-		t.Fatalf("resolved v4 payload = %#v: %s", payload, generator.last.UserPrompt)
+		t.Fatalf("resolved v5 payload = %#v: %s", payload, generator.last.UserPrompt)
 	}
 }
 
@@ -468,20 +468,22 @@ func TestIELTSEvaluatorUsesTaggedFullRawFallbackPayload(t *testing.T) {
 	); err != nil {
 		t.Fatalf("EvaluateIELTS() error = %v", err)
 	}
-	var payload fallbackIELTSProviderInputV4
+	var payload fallbackIELTSProviderInputV5
 	if err := evaluation.DecodeStrict(
 		json.RawMessage(generator.last.UserPrompt), &payload,
 	); err != nil {
-		t.Fatalf("decode fallback v4 payload: %v: %s", err, generator.last.UserPrompt)
+		t.Fatalf("decode fallback v5 payload: %v: %s", err, generator.last.UserPrompt)
 	}
 	if payload.SchemaVersion != ieltsInputSchemaVersionV4 ||
 		payload.EvidenceMode != ieltsInputFullRawFallback ||
-		len(payload.Questions) != 2 || len(payload.Turns) != 1 ||
+		payload.EvaluatedParticipantRole != "LEARNER" ||
+		!payload.EffectiveTurnsAreConfirmedEvaluatedResponses ||
+		len(payload.Questions) != 1 || len(payload.Turns) != 1 ||
 		payload.Turns[0].Transcript != snapshot.Turns[0].Transcript ||
 		strings.Contains(generator.last.UserPrompt, "INEFFECTIVE_RAW_TRANSCRIPT") ||
 		strings.Contains(generator.last.UserPrompt, `"cumulative_profile"`) ||
 		strings.Contains(generator.last.UserPrompt, `"part_3_effective_turns"`) {
-		t.Fatalf("fallback v4 payload = %#v: %s", payload, generator.last.UserPrompt)
+		t.Fatalf("fallback v5 payload = %#v: %s", payload, generator.last.UserPrompt)
 	}
 }
 
@@ -742,7 +744,7 @@ func TestGeneralEvaluatorPassesExactReportContract(t *testing.T) {
 		generator.last.Report.ScoreMaximum != 100 {
 		t.Fatalf("report contract = %#v", generator.last.Report)
 	}
-	var input providerInput
+	var input providerInputV3
 	if err := json.Unmarshal([]byte(generator.last.UserPrompt), &input); err != nil {
 		t.Fatal(err)
 	}
@@ -757,6 +759,209 @@ func TestGeneralEvaluatorPassesExactReportContract(t *testing.T) {
 		if !strings.Contains(generator.last.SystemPrompt, requirement) {
 			t.Fatalf("system prompt omitted learner evidence rule %q", requirement)
 		}
+	}
+}
+
+func TestGeneralV3ProjectsAnsweredQuestionsButReportKeepsPending(t *testing.T) {
+	generator := &reportGeneratorFake{}
+	evaluators, err := New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := generalSnapshotFixture()
+	appendPendingQuestions(&snapshot, 5)
+
+	encoded, err := evaluators.EvaluateGeneral(
+		context.Background(), evaluation.Record{}, snapshot, lineages.General,
+	)
+	if err != nil {
+		t.Fatalf("EvaluateGeneral() error = %v", err)
+	}
+	assertJSONKeys(t, generator.last.UserPrompt, []string{
+		"evaluated_participant_role",
+		"effective_turns_are_confirmed_evaluated_responses",
+		"confirmed_learner_response_count",
+		"scene_type", "practice_mode", "dimension_keys", "questions", "effective_turns",
+	})
+	var input providerInputV3
+	if err := evaluation.DecodeStrict(json.RawMessage(generator.last.UserPrompt), &input); err != nil {
+		t.Fatal(err)
+	}
+	if len(input.Questions) != 1 || input.Questions[0].ID != snapshot.Turns[0].QuestionID {
+		t.Fatalf("provider questions = %#v", input.Questions)
+	}
+	if input.ConfirmedLearnerResponseCount != 1 {
+		t.Fatalf("confirmed learner response count = %d, want 1", input.ConfirmedLearnerResponseCount)
+	}
+
+	var formal report.FormalReport
+	if err := evaluation.DecodeStrict(encoded, &formal); err != nil {
+		t.Fatal(err)
+	}
+	if len(formal.Questions) != 5 || formal.Questions[4].Text != snapshot.Questions[4].Text ||
+		formal.Questions[4].Answer != nil {
+		t.Fatalf("report questions = %#v", formal.Questions)
+	}
+}
+
+func TestInterviewV2AndV3ProviderInputContracts(t *testing.T) {
+	evaluators, err := New(&reportGeneratorFake{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := interviewSnapshotFixture()
+	appendPendingQuestions(&snapshot, 2)
+	tests := []struct {
+		name          string
+		version       string
+		wantKeys      []string
+		wantQuestions int
+	}{
+		{
+			name: "v2 preserves historical input", version: interviewPromptVersionV2,
+			wantKeys:      []string{"scene_type", "practice_mode", "dimension_keys", "questions", "effective_turns"},
+			wantQuestions: 2,
+		},
+		{
+			name: "v3 adds learner semantics and projects answered questions", version: interviewPromptVersionV3,
+			wantKeys: []string{
+				"evaluated_participant_role", "effective_turns_are_confirmed_evaluated_responses",
+				"confirmed_learner_response_count",
+				"scene_type", "practice_mode", "dimension_keys", "questions", "effective_turns",
+			},
+			wantQuestions: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generator := &reportGeneratorFake{}
+			evaluators.interview.generator = generator
+			lineage := lineages.Interview
+			lineage.PromptVersion = test.version
+			if _, err := evaluators.EvaluateInterview(
+				context.Background(), evaluation.Record{}, snapshot, lineage,
+			); err != nil {
+				t.Fatalf("EvaluateInterview() error = %v", err)
+			}
+			assertJSONKeys(t, generator.last.UserPrompt, test.wantKeys)
+			var input struct {
+				Questions []evaluation.SessionEvidenceQuestion `json:"questions"`
+			}
+			if err := json.Unmarshal([]byte(generator.last.UserPrompt), &input); err != nil {
+				t.Fatal(err)
+			}
+			if len(input.Questions) != test.wantQuestions {
+				t.Fatalf("provider question count = %d, want %d", len(input.Questions), test.wantQuestions)
+			}
+		})
+	}
+}
+
+func TestIELTSProviderInputKeysAndQuestionProjectionByRecordedVersion(t *testing.T) {
+	lineages, err := Lineages("qianwen", "qwen-plus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldRawKeys := []string{
+		"scene_type", "practice_mode", "dimension_keys", "questions", "effective_turns",
+	}
+	currentRawKeys := []string{
+		"evaluated_participant_role", "effective_turns_are_confirmed_evaluated_responses",
+		"confirmed_learner_response_count",
+		"schema_version", "evidence_mode", "scene_type", "practice_mode", "dimension_keys",
+		"questions", "effective_turns",
+	}
+	v4FallbackKeys := []string{
+		"schema_version", "evidence_mode", "scene_type", "practice_mode", "dimension_keys",
+		"questions", "effective_turns",
+	}
+	oldIncrementalKeys := []string{
+		"scene_type", "practice_mode", "dimension_keys", "cumulative_profile",
+		"part_3_questions", "part_3_effective_turns",
+	}
+	v4ResolvedKeys := []string{
+		"schema_version", "evidence_mode", "scene_type", "practice_mode", "dimension_keys",
+		"cumulative_profile", "part_3_questions", "part_3_effective_turns",
+	}
+	v5ResolvedKeys := append([]string{
+		"evaluated_participant_role", "effective_turns_are_confirmed_evaluated_responses",
+		"confirmed_learner_response_count",
+	}, v4ResolvedKeys...)
+
+	run := func(
+		t *testing.T,
+		lineage evaluation.ConfigLineage,
+		snapshot evaluation.SessionInputSnapshot,
+		wantKeys []string,
+		questionField string,
+		wantQuestions int,
+	) {
+		t.Helper()
+		generator := &reportGeneratorFake{}
+		evaluators, err := New(generator)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := evaluators.EvaluateIELTS(
+			context.Background(), evaluation.Record{}, snapshot, lineage,
+		); err != nil {
+			t.Fatalf("EvaluateIELTS() error = %v", err)
+		}
+		assertJSONKeys(t, generator.last.UserPrompt, wantKeys)
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(generator.last.UserPrompt), &object); err != nil {
+			t.Fatal(err)
+		}
+		var questions []evaluation.SessionEvidenceQuestion
+		if err := json.Unmarshal(object[questionField], &questions); err != nil {
+			t.Fatalf("decode %s: %v", questionField, err)
+		}
+		if len(questions) != wantQuestions {
+			t.Fatalf("%s count = %d, want %d: %s", questionField, len(questions), wantQuestions, generator.last.UserPrompt)
+		}
+	}
+
+	fallback := sessionSnapshotFixture()
+	appendPendingQuestions(&fallback, 2)
+	for _, test := range []struct {
+		name    string
+		lineage evaluation.ConfigLineage
+		keys    []string
+		count   int
+	}{
+		{name: "v1 fallback", lineage: withPromptVersion(lineages.IELTS, ieltsPromptVersionV1), keys: oldRawKeys, count: 2},
+		{name: "IELTS practice v2 fallback", lineage: lineages.IELTSPractice, keys: oldRawKeys, count: 2},
+		{name: "v3 fallback", lineage: withPromptVersion(lineages.IELTS, ieltsPromptVersionV3), keys: oldRawKeys, count: 2},
+		{name: "v4 fallback", lineage: withPromptVersion(lineages.IELTS, ieltsPromptVersionV4), keys: v4FallbackKeys, count: 2},
+		{name: "v5 fallback", lineage: lineages.IELTS, keys: currentRawKeys, count: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			run(t, test.lineage, fallback, test.keys, "questions", test.count)
+		})
+	}
+
+	resolved := resolvedFullMockSnapshot()
+	appendPendingQuestions(&resolved, 4)
+	for _, test := range []struct {
+		name    string
+		lineage evaluation.ConfigLineage
+		keys    []string
+	}{
+		{name: "v3 cumulative", lineage: withPromptVersion(lineages.IELTS, ieltsPromptVersionV3), keys: oldIncrementalKeys},
+		{name: "v4 resolved", lineage: withPromptVersion(lineages.IELTS, ieltsPromptVersionV4), keys: v4ResolvedKeys},
+		{name: "v5 resolved", lineage: lineages.IELTS, keys: v5ResolvedKeys},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			run(t, test.lineage, resolved, test.keys, "part_3_questions", 1)
+		})
 	}
 }
 
@@ -1127,6 +1332,60 @@ func sessionSnapshotFixture() evaluation.SessionInputSnapshot {
 			Transcript:              "I work with a small engineering team.", Effective: true,
 			ConfirmedAt: now,
 		}},
+	}
+}
+
+func generalSnapshotFixture() evaluation.SessionInputSnapshot {
+	snapshot := sessionSnapshotFixture()
+	snapshot.EvaluationPolicyRef = evaluation.WorkplaceEvaluationPolicyRef
+	snapshot.PracticeExperience = "WORKPLACE"
+	snapshot.SceneCategory = "WORKPLACE_GENERAL"
+	snapshot.PracticeMode = "GUIDED"
+	return snapshot
+}
+
+func interviewSnapshotFixture() evaluation.SessionInputSnapshot {
+	snapshot := sessionSnapshotFixture()
+	snapshot.EvaluationPolicyRef = evaluation.InterviewEvaluationPolicyRef
+	snapshot.PracticeExperience = "INTERVIEW"
+	snapshot.SceneCategory = "INTERVIEW_RECRUITER"
+	snapshot.PracticeMode = "FULL_SIMULATION"
+	return snapshot
+}
+
+func appendPendingQuestions(snapshot *evaluation.SessionInputSnapshot, wantCount int) {
+	for position := len(snapshot.Questions) + 1; position <= wantCount; position++ {
+		snapshot.Questions = append(snapshot.Questions, evaluation.SessionEvidenceQuestion{
+			ID:                      fmt.Sprintf("40000000-0000-4000-8000-%012d", position),
+			Position:                position,
+			Text:                    fmt.Sprintf("Pending question %d", position),
+			SpeakerParticipantID:    "assistant-1",
+			AddresseeParticipantIDs: []string{"user-1"},
+		})
+	}
+}
+
+func withPromptVersion(
+	lineage evaluation.ConfigLineage,
+	version string,
+) evaluation.ConfigLineage {
+	lineage.PromptVersion = version
+	return lineage
+}
+
+func assertJSONKeys(t *testing.T, source string, want []string) {
+	t.Helper()
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(source), &object); err != nil {
+		t.Fatal(err)
+	}
+	if len(object) != len(want) {
+		t.Fatalf("JSON keys = %#v, want exactly %#v", object, want)
+	}
+	for _, key := range want {
+		if _, exists := object[key]; !exists {
+			t.Fatalf("JSON keys = %#v, missing %q", object, key)
+		}
 	}
 }
 

--- a/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/evaluator_test.go
@@ -35,9 +35,9 @@ func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) 
 	generated := mustProviderResult(t, providerReport{
 		ScoreabilityStatus: report.ReportScoreabilityInsufficient,
 		Summary:            "The available evidence is insufficient.",
-		Dimensions: []providerDimension{
+		Dimensions: providerDimensions(
 			providerDimensionFixture("FLUENCY_COHERENCE", &score),
-		},
+		),
 		PriorityActions: []providerPriorityAction{{
 			DimensionKey: "UNKNOWN", ImprovementIndex: 99,
 		}},
@@ -61,6 +61,29 @@ func TestInsufficientProviderReportClearsScoresAndPriorityActions(t *testing.T) 
 	}
 }
 
+func TestProviderReportRejectsDimensionKeyInWrongStructuralSlot(t *testing.T) {
+	score := 7.0
+	snapshot := sessionSnapshotFixture()
+	_, err := normalizeProviderReport(
+		mustProviderResult(t, providerReport{
+			ScoreabilityStatus: report.ReportScoreabilityProvisional,
+			Summary:            "Provisional report.",
+			Dimensions: map[string]providerDimension{
+				"dimension_1": providerDimensionFixture("LEXICAL_RESOURCE", &score),
+				"dimension_2": providerDimensionFixture("LEXICAL_RESOURCE", &score),
+			},
+			PriorityActions: []providerPriorityAction{},
+		}),
+		snapshot, evaluation.SceneIELTSSpeaking,
+		[]string{"FLUENCY_COHERENCE", "LEXICAL_RESOURCE"}, report.ReportScaleIELTSBand,
+		"qianwen", "qwen-plus", fullRawProviderEvidencePolicy(snapshot),
+	)
+	if !errors.Is(err, ErrProviderResponse) ||
+		normalizeReasonFromError(err) != normalizeReasonDimensionOrderInvalid {
+		t.Fatalf("wrong structural slot error = %v, reason = %q", err, normalizeReasonFromError(err))
+	}
+}
+
 func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T) {
 	score := 7.0
 	snapshot := sessionSnapshotFixture()
@@ -75,7 +98,7 @@ func TestInsufficientProviderReportDoesNotFabricateInvalidEvidence(t *testing.T)
 	_, err := normalizeProviderReport(
 		mustProviderResult(t, providerReport{
 			ScoreabilityStatus: report.ReportScoreabilityInsufficient,
-			Summary:            "The available evidence is insufficient.", Dimensions: []providerDimension{dimension},
+			Summary:            "The available evidence is insufficient.", Dimensions: providerDimensions(dimension),
 			PriorityActions: []providerPriorityAction{},
 		}),
 		snapshot, evaluation.SceneIELTSSpeaking,
@@ -101,9 +124,9 @@ func TestProvisionalProviderReportRemainsFailClosed(t *testing.T) {
 				return providerReport{
 					ScoreabilityStatus: report.ReportScoreabilityProvisional,
 					Summary:            "Provisional report.",
-					Dimensions: []providerDimension{
+					Dimensions: providerDimensions(
 						providerDimensionFixture("FLUENCY_COHERENCE", &score),
-					},
+					),
 					PriorityActions: []providerPriorityAction{},
 				}
 			}(),
@@ -116,9 +139,9 @@ func TestProvisionalProviderReportRemainsFailClosed(t *testing.T) {
 				return providerReport{
 					ScoreabilityStatus: report.ReportScoreabilityProvisional,
 					Summary:            "Provisional report.",
-					Dimensions: []providerDimension{
+					Dimensions: providerDimensions(
 						providerDimensionFixture("FLUENCY_COHERENCE", &score),
-					},
+					),
 					PriorityActions: []providerPriorityAction{{
 						DimensionKey: "FLUENCY_COHERENCE", ImprovementIndex: 1,
 					}},
@@ -279,9 +302,11 @@ func TestIELTSEvaluatorUsesCumulativeProfileAndOnlyPart3RawEvidence(t *testing.T
 	); err != nil {
 		t.Fatalf("decode resolved v4 payload: %v: %s", err, generator.last.UserPrompt)
 	}
-	if lineages.IELTS.PromptVersion != ieltsPromptVersionV4 ||
+	if lineages.IELTS.PromptVersion != ieltsPromptVersionV5 ||
 		payload.SchemaVersion != ieltsInputSchemaVersionV4 ||
 		payload.EvidenceMode != ieltsInputCumulativeParts12PlusPart3 ||
+		payload.EvaluatedParticipantRole != "LEARNER" ||
+		!payload.EffectiveTurnsAreConfirmedEvaluatedResponses ||
 		len(payload.CumulativeProfile.CompletedParts) != 2 ||
 		len(payload.Questions) != 1 || len(payload.Turns) != 1 ||
 		payload.Turns[0].Transcript != "PART_THREE_RAW_TRANSCRIPT" ||
@@ -717,6 +742,22 @@ func TestGeneralEvaluatorPassesExactReportContract(t *testing.T) {
 		generator.last.Report.ScoreMaximum != 100 {
 		t.Fatalf("report contract = %#v", generator.last.Report)
 	}
+	var input providerInput
+	if err := json.Unmarshal([]byte(generator.last.UserPrompt), &input); err != nil {
+		t.Fatal(err)
+	}
+	if input.EvaluatedParticipantRole != "LEARNER" ||
+		!input.EffectiveTurnsAreConfirmedEvaluatedResponses {
+		t.Fatalf("learner evidence semantics = %#v", input)
+	}
+	for _, requirement := range []string{
+		"confirmed response by the LEARNER being evaluated",
+		"never use question speaker metadata to reassign response authorship",
+	} {
+		if !strings.Contains(generator.last.SystemPrompt, requirement) {
+			t.Fatalf("system prompt omitted learner evidence rule %q", requirement)
+		}
+	}
 }
 
 func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *testing.T) {
@@ -725,9 +766,9 @@ func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *te
 		prompt  string
 		version string
 	}{
-		{name: "interview", prompt: interviewSystemPromptV2, version: interviewPromptVersionV2},
-		{name: "IELTS", prompt: ieltsSystemPromptV4, version: ieltsPromptVersionV4},
-		{name: "general", prompt: generalSystemPromptV2, version: generalPromptVersionV2},
+		{name: "interview", prompt: interviewSystemPromptV3, version: interviewPromptVersionV3},
+		{name: "IELTS", prompt: ieltsSystemPromptV5, version: ieltsPromptVersionV5},
+		{name: "general", prompt: generalSystemPromptV3, version: generalPromptVersionV3},
 	}
 	lineages, err := Lineages("qianwen", "qwen-plus")
 	if err != nil {
@@ -745,6 +786,8 @@ func TestSessionEvaluationPromptsRequireChineseFeedbackAndOriginalEvidence(t *te
 				"suggestions for strengths and improvements in Simplified Chinese",
 				"directly reusable English expression in suggestion",
 				"question, answer, and evidence quote in its original language",
+				"confirmed response by the LEARNER being evaluated",
+				"never use question speaker metadata to reassign response authorship",
 			} {
 				if !strings.Contains(test.prompt, requirement) {
 					t.Fatalf("prompt omitted language requirement %q: %s", requirement, test.prompt)
@@ -923,9 +966,9 @@ func (generator *repairReportGeneratorFake) Generate(
 		dimensionKeys = repair.Input.DimensionKeys
 	}
 	score := 7.0
-	dimensions := make([]providerDimension, len(dimensionKeys))
+	dimensions := make(map[string]providerDimension, len(dimensionKeys))
 	for index, key := range dimensionKeys {
-		dimensions[index] = providerDimensionFixture(key, &score)
+		dimensions[providerDimensionSlot(index)] = providerDimensionFixture(key, &score)
 	}
 	actions := []providerPriorityAction{}
 	if len(generator.requests) == 1 {
@@ -956,6 +999,14 @@ func providerDimensionFixture(key string, score *float64) providerDimension {
 	}
 }
 
+func providerDimensions(values ...providerDimension) map[string]providerDimension {
+	dimensions := make(map[string]providerDimension, len(values))
+	for index, value := range values {
+		dimensions[providerDimensionSlot(index)] = value
+	}
+	return dimensions
+}
+
 func mustProviderResult(t *testing.T, value providerReport) textgeneration.Result {
 	t.Helper()
 	content, err := json.Marshal(value)
@@ -980,7 +1031,7 @@ func (generator *reportGeneratorFake) Generate(
 	if err := json.Unmarshal([]byte(request.UserPrompt), &input); err != nil {
 		return textgeneration.Result{}, err
 	}
-	dimensions := make([]map[string]any, len(input.DimensionKeys))
+	dimensions := make(map[string]any, len(input.DimensionKeys))
 	for index, key := range input.DimensionKeys {
 		strengths := []any{}
 		if index == 0 && generator.evidence != nil {
@@ -989,7 +1040,7 @@ func (generator *reportGeneratorFake) Generate(
 				"evidence": []providerEvidence{*generator.evidence},
 			}}
 		}
-		dimensions[index] = map[string]any{
+		dimensions[providerDimensionSlot(index)] = map[string]any{
 			"key": key, "score": 7.0, "coverage": 1.0, "confidence": 0.8,
 			"reason_codes": []string{}, "strengths": strengths,
 			"improvements": []any{}, "recommended_examples": []any{},

--- a/server/internal/coaching/evaluation/sessionevaluation/general_live_test.go
+++ b/server/internal/coaching/evaluation/sessionevaluation/general_live_test.go
@@ -1,0 +1,174 @@
+//go:build live
+
+package sessionevaluation_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/report"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/sessionevaluation"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/config"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen"
+)
+
+func TestQiniuGeneralEvaluatorProducesStableValidReports(t *testing.T) {
+	snapshot := generalLiveSnapshot()
+	if !snapshot.Valid() {
+		t.Fatal("live GeneralEvaluator snapshot is invalid")
+	}
+	if os.Getenv("QIANWEN_LIVE_TEST") != "1" {
+		t.Skip("set QIANWEN_LIVE_TEST=1 to run billable provider calls")
+	}
+	configuration, err := config.LoadTextGeneration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configuration.Provider != config.TextProviderQiniu {
+		t.Fatalf("TEXT_GENERATION_PROVIDER = %q, want qiniu", configuration.Provider)
+	}
+	realGenerator, err := qianwen.NewEvaluationScoringGenerator(qianwen.TextConfig{
+		Provider: configuration.Provider, BaseURL: configuration.BaseURL,
+		Model: configuration.EvaluationModel, Timeout: configuration.Timeout,
+		MaxOutputTokens: configuration.MaxOutputTokens,
+	}, configuration.APIKey.Reveal())
+	if err != nil {
+		t.Fatal(err)
+	}
+	generator := &countingGenerator{delegate: realGenerator}
+	evaluators, err := sessionevaluation.New(generator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineages, err := sessionevaluation.Lineages(
+		configuration.Provider, configuration.EvaluationModel,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKeys := []string{
+		"TASK_ACHIEVEMENT", "CLARITY_COHERENCE", "LANGUAGE_CONTROL", "INTERACTION",
+	}
+	for attempt := 1; attempt <= 3; attempt++ {
+		before := generator.calls
+		ctx, cancel := context.WithTimeout(context.Background(), configuration.Timeout)
+		encoded, evaluateErr := evaluators.EvaluateGeneral(
+			ctx, evaluation.Record{}, snapshot, lineages.General,
+		)
+		cancel()
+		if evaluateErr != nil {
+			t.Fatalf("attempt %d EvaluateGeneral() error = %v", attempt, evaluateErr)
+		}
+		if generator.calls-before != 1 {
+			t.Fatalf("attempt %d generation calls = %d, want 1", attempt, generator.calls-before)
+		}
+		var formal report.FormalReport
+		if err := evaluation.DecodeStrict(encoded, &formal); err != nil {
+			t.Fatalf("attempt %d decode report: %v", attempt, err)
+		}
+		if !formal.Valid() {
+			t.Fatalf("attempt %d produced an invalid FormalReport", attempt)
+		}
+		if formal.ScoreabilityStatus != report.ReportScoreabilityProvisional {
+			t.Fatalf(
+				"attempt %d scoreability = %q, want PROVISIONAL",
+				attempt,
+				formal.ScoreabilityStatus,
+			)
+		}
+		if len(formal.Questions) != 3 {
+			t.Fatalf("attempt %d questions = %d, want 3", attempt, len(formal.Questions))
+		}
+		for index, question := range formal.Questions {
+			if question.Answer == nil || question.Answer.Transcript == "" {
+				t.Fatalf("attempt %d question %d has no answer", attempt, index+1)
+			}
+		}
+		gotKeys := make([]string, len(formal.Dimensions))
+		seen := make(map[string]struct{}, len(formal.Dimensions))
+		for index, dimension := range formal.Dimensions {
+			gotKeys[index] = dimension.Key
+			if dimension.Score == nil {
+				t.Fatalf(
+					"attempt %d dimension %q has no score",
+					attempt,
+					dimension.Key,
+				)
+			}
+			if _, duplicate := seen[dimension.Key]; duplicate {
+				t.Fatalf("attempt %d duplicated dimension key %q", attempt, dimension.Key)
+			}
+			seen[dimension.Key] = struct{}{}
+		}
+		if !slices.Equal(gotKeys, wantKeys) {
+			t.Fatalf("attempt %d dimension keys = %#v, want %#v", attempt, gotKeys, wantKeys)
+		}
+	}
+}
+
+type countingGenerator struct {
+	delegate textgeneration.Generator
+	calls    int
+}
+
+func (generator *countingGenerator) Generate(
+	ctx context.Context,
+	request textgeneration.Request,
+) (textgeneration.Result, error) {
+	generator.calls++
+	return generator.delegate.Generate(ctx, request)
+}
+
+func generalLiveSnapshot() evaluation.SessionInputSnapshot {
+	now := time.Now().UTC()
+	questions := []string{
+		"Explain the project delay to your manager.",
+		"What caused the delay and what did you learn?",
+		"What concrete next step do you recommend?",
+	}
+	transcripts := []string{
+		"The release is currently two days late because the payment integration took longer than our estimate. I should have raised that risk in Monday's stand-up, so I take responsibility for the late warning. The core user flow is stable, but two edge cases still fail in regression testing. I want to explain the impact clearly and agree on a realistic recovery plan with you today.",
+		"The main cause was an external dependency whose ownership and response time were not confirmed before implementation started. I initially treated it as a small task, but it affected authentication, error handling, and our test environment. I learned that I need to identify cross-team dependencies during planning, assign an owner, and escalate a blocked item within one working day instead of waiting for the next status meeting.",
+		"I recommend that we finish the critical authentication fix today, run the complete regression suite tomorrow morning, and publish the verified build by Friday afternoon. I will send you a written update at noon with passed and failed cases. If the remaining edge case is still unresolved, we can disable only that optional payment method and release the rest safely. Does that plan match the priority you want for this week?",
+	}
+	snapshot := evaluation.SessionInputSnapshot{
+		SchemaVersion:       evaluation.SessionInputSchemaVersion,
+		SessionID:           "20000000-0000-4000-8000-000000000002",
+		SessionVersion:      1,
+		EvaluationPolicyRef: evaluation.WorkplaceEvaluationPolicyRef,
+		PracticeExperience:  "WORKPLACE",
+		SceneCategory:       "WORKPLACE_GENERAL",
+		PracticeMode:        "GUIDED",
+		CompletedAt:         now,
+		AcousticCapability:  evaluation.AcousticCapabilityNotConfigured,
+		PlanSnapshot:        json.RawMessage(`{}`),
+		Participants:        json.RawMessage(`[]`),
+		Questions:           make([]evaluation.SessionEvidenceQuestion, len(questions)),
+		Turns:               make([]evaluation.SessionEvidenceTurn, len(transcripts)),
+	}
+	for index := range questions {
+		position := index + 1
+		questionID := fmt.Sprintf("40000000-0000-4000-8000-%012d", position)
+		turnID := fmt.Sprintf("30000000-0000-4000-8000-%012d", position)
+		snapshot.Questions[index] = evaluation.SessionEvidenceQuestion{
+			ID: questionID, Position: position, Text: questions[index],
+			SpeakerParticipantID:    "assistant-1",
+			AddresseeParticipantIDs: []string{"user-1"},
+		}
+		snapshot.Turns[index] = evaluation.SessionEvidenceTurn{
+			ID: turnID, Position: position, QuestionID: questionID,
+			RespondentParticipantID: "user-1", Transcript: transcripts[index],
+			Effective: true, ConfirmedAt: now,
+		}
+	}
+	return snapshot
+}
+
+var _ textgeneration.Generator = (*countingGenerator)(nil)

--- a/server/internal/coaching/evaluation/textgeneration/text_generation.go
+++ b/server/internal/coaching/evaluation/textgeneration/text_generation.go
@@ -1,10 +1,37 @@
 package textgeneration
 
-import "context"
+import (
+	"context"
+	"strings"
+)
+
+type ReportContract struct {
+	DimensionKeys []string
+	ScoreMaximum  float64
+}
+
+func (contract ReportContract) Valid() bool {
+	if len(contract.DimensionKeys) == 0 || len(contract.DimensionKeys) > 8 ||
+		(contract.ScoreMaximum != 9 && contract.ScoreMaximum != 100) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(contract.DimensionKeys))
+	for _, key := range contract.DimensionKeys {
+		if key == "" || key != strings.TrimSpace(key) {
+			return false
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return false
+		}
+		seen[key] = struct{}{}
+	}
+	return true
+}
 
 type Request struct {
 	SystemPrompt string
 	UserPrompt   string
+	Report       ReportContract
 }
 
 type Result struct {

--- a/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
+++ b/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -336,9 +337,9 @@ func (customLifecycleReportGenerator) Generate(
 	if err := json.Unmarshal([]byte(request.UserPrompt), &input); err != nil {
 		return textgeneration.Result{}, err
 	}
-	dimensions := make([]map[string]any, len(input.DimensionKeys))
+	dimensions := make(map[string]map[string]any, len(input.DimensionKeys))
 	for index, key := range input.DimensionKeys {
-		dimensions[index] = map[string]any{
+		dimensions[fmt.Sprintf("dimension_%d", index+1)] = map[string]any{
 			"key":                  key,
 			"score":                78.0,
 			"coverage":             1.0,

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -1082,9 +1082,9 @@ func (migrationReportGenerator) Generate(
 	if err := json.Unmarshal([]byte(request.UserPrompt), &input); err != nil {
 		return textgeneration.Result{}, err
 	}
-	dimensions := make([]map[string]any, len(input.DimensionKeys))
+	dimensions := make(map[string]map[string]any, len(input.DimensionKeys))
 	for index, key := range input.DimensionKeys {
-		dimensions[index] = map[string]any{
+		dimensions[fmt.Sprintf("dimension_%d", index+1)] = map[string]any{
 			"key":                  key,
 			"score":                75.0,
 			"coverage":             1.0,

--- a/server/internal/providers/qianwen/business_generation_test.go
+++ b/server/internal/providers/qianwen/business_generation_test.go
@@ -41,6 +41,10 @@ func TestBusinessGeneratorsMapOwnedRequests(t *testing.T) {
 					textgeneration.Request{
 						SystemPrompt: "evaluate frozen evidence",
 						UserPrompt:   "sanitized evidence payload",
+						Report: textgeneration.ReportContract{
+							DimensionKeys: []string{"TASK_ACHIEVEMENT"},
+							ScoreMaximum:  100,
+						},
 					},
 				)
 				return result.Provider, result.Model, result.Content, err

--- a/server/internal/providers/qianwen/business_generation_test.go
+++ b/server/internal/providers/qianwen/business_generation_test.go
@@ -223,9 +223,13 @@ func assertEvaluationFindingSchema(
 	if !ok {
 		t.Fatalf("evaluation dimensions schema = %#v", properties["dimensions"])
 	}
-	dimension, ok := dimensions["items"].(map[string]any)
+	dimensionSlots, ok := dimensions["properties"].(map[string]any)
 	if !ok {
-		t.Fatalf("evaluation dimension item = %#v", dimensions["items"])
+		t.Fatalf("evaluation dimension slots = %#v", dimensions["properties"])
+	}
+	dimension, ok := dimensionSlots["dimension_1"].(map[string]any)
+	if !ok {
+		t.Fatalf("evaluation first dimension slot = %#v", dimensionSlots["dimension_1"])
 	}
 	dimensionProperties, ok := dimension["properties"].(map[string]any)
 	if !ok {

--- a/server/internal/providers/qianwen/evaluation_scoring.go
+++ b/server/internal/providers/qianwen/evaluation_scoring.go
@@ -3,6 +3,7 @@ package qianwen
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
@@ -30,10 +31,14 @@ func (generator *EvaluationScoringGenerator) Generate(
 ) (textgeneration.Result, error) {
 	if generator == nil || generator.generator == nil || ctx == nil ||
 		strings.TrimSpace(request.SystemPrompt) == "" ||
-		strings.TrimSpace(request.UserPrompt) == "" {
+		strings.TrimSpace(request.UserPrompt) == "" || !request.Report.Valid() {
 		return textgeneration.Result{}, errors.New(
 			"qianwen: invalid Evaluation scoring request",
 		)
+	}
+	schema, err := evaluationReportSchema(request.Report)
+	if err != nil {
+		return textgeneration.Result{}, err
 	}
 	generated, err := generator.generator.Generate(ctx, protocol.TextRequest{
 		Messages: []protocol.TextMessage{
@@ -44,7 +49,7 @@ func (generator *EvaluationScoringGenerator) Generate(
 		ResponseSchema: &protocol.JSONSchemaDefinition{
 			Name:   "evaluation_report",
 			Strict: true,
-			Schema: evaluationReportSchema(),
+			Schema: schema,
 		},
 	})
 	if err != nil {
@@ -58,14 +63,28 @@ func (generator *EvaluationScoringGenerator) Generate(
 	}, nil
 }
 
-func evaluationReportSchema() map[string]any {
+func evaluationReportSchema(
+	contract textgeneration.ReportContract,
+) (map[string]any, error) {
+	if !contract.Valid() {
+		return nil, errors.New("qianwen: invalid Evaluation report contract")
+	}
+	dimensionKeys := make([]any, len(contract.DimensionKeys))
+	for index, key := range contract.DimensionKeys {
+		dimensionKeys[index] = key
+	}
+	requiredDimensionOrder := strings.Join(contract.DimensionKeys, ", ")
 	evidence := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
 		"required":             []any{"turn_id", "quote", "occurrence"},
 		"properties": map[string]any{
-			"turn_id":    map[string]any{"type": "string"},
-			"quote":      map[string]any{"type": "string"},
+			"turn_id": map[string]any{
+				"type": "string", "minLength": 36, "maxLength": 36,
+			},
+			"quote": map[string]any{
+				"type": "string", "minLength": 1, "maxLength": 16 * 1024,
+			},
 			"occurrence": map[string]any{"type": "integer", "minimum": 1},
 		},
 	}
@@ -74,8 +93,12 @@ func evaluationReportSchema() map[string]any {
 		"additionalProperties": false,
 		"required":             []any{"message", "suggestion", "evidence"},
 		"properties": map[string]any{
-			"message":    map[string]any{"type": "string"},
-			"suggestion": map[string]any{"type": "string"},
+			"message": map[string]any{
+				"type": "string", "minLength": 1, "maxLength": 2048,
+			},
+			"suggestion": map[string]any{
+				"type": "string", "maxLength": 2048,
+			},
 			"evidence": map[string]any{
 				"type": "array", "maxItems": 8, "items": evidence,
 			},
@@ -94,18 +117,31 @@ func evaluationReportSchema() map[string]any {
 			"strengths", "improvements", "recommended_examples",
 		},
 		"properties": map[string]any{
-			"key": map[string]any{"type": "string"},
+			"key": map[string]any{
+				"type": "string", "enum": dimensionKeys,
+				"description": "Use each requested dimension key exactly once in the requested order.",
+			},
 			"score": map[string]any{
 				"anyOf": []any{
-					map[string]any{"type": "number"},
+					map[string]any{
+						"type": "number", "minimum": 0,
+						"maximum": contract.ScoreMaximum,
+					},
 					map[string]any{"type": "null"},
 				},
 			},
-			"coverage":   map[string]any{"type": "number"},
-			"confidence": map[string]any{"type": "number"},
+			"coverage": map[string]any{
+				"type": "number", "minimum": 0, "maximum": 1,
+			},
+			"confidence": map[string]any{
+				"type": "number", "minimum": 0, "maximum": 1,
+			},
 			"reason_codes": map[string]any{
 				"type": "array", "maxItems": 8,
-				"items": map[string]any{"type": "string"},
+				"items": map[string]any{
+					"type": "string", "minLength": 1, "maxLength": 128,
+					"pattern": `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`,
+				},
 			},
 			"strengths":            findings(),
 			"improvements":         findings(),
@@ -117,12 +153,18 @@ func evaluationReportSchema() map[string]any {
 		"additionalProperties": false,
 		"required":             []any{"dimension_key", "improvement_index"},
 		"properties": map[string]any{
-			"dimension_key": map[string]any{"type": "string"},
+			"dimension_key": map[string]any{
+				"type": "string", "enum": dimensionKeys,
+			},
 			"improvement_index": map[string]any{
-				"type": "integer", "minimum": 1,
+				"type": "integer", "minimum": 1, "maximum": 5,
 			},
 		},
 	}
+	// discipline: the provider's strict-schema subset has no positional-array
+	// keyword. Exact cardinality + the dynamic enum + this ordered instruction
+	// guide generation; normalizeProviderReport remains the fail-closed authority
+	// for cross-item uniqueness and order.
 	return map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -133,15 +175,22 @@ func evaluationReportSchema() map[string]any {
 			"scoreability_status": map[string]any{
 				"type": "string", "enum": []any{"PROVISIONAL", "INSUFFICIENT"},
 			},
-			"summary": map[string]any{"type": "string"},
+			"summary": map[string]any{
+				"type": "string", "minLength": 1, "maxLength": 2048,
+			},
 			"dimensions": map[string]any{
-				"type": "array", "minItems": 1, "maxItems": 8, "items": dimension,
+				"type": "array", "minItems": len(contract.DimensionKeys),
+				"maxItems": len(contract.DimensionKeys), "items": dimension,
+				"description": fmt.Sprintf(
+					"Return each key exactly once and in this order: %s.",
+					requiredDimensionOrder,
+				),
 			},
 			"priority_actions": map[string]any{
 				"type": "array", "maxItems": 5, "items": priorityAction,
 			},
 		},
-	}
+	}, nil
 }
 
 var _ textgeneration.Generator = (*EvaluationScoringGenerator)(nil)

--- a/server/internal/providers/qianwen/evaluation_scoring.go
+++ b/server/internal/providers/qianwen/evaluation_scoring.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
@@ -73,18 +74,16 @@ func evaluationReportSchema(
 	for index, key := range contract.DimensionKeys {
 		dimensionKeys[index] = key
 	}
-	requiredDimensionOrder := strings.Join(contract.DimensionKeys, ", ")
 	evidence := map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
 		"required":             []any{"turn_id", "quote", "occurrence"},
 		"properties": map[string]any{
 			"turn_id": map[string]any{
-				"type": "string", "minLength": 36, "maxLength": 36,
+				"type":    "string",
+				"pattern": `^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$`,
 			},
-			"quote": map[string]any{
-				"type": "string", "minLength": 1, "maxLength": 16 * 1024,
-			},
+			"quote":      utf8ByteBoundedStringSchema(16*1024, true),
 			"occurrence": map[string]any{"type": "integer", "minimum": 1},
 		},
 	}
@@ -93,12 +92,8 @@ func evaluationReportSchema(
 		"additionalProperties": false,
 		"required":             []any{"message", "suggestion", "evidence"},
 		"properties": map[string]any{
-			"message": map[string]any{
-				"type": "string", "minLength": 1, "maxLength": 2048,
-			},
-			"suggestion": map[string]any{
-				"type": "string", "maxLength": 2048,
-			},
+			"message":    utf8ByteBoundedStringSchema(2048, true),
+			"suggestion": utf8ByteBoundedStringSchema(2048, false),
 			"evidence": map[string]any{
 				"type": "array", "maxItems": 8, "items": evidence,
 			},
@@ -109,44 +104,51 @@ func evaluationReportSchema(
 			"type": "array", "maxItems": 5, "items": finding,
 		}
 	}
-	dimension := map[string]any{
-		"type":                 "object",
-		"additionalProperties": false,
-		"required": []any{
-			"key", "score", "coverage", "confidence", "reason_codes",
-			"strengths", "improvements", "recommended_examples",
-		},
-		"properties": map[string]any{
-			"key": map[string]any{
-				"type": "string", "enum": dimensionKeys,
-				"description": "Use each requested dimension key exactly once in the requested order.",
+	dimensionSlots := make(map[string]any, len(contract.DimensionKeys))
+	requiredDimensionSlots := make([]any, len(contract.DimensionKeys))
+	dimensionSlotOrder := make([]string, len(contract.DimensionKeys))
+	for index, key := range contract.DimensionKeys {
+		slot := fmt.Sprintf("dimension_%d", index+1)
+		requiredDimensionSlots[index] = slot
+		dimensionSlotOrder[index] = slot + "=" + key
+		dimensionSlots[slot] = map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"required": []any{
+				"key", "score", "coverage", "confidence", "reason_codes",
+				"strengths", "improvements", "recommended_examples",
 			},
-			"score": map[string]any{
-				"anyOf": []any{
-					map[string]any{
-						"type": "number", "minimum": 0,
-						"maximum": contract.ScoreMaximum,
+			"properties": map[string]any{
+				"key": map[string]any{
+					"type": "string", "enum": []any{key},
+				},
+				"score": map[string]any{
+					"anyOf": []any{
+						map[string]any{
+							"type": "number", "minimum": 0,
+							"maximum": contract.ScoreMaximum,
+						},
+						map[string]any{"type": "null"},
 					},
-					map[string]any{"type": "null"},
 				},
-			},
-			"coverage": map[string]any{
-				"type": "number", "minimum": 0, "maximum": 1,
-			},
-			"confidence": map[string]any{
-				"type": "number", "minimum": 0, "maximum": 1,
-			},
-			"reason_codes": map[string]any{
-				"type": "array", "maxItems": 8,
-				"items": map[string]any{
-					"type": "string", "minLength": 1, "maxLength": 128,
-					"pattern": `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`,
+				"coverage": map[string]any{
+					"type": "number", "minimum": 0, "maximum": 1,
 				},
+				"confidence": map[string]any{
+					"type": "number", "minimum": 0, "maximum": 1,
+				},
+				"reason_codes": map[string]any{
+					"type": "array", "maxItems": 8,
+					"items": map[string]any{
+						"type": "string", "minLength": 1, "maxLength": 128,
+						"pattern": `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`,
+					},
+				},
+				"strengths":            findings(),
+				"improvements":         findings(),
+				"recommended_examples": findings(),
 			},
-			"strengths":            findings(),
-			"improvements":         findings(),
-			"recommended_examples": findings(),
-		},
+		}
 	}
 	priorityAction := map[string]any{
 		"type":                 "object",
@@ -161,10 +163,6 @@ func evaluationReportSchema(
 			},
 		},
 	}
-	// discipline: the provider's strict-schema subset has no positional-array
-	// keyword. Exact cardinality + the dynamic enum + this ordered instruction
-	// guide generation; normalizeProviderReport remains the fail-closed authority
-	// for cross-item uniqueness and order.
 	return map[string]any{
 		"type":                 "object",
 		"additionalProperties": false,
@@ -175,15 +173,13 @@ func evaluationReportSchema(
 			"scoreability_status": map[string]any{
 				"type": "string", "enum": []any{"PROVISIONAL", "INSUFFICIENT"},
 			},
-			"summary": map[string]any{
-				"type": "string", "minLength": 1, "maxLength": 2048,
-			},
+			"summary": utf8ByteBoundedStringSchema(2048, true),
 			"dimensions": map[string]any{
-				"type": "array", "minItems": len(contract.DimensionKeys),
-				"maxItems": len(contract.DimensionKeys), "items": dimension,
+				"type": "object", "additionalProperties": false,
+				"required": requiredDimensionSlots, "properties": dimensionSlots,
 				"description": fmt.Sprintf(
-					"Return each key exactly once and in this order: %s.",
-					requiredDimensionOrder,
+					"Return the ordered dimension slots exactly as follows: %s.",
+					strings.Join(dimensionSlotOrder, ", "),
 				),
 			},
 			"priority_actions": map[string]any{
@@ -191,6 +187,16 @@ func evaluationReportSchema(
 			},
 		},
 	}, nil
+}
+
+func utf8ByteBoundedStringSchema(maximumBytes int, requireNonEmpty bool) map[string]any {
+	schema := map[string]any{
+		"type": "string", "maxLength": maximumBytes / utf8.UTFMax,
+	}
+	if requireNonEmpty {
+		schema["minLength"] = 1
+	}
+	return schema
 }
 
 var _ textgeneration.Generator = (*EvaluationScoringGenerator)(nil)

--- a/server/internal/providers/qianwen/evaluation_scoring_test.go
+++ b/server/internal/providers/qianwen/evaluation_scoring_test.go
@@ -1,0 +1,87 @@
+package qianwen
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
+)
+
+func TestEvaluationReportSchemaMatchesFormalReportBounds(t *testing.T) {
+	keys := []string{
+		"TASK_ACHIEVEMENT", "CLARITY_COHERENCE", "LANGUAGE_CONTROL", "INTERACTION",
+	}
+	schema, err := evaluationReportSchema(textgeneration.ReportContract{
+		DimensionKeys: keys,
+		ScoreMaximum:  100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	properties := schemaMap(t, schema, "properties")
+	dimensions := schemaMap(t, properties, "dimensions")
+	if dimensions["minItems"] != len(keys) || dimensions["maxItems"] != len(keys) ||
+		!strings.Contains(dimensions["description"].(string), strings.Join(keys, ", ")) {
+		t.Fatalf("dimensions schema = %#v", dimensions)
+	}
+	dimension := schemaMap(t, dimensions, "items")
+	dimensionProperties := schemaMap(t, dimension, "properties")
+	key := schemaMap(t, dimensionProperties, "key")
+	wantEnum := []any{
+		"TASK_ACHIEVEMENT", "CLARITY_COHERENCE", "LANGUAGE_CONTROL", "INTERACTION",
+	}
+	if !reflect.DeepEqual(key["enum"], wantEnum) {
+		t.Fatalf("dimension key enum = %#v", key["enum"])
+	}
+	score := schemaMap(t, dimensionProperties, "score")
+	number := score["anyOf"].([]any)[0].(map[string]any)
+	if number["minimum"] != 0 || number["maximum"] != float64(100) {
+		t.Fatalf("score schema = %#v", number)
+	}
+	for _, name := range []string{"coverage", "confidence"} {
+		ratio := schemaMap(t, dimensionProperties, name)
+		if ratio["minimum"] != 0 || ratio["maximum"] != 1 {
+			t.Fatalf("%s schema = %#v", name, ratio)
+		}
+	}
+	summary := schemaMap(t, properties, "summary")
+	if summary["minLength"] != 1 || summary["maxLength"] != 2048 {
+		t.Fatalf("summary schema = %#v", summary)
+	}
+}
+
+func TestEvaluationReportSchemaUsesIELTSScoreRange(t *testing.T) {
+	schema, err := evaluationReportSchema(textgeneration.ReportContract{
+		DimensionKeys: []string{"FLUENCY_COHERENCE", "LEXICAL_RESOURCE"},
+		ScoreMaximum:  9,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dimensions := schemaMap(t, schemaMap(t, schema, "properties"), "dimensions")
+	dimension := schemaMap(t, dimensions, "items")
+	score := schemaMap(t, schemaMap(t, dimension, "properties"), "score")
+	number := score["anyOf"].([]any)[0].(map[string]any)
+	if number["minimum"] != 0 || number["maximum"] != float64(9) {
+		t.Fatalf("IELTS score schema = %#v", number)
+	}
+}
+
+func TestEvaluationReportSchemaRejectsDuplicateDimensionKeys(t *testing.T) {
+	if _, err := evaluationReportSchema(textgeneration.ReportContract{
+		DimensionKeys: []string{"INTERACTION", "INTERACTION"},
+		ScoreMaximum:  100,
+	}); err == nil {
+		t.Fatal("duplicate dimension keys were accepted")
+	}
+}
+
+func schemaMap(t *testing.T, source map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := source[key].(map[string]any)
+	if !ok {
+		t.Fatalf("schema[%q] = %#v", key, source[key])
+	}
+	return value
+}

--- a/server/internal/providers/qianwen/evaluation_scoring_test.go
+++ b/server/internal/providers/qianwen/evaluation_scoring_test.go
@@ -1,9 +1,11 @@
 package qianwen
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
 )
@@ -21,19 +23,27 @@ func TestEvaluationReportSchemaMatchesFormalReportBounds(t *testing.T) {
 	}
 	properties := schemaMap(t, schema, "properties")
 	dimensions := schemaMap(t, properties, "dimensions")
-	if dimensions["minItems"] != len(keys) || dimensions["maxItems"] != len(keys) ||
-		!strings.Contains(dimensions["description"].(string), strings.Join(keys, ", ")) {
+	wantSlots := []any{"dimension_1", "dimension_2", "dimension_3", "dimension_4"}
+	if dimensions["type"] != "object" || dimensions["additionalProperties"] != false ||
+		!reflect.DeepEqual(dimensions["required"], wantSlots) {
 		t.Fatalf("dimensions schema = %#v", dimensions)
 	}
-	dimension := schemaMap(t, dimensions, "items")
+	dimensionSlots := schemaMap(t, dimensions, "properties")
+	for index, wantKey := range keys {
+		slot := fmt.Sprintf("dimension_%d", index+1)
+		dimension := schemaMap(t, dimensionSlots, slot)
+		dimensionProperties := schemaMap(t, dimension, "properties")
+		key := schemaMap(t, dimensionProperties, "key")
+		if !reflect.DeepEqual(key["enum"], []any{wantKey}) {
+			t.Fatalf("%s key enum = %#v", slot, key["enum"])
+		}
+	}
+	wantOrder := "dimension_1=TASK_ACHIEVEMENT, dimension_2=CLARITY_COHERENCE, dimension_3=LANGUAGE_CONTROL, dimension_4=INTERACTION"
+	if !strings.Contains(dimensions["description"].(string), wantOrder) {
+		t.Fatalf("dimensions description = %q", dimensions["description"])
+	}
+	dimension := schemaMap(t, dimensionSlots, "dimension_1")
 	dimensionProperties := schemaMap(t, dimension, "properties")
-	key := schemaMap(t, dimensionProperties, "key")
-	wantEnum := []any{
-		"TASK_ACHIEVEMENT", "CLARITY_COHERENCE", "LANGUAGE_CONTROL", "INTERACTION",
-	}
-	if !reflect.DeepEqual(key["enum"], wantEnum) {
-		t.Fatalf("dimension key enum = %#v", key["enum"])
-	}
 	score := schemaMap(t, dimensionProperties, "score")
 	number := score["anyOf"].([]any)[0].(map[string]any)
 	if number["minimum"] != 0 || number["maximum"] != float64(100) {
@@ -46,9 +56,39 @@ func TestEvaluationReportSchemaMatchesFormalReportBounds(t *testing.T) {
 		}
 	}
 	summary := schemaMap(t, properties, "summary")
-	if summary["minLength"] != 1 || summary["maxLength"] != 2048 {
+	if summary["minLength"] != 1 || summary["maxLength"] != 2048/utf8.UTFMax {
 		t.Fatalf("summary schema = %#v", summary)
 	}
+}
+
+func TestEvaluationReportSchemaStringLimitsCannotExceedDomainUTF8ByteLimits(t *testing.T) {
+	schema, err := evaluationReportSchema(textgeneration.ReportContract{
+		DimensionKeys: []string{"INTERACTION"}, ScoreMaximum: 100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	properties := schemaMap(t, schema, "properties")
+	dimensions := schemaMap(t, schemaMap(t, properties, "dimensions"), "properties")
+	dimension := schemaMap(t, dimensions, "dimension_1")
+	findingItems := schemaMap(t,
+		schemaMap(t, schemaMap(t, dimension, "properties"), "strengths"), "items",
+	)
+	findingProperties := schemaMap(t, findingItems, "properties")
+	evidenceItems := schemaMap(t, schemaMap(t, findingProperties, "evidence"), "items")
+	evidenceProperties := schemaMap(t, evidenceItems, "properties")
+
+	assertUTF8Bound := func(name string, value map[string]any, maximumBytes int) {
+		t.Helper()
+		maximumCharacters, ok := value["maxLength"].(int)
+		if !ok || maximumCharacters*utf8.UTFMax > maximumBytes {
+			t.Fatalf("%s schema = %#v; may exceed %d UTF-8 bytes", name, value, maximumBytes)
+		}
+	}
+	assertUTF8Bound("summary", schemaMap(t, properties, "summary"), 2048)
+	assertUTF8Bound("message", schemaMap(t, findingProperties, "message"), 2048)
+	assertUTF8Bound("suggestion", schemaMap(t, findingProperties, "suggestion"), 2048)
+	assertUTF8Bound("quote", schemaMap(t, evidenceProperties, "quote"), 16*1024)
 }
 
 func TestEvaluationReportSchemaUsesIELTSScoreRange(t *testing.T) {
@@ -60,7 +100,7 @@ func TestEvaluationReportSchemaUsesIELTSScoreRange(t *testing.T) {
 		t.Fatal(err)
 	}
 	dimensions := schemaMap(t, schemaMap(t, schema, "properties"), "dimensions")
-	dimension := schemaMap(t, dimensions, "items")
+	dimension := schemaMap(t, schemaMap(t, dimensions, "properties"), "dimension_1")
 	score := schemaMap(t, schemaMap(t, dimension, "properties"), "score")
 	number := score["anyOf"].([]any)[0].(map[string]any)
 	if number["minimum"] != 0 || number["maximum"] != float64(9) {


### PR DESCRIPTION
## 功能描述

- 修复七牛评估报告偶发返回百分数比例、重复/乱序维度或 UTF-8 文本越界，导致单次报告生成失败的问题。
- 将业务端要求的维度 key、顺序、评分上限和学习者证据语义显式传给 Provider。
- 真实报告不再把已确认的学习者回答误判成“没有学习者回答”。

## 实现思路

- `sessionevaluation` 生成不可歧义的 `ReportContract`，并明确 `effective_turns` 是被评估 LEARNER 的确认回答。
- 七牛 strict JSON Schema 使用固定 `dimension_1..N` 槽位，每个槽位只允许对应维度 key，因此 Schema 本身无法接受重复或乱序。
- 文本 schema 使用保守 Unicode 长度上限，保证任何合法 JSON 字符串都不会超过领域层 UTF-8 字节限制。
- 业务标准化仍保持 fail-closed，不做静默比例换算或证据猜测。

## 可复现测试

- `go test ./internal/coaching/evaluation/sessionevaluation ./internal/providers/qianwen -count=1`
- `go test ./internal/... -count=1`
- `QIANWEN_LIVE_TEST=1 go test -tags=live ./internal/coaching/evaluation/sessionevaluation -run '^TestQiniuGeneralEvaluatorProducesStableValidReports$' -count=1 -v`
  - 最新提交真实七牛调用通过，报告满足领域校验，学习者回答与维度评分均存在。
- `git diff --check`

Closes #1082
