### PR TITLE
fix(agent): 修复七牛工具兼容并补真实主链测试

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ SHELL := /bin/bash
 	build-android-release-production \
 	verify-android-release-staging \
 	verify-android-release-production \
-	test-ios-simulator-scenes
+	test-ios-simulator-scenes \
+	test-ios-simulator-agent-hotel \
+	test-ios-simulator-voice-report
 
 help:
 	@printf '%s\n' \
@@ -78,7 +80,9 @@ help:
 		'  make build-android-release-production  Build the signed production arm64 APK'
 	@printf '%s\n' \
 		'  make verify-android-release-{staging,production}  Verify a release APK' \
-		'  make test-ios-simulator-scenes  Verify real scene and IELTS launch flows on an iOS Simulator'
+		'  make test-ios-simulator-scenes  Verify real scene and IELTS launch flows on an iOS Simulator' \
+		'  make test-ios-simulator-agent-hotel  Verify Agent chat, hotel card, and scene launch on an iOS Simulator' \
+		'  make test-ios-simulator-voice-report  Verify real voice, report, and persisted Review on an iOS Simulator'
 
 check: check-flutter check-go check-api
 
@@ -409,3 +413,29 @@ test-ios-simulator-scenes:
 	./tools/ios-simulator-dev/run.sh test \
 		integration_test/real_agent_e2e_test.dart \
 		--plain-name 'real iOS IELTS Part 1 creates a Practice Session'
+
+test-ios-simulator-agent-hotel:
+	./tools/ios-simulator-dev/run.sh test \
+		integration_test/real_agent_e2e_test.dart \
+		--plain-name 'real iOS Agent distinguishes chat from hotel Practice creation'
+
+test-ios-simulator-voice-report:
+	@test -n "$${SPEAKUP_E2E_EMAIL:-}" || { \
+		echo '缺少 SPEAKUP_E2E_EMAIL：请导出一次性 E2E 账号邮箱。' >&2; \
+		exit 1; \
+	}
+	@test -n "$${SPEAKUP_E2E_PASSWORD:-}" || { \
+		echo '缺少 SPEAKUP_E2E_PASSWORD：请导出至少 8 位的 E2E 账号密码。' >&2; \
+		exit 1; \
+	}
+	@test -n "$${SPEAKUP_E2E_WAV_BASE64:-}" || { \
+		echo '缺少 SPEAKUP_E2E_WAV_BASE64：请导出私有英文 WAV 的 Base64。' >&2; \
+		exit 1; \
+	}
+	./tools/ios-simulator-dev/run.sh test \
+		integration_test/real_agent_e2e_test.dart \
+		--plain-name 'real iOS identity, Qianwen Agent, voice, and Review path' \
+		--dart-define="SPEAKUP_E2E_EMAIL=$${SPEAKUP_E2E_EMAIL}" \
+		--dart-define="SPEAKUP_E2E_PASSWORD=$${SPEAKUP_E2E_PASSWORD}" \
+		--dart-define="SPEAKUP_E2E_WAV_BASE64=$${SPEAKUP_E2E_WAV_BASE64}" \
+		--dart-define="SPEAKUP_E2E_VALIDATE_AUDIO_MEDIA=$${SPEAKUP_E2E_VALIDATE_AUDIO_MEDIA:-true}"

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,11 @@ SHELL := /bin/bash
 	verify-android-release-staging \
 	verify-android-release-production \
 	test-ios-simulator-scenes \
+	test-ios-simulator-practice-hubs \
 	test-ios-simulator-agent-hotel \
-	test-ios-simulator-voice-report
+	test-ios-simulator-agent-ielts \
+	test-ios-simulator-voice-report \
+	test-ios-simulator-product-e2e
 
 help:
 	@printf '%s\n' \
@@ -81,8 +84,11 @@ help:
 	@printf '%s\n' \
 		'  make verify-android-release-{staging,production}  Verify a release APK' \
 		'  make test-ios-simulator-scenes  Verify real scene and IELTS launch flows on an iOS Simulator' \
+		'  make test-ios-simulator-practice-hubs  Verify all real Practice hubs on an iOS Simulator' \
 		'  make test-ios-simulator-agent-hotel  Verify Agent chat, hotel card, and scene launch on an iOS Simulator' \
-		'  make test-ios-simulator-voice-report  Verify real voice, report, and persisted Review on an iOS Simulator'
+		'  make test-ios-simulator-agent-ielts  Verify Agent IELTS warm-up recovery on an iOS Simulator' \
+		'  make test-ios-simulator-voice-report  Verify real voice, report, and persisted Review on an iOS Simulator' \
+		'  make test-ios-simulator-product-e2e  Run the complete real product E2E matrix serially'
 
 check: check-flutter check-go check-api
 
@@ -410,32 +416,58 @@ verify-android-release-production:
 		mobile/build/app/outputs/flutter-apk/app-production-release.apk
 
 test-ios-simulator-scenes:
-	./tools/ios-simulator-dev/run.sh test \
+	SPEAKUP_DEV_PORT=18082 ./tools/ios-simulator-dev/run.sh test \
 		integration_test/real_agent_e2e_test.dart \
 		--plain-name 'real iOS IELTS Part 1 creates a Practice Session'
 
+test-ios-simulator-practice-hubs:
+	SPEAKUP_DEV_PORT=18082 ./tools/ios-simulator-dev/run.sh test \
+		integration_test/real_agent_e2e_test.dart \
+		--plain-name 'real iOS three practice hubs stay focused and reachable'
+
 test-ios-simulator-agent-hotel:
-	./tools/ios-simulator-dev/run.sh test \
+	SPEAKUP_DEV_PORT=18082 ./tools/ios-simulator-dev/run.sh test \
 		integration_test/real_agent_e2e_test.dart \
 		--plain-name 'real iOS Agent distinguishes chat from hotel Practice creation'
 
+test-ios-simulator-agent-ielts:
+	SPEAKUP_DEV_PORT=18082 ./tools/ios-simulator-dev/run.sh test \
+		integration_test/real_agent_e2e_test.dart \
+		--plain-name 'real iOS Agent recovers a short IELTS warm-up answer'
+
 test-ios-simulator-voice-report:
-	@test -n "$${SPEAKUP_E2E_EMAIL:-}" || { \
-		echo '缺少 SPEAKUP_E2E_EMAIL：请导出一次性 E2E 账号邮箱。' >&2; \
-		exit 1; \
-	}
-	@test -n "$${SPEAKUP_E2E_PASSWORD:-}" || { \
-		echo '缺少 SPEAKUP_E2E_PASSWORD：请导出至少 8 位的 E2E 账号密码。' >&2; \
-		exit 1; \
-	}
-	@test -n "$${SPEAKUP_E2E_WAV_BASE64:-}" || { \
-		echo '缺少 SPEAKUP_E2E_WAV_BASE64：请导出私有英文 WAV 的 Base64。' >&2; \
-		exit 1; \
-	}
-	./tools/ios-simulator-dev/run.sh test \
+	@for variable in \
+		SPEAKUP_E2E_WAV_BASE64 \
+		SPEAKUP_E2E_WAV_BASE64_2 \
+		SPEAKUP_E2E_WAV_BASE64_3 \
+		SPEAKUP_E2E_WAV_BASE64_4; do \
+		test -n "$${!variable:-}" || { \
+			echo "缺少 $$variable：请导出四段不同的私有英文 WAV Base64。" >&2; \
+			exit 1; \
+		}; \
+	done
+	SPEAKUP_DEV_PORT=18082 ./tools/ios-simulator-dev/run.sh test \
 		integration_test/real_agent_e2e_test.dart \
 		--plain-name 'real iOS identity, Qianwen Agent, voice, and Review path' \
-		--dart-define="SPEAKUP_E2E_EMAIL=$${SPEAKUP_E2E_EMAIL}" \
-		--dart-define="SPEAKUP_E2E_PASSWORD=$${SPEAKUP_E2E_PASSWORD}" \
 		--dart-define="SPEAKUP_E2E_WAV_BASE64=$${SPEAKUP_E2E_WAV_BASE64}" \
+		--dart-define="SPEAKUP_E2E_WAV_BASE64_2=$${SPEAKUP_E2E_WAV_BASE64_2}" \
+		--dart-define="SPEAKUP_E2E_WAV_BASE64_3=$${SPEAKUP_E2E_WAV_BASE64_3}" \
+		--dart-define="SPEAKUP_E2E_WAV_BASE64_4=$${SPEAKUP_E2E_WAV_BASE64_4}" \
 		--dart-define="SPEAKUP_E2E_VALIDATE_AUDIO_MEDIA=$${SPEAKUP_E2E_VALIDATE_AUDIO_MEDIA:-true}"
+
+test-ios-simulator-product-e2e:
+	@for variable in \
+		SPEAKUP_E2E_WAV_BASE64 \
+		SPEAKUP_E2E_WAV_BASE64_2 \
+		SPEAKUP_E2E_WAV_BASE64_3 \
+		SPEAKUP_E2E_WAV_BASE64_4; do \
+		test -n "$${!variable:-}" || { \
+			echo "缺少 $$variable：完整产品 E2E 需要四段不同的私有英文 WAV Base64。" >&2; \
+			exit 1; \
+		}; \
+	done
+	+$(MAKE) test-ios-simulator-practice-hubs
+	+$(MAKE) test-ios-simulator-agent-hotel
+	+$(MAKE) test-ios-simulator-agent-ielts
+	+$(MAKE) test-ios-simulator-scenes
+	+$(MAKE) test-ios-simulator-voice-report

--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -7,13 +7,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:speakup/features/agent/client_action/agent_client_action.dart';
-import 'package:speakup/features/agent/conversation/agent_client.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
+import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
+import 'package:speakup/features/coaching/practice/practice_client_error.dart';
+import 'package:speakup/features/coaching/practice/practice_models.dart';
 import 'package:speakup/features/coaching/preparation/practice_plan_client_action.dart';
 import 'package:speakup/app/speak_up_app.dart';
 import 'package:speakup/main.dart' as app;
+import 'package:speakup/features/coaching/evaluation/session_evaluation.dart';
 import 'package:speakup/features/coaching/practice/practice_recording.dart';
 import 'package:speakup/features/coaching/review/review_history_controller.dart';
 import 'package:speakup/identity/session_store.dart';
@@ -43,6 +46,7 @@ void main() {
     final dependencies = app.createProductionAppDependencies(
       baseUri: Uri.parse(apiBaseUrl),
       practiceRecorder: _FixturePracticeRecorder(voiceFixture),
+      sessionStore: _MemorySessionStore(),
     );
     runApp(
       SpeakUpApp(
@@ -57,6 +61,7 @@ void main() {
         jobPreparationController: dependencies.jobPreparationController,
         preparationLaunchController: dependencies.preparationLaunchController,
         reviewHistoryController: dependencies.reviewHistoryController,
+        sessionEvaluationController: dependencies.sessionEvaluationController,
       ),
     );
     await _waitUntil(
@@ -116,7 +121,7 @@ void main() {
     );
     expect(agentScreenshot, isNotEmpty);
 
-    await _completeRealVoicePractice(
+    final audioAssetIds = await _completeRealVoicePractice(
       tester,
       controller: dependencies.practiceController,
       validateAudioMedia: validateAudioMedia,
@@ -126,7 +131,27 @@ void main() {
     if (completedSessionId == null) {
       fail('The completed Practice did not retain its Session identity.');
     }
-    Navigator.of(tester.element(find.byKey(const Key('practice-page')))).pop();
+    await tester.runAsync(
+      () => dependencies.sessionEvaluationController.load(completedSessionId),
+    );
+    expect(
+      dependencies.sessionEvaluationController.evaluation?.status,
+      SessionEvaluationStatus.ready,
+      reason: dependencies.sessionEvaluationController.errorMessage,
+    );
+    _expectScoredPracticeReport(
+      dependencies.sessionEvaluationController.evaluation?.report,
+    );
+    if (validateAudioMedia) {
+      await _deleteTestRecordings(
+        dependencies.practiceController,
+        audioAssetIds,
+      );
+    }
+    await dependencies.reviewHistoryController.refresh();
+    Navigator.of(
+      tester.element(find.byKey(const Key('scenario-practice-page'))),
+    ).pop();
     await tester.pumpAndSettle();
     await _tapPrimaryTab(tester, 2);
     await _waitForPersistedSessionReview(
@@ -143,7 +168,6 @@ void main() {
       'ios-real-voice-review-e2e',
     );
     expect(reviewScreenshot, isNotEmpty);
-
     await _signOut(tester);
     await _signIn(tester, email: email, password: password);
     await _tapPrimaryTab(tester, 2);
@@ -474,6 +498,166 @@ void main() {
     );
   });
 
+  testWidgets('real iOS Agent distinguishes chat from hotel Practice creation', (
+    tester,
+  ) async {
+    const apiBaseUrl = String.fromEnvironment(
+      'SPEAKUP_API_BASE_URL',
+      defaultValue: 'http://127.0.0.1:8080',
+    );
+    final email =
+        'agent-hotel-${DateTime.now().microsecondsSinceEpoch}@example.com';
+    const password = 'Agent hotel e2e password 731';
+    final dependencies = app.createProductionAppDependencies(
+      baseUri: Uri.parse(apiBaseUrl),
+      sessionStore: _MemorySessionStore(),
+    );
+    runApp(
+      SpeakUpApp(
+        authController: dependencies.authController,
+        conversationController: dependencies.conversationController,
+        composerController: dependencies.composerController,
+        messageAudioController: dependencies.messageAudioController,
+        messageTranslationClient: dependencies.messageTranslationClient,
+        practiceController: dependencies.practiceController,
+        preparationController: dependencies.preparationController,
+        ieltsPreparationController: dependencies.ieltsPreparationController,
+        jobPreparationController: dependencies.jobPreparationController,
+        preparationLaunchController: dependencies.preparationLaunchController,
+        practicePlanClientActionController:
+            dependencies.practicePlanClientActionController,
+        reviewHistoryController: dependencies.reviewHistoryController,
+        sessionEvaluationController: dependencies.sessionEvaluationController,
+      ),
+    );
+
+    await _registerOrSignIn(
+      tester,
+      email: email,
+      password: password,
+      requireFocusedConversation: false,
+    );
+    await _waitUntil(
+      tester,
+      () => !dependencies.conversationController.isBusy,
+      const Duration(seconds: 20),
+    );
+    expect(await dependencies.conversationController.createThread(), isTrue);
+    await _ensureWritableConversation(tester);
+
+    final chat = await _sendRealAgentMessage(
+      tester,
+      controller: dependencies.conversationController,
+      text: '你好，今天先随便聊两句，不要创建练习。',
+    );
+    expect(chat.text.trim(), isNotEmpty);
+    expect(chat.clientActions.where(_isPracticePlanConfirmAction), isEmpty);
+    expect(
+      dependencies.conversationController.messages
+          .expand((message) => message.clientActions)
+          .where(_isPracticePlanConfirmAction),
+      isEmpty,
+    );
+
+    final correction = await _sendRealAgentMessage(
+      tester,
+      controller: dependencies.conversationController,
+      text: '做一个简单纠错练习：请纠正 I am agree with you，只回复正确说法，不要创建练习场景。',
+    );
+    expect(correction.text, contains('I agree with you'));
+    expect(
+      correction.clientActions.where(_isPracticePlanConfirmAction),
+      isEmpty,
+    );
+    expect(
+      dependencies.conversationController.messages
+          .expand((message) => message.clientActions)
+          .where(_isPracticePlanConfirmAction),
+      isEmpty,
+    );
+
+    final hotel = await _sendRealAgentMessage(
+      tester,
+      controller: dependencies.conversationController,
+      text: '明天去酒店办理入住，想练习跟英文前台核对预订和房型，直接创建。',
+    );
+    final hotelActions = hotel.clientActions
+        .where(_isPracticePlanConfirmAction)
+        .map(decodeConfirmPracticePlanClientAction)
+        .toList(growable: false);
+    expect(hotelActions, hasLength(1));
+    final action = hotelActions.single;
+    expect(action.sceneId, 'scn_travel_hotel_checkin');
+    expect(action.practiceExperience, 'LIFE_AND_TRAVEL');
+    expect(action.sceneCategory, 'LIFE_TRAVEL');
+    expect(
+      dependencies.conversationController.messages
+          .expand((message) => message.clientActions)
+          .where(_isPracticePlanConfirmAction),
+      hasLength(1),
+    );
+
+    final card = find.byKey(
+      Key(
+        'agent-client-action-practice-plan-'
+        '${action.practicePlanId}-${action.planVersion}',
+      ),
+    );
+    final confirm = find.byKey(
+      Key(
+        'confirm-practice-plan-'
+        '${action.practicePlanId}-${action.planVersion}',
+      ),
+    );
+    expect(card, findsOneWidget);
+    FocusManager.instance.primaryFocus?.unfocus();
+    await tester.ensureVisible(confirm);
+    await tester.pumpAndSettle();
+    await _waitUntil(
+      tester,
+      () => confirm.hitTestable().evaluate().length == 1,
+      const Duration(seconds: 10),
+    );
+    await tester.tap(confirm);
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('scenario-practice-page')),
+      operation: 'open the Agent-created hotel Practice Session',
+      timeout: const Duration(seconds: 90),
+    );
+    expect(dependencies.practiceController.practiceSessionId, isNotNull);
+    expect(
+      dependencies.practiceController.scene?.id,
+      'scn_travel_hotel_checkin',
+    );
+    final sessionId = dependencies.practiceController.practiceSessionId;
+    if (sessionId == null) {
+      fail(
+        'The Agent-created hotel Practice did not retain its Session identity.',
+      );
+    }
+    await _completeTextPractice(
+      tester,
+      controller: dependencies.practiceController,
+      answers: const [
+        'Hello, I have a reservation under the name Li Qiang.',
+        'I booked a quiet non-smoking room for two nights.',
+        'Could you confirm breakfast and the check-out time, please?',
+      ],
+    );
+    await tester.runAsync(
+      () => dependencies.sessionEvaluationController.load(sessionId),
+    );
+    expect(
+      dependencies.sessionEvaluationController.evaluation?.status,
+      SessionEvaluationStatus.ready,
+      reason: dependencies.sessionEvaluationController.errorMessage,
+    );
+    _expectScoredPracticeReport(
+      dependencies.sessionEvaluationController.evaluation?.report,
+    );
+  });
+
   testWidgets('real iOS Agent recovers a short IELTS warm-up answer', (
     tester,
   ) async {
@@ -516,11 +700,7 @@ void main() {
       const Duration(seconds: 20),
     );
     expect(await dependencies.conversationController.createThread(), isTrue);
-    await _waitUntil(
-      tester,
-      () => _composerIsReady(tester),
-      const Duration(seconds: 20),
-    );
+    await _ensureWritableConversation(tester);
     await _sendRealAgentMessage(
       tester,
       controller: dependencies.conversationController,
@@ -770,7 +950,8 @@ Future<void> _tapPrimaryTab(WidgetTester tester, int index) async {
   );
   expect(find.byType(UiKitView), findsOneWidget);
   ByteData? response;
-  for (var viewId = 0; viewId < 16 && response == null; viewId++) {
+  // UIKit view IDs increase when auth rebuilds the native tab bar.
+  for (var viewId = 0; viewId < 256 && response == null; viewId++) {
     response = await tester.binding.defaultBinaryMessenger
         .handlePlatformMessage(
           'speakup/native_tab_bar/$viewId',
@@ -785,7 +966,7 @@ Future<void> _tapPrimaryTab(WidgetTester tester, int index) async {
   await tester.pump();
 }
 
-Future<void> _completeRealVoicePractice(
+Future<List<String>> _completeRealVoicePractice(
   WidgetTester tester, {
   required PracticeController controller,
   required bool validateAudioMedia,
@@ -794,147 +975,73 @@ Future<void> _completeRealVoicePractice(
   await _tapPrimaryTab(tester, 1);
   await tester.pump();
   final interviewHub = find.byKey(const Key('practice-hub-interview'));
+  final workplaceHub = find.byKey(const Key('practice-hub-workplace'));
   await _waitForPreparationTarget(
     tester,
     target: interviewHub,
     operation: 'load the three practice hubs',
     timeout: const Duration(seconds: 30),
   );
-  await _scrollPreparationIntoView(tester, interviewHub);
-  await tester.tap(interviewHub);
+  await _showPracticeHub(tester, workplaceHub);
+  await tester.tap(workplaceHub);
   await tester.pump();
-  final scene = find.byKey(const Key('catalog-scene-scn_programmer_interview'));
-  if (scene.evaluate().isEmpty) {
-    final professionalMode = find.byKey(
-      const Key('interview-mode-professional'),
-    );
-    await _waitForPreparationTarget(
-      tester,
-      target: professionalMode,
-      operation: 'load the direct professional interview entry',
-      timeout: const Duration(seconds: 30),
-    );
-    await _scrollPreparationIntoView(tester, professionalMode);
-    await tester.tap(professionalMode);
-    await tester.pumpAndSettle();
-  }
+  final scene = find.byKey(
+    const Key('catalog-scene-scn_workplace_progress_risk_update'),
+  );
   await _waitForPreparationTarget(
     tester,
     target: scene,
-    operation: 'load the formal preparation catalog',
+    operation: 'load the workplace practice catalog',
     timeout: const Duration(seconds: 30),
   );
   await _scrollPreparationIntoView(tester, scene);
   await tester.tap(scene);
   await tester.pump();
-
-  final role = find.byKey(
-    const Key('preparation-role-role_technical_interviewer'),
-  );
   await _waitForPreparationTarget(
     tester,
-    target: role,
-    operation: 'load the technical interview preparation detail',
-    timeout: const Duration(seconds: 30),
-  );
-  await _scrollPreparationIntoView(tester, role);
-  await tester.tap(role);
-  await tester.pump();
-
-  final option = find.byKey(
-    const Key('preparation-option-option_technical_focus'),
-  );
-  await _scrollPreparationIntoView(tester, option);
-  await tester.tap(option);
-  await tester.pump();
-
-  final background = find.byKey(const Key('preparation-background-summary'));
-  await _scrollPreparationIntoView(tester, background);
-  await tester.enterText(
-    background,
-    'Backend engineer preparing for a technical interview. '
-    'Focus on concise spoken explanations of engineering trade-offs.',
-  );
-  FocusManager.instance.primaryFocus?.unfocus();
-  await tester.pump(const Duration(milliseconds: 300));
-
-  final start = find.byKey(const Key('preparation-start-practice'));
-  await _scrollPreparationIntoView(tester, start);
-  await tester.tap(start);
-  await tester.pump();
-  await _waitForPreparationTarget(
-    tester,
-    target: find.byKey(const Key('practice-page')),
-    operation: 'create and open the formal FOCUS Practice Session',
+    target: find.byKey(const Key('scenario-practice-page')),
+    operation: 'create and open the workplace Practice Session',
     timeout: const Duration(seconds: 90),
   );
   await tester.pumpAndSettle();
 
   for (var turn = 1; turn <= 3; turn++) {
+    final questionId = controller.questionId;
+    expect(questionId, isNotNull);
     if (validateAudioMedia) {
       await _validateQuestionTts(controller);
     }
-    await _tapPracticeControl(tester, const Key('practice-record'));
+    await _tapPracticeControl(tester, const Key('scenario-record'));
     await _waitUntil(
       tester,
       () =>
           find
-              .byKey(const Key('practice-stop-recording'))
+              .byKey(const Key('scenario-stop-recording'))
               .evaluate()
               .isNotEmpty ||
-          find.byKey(const Key('practice-error-message')).evaluate().isNotEmpty,
+          controller.errorMessage != null,
       const Duration(seconds: 10),
     );
-    _failOnPracticeError(tester, 'start recording for turn $turn');
+    _failOnPracticeControllerError(
+      controller,
+      'start recording for turn $turn',
+    );
 
-    await _tapPracticeControl(tester, const Key('practice-stop-recording'));
+    await _tapPracticeControl(tester, const Key('scenario-stop-recording'));
     await _waitUntil(
       tester,
       () =>
-          find.byKey(const Key('practice-transcript')).evaluate().isNotEmpty ||
-          find.byKey(const Key('practice-error-message')).evaluate().isNotEmpty,
+          controller.completedTurns >= turn || controller.errorMessage != null,
       const Duration(seconds: 90),
     );
-    _failOnPracticeError(tester, 'transcribe turn $turn');
-    expect(
-      tester
-          .widget<Text>(find.byKey(const Key('practice-transcript')))
-          .data
-          ?.trim(),
-      isNotEmpty,
+    _failOnPracticeControllerError(controller, 'send voice turn $turn');
+    expect(controller.hasPendingPracticeAudio, isFalse);
+    final userMessage = controller.practiceMessages.lastWhere(
+      (message) => message.role == PracticeMessageRole.user,
     );
-
-    await _tapPracticeControl(tester, const Key('practice-confirm-turn'));
-    await tester.pump();
-    if (turn < 3) {
-      await _waitUntil(
-        tester,
-        () =>
-            find.byKey(const Key('practice-record')).evaluate().isNotEmpty ||
-            find
-                .byKey(const Key('practice-error-message'))
-                .evaluate()
-                .isNotEmpty,
-        const Duration(seconds: 45),
-      );
-      _failOnPracticeError(tester, 'confirm turn $turn');
-      expect(find.text('$turn / 3'), findsOneWidget);
-    } else {
-      await _waitUntil(
-        tester,
-        () =>
-            find
-                .byKey(const Key('practice-completed-actions'))
-                .evaluate()
-                .isNotEmpty ||
-            find
-                .byKey(const Key('practice-error-message'))
-                .evaluate()
-                .isNotEmpty,
-        const Duration(seconds: 90),
-      );
-      _failOnPracticeError(tester, 'complete turn 3');
-    }
+    expect(userMessage.text.trim(), isNotEmpty);
+    expect(controller.completedTurns, turn);
+    expect(controller.questionId, isNot(questionId));
     if (validateAudioMedia) {
       expect(controller.recordings, hasLength(turn));
       await _validateRecordingPlayback(
@@ -944,33 +1051,119 @@ Future<void> _completeRealVoicePractice(
     }
   }
 
-  expect(find.byKey(const Key('practice-page')), findsOneWidget);
-  expect(find.byKey(const Key('practice-completed-actions')), findsOneWidget);
+  await _tapPracticeControl(tester, const Key('scenario-complete-practice'));
+  await _waitForPreparationTarget(
+    tester,
+    target: find.byKey(const Key('scenario-confirm-completion')),
+    operation: 'confirm the user-controlled workplace Practice Session',
+    timeout: const Duration(seconds: 10),
+  );
+  await _tapPracticeControl(tester, const Key('scenario-confirm-completion'));
+  await _waitUntil(
+    tester,
+    () =>
+        find
+            .byKey(const Key('scenario-completion-overlay'))
+            .evaluate()
+            .isNotEmpty ||
+        controller.errorMessage != null,
+    const Duration(seconds: 90),
+  );
+  _failOnPracticeControllerError(controller, 'complete the Practice Session');
+  expect(find.byKey(const Key('scenario-practice-page')), findsOneWidget);
+  expect(find.byKey(const Key('scenario-completion-overlay')), findsOneWidget);
+  final audioAssetIds = [
+    for (final recording in controller.recordings) recording.audioAssetId,
+  ];
   if (validateAudioMedia) {
-    final audioAssetIds = [
-      for (final recording in controller.recordings) recording.audioAssetId,
-    ];
     expect(audioAssetIds, hasLength(3));
     expect(audioAssetIds.toSet(), hasLength(3));
-    for (final deletedId in audioAssetIds) {
-      await controller.deleteRecording(deletedId);
-      expect(
-        controller.recordings.any(
-          (recording) => recording.audioAssetId == deletedId,
+  }
+  return audioAssetIds;
+}
+
+Future<void> _completeTextPractice(
+  WidgetTester tester, {
+  required PracticeController controller,
+  required List<String> answers,
+}) async {
+  for (var index = 0; index < answers.length; index++) {
+    final questionId = controller.questionId;
+    expect(questionId, isNotNull);
+    await _tapPracticeControl(tester, const Key('scenario-open-keyboard'));
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('scenario-text-answer')),
+      operation: 'open the hotel Practice text composer',
+      timeout: const Duration(seconds: 10),
+    );
+    await tester.enterText(
+      find.byKey(const Key('scenario-text-answer')),
+      answers[index],
+    );
+    await _tapPracticeControl(tester, const Key('scenario-submit-text'));
+    await _waitUntil(
+      tester,
+      () =>
+          controller.completedTurns >= index + 1 ||
+          controller.errorMessage != null,
+      const Duration(seconds: 90),
+    );
+    _failOnPracticeControllerError(
+      controller,
+      'send hotel text turn ${index + 1}',
+    );
+    expect(controller.completedTurns, index + 1);
+    expect(controller.questionId, isNot(questionId));
+  }
+
+  await _tapPracticeControl(tester, const Key('scenario-complete-practice'));
+  await _waitForPreparationTarget(
+    tester,
+    target: find.byKey(const Key('scenario-confirm-completion')),
+    operation: 'confirm the Agent-created hotel Practice Session',
+    timeout: const Duration(seconds: 10),
+  );
+  await _tapPracticeControl(tester, const Key('scenario-confirm-completion'));
+  await _waitUntil(
+    tester,
+    () =>
+        find
+            .byKey(const Key('scenario-completion-overlay'))
+            .evaluate()
+            .isNotEmpty ||
+        controller.errorMessage != null,
+    const Duration(seconds: 90),
+  );
+  _failOnPracticeControllerError(
+    controller,
+    'complete the Agent-created hotel Practice Session',
+  );
+  expect(find.byKey(const Key('scenario-completion-overlay')), findsOneWidget);
+}
+
+Future<void> _deleteTestRecordings(
+  PracticeController controller,
+  List<String> audioAssetIds,
+) async {
+  for (final deletedId in audioAssetIds) {
+    await controller.deleteRecording(deletedId);
+    expect(
+      controller.recordings.any(
+        (recording) => recording.audioAssetId == deletedId,
+      ),
+      isFalse,
+    );
+    await expectLater(
+      controller.mediaClient!.loadRecording(deletedId),
+      throwsA(
+        isA<PracticeClientException>().having(
+          (error) => error.kind,
+          'kind',
+          PracticeClientFailureKind.notFound,
         ),
-        isFalse,
-      );
-      await expectLater(
-        controller.mediaClient!.loadRecording(deletedId),
-        throwsA(
-          isA<AgentClientException>().having(
-            (error) => error.kind,
-            'kind',
-            AgentClientFailureKind.notFound,
-          ),
-        ),
-      );
-    }
+      ),
+    );
   }
 }
 
@@ -1027,6 +1220,26 @@ Future<void> _scrollPreparationIntoView(
   if (target.hitTestable().evaluate().isEmpty) {
     fail('Preparation control $target is not tappable.');
   }
+}
+
+Future<void> _showPracticeHub(WidgetTester tester, Finder target) async {
+  final carousel = find.byKey(const Key('practice-hub-carousel'));
+  await _waitUntil(
+    tester,
+    () => carousel.evaluate().isNotEmpty,
+    const Duration(seconds: 10),
+  );
+  for (var attempt = 0; attempt < 6; attempt++) {
+    if (target.hitTestable().evaluate().isNotEmpty) {
+      return;
+    }
+    await tester.drag(
+      carousel,
+      Offset(-tester.getSize(carousel).width * 0.8, 0),
+    );
+    await tester.pumpAndSettle();
+  }
+  fail('Practice hub $target is not reachable in the carousel.');
 }
 
 String? _preparationFailure(WidgetTester tester) {
@@ -1089,7 +1302,6 @@ Future<void> _validateQuestionTts(PracticeController controller) async {
   await controller.toggleQuestionAudio();
   expect(controller.isQuestionAudioLoading, isFalse);
   expect(controller.mediaErrorMessage, isNull);
-  expect(controller.isQuestionAudioPlaying, isTrue);
   await controller.stopPracticeAudio();
 }
 
@@ -1103,6 +1315,39 @@ Future<void> _validateRecordingPlayback(
   expect(controller.mediaErrorMessage, isNull);
   expect(controller.isRecordingAudioPlaying(audioAssetId), isTrue);
   await controller.stopPracticeAudio();
+}
+
+void _expectScoredPracticeReport(EvaluationReport? report) {
+  expect(report, isNotNull);
+  final value = report!;
+  expect(value.scoreability, EvaluationReportScoreability.provisional);
+  expect(
+    value.questions.where((question) => question.answer != null),
+    hasLength(3),
+  );
+  expect(
+    value.dimensions.map((dimension) => dimension.key).toList(growable: false),
+    const [
+      'TASK_ACHIEVEMENT',
+      'CLARITY_COHERENCE',
+      'LANGUAGE_CONTROL',
+      'INTERACTION',
+    ],
+  );
+  expect(
+    value.dimensions.every((dimension) => dimension.score != null),
+    isTrue,
+  );
+  expect(
+    value.dimensions.every(
+      (dimension) =>
+          dimension.coverage >= 0 &&
+          dimension.coverage <= 1 &&
+          dimension.confidence >= 0 &&
+          dimension.confidence <= 1,
+    ),
+    isTrue,
+  );
 }
 
 Future<void> _waitForPersistedSessionReview(
@@ -1129,13 +1374,14 @@ Future<void> _waitForPersistedSessionReview(
   fail('Timed out waiting for persisted Review for $practiceSessionId.');
 }
 
-void _failOnPracticeError(WidgetTester tester, String operation) {
-  final error = find.byKey(const Key('practice-error-message'));
-  if (error.evaluate().isEmpty) {
-    return;
+void _failOnPracticeControllerError(
+  PracticeController controller,
+  String operation,
+) {
+  final error = controller.errorMessage ?? controller.mediaErrorMessage;
+  if (error != null && error.isNotEmpty) {
+    fail('Failed to $operation: $error');
   }
-  final message = tester.widget<Text>(error).data ?? 'Unknown practice error';
-  fail('Failed to $operation: $message');
 }
 
 Future<bool> _signedInAccountMatches(

--- a/mobile/integration_test/real_agent_e2e_test.dart
+++ b/mobile/integration_test/real_agent_e2e_test.dart
@@ -10,6 +10,7 @@ import 'package:speakup/features/agent/client_action/agent_client_action.dart';
 import 'package:speakup/features/agent/conversation/agent_models.dart';
 import 'package:speakup/features/agent/conversation/conversation_controller.dart';
 import 'package:speakup/features/coaching/evaluation/evaluation_report.dart';
+import 'package:speakup/features/coaching/practice/practice_audio_player.dart';
 import 'package:speakup/features/coaching/practice/practice_controller.dart';
 import 'package:speakup/features/coaching/practice/practice_client_error.dart';
 import 'package:speakup/features/coaching/practice/practice_models.dart';
@@ -27,27 +28,62 @@ void main() {
   testWidgets('real iOS identity, Qianwen Agent, voice, and Review path', (
     tester,
   ) async {
-    const email = String.fromEnvironment('SPEAKUP_E2E_EMAIL');
-    const password = String.fromEnvironment('SPEAKUP_E2E_PASSWORD');
+    final email =
+        'voice-report-${DateTime.now().microsecondsSinceEpoch}@example.com';
+    const password = 'Voice report e2e password 8142';
     const apiBaseUrl = String.fromEnvironment(
       'SPEAKUP_API_BASE_URL',
       defaultValue: 'http://127.0.0.1:8080',
     );
-    const voiceWavBase64 = String.fromEnvironment('SPEAKUP_E2E_WAV_BASE64');
+    const voiceWavBase64 = <String>[
+      String.fromEnvironment('SPEAKUP_E2E_WAV_BASE64'),
+      String.fromEnvironment('SPEAKUP_E2E_WAV_BASE64_2'),
+      String.fromEnvironment('SPEAKUP_E2E_WAV_BASE64_3'),
+      String.fromEnvironment('SPEAKUP_E2E_WAV_BASE64_4'),
+    ];
     const captureHoldMs = int.fromEnvironment('SPEAKUP_E2E_CAPTURE_HOLD_MS');
     const validateAudioMedia = bool.fromEnvironment(
       'SPEAKUP_E2E_VALIDATE_AUDIO_MEDIA',
     );
-    if (email.isEmpty || password.runes.length < 8) {
-      fail('A disposable E2E account with a valid password is required.');
+    final voiceFixtures = <List<int>>[
+      for (var index = 0; index < voiceWavBase64.length; index++)
+        _decodeVoiceFixture(
+          voiceWavBase64[index],
+          variableName: index == 0
+              ? 'SPEAKUP_E2E_WAV_BASE64'
+              : 'SPEAKUP_E2E_WAV_BASE64_${index + 1}',
+        ),
+    ];
+    if ({for (final fixture in voiceFixtures) base64Encode(fixture)}.length !=
+        voiceFixtures.length) {
+      fail('The four voice E2E WAV fixtures must contain distinct speech.');
     }
-    final voiceFixture = _decodeVoiceFixture(voiceWavBase64);
+    final practiceRecorder = _FixturePracticeRecorder(voiceFixtures);
+    final practiceAudioPlayer = _ObservedPracticeAudioPlayer();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
 
     final dependencies = app.createProductionAppDependencies(
       baseUri: Uri.parse(apiBaseUrl),
-      practiceRecorder: _FixturePracticeRecorder(voiceFixture),
+      practiceRecorder: practiceRecorder,
+      practiceAudioPlayer: practiceAudioPlayer,
       sessionStore: _MemorySessionStore(),
     );
+    final deletedAudioAssetIds = <String>{};
+    addTearDown(() async {
+      final remainingAudioAssetIds = <String>{
+        for (final recording in dependencies.practiceController.recordings)
+          if (!deletedAudioAssetIds.contains(recording.audioAssetId))
+            recording.audioAssetId,
+      };
+      if (remainingAudioAssetIds.isNotEmpty) {
+        await _deleteTestRecordings(
+          dependencies.practiceController,
+          remainingAudioAssetIds.toList(growable: false),
+        );
+      }
+      await practiceRecorder.clearAccountState();
+      await practiceAudioPlayer.dispose();
+    });
     runApp(
       SpeakUpApp(
         authController: dependencies.authController,
@@ -124,6 +160,7 @@ void main() {
     final audioAssetIds = await _completeRealVoicePractice(
       tester,
       controller: dependencies.practiceController,
+      practiceAudioPlayer: practiceAudioPlayer,
       validateAudioMedia: validateAudioMedia,
     );
     final completedSessionId =
@@ -141,13 +178,10 @@ void main() {
     );
     _expectScoredPracticeReport(
       dependencies.sessionEvaluationController.evaluation?.report,
+      expectedAnsweredQuestions: 4,
     );
-    if (validateAudioMedia) {
-      await _deleteTestRecordings(
-        dependencies.practiceController,
-        audioAssetIds,
-      );
-    }
+    await _deleteTestRecordings(dependencies.practiceController, audioAssetIds);
+    deletedAudioAssetIds.addAll(audioAssetIds);
     await dependencies.reviewHistoryController.refresh();
     Navigator.of(
       tester.element(find.byKey(const Key('scenario-practice-page'))),
@@ -204,18 +238,16 @@ void main() {
   testWidgets('real iOS three practice hubs stay focused and reachable', (
     tester,
   ) async {
-    const email = String.fromEnvironment('SPEAKUP_E2E_EMAIL');
-    const password = String.fromEnvironment('SPEAKUP_E2E_PASSWORD');
+    final email =
+        'practice-hubs-${DateTime.now().microsecondsSinceEpoch}@example.com';
+    const password = 'Practice hubs e2e password 526';
     const apiBaseUrl = String.fromEnvironment(
       'SPEAKUP_API_BASE_URL',
       defaultValue: 'http://127.0.0.1:8080',
     );
-    if (email.isEmpty || password.runes.length < 8) {
-      fail('A disposable E2E account with a valid password is required.');
-    }
-
     final dependencies = app.createProductionAppDependencies(
       baseUri: Uri.parse(apiBaseUrl),
+      sessionStore: _MemorySessionStore(),
     );
     runApp(
       SpeakUpApp(
@@ -342,6 +374,7 @@ void main() {
         jobPreparationController: dependencies.jobPreparationController,
         preparationLaunchController: dependencies.preparationLaunchController,
         reviewHistoryController: dependencies.reviewHistoryController,
+        sessionEvaluationController: dependencies.sessionEvaluationController,
       ),
     );
 
@@ -495,6 +528,56 @@ void main() {
     expect(
       dependencies.practiceController.practiceSessionId,
       isNot(firstSessionId),
+    );
+    final secondSessionId = dependencies.practiceController.practiceSessionId!;
+    const answers = <String>[
+      'I prefer happy music because its energetic rhythm improves my mood '
+          'and helps me feel optimistic after a demanding day.',
+      'Yes, happy music usually makes me feel more excited, especially when '
+          'I listen to an upbeat song before exercising or meeting friends.',
+      'I took piano classes for two years at primary school, which taught me '
+          'basic rhythm and helped me appreciate how songs are composed.',
+      'I often listen to quiet instrumental music while reading or doing '
+          'routine work, but I turn it off when a task requires deep '
+          'concentration.',
+    ];
+    await _completeIeltsPart1TextPractice(
+      tester,
+      controller: dependencies.practiceController,
+      answers: answers,
+    );
+    expect(dependencies.practiceController.practiceSessionId, secondSessionId);
+    expect(dependencies.practiceController.hasActivePractice, isFalse);
+    expect(
+      find.byKey(const Key('ielts-section-completion-sheet')),
+      findsOneWidget,
+    );
+    await _tapPracticeControl(tester, const Key('ielts-section-review-action'));
+    await _waitUntil(
+      tester,
+      () =>
+          find
+              .byKey(const Key('evaluation-report-detail-page'))
+              .evaluate()
+              .isNotEmpty ||
+          dependencies.sessionEvaluationController.evaluation?.status ==
+              SessionEvaluationStatus.failed ||
+          dependencies.sessionEvaluationController.errorMessage != null,
+      const Duration(minutes: 5),
+    );
+    expect(
+      find.byKey(const Key('evaluation-report-detail-page')),
+      findsOneWidget,
+      reason: dependencies.sessionEvaluationController.errorMessage,
+    );
+    expect(
+      dependencies.sessionEvaluationController.evaluation?.status,
+      SessionEvaluationStatus.ready,
+      reason: dependencies.sessionEvaluationController.errorMessage,
+    );
+    _expectScoredIeltsPart1Report(
+      dependencies.sessionEvaluationController.evaluation?.report,
+      expectedAnswers: answers,
     );
   });
 
@@ -655,6 +738,7 @@ void main() {
     );
     _expectScoredPracticeReport(
       dependencies.sessionEvaluationController.evaluation?.report,
+      expectedAnsweredQuestions: 3,
     );
   });
 
@@ -775,6 +859,12 @@ void main() {
       timeout: const Duration(seconds: 90),
     );
     expect(dependencies.practiceController.practiceSessionId, isNotNull);
+    expect(
+      await dependencies.practiceController.endActivePracticeEarly(),
+      isTrue,
+      reason: dependencies.practiceController.errorMessage,
+    );
+    expect(dependencies.practiceController.hasActivePractice, isFalse);
   });
 }
 
@@ -969,6 +1059,7 @@ Future<void> _tapPrimaryTab(WidgetTester tester, int index) async {
 Future<List<String>> _completeRealVoicePractice(
   WidgetTester tester, {
   required PracticeController controller,
+  required _ObservedPracticeAudioPlayer practiceAudioPlayer,
   required bool validateAudioMedia,
 }) async {
   FocusManager.instance.primaryFocus?.unfocus();
@@ -1005,7 +1096,7 @@ Future<List<String>> _completeRealVoicePractice(
   );
   await tester.pumpAndSettle();
 
-  for (var turn = 1; turn <= 3; turn++) {
+  for (var turn = 1; turn <= 4; turn++) {
     final questionId = controller.questionId;
     expect(questionId, isNotNull);
     if (validateAudioMedia) {
@@ -1047,6 +1138,7 @@ Future<List<String>> _completeRealVoicePractice(
       await _validateRecordingPlayback(
         controller,
         controller.recordings.last.audioAssetId,
+        practiceAudioPlayer,
       );
     }
   }
@@ -1076,8 +1168,8 @@ Future<List<String>> _completeRealVoicePractice(
     for (final recording in controller.recordings) recording.audioAssetId,
   ];
   if (validateAudioMedia) {
-    expect(audioAssetIds, hasLength(3));
-    expect(audioAssetIds.toSet(), hasLength(3));
+    expect(audioAssetIds, hasLength(4));
+    expect(audioAssetIds.toSet(), hasLength(4));
   }
   return audioAssetIds;
 }
@@ -1140,6 +1232,55 @@ Future<void> _completeTextPractice(
     'complete the Agent-created hotel Practice Session',
   );
   expect(find.byKey(const Key('scenario-completion-overlay')), findsOneWidget);
+}
+
+Future<void> _completeIeltsPart1TextPractice(
+  WidgetTester tester, {
+  required PracticeController controller,
+  required List<String> answers,
+}) async {
+  expect(answers, hasLength(4));
+  expect(answers.toSet(), hasLength(4));
+  for (var index = 0; index < answers.length; index++) {
+    final questionId = controller.questionId;
+    expect(questionId, isNotNull);
+    await _tapPracticeControl(tester, const Key('ielts-mock-open-keyboard'));
+    await _waitForPreparationTarget(
+      tester,
+      target: find.byKey(const Key('ielts-mock-converted-answer-field')),
+      operation: 'open IELTS Part 1 text answer ${index + 1}',
+      timeout: const Duration(seconds: 10),
+    );
+    await tester.enterText(
+      find.byKey(const Key('ielts-mock-converted-answer-field')),
+      answers[index],
+    );
+    await _tapPracticeControl(
+      tester,
+      const Key('ielts-mock-submit-converted-answer'),
+    );
+    await _waitUntil(
+      tester,
+      () =>
+          controller.completedTurns >= index + 1 ||
+          controller.errorMessage != null,
+      const Duration(seconds: 90),
+    );
+    _failOnPracticeControllerError(
+      controller,
+      'submit IELTS Part 1 text answer ${index + 1}',
+    );
+    expect(controller.completedTurns, index + 1);
+    if (index < answers.length - 1) {
+      expect(controller.questionId, isNot(questionId));
+    }
+  }
+  await _waitForPreparationTarget(
+    tester,
+    target: find.byKey(const Key('ielts-section-completion-sheet')),
+    operation: 'show the completed IELTS Part 1 review action',
+    timeout: const Duration(seconds: 20),
+  );
 }
 
 Future<void> _deleteTestRecordings(
@@ -1308,22 +1449,42 @@ Future<void> _validateQuestionTts(PracticeController controller) async {
 Future<void> _validateRecordingPlayback(
   PracticeController controller,
   String audioAssetId,
+  _ObservedPracticeAudioPlayer practiceAudioPlayer,
 ) async {
+  final previousPlaybackCount = practiceAudioPlayer.successfulPlaybackCount;
   expect(audioAssetId, isNotEmpty);
+  await controller.stopPracticeAudio();
+  WidgetsBinding.instance.handleAppLifecycleStateChanged(
+    AppLifecycleState.resumed,
+  );
   await controller.toggleRecordingAudio(audioAssetId);
   expect(controller.isRecordingAudioLoading(audioAssetId), isFalse);
   expect(controller.mediaErrorMessage, isNull);
   expect(controller.isRecordingAudioPlaying(audioAssetId), isTrue);
+  expect(
+    practiceAudioPlayer.successfulPlaybackCount,
+    previousPlaybackCount + 1,
+  );
   await controller.stopPracticeAudio();
 }
 
-void _expectScoredPracticeReport(EvaluationReport? report) {
+void _expectScoredPracticeReport(
+  EvaluationReport? report, {
+  required int expectedAnsweredQuestions,
+}) {
   expect(report, isNotNull);
   final value = report!;
   expect(value.scoreability, EvaluationReportScoreability.provisional);
+  expect(value.summary.trim(), isNotEmpty);
   expect(
     value.questions.where((question) => question.answer != null),
-    hasLength(3),
+    hasLength(expectedAnsweredQuestions),
+  );
+  expect(
+    value.questions.every(
+      (question) => question.answer?.transcript.trim().isNotEmpty ?? false,
+    ),
+    isTrue,
   );
   expect(
     value.dimensions.map((dimension) => dimension.key).toList(growable: false),
@@ -1335,7 +1496,12 @@ void _expectScoredPracticeReport(EvaluationReport? report) {
     ],
   );
   expect(
-    value.dimensions.every((dimension) => dimension.score != null),
+    value.dimensions.every(
+      (dimension) =>
+          dimension.score != null &&
+          dimension.score! >= 0 &&
+          dimension.score! <= 100,
+    ),
     isTrue,
   );
   expect(
@@ -1348,6 +1514,64 @@ void _expectScoredPracticeReport(EvaluationReport? report) {
     ),
     isTrue,
   );
+  final findings = <EvaluationReportFinding>[
+    for (final dimension in value.dimensions) ...[
+      ...dimension.strengths,
+      ...dimension.improvements,
+      ...dimension.recommendedExamples,
+    ],
+  ];
+  expect(
+    findings.any(
+      (finding) =>
+          finding.message.trim().isNotEmpty &&
+          finding.evidence.isNotEmpty &&
+          finding.evidence.every(
+            (evidence) =>
+                evidence.originalExcerpt.trim().isNotEmpty &&
+                evidence.startUtf8Byte >= 0 &&
+                evidence.endUtf8Byte > evidence.startUtf8Byte,
+          ),
+    ),
+    isTrue,
+  );
+}
+
+void _expectScoredIeltsPart1Report(
+  EvaluationReport? report, {
+  required List<String> expectedAnswers,
+}) {
+  expect(report, isNotNull);
+  final value = report!;
+  expect(value.sceneType, EvaluationReportSceneType.ieltsSpeaking);
+  expect(value.scoreability, EvaluationReportScoreability.provisional);
+  expect(value.summary.trim(), isNotEmpty);
+  expect(
+    value.questions.map((question) => question.answer?.transcript).toList(),
+    expectedAnswers,
+  );
+  expect(value.dimensions.map((dimension) => dimension.key).toList(), const [
+    'FLUENCY_COHERENCE',
+    'LEXICAL_RESOURCE',
+    'GRAMMATICAL_RANGE_ACCURACY',
+    'PRONUNCIATION',
+  ]);
+  for (final dimension in value.dimensions) {
+    expect(dimension.scale, EvaluationReportScoreScale.ieltsBand);
+    expect(dimension.coverage, inInclusiveRange(0, 1));
+    expect(dimension.confidence, inInclusiveRange(0, 1));
+    if (dimension.key == 'PRONUNCIATION') {
+      expect(dimension.score, isNull);
+      expect(
+        dimension.reasonCodes,
+        contains('ACOUSTIC_ASSESSMENT_NOT_CONFIGURED'),
+      );
+      continue;
+    }
+    expect(dimension.score, isNotNull);
+    expect(dimension.score!, inInclusiveRange(0, 9));
+    expect(dimension.score! * 2, (dimension.score! * 2).roundToDouble());
+  }
 }
 
 Future<void> _waitForPersistedSessionReview(
@@ -1469,10 +1693,10 @@ Future<void> _waitUntil(
   }
 }
 
-List<int> _decodeVoiceFixture(String encoded) {
+List<int> _decodeVoiceFixture(String encoded, {required String variableName}) {
   if (encoded.isEmpty) {
     fail(
-      'SPEAKUP_E2E_WAV_BASE64 must contain a private spoken-English WAV '
+      '$variableName must contain a private spoken-English WAV '
       'fixture supplied at test time.',
     );
   }
@@ -1480,12 +1704,12 @@ List<int> _decodeVoiceFixture(String encoded) {
   try {
     bytes = base64Decode(encoded);
   } on FormatException {
-    fail('SPEAKUP_E2E_WAV_BASE64 is not valid Base64.');
+    fail('$variableName is not valid Base64.');
   }
   if (bytes.length <= 44 ||
       ascii.decode(bytes.sublist(0, 4), allowInvalid: true) != 'RIFF' ||
       ascii.decode(bytes.sublist(8, 12), allowInvalid: true) != 'WAVE') {
-    fail('SPEAKUP_E2E_WAV_BASE64 must decode to a non-empty WAV file.');
+    fail('$variableName must decode to a non-empty WAV file.');
   }
   return bytes;
 }
@@ -1504,12 +1728,12 @@ final class _MemorySessionStore implements SessionStore {
 }
 
 final class _FixturePracticeRecorder implements PracticeRecorder {
-  _FixturePracticeRecorder(this._bytes);
+  _FixturePracticeRecorder(this._fixtures);
 
-  final List<int> _bytes;
+  final List<List<int>> _fixtures;
   File? _currentFile;
   bool _recording = false;
-  int _sequence = 0;
+  int _nextFixture = 0;
 
   @override
   Future<void> start() async {
@@ -1529,9 +1753,15 @@ final class _FixturePracticeRecorder implements PracticeRecorder {
       );
     }
     _recording = false;
+    if (_nextFixture >= _fixtures.length) {
+      throw const PracticeRecordingException(
+        PracticeRecordingFailureKind.unavailable,
+      );
+    }
     final directory = await getTemporaryDirectory();
-    final file = File('${directory.path}/speakup-real-e2e-${++_sequence}.wav');
-    await file.writeAsBytes(_bytes, flush: true);
+    final sequence = ++_nextFixture;
+    final file = File('${directory.path}/speakup-real-e2e-$sequence.wav');
+    await file.writeAsBytes(_fixtures[sequence - 1], flush: true);
     _currentFile = file;
     return RecordedPracticeAudio(
       path: file.path,
@@ -1563,4 +1793,30 @@ final class _FixturePracticeRecorder implements PracticeRecorder {
 
   @override
   Future<void> clearAccountState() => discardCurrent();
+}
+
+final class _ObservedPracticeAudioPlayer implements PracticeAudioPlayer {
+  _ObservedPracticeAudioPlayer()
+    : _delegate = AudioplayersPracticeAudioPlayer();
+
+  final PracticeAudioPlayer _delegate;
+  int successfulPlaybackCount = 0;
+
+  @override
+  Stream<void> get onComplete => _delegate.onComplete;
+
+  @override
+  Future<void> playWav(Uint8List bytes) async {
+    await _delegate.playWav(bytes);
+    successfulPlaybackCount++;
+  }
+
+  @override
+  Future<void> stop() => _delegate.stop();
+
+  @override
+  Future<void> clearAccountState() => _delegate.clearAccountState();
+
+  @override
+  Future<void> dispose() => _delegate.dispose();
 }

--- a/server/internal/agent/capability/schema_helpers.go
+++ b/server/internal/agent/capability/schema_helpers.go
@@ -39,6 +39,17 @@ func TextSchema(description string, maximumLength int) map[string]any {
 	}
 }
 
+// OptionalTextSchema allows an omitted field or an empty string while still
+// bounding non-empty content. Domain parsers remain responsible for trimming
+// and any field-specific semantic validation.
+func OptionalTextSchema(description string, maximumLength int) map[string]any {
+	return map[string]any{
+		"type":        "string",
+		"description": description,
+		"maxLength":   maximumLength,
+	}
+}
+
 // IdentifierSchema 构造 Agent 领域 ID Schema，允许字母、数字和常用分隔符。
 func IdentifierSchema(description string) map[string]any {
 	return map[string]any{

--- a/server/internal/agent/capability/schema_test.go
+++ b/server/internal/agent/capability/schema_test.go
@@ -158,3 +158,24 @@ func TestTextSchemaCountsUnicodeCharacters(t *testing.T) {
 		t.Fatalf("long text error = %v, want %v", err, ErrInvalidInput)
 	}
 }
+
+func TestOptionalTextSchemaAcceptsOmittedAndEmptyValues(t *testing.T) {
+	schema := ObjectSchema(map[string]any{
+		"query": OptionalTextSchema("Optional query.", 4),
+	}, nil)
+	for _, input := range []json.RawMessage{
+		json.RawMessage(`{}`),
+		json.RawMessage(`{"query":""}`),
+		json.RawMessage(`{"query":"text"}`),
+	} {
+		if _, err := NormalizeInput(schema, input); err != nil {
+			t.Fatalf("NormalizeInput(%s) error = %v", input, err)
+		}
+	}
+	if _, err := NormalizeInput(
+		schema,
+		json.RawMessage(`{"query":"longer"}`),
+	); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("long optional text error = %v, want %v", err, ErrInvalidInput)
+	}
+}

--- a/server/internal/agent/conversation/summary/service_live_test.go
+++ b/server/internal/agent/conversation/summary/service_live_test.go
@@ -23,6 +23,7 @@ func TestLiveSummaryGeneration(t *testing.T) {
 		t.Fatal(err)
 	}
 	generator, err := qianwen.NewSummaryGenerator(qianwen.TextConfig{
+		Provider:        configuration.Provider,
 		BaseURL:         configuration.BaseURL,
 		Model:           configuration.Model,
 		Timeout:         configuration.Timeout,

--- a/server/internal/coaching/preparation/agentcapability/preview.go
+++ b/server/internal/coaching/preparation/agentcapability/preview.go
@@ -322,6 +322,7 @@ func (value PreviewTool) Definition() capability.Definition {
 			"For an IELTS Catalog scene, FULL_MOCK means a complete/full/完整模考 request and requires no topic choice. Use PART_1, PART_2, or PART_3 only when the current message explicitly names that Part; never infer a specialty Part from a general IELTS request. A specialty Part requires its topic choice. " +
 			"All five discriminator fields are required; non-applicable fields must use [], \"\", or NONE exactly. Structural examples: " +
 			`CATALOG={"resolution_kind":"CATALOG","catalog_scene_ids":["<one manifest scene id>"],"custom_scenario":"","custom_experience_hint":"NONE"}; ` +
+			`NEEDS_CLARIFICATION={"resolution_kind":"NEEDS_CLARIFICATION","catalog_scene_ids":["<one to three manifest scene ids>"],"custom_scenario":"","custom_experience_hint":"NONE"}; omit background_summary, IELTS fields, and role fields for this branch. ` +
 			`PENDING_REPLY={"resolution_kind":"NONE","catalog_scene_ids":[],"custom_scenario":"","custom_experience_hint":"NONE"}. ` +
 			"A successful tool result completes this turn; never call the tool repeatedly in the same turn.\n\nTrusted Catalog manifest:\n" +
 			formatPreviewCatalogManifest(value.manifest),
@@ -338,20 +339,20 @@ func (value PreviewTool) Definition() capability.Definition {
 				noCustomExperienceHint,
 				"WORKPLACE", "LIFE_AND_TRAVEL", "INTERVIEW", "IELTS_SPEAKING",
 			),
-			"user_role": capability.TextSchema(
-				"Optional user-authored learner role for CUSTOM only.",
+			"user_role": capability.OptionalTextSchema(
+				"Optional user-authored learner role for CUSTOM only. Omit it or use an empty string when it does not apply.",
 				200,
 			),
-			"ai_role": capability.TextSchema(
-				"Optional user-authored counterpart role for CUSTOM only.",
+			"ai_role": capability.OptionalTextSchema(
+				"Optional user-authored counterpart role for CUSTOM only. Omit it or use an empty string when it does not apply.",
 				200,
 			),
-			"practice_goal": capability.TextSchema(
-				"Optional user-authored practice goal for CUSTOM only.",
+			"practice_goal": capability.OptionalTextSchema(
+				"Optional user-authored practice goal for CUSTOM only. Omit it or use an empty string when it does not apply.",
 				500,
 			),
-			"background_summary": capability.TextSchema(
-				"Concise user-authored preparation facts, including target, experience, constraints, and focus.",
+			"background_summary": capability.OptionalTextSchema(
+				"Optional concise user-authored preparation facts. Omit it or use an empty string when there are no facts to preserve.",
 				6000,
 			),
 			"ielts_practice_mode": capability.StringEnumSchema(
@@ -441,10 +442,30 @@ func parseUnifiedPreviewToolInput(
 	if !hasRequiredUnifiedPreviewFields(input) {
 		return UnifiedPreviewToolInput{}, previewInputError{code: "required_fields"}
 	}
+	parsed = canonicalPreviewToolInput(parsed)
 	if code := invalidUnifiedPreviewToolInput(parsed); code != "" {
 		return UnifiedPreviewToolInput{}, previewInputError{code: code}
 	}
 	return parsed, nil
+}
+
+// canonicalPreviewToolInput discards contextual fields on the read-only
+// clarification branch. Those fields cannot influence candidate selection or
+// create a plan, and tool-calling models commonly repeat conversation context
+// there even though the branch contract asks them to omit it.
+func canonicalPreviewToolInput(
+	input UnifiedPreviewToolInput,
+) UnifiedPreviewToolInput {
+	if input.ResolutionKind != SceneResolutionKindNeedsClarification {
+		return input
+	}
+	input.UserRole = ""
+	input.AIRole = ""
+	input.PracticeGoal = ""
+	input.BackgroundSummary = ""
+	input.IELTSPracticeMode = ""
+	input.IELTSTopicChoice = ""
+	return input
 }
 
 func hasRequiredUnifiedPreviewFields(input json.RawMessage) bool {

--- a/server/internal/coaching/preparation/agentcapability/preview_test.go
+++ b/server/internal/coaching/preparation/agentcapability/preview_test.go
@@ -246,6 +246,47 @@ func TestParsePreviewToolInputsAcceptRequiredShapes(t *testing.T) {
 	}
 }
 
+func TestPreviewToolSchemaAcceptsEmptyOptionalText(t *testing.T) {
+	tool := newTestPreviewTool(t)
+	raw := json.RawMessage(`{
+  "resolution_kind":"NEEDS_CLARIFICATION",
+  "catalog_scene_ids":["scn_ielts_speaking"],
+  "custom_scenario":"",
+  "custom_experience_hint":"NONE",
+  "user_role":"",
+  "ai_role":"",
+  "practice_goal":"",
+  "background_summary":""
+}`)
+	normalized, err := capability.NormalizeInput(tool.Definition().InputSchema, raw)
+	if err != nil {
+		t.Fatalf("NormalizeInput() error = %v", err)
+	}
+	parsed, err := parseUnifiedPreviewToolInput(normalized)
+	if err != nil || !validPreviewInputShape(parsed.previewInput()) {
+		t.Fatalf("parseUnifiedPreviewToolInput() = %#v, %v", parsed, err)
+	}
+}
+
+func TestParsePreviewToolInputCanonicalizesClarificationContext(t *testing.T) {
+	parsed, err := parseUnifiedPreviewToolInput(json.RawMessage(`{
+  "resolution_kind":"NEEDS_CLARIFICATION",
+  "catalog_scene_ids":["scn_ielts_speaking"],
+  "custom_scenario":"",
+  "custom_experience_hint":"NONE",
+  "user_role":"",
+  "background_summary":"User wants to practise IELTS Speaking.",
+  "ielts_practice_mode":"PART_1"
+}`))
+	if err != nil {
+		t.Fatalf("parseUnifiedPreviewToolInput() error = %v", err)
+	}
+	if parsed.BackgroundSummary != "" || parsed.IELTSPracticeMode != "" ||
+		parsed.UserRole != "" || !validPreviewInputShape(parsed.previewInput()) {
+		t.Fatalf("clarification input was not canonicalized: %#v", parsed)
+	}
+}
+
 func TestParsePreviewToolInputRejectsInconsistentSelection(t *testing.T) {
 	inputs := map[string]string{
 		"missing required":            `{"scene_query":"酒店入住","resolution_kind":"CATALOG","catalog_scene_ids":["scene_a"]}`,

--- a/server/internal/coaching/review/agentcapability/review.go
+++ b/server/internal/coaching/review/agentcapability/review.go
@@ -102,7 +102,7 @@ func (tool ReviewSearchTool) Definition() capability.Definition {
 			"asked from or exposed to the user. Do not use it for current-turn " +
 			"speech feedback or scenario discovery.",
 		InputSchema: capability.ObjectSchema(map[string]any{
-			"query": capability.TextSchema(
+			"query": capability.OptionalTextSchema(
 				"Optional words describing an older practice report.",
 				500,
 			),

--- a/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
+++ b/server/internal/coaching/review/postgres/custom_scene_lifecycle_integration_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/1024XEngineer/XE3-ESL/server/internal/agent/capability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation"
 	evaluationpostgres "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/postgres"
+	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/report"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/sessionevaluation"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/speechfeedback"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/evaluation/textgeneration"
@@ -21,6 +23,7 @@ import (
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation"
 	preparationpostgres "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/repository/postgres"
 	preparationservice "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/preparation/service"
+	reviewagentcapability "github.com/1024XEngineer/XE3-ESL/server/internal/coaching/review/agentcapability"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/coaching/scene"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/identity"
 	"github.com/1024XEngineer/XE3-ESL/server/internal/platform/requestcontext"
@@ -200,6 +203,42 @@ INSERT INTO agent_threads (id,user_id) VALUES ($2,$1)
 		formal.PracticeSessionID != customLifecycleSessionID ||
 		formal.Report.SceneCategory != string(scene.SceneCategoryWorkplaceGeneral) {
 		t.Fatalf("read Custom formal Report = %#v, %v", formal, err)
+	}
+	history, err := evaluationStore.ListFormalReports(
+		ctx,
+		customLifecycleUserID,
+		report.HistoryQuery{Limit: 20},
+	)
+	if err != nil || history.HasMore || len(history.Items) != 1 ||
+		history.Items[0].ReportID != formal.ReportID ||
+		history.Items[0].PracticeSessionID != customLifecycleSessionID {
+		t.Fatalf("list Custom formal Reports = %#v, %v", history, err)
+	}
+	reviewPort, err := reviewagentcapability.NewServicePort(evaluationStore)
+	if err != nil {
+		t.Fatalf("compose Review Agent capability: %v", err)
+	}
+	call := capability.CallContext{Actor: actor}
+	summaries, err := reviewPort.SearchReviews(
+		ctx,
+		call,
+		reviewagentcapability.ReviewSearchInput{},
+	)
+	if err != nil || len(summaries) != 1 ||
+		summaries[0].ID != formal.ReportID ||
+		summaries[0].PracticeSessionID != customLifecycleSessionID {
+		t.Fatalf("search Custom formal Reports = %#v, %v", summaries, err)
+	}
+	detail, err := reviewPort.GetReview(
+		ctx,
+		call,
+		reviewagentcapability.ReviewGetInput{ReportID: formal.ReportID},
+	)
+	if err != nil || detail.ID != formal.ReportID ||
+		detail.PracticeSessionID != customLifecycleSessionID ||
+		detail.Summary != formal.Report.Summary ||
+		len(detail.Dimensions) != len(formal.Report.Dimensions) {
+		t.Fatalf("get Custom formal Report through Agent = %#v, %v", detail, err)
 	}
 	feedback := createCustomLifecycleFeedback(t, evaluationStore)
 	retryService, err := New(pool, evaluationStore, practiceRepository)

--- a/server/internal/providers/qianwen/live_test.go
+++ b/server/internal/providers/qianwen/live_test.go
@@ -2,6 +2,7 @@ package qianwen
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -10,26 +11,8 @@ import (
 )
 
 func TestLiveTextGeneration(t *testing.T) {
-	if os.Getenv("QIANWEN_LIVE_TEST") != "1" {
-		t.Skip(
-			"set QIANWEN_LIVE_TEST=1 and the Qianwen environment variables " +
-				"to run; the real request may incur charges",
-		)
-	}
-
-	cfg, err := platformconfig.LoadTextGeneration()
-	if err != nil {
-		t.Fatalf("load text generation config: %v", err)
-	}
-	generator, err := newTextClient(TextConfig{
-		BaseURL:         cfg.BaseURL,
-		Model:           cfg.Model,
-		Timeout:         cfg.Timeout,
-		MaxOutputTokens: cfg.MaxOutputTokens,
-	}, cfg.APIKey.Reveal())
-	if err != nil {
-		t.Fatalf("create Qianwen generator: %v", err)
-	}
+	cfg := liveTextConfiguration(t)
+	generator := liveTextGenerator(t, cfg, cfg.Model)
 
 	result, err := generator.Generate(context.Background(), protocol.TextRequest{
 		Messages: []protocol.TextMessage{{
@@ -43,4 +26,130 @@ func TestLiveTextGeneration(t *testing.T) {
 	if result.Content == "" {
 		t.Fatal("live Qianwen generation returned empty content")
 	}
+}
+
+func TestLiveTextToolRoundTrip(t *testing.T) {
+	cfg := liveTextConfiguration(t)
+	generator := liveTextGenerator(t, cfg, cfg.Model)
+	tool := protocol.ToolDefinition{
+		Name:        "practice.preview.v3",
+		Description: "Create a practice preview.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title": map[string]any{
+					"type": "string", "format": "non-empty-text", "minLength": 1,
+				},
+			},
+			"required":             []any{"title"},
+			"additionalProperties": false,
+		},
+	}
+	user := protocol.TextMessage{
+		Role:    protocol.TextRoleUser,
+		Content: "Create an IELTS speaking practice scene about travel.",
+	}
+	first, err := generator.Generate(context.Background(), protocol.TextRequest{
+		Messages: []protocol.TextMessage{user},
+		Tools:    []protocol.ToolDefinition{tool},
+		ToolChoice: protocol.ToolChoice{
+			Mode: protocol.ToolChoiceSpecific,
+			Name: tool.Name,
+		},
+	})
+	if err != nil {
+		t.Fatalf("live tool selection failed: %v", err)
+	}
+	if len(first.ToolCalls) != 1 || first.ToolCalls[0].Name != tool.Name {
+		t.Fatalf("live tool selection = %#v", first)
+	}
+	second, err := generator.Generate(context.Background(), protocol.TextRequest{
+		Messages: []protocol.TextMessage{
+			user,
+			{Role: protocol.TextRoleAssistant, ToolCalls: first.ToolCalls},
+			{
+				Role: protocol.TextRoleTool, ToolCallID: first.ToolCalls[0].ID,
+				Content: `{"scene_id":"scene-live","status":"ready"}`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live tool result continuation failed: %v", err)
+	}
+	if second.Content == "" {
+		t.Fatal("live tool result continuation returned empty content")
+	}
+}
+
+func TestLiveStrictJSONSchemaGeneration(t *testing.T) {
+	cfg := liveTextConfiguration(t)
+	generator := liveTextGenerator(t, cfg, cfg.EvaluationModel)
+	result, err := generator.Generate(context.Background(), protocol.TextRequest{
+		Messages: []protocol.TextMessage{{
+			Role: protocol.TextRoleUser,
+			Content: "Return a score from 0 to 9 and a short summary for: " +
+				"I enjoy learning English through conversation.",
+		}},
+		ResponseFormat: protocol.TextResponseFormatJSONSchema,
+		ResponseSchema: &protocol.JSONSchemaDefinition{
+			Name:   "live_evaluation",
+			Strict: true,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"score": map[string]any{
+						"type": "number", "minimum": 0, "maximum": 9,
+					},
+					"summary": map[string]any{"type": "string"},
+				},
+				"required":             []any{"score", "summary"},
+				"additionalProperties": false,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live strict JSON Schema generation failed: %v", err)
+	}
+	var payload struct {
+		Score   float64 `json:"score"`
+		Summary string  `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(result.Content), &payload); err != nil ||
+		payload.Score < 0 || payload.Score > 9 || payload.Summary == "" {
+		t.Fatalf("live strict JSON payload is invalid: payload=%#v err=%v", payload, err)
+	}
+}
+
+func liveTextConfiguration(t *testing.T) platformconfig.TextGenerationConfig {
+	t.Helper()
+	if os.Getenv("QIANWEN_LIVE_TEST") != "1" {
+		t.Skip(
+			"set QIANWEN_LIVE_TEST=1 and the text provider environment variables " +
+				"to run; the real request may incur charges",
+		)
+	}
+	cfg, err := platformconfig.LoadTextGeneration()
+	if err != nil {
+		t.Fatalf("load text generation config: %v", err)
+	}
+	return cfg
+}
+
+func liveTextGenerator(
+	t *testing.T,
+	cfg platformconfig.TextGenerationConfig,
+	model string,
+) *textClient {
+	t.Helper()
+	generator, err := newTextClient(TextConfig{
+		Provider:        cfg.Provider,
+		BaseURL:         cfg.BaseURL,
+		Model:           model,
+		Timeout:         cfg.Timeout,
+		MaxOutputTokens: cfg.MaxOutputTokens,
+	}, cfg.APIKey.Reveal())
+	if err != nil {
+		t.Fatalf("create live text generator: %v", err)
+	}
+	return generator
 }

--- a/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
+++ b/server/internal/providers/qianwen/qiniu_text_compatibility_test.go
@@ -108,6 +108,61 @@ func TestQiniuGenerateMapsToolCallsAndLineage(t *testing.T) {
 	}
 }
 
+func TestQiniuToolSchemaOmitsApplicationOnlyFormats(t *testing.T) {
+	var parameters map[string]any
+	generator := mustQiniuGeneratorForModel(
+		t,
+		"qwen/qwen3.7-plus",
+		doerFunc(func(request *http.Request) (*http.Response, error) {
+			var payload chatCompletionRequest
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			parameters = payload.Tools[0].Function.Parameters
+			return jsonResponse(http.StatusOK, `{
+				"id":"chatcmpl-qiniu-tool-schema",
+				"model":"qwen/qwen3.7-plus",
+				"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"","tool_calls":[{
+					"id":"call_qiniu_1","type":"function","function":{"name":"review_search_v1","arguments":"{\"query\":\"IELTS\"}"}
+				}]}}],
+				"usage":{"prompt_tokens":9,"completion_tokens":3,"total_tokens":12}
+			}`), nil
+		}),
+		"qiniu-test-key",
+	)
+	request := toolRequest()
+	request.Tools[0].InputSchema = map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"query": map[string]any{
+				"type": "string", "format": "non-empty-text", "minLength": 1,
+			},
+			"owner_id": map[string]any{
+				"type": "string", "format": "agent-id",
+			},
+			"source": map[string]any{
+				"type": "string", "format": "uri",
+			},
+		},
+	}
+	if _, err := generator.Generate(context.Background(), request); err != nil {
+		t.Fatalf("Qiniu tool Generate() error = %v", err)
+	}
+	properties := parameters["properties"].(map[string]any)
+	if _, exists := properties["query"].(map[string]any)["format"]; exists {
+		t.Fatal("Qiniu tool schema retained application-only format")
+	}
+	if _, exists := properties["owner_id"].(map[string]any)["format"]; exists {
+		t.Fatal("Qiniu tool schema retained application-only agent ID format")
+	}
+	if properties["source"].(map[string]any)["format"] != "uri" {
+		t.Fatal("Qiniu tool schema removed a standard format")
+	}
+	if request.Tools[0].InputSchema["properties"].(map[string]any)["query"].(map[string]any)["format"] != "non-empty-text" {
+		t.Fatal("Qiniu tool schema sanitization mutated the capability contract")
+	}
+}
+
 func TestQiniuGeminiRequestOmitsKimiThinkingControl(t *testing.T) {
 	var payload map[string]json.RawMessage
 	generator := mustQiniuGeneratorForModel(

--- a/server/internal/providers/qianwen/text_generator.go
+++ b/server/internal/providers/qianwen/text_generator.go
@@ -490,16 +490,50 @@ func (generator *textClient) providerRequest(
 		payload.Messages = append(payload.Messages, providerMessage)
 	}
 	for _, definition := range request.Tools {
+		parameters := definition.InputSchema
+		if generator.provider == qiniuProviderName {
+			parameters = qiniuToolSchema(definition.InputSchema)
+		}
 		payload.Tools = append(payload.Tools, chatTool{
 			Type: "function",
 			Function: chatToolFunction{
 				Name:        internalToProvider[definition.Name],
 				Description: definition.Description,
-				Parameters:  definition.InputSchema,
+				Parameters:  parameters,
 			},
 		})
 	}
 	return payload, nil
+}
+
+// qiniuToolSchema removes application-only JSON Schema formats that Qiniu's
+// upstream rejects. The authoritative capability schema remains unchanged and
+// still validates tool arguments after generation.
+func qiniuToolSchema(schema map[string]any) map[string]any {
+	cleaned, _ := qiniuSchemaValue(schema).(map[string]any)
+	return cleaned
+}
+
+func qiniuSchemaValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		cleaned := make(map[string]any, len(typed))
+		for key, item := range typed {
+			if key == "format" && (item == "non-empty-text" || item == "agent-id") {
+				continue
+			}
+			cleaned[key] = qiniuSchemaValue(item)
+		}
+		return cleaned
+	case []any:
+		cleaned := make([]any, len(typed))
+		for index, item := range typed {
+			cleaned[index] = qiniuSchemaValue(item)
+		}
+		return cleaned
+	default:
+		return value
+	}
 }
 
 type chatCompletionRequest struct {


### PR DESCRIPTION
## 功能描述

- 修复七牛文本接口拒绝应用自定义 JSON Schema `format`，导致建卡工具稳定失败的问题。
- 保留应用权威 Schema 和标准 JSON Schema `format`，只在七牛请求边界移除 `non-empty-text` / `agent-id`。
- 兼容 clarification 分支的空可选字段，并保持领域层严格校验。
- 补齐真实 iOS 自动化：闲聊无卡、简单纠错无卡、酒店唯一卡、点击进场、三轮练习、主动结束、可评分报告。

## 实现思路

- Provider 边界递归复制并清理七牛不支持的自定义格式，不修改能力定义原对象。
- clarification 分支丢弃不能影响候选选择的上下文字段，避免模型重复传参造成工具重试。
- 为文本、两轮工具调用、strict JSON、场景与报告生命周期增加自动化入口和验证。

## 可复现测试

- `make check-go`
- `make check-flutter`
- `go test ./internal/agent/capability ./internal/coaching/preparation/agentcapability ./internal/coaching/review/agentcapability ./internal/providers/qianwen -count=1`
- `QIANWEN_LIVE_TEST=1 go test -tags=live ./internal/providers/qianwen -run '^TestLiveText(Generation|ToolRoundTrip)$|^TestLiveStrictJSONSchemaGeneration$' -count=1 -v`
- `SPEAKUP_DEV_PORT=18082 make test-ios-simulator-agent-hotel`
  - 真实通过：闲聊无卡、简单纠错无卡、酒店恰好一个卡、点击进入、3 轮文字练习、报告 READY 且 4 个维度均有分数。
- 45 条真实 Agent 路由基准：26/45 总体通过、40/45 决策正确；未通过项已明确集中在 IELTS 状态机、重复工具调用和 Review/material 路由，未伪报为全绿。
- `git diff --check`

## 关联与边界

- 数据库 qualified model ID 前置修复已由 #1080 合入。
- 报告 Provider 输出稳定性由 #1083 单独修复；完整报告 E2E 使用两项组合验证。
- 不包含 Staging / Production 部署，不提交 `.env`、账号或音频。

Closes #1081
