### PR TITLE
feat(tools): 增加 SpatialReal 数字人兼容性检查

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ SHELL := /bin/bash
 	check-android-download \
 	check-tls-lifecycle \
 	check-observability \
+	check-spatialreal-avatar-tool \
+	check-spatialreal-avatars \
 	check-production-deploy \
 	check-production-nginx \
 	check-cn-backend-experiment \
@@ -71,6 +73,8 @@ help:
 		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-tls-lifecycle  Validate TLS issuance and renewal contracts' \
 		'  make check-observability  Validate monitoring, alert, and log rotation contracts' \
+		'  make check-spatialreal-avatar-tool  Test the SpatialReal metadata checker offline' \
+		'  make check-spatialreal-avatars  Check configured avatars against the live metadata API' \
 		'  make check-production-deploy  Validate the immutable Production contract' \
 		'  make check-production-nginx  Run nginx -t against the Production template' \
 		'  make check-cn-backend-experiment  Validate the isolated China backend experiment contract' \
@@ -342,6 +346,12 @@ check-offline-release:
 
 check-android-download:
 	node --test tools/android-download/*.test.mjs
+
+check-spatialreal-avatar-tool:
+	node --test tools/spatialreal-avatar-check/*.test.mjs
+
+check-spatialreal-avatars:
+	node tools/spatialreal-avatar-check/check.mjs
 	./deploy/android-download/test.sh
 
 check-tls-lifecycle:

--- a/tools/spatialreal-avatar-check/README.md
+++ b/tools/spatialreal-avatar-check/README.md
@@ -1,0 +1,28 @@
+# SpatialReal avatar compatibility check
+
+This tool checks whether SpatialReal character metadata satisfies the resource
+shape required by the Android AvatarKit version currently used by SpeakUp. It
+does not read an API key and does not create an avatar session.
+
+Check the avatars configured in `avatars.json`:
+
+```bash
+make check-spatialreal-avatars
+```
+
+Check one or more IDs copied from SpatialReal Studio:
+
+```bash
+node tools/spatialreal-avatar-check/check.mjs \
+  --avatar Lisa=94a60c13-e835-4bde-aa93-00a1cf178dcd \
+  --avatar Nathan=1843ff9f-db3a-45de-be28-9c2b9d6412a3
+```
+
+Add `--probe-assets` to send a `HEAD` request to every referenced CDN asset,
+or `--json` for machine-readable output. The command exits with status `1` if
+any avatar is incompatible or unavailable, and status `2` for invalid usage.
+
+Passing this preflight means that the metadata and optional CDN resources are
+compatible. It does not replace a physical-device rendering test, which also
+depends on session authorization, device support, networking, and the native
+renderer.

--- a/tools/spatialreal-avatar-check/avatars.json
+++ b/tools/spatialreal-avatar-check/avatars.json
@@ -1,0 +1,10 @@
+[
+  {
+    "label": "Lisa",
+    "id": "94a60c13-e835-4bde-aa93-00a1cf178dcd"
+  },
+  {
+    "label": "Nathan",
+    "id": "1843ff9f-db3a-45de-be28-9c2b9d6412a3"
+  }
+]

--- a/tools/spatialreal-avatar-check/check.mjs
+++ b/tools/spatialreal-avatar-check/check.mjs
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const avatarIDPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const defaultEndpoint = "https://api.intl.spatialwalk.cloud/v2/character/";
+const toolDirectory = path.dirname(fileURLToPath(import.meta.url));
+const defaultCatalogPath = path.join(toolDirectory, "avatars.json");
+const maximumMetadataBytes = 2 * 1024 * 1024;
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSpatialRealAssetHost(hostname) {
+  return (
+    hostname === "spatialwalk.cloud" ||
+    hostname.endsWith(".spatialwalk.cloud") ||
+    hostname === "spatialwalk.top" ||
+    hostname.endsWith(".spatialwalk.top")
+  );
+}
+
+function remoteResources(value, resources = new Set()) {
+  if (Array.isArray(value)) {
+    for (const item of value) remoteResources(item, resources);
+    return resources;
+  }
+  if (!isObject(value)) return resources;
+  if (typeof value.remote === "string") resources.add(value.remote);
+  for (const child of Object.values(value)) remoteResources(child, resources);
+  return resources;
+}
+
+function requireResourceGroup(metadata, field, reasons) {
+  const group = metadata[field];
+  if (!isObject(group)) {
+    reasons.push(`${field} must be an object (received ${group === null ? "null" : typeof group})`);
+    return;
+  }
+  if (remoteResources(group).size === 0) {
+    reasons.push(`${field} does not contain a downloadable remote resource`);
+  }
+}
+
+export function assessMetadata(metadata, expectedID) {
+  const reasons = [];
+  if (!isObject(metadata)) {
+    return { compatible: false, reasons: ["metadata must be a JSON object"], resourceURLs: [] };
+  }
+  if (metadata.characterId !== expectedID) {
+    reasons.push("characterId does not match the requested avatar ID");
+  }
+  if (typeof metadata.version !== "string" || metadata.version.trim() === "") {
+    reasons.push("version must be a non-empty string");
+  }
+  requireResourceGroup(metadata, "camera", reasons);
+  requireResourceGroup(metadata, "models", reasons);
+  requireResourceGroup(metadata, "animations", reasons);
+
+  const resourceURLs = [...remoteResources(metadata)];
+  for (const resourceURL of resourceURLs) {
+    let parsed;
+    try {
+      parsed = new URL(resourceURL);
+    } catch {
+      reasons.push(`resource URL is invalid: ${resourceURL}`);
+      continue;
+    }
+    if (parsed.protocol !== "https:") {
+      reasons.push(`resource URL must use HTTPS: ${resourceURL}`);
+    } else if (!isSpatialRealAssetHost(parsed.hostname)) {
+      reasons.push(`resource URL uses an unexpected host: ${parsed.hostname}`);
+    }
+  }
+  return { compatible: reasons.length === 0, reasons, resourceURLs };
+}
+
+async function fetchWithTimeout(fetchImpl, url, options, timeoutMilliseconds) {
+  return fetchImpl(url, {
+    ...options,
+    signal: AbortSignal.timeout(timeoutMilliseconds),
+  });
+}
+
+async function probeResource(fetchImpl, url, timeoutMilliseconds) {
+  let response = await fetchWithTimeout(
+    fetchImpl,
+    url,
+    { method: "HEAD", redirect: "follow" },
+    timeoutMilliseconds,
+  );
+  if (response.status === 405 || response.status === 501) {
+    response = await fetchWithTimeout(
+      fetchImpl,
+      url,
+      {
+        method: "GET",
+        headers: { Range: "bytes=0-0" },
+        redirect: "follow",
+      },
+      timeoutMilliseconds,
+    );
+    await response.body?.cancel();
+  }
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+}
+
+export async function checkAvatar(
+  avatar,
+  {
+    endpoint = defaultEndpoint,
+    fetchImpl = fetch,
+    probeAssets = false,
+    timeoutMilliseconds = 10_000,
+  } = {},
+) {
+  if (!avatarIDPattern.test(avatar.id)) {
+    return {
+      ...avatar,
+      status: "error",
+      reasons: ["avatar ID must be a UUID"],
+      resourceCount: 0,
+    };
+  }
+
+  let response;
+  try {
+    response = await fetchWithTimeout(
+      fetchImpl,
+      new URL(encodeURIComponent(avatar.id), endpoint),
+      { headers: { Accept: "application/json" }, redirect: "follow" },
+      timeoutMilliseconds,
+    );
+  } catch (error) {
+    return {
+      ...avatar,
+      status: "error",
+      reasons: [`metadata request failed: ${error.message}`],
+      resourceCount: 0,
+    };
+  }
+  if (!response.ok) {
+    await response.body?.cancel();
+    return {
+      ...avatar,
+      status: "error",
+      reasons: [`metadata request returned HTTP ${response.status}`],
+      resourceCount: 0,
+    };
+  }
+
+  let body;
+  try {
+    body = await response.text();
+  } catch (error) {
+    return {
+      ...avatar,
+      status: "error",
+      reasons: [`metadata response could not be read: ${error.message}`],
+      resourceCount: 0,
+    };
+  }
+  if (Buffer.byteLength(body) > maximumMetadataBytes) {
+    return {
+      ...avatar,
+      status: "error",
+      reasons: ["metadata response exceeds 2 MiB"],
+      resourceCount: 0,
+    };
+  }
+  let metadata;
+  try {
+    metadata = JSON.parse(body);
+  } catch {
+    return {
+      ...avatar,
+      status: "error",
+      reasons: ["metadata response is not valid JSON"],
+      resourceCount: 0,
+    };
+  }
+
+  const assessment = assessMetadata(metadata, avatar.id);
+  const reasons = [...assessment.reasons];
+  if (assessment.compatible && probeAssets) {
+    const probes = await Promise.allSettled(
+      assessment.resourceURLs.map((url) =>
+        probeResource(fetchImpl, url, timeoutMilliseconds),
+      ),
+    );
+    probes.forEach((probe, index) => {
+      if (probe.status === "rejected") {
+        const resource = new URL(assessment.resourceURLs[index]);
+        reasons.push(
+          `asset probe failed for ${resource.hostname}${resource.pathname}: ${probe.reason.message}`,
+        );
+      }
+    });
+  }
+
+  return {
+    ...avatar,
+    status: reasons.length === 0 ? "compatible" : "incompatible",
+    version: typeof metadata.version === "string" ? metadata.version : null,
+    reasons,
+    resourceCount: assessment.resourceURLs.length,
+  };
+}
+
+function usage() {
+  return `Usage:
+  node tools/spatialreal-avatar-check/check.mjs [options]
+
+Options:
+  --avatar LABEL=UUID   Check one avatar; repeat to check several
+  --catalog PATH        Read avatars from a JSON catalog (default: bundled catalog)
+  --probe-assets        Also verify every referenced CDN asset
+  --json                Print machine-readable JSON
+  --timeout-ms NUMBER   Per-request timeout (default: 10000)
+  --help                Show this help
+
+This is a metadata compatibility preflight for the current Android AvatarKit.
+It does not guarantee that a supported device can complete a rendering session.`;
+}
+
+export function parseArguments(arguments_) {
+  const options = {
+    avatars: [],
+    catalogPath: defaultCatalogPath,
+    json: false,
+    probeAssets: false,
+    timeoutMilliseconds: 10_000,
+  };
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--avatar") {
+      const value = arguments_[index + 1];
+      if (!value) throw new Error("--avatar requires LABEL=UUID or UUID");
+      index += 1;
+      const separator = value.indexOf("=");
+      options.avatars.push(
+        separator === -1
+          ? { label: value, id: value }
+          : { label: value.slice(0, separator), id: value.slice(separator + 1) },
+      );
+    } else if (argument === "--catalog") {
+      if (!arguments_[index + 1]) throw new Error("--catalog requires a path");
+      options.catalogPath = path.resolve(arguments_[index + 1]);
+      index += 1;
+    } else if (argument === "--probe-assets") {
+      options.probeAssets = true;
+    } else if (argument === "--json") {
+      options.json = true;
+    } else if (argument === "--timeout-ms") {
+      const value = Number(arguments_[index + 1]);
+      if (!Number.isSafeInteger(value) || value < 100 || value > 120_000) {
+        throw new Error("--timeout-ms must be an integer from 100 to 120000");
+      }
+      options.timeoutMilliseconds = value;
+      index += 1;
+    } else if (argument === "--help") {
+      options.help = true;
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+  return options;
+}
+
+async function catalogAvatars(file) {
+  const parsed = JSON.parse(await readFile(file, "utf8"));
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    parsed.some(
+      (avatar) =>
+        !isObject(avatar) ||
+        typeof avatar.label !== "string" ||
+        avatar.label.trim() === "" ||
+        typeof avatar.id !== "string",
+    )
+  ) {
+    throw new Error("avatar catalog must be a non-empty array of {label, id}");
+  }
+  return parsed;
+}
+
+function printResults(results, json) {
+  if (json) {
+    console.log(JSON.stringify(results, null, 2));
+    return;
+  }
+  for (const result of results) {
+    const marker = result.status === "compatible" ? "PASS" : "FAIL";
+    const details = [
+      result.version ? `version=${result.version}` : null,
+      `resources=${result.resourceCount}`,
+    ].filter(Boolean);
+    console.log(`${marker} ${result.label} (${result.id}) ${details.join(" ")}`);
+    for (const reason of result.reasons) console.log(`  - ${reason}`);
+  }
+  const compatible = results.filter((result) => result.status === "compatible").length;
+  console.log(`Summary: ${compatible}/${results.length} avatars passed metadata compatibility preflight.`);
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArguments(process.argv.slice(2));
+    if (options.help) {
+      console.log(usage());
+      return;
+    }
+    const avatars =
+      options.avatars.length > 0
+        ? options.avatars
+        : await catalogAvatars(options.catalogPath);
+    const results = [];
+    for (const avatar of avatars) {
+      results.push(
+        await checkAvatar(avatar, {
+          probeAssets: options.probeAssets,
+          timeoutMilliseconds: options.timeoutMilliseconds,
+        }),
+      );
+    }
+    printResults(results, options.json);
+    if (results.some((result) => result.status !== "compatible")) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    console.error(usage());
+    process.exitCode = 2;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) await main();

--- a/tools/spatialreal-avatar-check/check.test.mjs
+++ b/tools/spatialreal-avatar-check/check.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assessMetadata, checkAvatar, parseArguments } from "./check.mjs";
+
+const id = "1843ff9f-db3a-45de-be28-9c2b9d6412a3";
+const resource = (name) => ({
+  resource: {
+    type: name,
+    local: `${name}.bin`,
+    remote: `https://cdn.spatialwalk.cloud/${name}.bin`,
+  },
+});
+const validMetadata = () => ({
+  characterId: id,
+  version: "2.3.0",
+  camera: resource("camera"),
+  models: { gsStandard: resource("model") },
+  animations: { idle: resource("animation") },
+});
+
+test("accepts metadata with camera, model, and animation resources", () => {
+  const result = assessMetadata(validMetadata(), id);
+  assert.equal(result.compatible, true);
+  assert.equal(result.resourceURLs.length, 3);
+});
+
+test("rejects Lisa-shaped metadata whose top-level camera is null", () => {
+  const metadata = validMetadata();
+  metadata.camera = null;
+  metadata.characterSettings = { camera: { translationZ: 1.2 } };
+  const result = assessMetadata(metadata, id);
+  assert.equal(result.compatible, false);
+  assert.deepEqual(result.reasons, ["camera must be an object (received null)"]);
+});
+
+test("rejects asset resources hosted outside SpatialReal domains", () => {
+  const metadata = validMetadata();
+  metadata.camera.resource.remote = "https://example.test/camera.bin";
+  const result = assessMetadata(metadata, id);
+  assert.equal(result.compatible, false);
+  assert.deepEqual(result.reasons, [
+    "resource URL uses an unexpected host: example.test",
+  ]);
+});
+
+test("fails closed for invalid IDs without making a request", async () => {
+  let requested = false;
+  const result = await checkAvatar(
+    { label: "invalid", id: "not-an-id" },
+    { fetchImpl: async () => { requested = true; } },
+  );
+  assert.equal(result.status, "error");
+  assert.equal(requested, false);
+});
+
+test("reports non-success HTTP responses", async () => {
+  const result = await checkAvatar(
+    { label: "Nathan", id },
+    { fetchImpl: async () => new Response("missing", { status: 404 }) },
+  );
+  assert.equal(result.status, "error");
+  assert.deepEqual(result.reasons, ["metadata request returned HTTP 404"]);
+});
+
+test("reports malformed JSON responses", async () => {
+  const result = await checkAvatar(
+    { label: "Nathan", id },
+    { fetchImpl: async () => new Response("not-json") },
+  );
+  assert.equal(result.status, "error");
+  assert.deepEqual(result.reasons, ["metadata response is not valid JSON"]);
+});
+
+test("reports response body read failures", async () => {
+  const result = await checkAvatar(
+    { label: "Nathan", id },
+    {
+      fetchImpl: async () => ({
+        ok: true,
+        text: async () => {
+          throw new Error("socket closed");
+        },
+      }),
+    },
+  );
+  assert.equal(result.status, "error");
+  assert.deepEqual(result.reasons, [
+    "metadata response could not be read: socket closed",
+  ]);
+});
+
+test("reports network failures without exposing request configuration", async () => {
+  const result = await checkAvatar(
+    { label: "Nathan", id },
+    { fetchImpl: async () => { throw new Error("connection refused"); } },
+  );
+  assert.equal(result.status, "error");
+  assert.deepEqual(result.reasons, ["metadata request failed: connection refused"]);
+});
+
+test("parses repeated avatar arguments and probe options", () => {
+  const result = parseArguments([
+    "--avatar",
+    `Nathan=${id}`,
+    "--avatar",
+    id,
+    "--probe-assets",
+    "--json",
+    "--timeout-ms",
+    "5000",
+  ]);
+  assert.deepEqual(result.avatars, [
+    { label: "Nathan", id },
+    { label: id, id },
+  ]);
+  assert.equal(result.probeAssets, true);
+  assert.equal(result.json, true);
+  assert.equal(result.timeoutMilliseconds, 5000);
+});


### PR DESCRIPTION
## 功能描述

增加无密钥的 SpatialReal 数字人资产元数据预检工具，默认检查 SpeakUp 当前使用的 Lisa 与 Nathan，并支持传入任意 Studio avatar ID。

Closes #1085
关联 #1065

## 实现思路

- 调用 SpatialReal 官方 `/v2/character/{avatarId}` 元数据接口。
- 按当前 Android AvatarKit 所需契约检查 `camera`、`models`、`animations` 及远程资源地址。
- 可选 `--probe-assets` 检查所有 SpatialReal CDN 资源；限制资源域名，避免探测任意地址。
- 提供文本/JSON 输出和稳定退出码，不读取或输出 API Key。
- 默认目录包含 Lisa、Nathan，也可用重复的 `--avatar LABEL=UUID` 检查其他素材。

## 可复现测试

```bash
make check-spatialreal-avatar-tool
node tools/spatialreal-avatar-check/check.mjs --probe-assets
```

离线测试 9/9 通过。真实接口结果：Lisa 因顶层 `camera=null` 判定不兼容；Nathan 元数据及 8 个 CDN 资源通过。命令在发现不兼容素材时按设计返回退出码 1。
