### PR TITLE
fix(avatar): 替换不兼容的 Lisa 数字人资产

### DIFF
--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -77,6 +77,12 @@ func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 
 	changed, err = runner.DownOne()
 	if err != nil || !changed {
+		t.Fatalf("DownOne to v12 qualified model IDs = %t, %v", changed, err)
+	}
+	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
+
+	changed, err = runner.DownOne()
+	if err != nil || !changed {
 		t.Fatalf("DownOne to v11 presentation runtime = %t, %v", changed, err)
 	}
 	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
@@ -154,6 +160,100 @@ func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 	assertCleanBaselineSchema(t, admin, schema)
 }
 
+func TestLisaAvatarAssetMigrationUpdatesBindingAndPreservesPreference(t *testing.T) {
+	config, _, _ := isolatedMigrationConfig(t)
+	runner, err := openConfig(config)
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() { _ = runner.Close() })
+	if changed, upErr := runner.Up(); upErr != nil || !changed {
+		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+
+	database, err := pgx.ConnectConfig(context.Background(), config)
+	if err != nil {
+		t.Fatalf("connect Lisa avatar migration database: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close(context.Background()) })
+
+	assertAvatarBinding := func(optionID, avatarID string, bindingVersion int64) {
+		t.Helper()
+		var actualAvatarID string
+		var actualBindingVersion int64
+		if err := database.QueryRow(context.Background(), `
+SELECT provider_avatar_id, binding_version
+FROM coach_avatar_options
+WHERE id = $1
+`, optionID).Scan(&actualAvatarID, &actualBindingVersion); err != nil {
+			t.Fatalf("read %s avatar binding: %v", optionID, err)
+		}
+		if actualAvatarID != avatarID || actualBindingVersion != bindingVersion {
+			t.Fatalf(
+				"%s binding = %q v%d, want %q v%d",
+				optionID,
+				actualAvatarID,
+				actualBindingVersion,
+				avatarID,
+				bindingVersion,
+			)
+		}
+	}
+
+	assertAvatarBinding(
+		"avatar_lisa",
+		"ca9c5c22-6dba-4b59-ae3b-d26066f8c017",
+		2,
+	)
+	assertAvatarBinding(
+		"avatar_nathan",
+		"1843ff9f-db3a-45de-be28-9c2b9d6412a3",
+		1,
+	)
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v12 qualified model IDs = %t, %v", changed, downErr)
+	}
+	assertAvatarBinding(
+		"avatar_lisa",
+		"94a60c13-e835-4bde-aa93-00a1cf178dcd",
+		1,
+	)
+
+	const userID = "10000000-0000-4000-8000-000000000022"
+	if _, err := database.Exec(context.Background(), `
+INSERT INTO users (id, canonical_email)
+VALUES ($1, 'lisa-avatar-migration@example.com')
+`, userID); err != nil {
+		t.Fatalf("seed Lisa avatar preference owner: %v", err)
+	}
+	if _, err := database.Exec(context.Background(), `
+INSERT INTO user_coach_presentation_preferences (
+    user_id, avatar_option_id, voice_option_id
+) VALUES ($1, 'avatar_lisa', 'voice_ava')
+`, userID); err != nil {
+		t.Fatalf("seed Lisa avatar preference: %v", err)
+	}
+	if changed, upErr := runner.Up(); upErr != nil || !changed {
+		t.Fatalf("reapply Lisa avatar migration = %t, %v", changed, upErr)
+	}
+	assertAvatarBinding(
+		"avatar_lisa",
+		"ca9c5c22-6dba-4b59-ae3b-d26066f8c017",
+		2,
+	)
+	var preferenceAvatarID string
+	if err := database.QueryRow(context.Background(), `
+SELECT avatar_option_id
+FROM user_coach_presentation_preferences
+WHERE user_id = $1
+`, userID).Scan(&preferenceAvatarID); err != nil {
+		t.Fatalf("read preserved Lisa avatar preference: %v", err)
+	}
+	if preferenceAvatarID != "avatar_lisa" {
+		t.Fatalf("preserved avatar preference = %q", preferenceAvatarID)
+	}
+}
+
 func TestAgentRunQualifiedModelMigrationEnforcesDomainAndRollbackGuard(
 	t *testing.T,
 ) {
@@ -165,6 +265,9 @@ func TestAgentRunQualifiedModelMigrationEnforcesDomainAndRollbackGuard(
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v12 qualified model IDs = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v11 presentation runtime = %t, %v", changed, downErr)
@@ -248,6 +351,9 @@ WHERE id = $1
 		updateModel("qwen/qwen3.7-plus", "qwen/a..b"),
 		"23514",
 	)
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v12 qualified model IDs = %t, %v", changed, downErr)
+	}
 
 	changed, downErr := runner.DownOne()
 	if downErr == nil || changed || !strings.Contains(
@@ -284,6 +390,9 @@ func TestSceneSelectionSourceMigrationTransformsPlansAndPreservesSessions(
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v12 qualified model IDs = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v11 presentation runtime = %t, %v", changed, downErr)
@@ -434,6 +543,9 @@ FROM practice_sessions WHERE session_id = $1
 	}
 
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("roll back v13 = %t, %v", changed, downErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("roll back v12 = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
@@ -486,6 +598,9 @@ func TestMigratedLegacyCatalogPlanCompletesThroughFormalReport(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v12 qualified model IDs = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v11 presentation runtime = %t, %v", changed, downErr)
@@ -760,6 +875,9 @@ func TestSceneSelectionSourceMigrationRejectsDownWithCustomPlan(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v12 qualified model IDs = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v11 presentation runtime = %t, %v", changed, downErr)

--- a/server/internal/platform/migration/product_health_migration_integration_test.go
+++ b/server/internal/platform/migration/product_health_migration_integration_test.go
@@ -43,6 +43,10 @@ func TestProductHealthViewsAreAnonymousAccurateAndReadOnly(t *testing.T) {
 	assertProductHealthReaderPrivileges(t, admin, database, schema)
 
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("Lisa avatar asset DownOne = %t, %v", changed, downErr)
+	}
+	assertProductHealthViewSet(t, admin, schema)
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("qualified model IDs DownOne = %t, %v", changed, downErr)
 	}
 	assertProductHealthViewSet(t, admin, schema)

--- a/server/migrations/000013_lisa_avatar_asset.down.sql
+++ b/server/migrations/000013_lisa_avatar_asset.down.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+DO $$
+DECLARE
+    current_provider TEXT;
+    current_profile TEXT;
+    current_avatar_id TEXT;
+    current_binding_version BIGINT;
+BEGIN
+    SELECT provider, provider_profile, provider_avatar_id, binding_version
+    INTO current_provider, current_profile, current_avatar_id, current_binding_version
+    FROM coach_avatar_options
+    WHERE id = 'avatar_lisa';
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'cannot restore Lisa avatar asset: avatar_lisa is missing';
+    END IF;
+    IF current_provider <> 'spatialreal'
+        OR current_profile <> 'spatialreal_default'
+        OR current_avatar_id <> 'ca9c5c22-6dba-4b59-ae3b-d26066f8c017'
+        OR current_binding_version <> 2 THEN
+        RAISE EXCEPTION 'cannot restore Lisa avatar asset: binding has changed';
+    END IF;
+
+    UPDATE coach_avatar_options
+    SET provider_avatar_id = '94a60c13-e835-4bde-aa93-00a1cf178dcd',
+        binding_version = 1
+    WHERE id = 'avatar_lisa';
+END
+$$;
+
+COMMIT;

--- a/server/migrations/000013_lisa_avatar_asset.up.sql
+++ b/server/migrations/000013_lisa_avatar_asset.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+DO $$
+DECLARE
+    current_provider TEXT;
+    current_profile TEXT;
+    current_avatar_id TEXT;
+    current_binding_version BIGINT;
+BEGIN
+    SELECT provider, provider_profile, provider_avatar_id, binding_version
+    INTO current_provider, current_profile, current_avatar_id, current_binding_version
+    FROM coach_avatar_options
+    WHERE id = 'avatar_lisa';
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'cannot replace Lisa avatar asset: avatar_lisa is missing';
+    END IF;
+    IF current_provider <> 'spatialreal'
+        OR current_profile <> 'spatialreal_default'
+        OR current_avatar_id <> '94a60c13-e835-4bde-aa93-00a1cf178dcd'
+        OR current_binding_version <> 1 THEN
+        RAISE EXCEPTION 'cannot replace Lisa avatar asset: binding has changed';
+    END IF;
+
+    UPDATE coach_avatar_options
+    SET provider_avatar_id = 'ca9c5c22-6dba-4b59-ae3b-d26066f8c017',
+        binding_version = 2
+    WHERE id = 'avatar_lisa';
+END
+$$;
+
+COMMIT;

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -58,6 +58,8 @@ func TestEveryMigrationPairIsEmbedded(t *testing.T) {
 		"000011_coach_presentation_runtime.up.sql",
 		"000012_agent_run_qualified_model_ids.down.sql",
 		"000012_agent_run_qualified_model_ids.up.sql",
+		"000013_lisa_avatar_asset.down.sql",
+		"000013_lisa_avatar_asset.up.sql",
 	}
 	slices.Sort(files)
 	if !slices.Equal(files, want) {
@@ -91,6 +93,8 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		"000011_coach_presentation_runtime.down.sql",
 		"000012_agent_run_qualified_model_ids.up.sql",
 		"000012_agent_run_qualified_model_ids.down.sql",
+		"000013_lisa_avatar_asset.up.sql",
+		"000013_lisa_avatar_asset.down.sql",
 	} {
 		sql := readMigration(t, name)
 		if !strings.HasPrefix(sql, "BEGIN;") {
@@ -98,6 +102,32 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		}
 		if !strings.HasSuffix(sql, "COMMIT;") {
 			t.Errorf("%s must end with COMMIT", name)
+		}
+	}
+}
+
+func TestLisaAvatarAssetMigrationChangesOnlyTheReviewedBinding(t *testing.T) {
+	up := readMigration(t, "000013_lisa_avatar_asset.up.sql")
+	for _, required := range []string{
+		"WHERE id = 'avatar_lisa'",
+		"current_provider <> 'spatialreal'",
+		"current_profile <> 'spatialreal_default'",
+		"current_avatar_id <> '94a60c13-e835-4bde-aa93-00a1cf178dcd'",
+		"provider_avatar_id = 'ca9c5c22-6dba-4b59-ae3b-d26066f8c017'",
+		"binding_version = 2",
+	} {
+		if !strings.Contains(up, required) {
+			t.Errorf("Lisa avatar up migration is missing %q", required)
+		}
+	}
+	down := readMigration(t, "000013_lisa_avatar_asset.down.sql")
+	for _, required := range []string{
+		"current_avatar_id <> 'ca9c5c22-6dba-4b59-ae3b-d26066f8c017'",
+		"provider_avatar_id = '94a60c13-e835-4bde-aa93-00a1cf178dcd'",
+		"binding_version = 1",
+	} {
+		if !strings.Contains(down, required) {
+			t.Errorf("Lisa avatar down migration is missing %q", required)
 		}
 	}
 }


### PR DESCRIPTION
## 功能描述

将 `avatar_lisa` 从无法被当前 Android AvatarKit 解析的 SpatialReal 2.0.0 素材，切换到已验证兼容的 2.3.0 素材。用户选择的业务选项 ID 保持为 `avatar_lisa`。

Closes #1087
关联 #1065、#1085

## 实现思路

- 新增 schema v13 前向迁移，不改写已有迁移历史。
- 将 Lisa provider avatar ID 更新为 `ca9c5c22-6dba-4b59-ae3b-d26066f8c017`。
- 将 binding version 从 1 升到 2，明确区分供应商绑定版本。
- 升降级均校验预期 provider/profile/ID/version，状态漂移时失败闭合。
- 保持 Nathan、音色和 `user_coach_presentation_preferences.avatar_option_id` 不变。

## 可复现测试

```bash
make check-go
TEST_DATABASE_URL=... go test -count=1 -v ./internal/platform/migration \
  -run 'TestLisaAvatarAssetMigrationUpdatesBindingAndPreservesPreference|TestMigrationHistoryFreshUpDownUp'\n```\n\n- `make check-go`：通过。\n- PostgreSQL 隔离 schema 中 v12 → v13 → v12 → v13：通过。\n- 本地开发数据库已从 schema 12 升到 13，查询确认 Lisa 为新 ID / binding v2，Nathan 保持原 ID / binding v1。\n