### PR TITLE
feat(profile): 使用 Gaze 图标区分陪练音色

### DIFF
--- a/mobile/lib/features/profile/coach_presentation_page.dart
+++ b/mobile/lib/features/profile/coach_presentation_page.dart
@@ -517,12 +517,24 @@ class _VoiceSelectionEntry extends StatelessWidget {
         leading: CoachVoiceGazeAvatar(
           key: const Key('coach-selected-voice-gaze'),
           voiceId: option.id,
-          gender: option.gender,
           size: 36,
         ),
-        title: Text(
-          option.name,
-          style: SpeakUpDesign.cardTitle.copyWith(fontWeight: FontWeight.w600),
+        title: Row(
+          children: [
+            Flexible(
+              child: Text(
+                option.name,
+                style: SpeakUpDesign.cardTitle.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            const SizedBox(width: SpeakUpDesign.space4),
+            CoachVoiceGenderIcon(
+              key: const Key('coach-selected-voice-gender'),
+              gender: option.gender,
+            ),
+          ],
         ),
         trailing: const Icon(
           Icons.chevron_right_rounded,

--- a/mobile/lib/features/profile/coach_presentation_page.dart
+++ b/mobile/lib/features/profile/coach_presentation_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:speakup/design/speak_up_design.dart';
 import 'package:speakup/features/profile/coach_presentation_settings.dart';
+import 'package:speakup/features/profile/coach_voice_gaze_avatar.dart';
 import 'package:speakup/features/profile/coach_voice_selection_page.dart';
 
 const _avatarCarouselInitialPage = 1000;
@@ -58,6 +59,7 @@ class _CoachPresentationPageState extends State<CoachPresentationPage> {
           id: option.id,
           name: option.displayName,
           description: option.description,
+          gender: option.gender,
         ),
       )
       .toList(growable: false);
@@ -512,11 +514,11 @@ class _VoiceSelectionEntry extends StatelessWidget {
         contentPadding: const EdgeInsets.symmetric(
           horizontal: SpeakUpDesign.space16,
         ),
-        leading: const CircleAvatar(
-          radius: 18,
-          backgroundColor: Color(0xFFF0F3F5),
-          foregroundColor: SpeakUpDesign.ink,
-          child: Icon(Icons.graphic_eq_rounded, size: 20),
+        leading: CoachVoiceGazeAvatar(
+          key: const Key('coach-selected-voice-gaze'),
+          voiceId: option.id,
+          gender: option.gender,
+          size: 36,
         ),
         title: Text(
           option.name,

--- a/mobile/lib/features/profile/coach_voice_gaze_avatar.dart
+++ b/mobile/lib/features/profile/coach_voice_gaze_avatar.dart
@@ -1,0 +1,366 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// A deterministic, local rendering of DiceBear's CC0 Gaze style.
+///
+/// Source: https://www.dicebear.com/styles/gaze/
+class CoachVoiceGazeAvatar extends StatelessWidget {
+  const CoachVoiceGazeAvatar({
+    required this.voiceId,
+    required this.gender,
+    this.size = 48,
+    super.key,
+  }) : assert(gender == 'female' || gender == 'male');
+
+  static const femaleBodyColor = Color(0xFFEA7FA8);
+  static const femaleBackgroundColor = Color(0xFFFDECF3);
+  static const maleBodyColor = Color(0xFF5B8DEF);
+  static const maleBackgroundColor = Color(0xFFEAF2FF);
+  static const inkColor = Color(0xFF182230);
+
+  final String voiceId;
+  final String gender;
+  final double size;
+
+  Color get bodyColor => gender == 'male' ? maleBodyColor : femaleBodyColor;
+
+  Color get backgroundColor =>
+      gender == 'male' ? maleBackgroundColor : femaleBackgroundColor;
+
+  GazeVariant get variant => GazeVariant.fromVoiceId(voiceId);
+
+  @override
+  Widget build(BuildContext context) {
+    return ExcludeSemantics(
+      child: RepaintBoundary(
+        child: SizedBox.square(
+          dimension: size,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: backgroundColor,
+              shape: BoxShape.circle,
+            ),
+            child: CustomPaint(
+              painter: _GazePainter(
+                variant: variant,
+                bodyColor: bodyColor,
+                inkColor: inkColor,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+enum GazeShape {
+  arch,
+  circle,
+  column,
+  diamond,
+  egg,
+  hexagon,
+  octagon,
+  pentagon,
+  pill,
+  square,
+  triangle,
+}
+
+enum GazeEyes {
+  bars,
+  beans,
+  big,
+  dots,
+  grin,
+  happy,
+  shine,
+  small,
+  squint,
+  tall,
+  wide,
+}
+
+enum GazeSpacing { close, snug, normal, wide, far }
+
+@immutable
+final class GazeVariant {
+  const GazeVariant({
+    required this.shape,
+    required this.eyes,
+    required this.spacing,
+    required this.rotation,
+    required this.scale,
+  });
+
+  factory GazeVariant.fromVoiceId(String voiceId) {
+    final hash = _stableHash(voiceId);
+    return GazeVariant(
+      shape: GazeShape.values[hash % GazeShape.values.length],
+      eyes: GazeEyes
+          .values[(hash ~/ GazeShape.values.length) % GazeEyes.values.length],
+      spacing:
+          GazeSpacing.values[(hash ~/
+                  (GazeShape.values.length * GazeEyes.values.length)) %
+              GazeSpacing.values.length],
+      rotation: ((hash ~/ 605) % 13) - 6,
+      scale: 0.96 + ((hash ~/ 7865) % 7) / 100,
+    );
+  }
+
+  final GazeShape shape;
+  final GazeEyes eyes;
+  final GazeSpacing spacing;
+  final int rotation;
+  final double scale;
+
+  String get signature => '${shape.name}:${eyes.name}:${spacing.name}';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GazeVariant &&
+          shape == other.shape &&
+          eyes == other.eyes &&
+          spacing == other.spacing &&
+          rotation == other.rotation &&
+          scale == other.scale;
+
+  @override
+  int get hashCode => Object.hash(shape, eyes, spacing, rotation, scale);
+}
+
+int _stableHash(String value) {
+  var hash = 0x811C9DC5;
+  for (final byte in utf8.encode(value)) {
+    hash ^= byte;
+    hash = (hash * 0x01000193) & 0xFFFFFFFF;
+  }
+  return hash;
+}
+
+final class _GazePainter extends CustomPainter {
+  const _GazePainter({
+    required this.variant,
+    required this.bodyColor,
+    required this.inkColor,
+  });
+
+  final GazeVariant variant;
+  final Color bodyColor;
+  final Color inkColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final shortestSide = math.min(size.width, size.height);
+    canvas.save();
+    canvas.translate(
+      (size.width - shortestSide) / 2,
+      (size.height - shortestSide) / 2,
+    );
+    canvas.scale(shortestSide / 100);
+    canvas.translate(50, 50);
+    canvas.rotate(variant.rotation * math.pi / 180);
+    canvas.scale(variant.scale);
+    canvas.translate(-50, -50);
+
+    _drawBody(canvas);
+    _drawEyes(canvas);
+    canvas.restore();
+  }
+
+  void _drawBody(Canvas canvas) {
+    final paint = Paint()..color = bodyColor;
+    switch (variant.shape) {
+      case GazeShape.arch:
+        final path = Path()
+          ..moveTo(18, 86)
+          ..lineTo(18, 47)
+          ..cubicTo(18, 27, 31, 14, 50, 14)
+          ..cubicTo(69, 14, 82, 27, 82, 47)
+          ..lineTo(82, 86)
+          ..close();
+        canvas.drawPath(path, paint);
+      case GazeShape.circle:
+        canvas.drawCircle(const Offset(50, 50), 34, paint);
+      case GazeShape.column:
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            const Rect.fromLTWH(28, 11, 44, 78),
+            const Radius.circular(22),
+          ),
+          paint,
+        );
+      case GazeShape.diamond:
+        canvas.drawPath(
+          Path()
+            ..moveTo(50, 11)
+            ..lineTo(89, 50)
+            ..lineTo(50, 89)
+            ..lineTo(11, 50)
+            ..close(),
+          paint,
+        );
+      case GazeShape.egg:
+        final path = Path()
+          ..moveTo(50, 13)
+          ..cubicTo(69, 13, 79, 32, 79, 50)
+          ..cubicTo(79, 72, 66, 86, 50, 86)
+          ..cubicTo(34, 86, 21, 72, 21, 50)
+          ..cubicTo(21, 32, 31, 13, 50, 13)
+          ..close();
+        canvas.drawPath(path, paint);
+      case GazeShape.hexagon:
+        canvas.drawPath(_polygonPath(6, 38, -math.pi / 2), paint);
+      case GazeShape.octagon:
+        canvas.drawPath(_polygonPath(8, 38, math.pi / 8), paint);
+      case GazeShape.pentagon:
+        canvas.drawPath(_polygonPath(5, 38, -math.pi / 2), paint);
+      case GazeShape.pill:
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            const Rect.fromLTWH(11, 25, 78, 50),
+            const Radius.circular(25),
+          ),
+          paint,
+        );
+      case GazeShape.square:
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            const Rect.fromLTWH(16, 16, 68, 68),
+            const Radius.circular(15),
+          ),
+          paint,
+        );
+      case GazeShape.triangle:
+        canvas.drawPath(
+          Path()
+            ..moveTo(50, 12)
+            ..lineTo(88, 78)
+            ..lineTo(12, 78)
+            ..close(),
+          paint,
+        );
+    }
+  }
+
+  Path _polygonPath(int sides, double radius, double startAngle) {
+    final path = Path();
+    for (var index = 0; index < sides; index++) {
+      final angle = startAngle + index * math.pi * 2 / sides;
+      final point = Offset(
+        50 + math.cos(angle) * radius,
+        50 + math.sin(angle) * radius,
+      );
+      if (index == 0) {
+        path.moveTo(point.dx, point.dy);
+      } else {
+        path.lineTo(point.dx, point.dy);
+      }
+    }
+    return path..close();
+  }
+
+  void _drawEyes(Canvas canvas) {
+    final gap = switch (variant.spacing) {
+      GazeSpacing.close => 9.5,
+      GazeSpacing.snug => 11.0,
+      GazeSpacing.normal => 12.5,
+      GazeSpacing.wide => 14.0,
+      GazeSpacing.far => 15.5,
+    };
+    final eyeY = switch (variant.shape) {
+      GazeShape.triangle => 56.0,
+      GazeShape.arch => 54.0,
+      _ => 51.0,
+    };
+    _drawEye(canvas, Offset(50 - gap, eyeY));
+    _drawEye(canvas, Offset(50 + gap, eyeY));
+  }
+
+  void _drawEye(Canvas canvas, Offset center) {
+    final fill = Paint()..color = inkColor;
+    switch (variant.eyes) {
+      case GazeEyes.bars:
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            Rect.fromCenter(center: center, width: 12, height: 6.7),
+            const Radius.circular(3.4),
+          ),
+          fill,
+        );
+      case GazeEyes.beans:
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            Rect.fromCenter(center: center, width: 6.7, height: 12),
+            const Radius.circular(3.4),
+          ),
+          fill,
+        );
+      case GazeEyes.big:
+        canvas.drawCircle(center, 6.2, fill);
+      case GazeEyes.dots:
+        canvas.drawCircle(center, 4.9, fill);
+      case GazeEyes.grin:
+        _drawArcEye(canvas, center, width: 13, rise: 7, strokeWidth: 3.8);
+      case GazeEyes.happy:
+        _drawArcEye(canvas, center, width: 11, rise: 5, strokeWidth: 3.4);
+      case GazeEyes.shine:
+        canvas.drawCircle(center, 5.6, fill);
+        canvas.drawCircle(
+          center.translate(2.0, -2.1),
+          1.7,
+          Paint()..color = Colors.white,
+        );
+      case GazeEyes.small:
+        canvas.drawCircle(center, 3.6, fill);
+      case GazeEyes.squint:
+        _drawArcEye(canvas, center, width: 11, rise: 3.8, strokeWidth: 3.1);
+      case GazeEyes.tall:
+        canvas.drawOval(
+          Rect.fromCenter(center: center, width: 8.3, height: 12.3),
+          fill,
+        );
+      case GazeEyes.wide:
+        canvas.drawOval(
+          Rect.fromCenter(center: center, width: 12.3, height: 8.6),
+          fill,
+        );
+    }
+  }
+
+  void _drawArcEye(
+    Canvas canvas,
+    Offset center, {
+    required double width,
+    required double rise,
+    required double strokeWidth,
+  }) {
+    final path = Path()
+      ..moveTo(center.dx - width / 2, center.dy + rise / 3)
+      ..quadraticBezierTo(
+        center.dx,
+        center.dy - rise,
+        center.dx + width / 2,
+        center.dy + rise / 3,
+      );
+    canvas.drawPath(
+      path,
+      Paint()
+        ..color = inkColor
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_GazePainter oldDelegate) =>
+      oldDelegate.variant != variant ||
+      oldDelegate.bodyColor != bodyColor ||
+      oldDelegate.inkColor != inkColor;
+}

--- a/mobile/lib/features/profile/coach_voice_gaze_avatar.dart
+++ b/mobile/lib/features/profile/coach_voice_gaze_avatar.dart
@@ -9,27 +9,28 @@ import 'package:flutter/material.dart';
 class CoachVoiceGazeAvatar extends StatelessWidget {
   const CoachVoiceGazeAvatar({
     required this.voiceId,
-    required this.gender,
     this.size = 48,
     super.key,
-  }) : assert(gender == 'female' || gender == 'male');
+  });
 
-  static const femaleBodyColor = Color(0xFFEA7FA8);
-  static const femaleBackgroundColor = Color(0xFFFDECF3);
-  static const maleBodyColor = Color(0xFF5B8DEF);
-  static const maleBackgroundColor = Color(0xFFEAF2FF);
+  static const bodyColors = <Color>[
+    Color(0xFFFBABAF),
+    Color(0xFFFBB271),
+    Color(0xFF9BD78D),
+    Color(0xFF52DCD8),
+    Color(0xFF9CC8FB),
+    Color(0xFFD8B1FB),
+  ];
   static const inkColor = Color(0xFF182230);
 
   final String voiceId;
-  final String gender;
   final double size;
 
-  Color get bodyColor => gender == 'male' ? maleBodyColor : femaleBodyColor;
-
-  Color get backgroundColor =>
-      gender == 'male' ? maleBackgroundColor : femaleBackgroundColor;
-
   GazeVariant get variant => GazeVariant.fromVoiceId(voiceId);
+
+  Color get bodyColor => bodyColors[variant.colorIndex];
+
+  Color get backgroundColor => bodyColor.withValues(alpha: 0.18);
 
   @override
   Widget build(BuildContext context) {
@@ -54,6 +55,27 @@ class CoachVoiceGazeAvatar extends StatelessWidget {
       ),
     );
   }
+}
+
+class CoachVoiceGenderIcon extends StatelessWidget {
+  const CoachVoiceGenderIcon({required this.gender, this.size = 18, super.key})
+    : assert(gender == 'female' || gender == 'male');
+
+  static const femaleColor = Color(0xFFE96F9D);
+  static const maleColor = Color(0xFF4C8DFF);
+
+  final String gender;
+  final double size;
+
+  IconData get icon =>
+      gender == 'male' ? Icons.male_rounded : Icons.female_rounded;
+
+  Color get color => gender == 'male' ? maleColor : femaleColor;
+
+  @override
+  Widget build(BuildContext context) => ExcludeSemantics(
+    child: Icon(icon, size: size, color: color),
+  );
 }
 
 enum GazeShape {
@@ -92,6 +114,7 @@ final class GazeVariant {
     required this.shape,
     required this.eyes,
     required this.spacing,
+    required this.colorIndex,
     required this.rotation,
     required this.scale,
   });
@@ -106,6 +129,7 @@ final class GazeVariant {
           GazeSpacing.values[(hash ~/
                   (GazeShape.values.length * GazeEyes.values.length)) %
               GazeSpacing.values.length],
+      colorIndex: (hash ~/ 605) % CoachVoiceGazeAvatar.bodyColors.length,
       rotation: ((hash ~/ 605) % 13) - 6,
       scale: 0.96 + ((hash ~/ 7865) % 7) / 100,
     );
@@ -114,6 +138,7 @@ final class GazeVariant {
   final GazeShape shape;
   final GazeEyes eyes;
   final GazeSpacing spacing;
+  final int colorIndex;
   final int rotation;
   final double scale;
 
@@ -126,11 +151,13 @@ final class GazeVariant {
           shape == other.shape &&
           eyes == other.eyes &&
           spacing == other.spacing &&
+          colorIndex == other.colorIndex &&
           rotation == other.rotation &&
           scale == other.scale;
 
   @override
-  int get hashCode => Object.hash(shape, eyes, spacing, rotation, scale);
+  int get hashCode =>
+      Object.hash(shape, eyes, spacing, colorIndex, rotation, scale);
 }
 
 int _stableHash(String value) {

--- a/mobile/lib/features/profile/coach_voice_selection_page.dart
+++ b/mobile/lib/features/profile/coach_voice_selection_page.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:speakup/design/speak_up_design.dart';
+import 'package:speakup/features/profile/coach_voice_gaze_avatar.dart';
 
 final class CoachVoiceOption {
   const CoachVoiceOption({
     required this.id,
     required this.name,
     required this.description,
+    required this.gender,
   });
 
   final String id;
   final String name;
   final String description;
+  final String gender;
 }
 
 class CoachVoiceSelectionPage extends StatefulWidget {
@@ -126,10 +129,10 @@ class _VoiceOptionRow extends StatelessWidget {
         horizontal: SpeakUpDesign.space16,
         vertical: SpeakUpDesign.space8,
       ),
-      leading: const CircleAvatar(
-        backgroundColor: Color(0xFFF0F3F5),
-        foregroundColor: SpeakUpDesign.ink,
-        child: Icon(Icons.graphic_eq_rounded),
+      leading: CoachVoiceGazeAvatar(
+        key: Key('coach-voice-gaze-${option.id}'),
+        voiceId: option.id,
+        gender: option.gender,
       ),
       title: Text(option.name, style: SpeakUpDesign.cardTitle),
       subtitle: Text(

--- a/mobile/lib/features/profile/coach_voice_selection_page.dart
+++ b/mobile/lib/features/profile/coach_voice_selection_page.dart
@@ -132,9 +132,17 @@ class _VoiceOptionRow extends StatelessWidget {
       leading: CoachVoiceGazeAvatar(
         key: Key('coach-voice-gaze-${option.id}'),
         voiceId: option.id,
-        gender: option.gender,
       ),
-      title: Text(option.name, style: SpeakUpDesign.cardTitle),
+      title: Row(
+        children: [
+          Flexible(child: Text(option.name, style: SpeakUpDesign.cardTitle)),
+          const SizedBox(width: SpeakUpDesign.space4),
+          CoachVoiceGenderIcon(
+            key: Key('coach-voice-gender-${option.id}'),
+            gender: option.gender,
+          ),
+        ],
+      ),
       subtitle: Text(
         option.description,
         style: SpeakUpDesign.body.copyWith(fontSize: 13),

--- a/mobile/test/profile/coach_presentation_page_test.dart
+++ b/mobile/test/profile/coach_presentation_page_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speakup/design/speak_up_theme.dart';
 import 'package:speakup/features/profile/coach_presentation_page.dart';
 import 'package:speakup/features/profile/coach_presentation_settings.dart';
+import 'package:speakup/features/profile/coach_voice_gaze_avatar.dart';
 
 void main() {
   testWidgets('selects and saves the configured avatar and voice ids', (
@@ -60,6 +61,12 @@ void main() {
     expect(find.text('艾薇'), findsOneWidget);
     expect(store.avatarId, 'avatar_nathan');
     expect(store.voiceId, 'voice_ivy');
+    final selectedVoiceAvatar = tester.widget<CoachVoiceGazeAvatar>(
+      find.byKey(const Key('coach-selected-voice-gaze')),
+    );
+    expect(selectedVoiceAvatar.voiceId, 'voice_ivy');
+    expect(selectedVoiceAvatar.gender, 'female');
+    expect(selectedVoiceAvatar.bodyColor, CoachVoiceGazeAvatar.femaleBodyColor);
     expect(find.byKey(const Key('coach-presentation-save')), findsNothing);
   });
 

--- a/mobile/test/profile/coach_presentation_page_test.dart
+++ b/mobile/test/profile/coach_presentation_page_test.dart
@@ -65,8 +65,15 @@ void main() {
       find.byKey(const Key('coach-selected-voice-gaze')),
     );
     expect(selectedVoiceAvatar.voiceId, 'voice_ivy');
-    expect(selectedVoiceAvatar.gender, 'female');
-    expect(selectedVoiceAvatar.bodyColor, CoachVoiceGazeAvatar.femaleBodyColor);
+    expect(
+      CoachVoiceGazeAvatar.bodyColors,
+      contains(selectedVoiceAvatar.bodyColor),
+    );
+    final selectedVoiceGender = tester.widget<CoachVoiceGenderIcon>(
+      find.byKey(const Key('coach-selected-voice-gender')),
+    );
+    expect(selectedVoiceGender.gender, 'female');
+    expect(selectedVoiceGender.icon, Icons.female_rounded);
     expect(find.byKey(const Key('coach-presentation-save')), findsNothing);
   });
 

--- a/mobile/test/profile/coach_voice_gaze_avatar_test.dart
+++ b/mobile/test/profile/coach_voice_gaze_avatar_test.dart
@@ -18,13 +18,14 @@ void main() {
         shape: GazeShape.arch,
         eyes: GazeEyes.wide,
         spacing: GazeSpacing.snug,
+        colorIndex: 5,
         rotation: -3,
         scale: 0.97,
       ),
     );
   });
 
-  testWidgets('voice list renders distinct gender-colored Gaze icons', (
+  testWidgets('voice list renders Gaze colors and explicit gender icons', (
     tester,
   ) async {
     final options = previewCoachPresentationCatalog.voices
@@ -57,27 +58,38 @@ void main() {
       avatars.map((avatar) => avatar.variant.signature).toSet(),
       hasLength(options.length),
     );
+    expect(
+      avatars.every(
+        (avatar) => CoachVoiceGazeAvatar.bodyColors.contains(avatar.bodyColor),
+      ),
+      isTrue,
+    );
 
-    final maleAvatars = avatars.where((avatar) => avatar.gender == 'male');
-    final femaleAvatars = avatars.where((avatar) => avatar.gender == 'female');
-    expect(maleAvatars, isNotEmpty);
-    expect(femaleAvatars, isNotEmpty);
+    final genderIcons = tester
+        .widgetList<CoachVoiceGenderIcon>(find.byType(CoachVoiceGenderIcon))
+        .toList(growable: false);
+    expect(genderIcons, hasLength(options.length));
     expect(
-      maleAvatars.every(
-        (avatar) =>
-            avatar.bodyColor == CoachVoiceGazeAvatar.maleBodyColor &&
-            avatar.backgroundColor == CoachVoiceGazeAvatar.maleBackgroundColor,
-      ),
+      genderIcons
+          .where((icon) => icon.gender == 'male')
+          .every(
+            (icon) =>
+                icon.icon == Icons.male_rounded &&
+                icon.color == CoachVoiceGenderIcon.maleColor,
+          ),
       isTrue,
     );
     expect(
-      femaleAvatars.every(
-        (avatar) =>
-            avatar.bodyColor == CoachVoiceGazeAvatar.femaleBodyColor &&
-            avatar.backgroundColor ==
-                CoachVoiceGazeAvatar.femaleBackgroundColor,
-      ),
+      genderIcons
+          .where((icon) => icon.gender == 'female')
+          .every(
+            (icon) =>
+                icon.icon == Icons.female_rounded &&
+                icon.color == CoachVoiceGenderIcon.femaleColor,
+          ),
       isTrue,
     );
+    expect(genderIcons.where((icon) => icon.gender == 'male'), isNotEmpty);
+    expect(genderIcons.where((icon) => icon.gender == 'female'), isNotEmpty);
   });
 }

--- a/mobile/test/profile/coach_voice_gaze_avatar_test.dart
+++ b/mobile/test/profile/coach_voice_gaze_avatar_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:speakup/design/speak_up_theme.dart';
+import 'package:speakup/features/profile/coach_presentation_settings.dart';
+import 'package:speakup/features/profile/coach_voice_gaze_avatar.dart';
+import 'package:speakup/features/profile/coach_voice_selection_page.dart';
+
+void main() {
+  test('current coach voices receive distinct stable Gaze variants', () {
+    final variants = previewCoachPresentationCatalog.voices
+        .map((voice) => GazeVariant.fromVoiceId(voice.id))
+        .toList(growable: false);
+
+    expect(variants.toSet(), hasLength(variants.length));
+    expect(
+      GazeVariant.fromVoiceId('voice_ava'),
+      const GazeVariant(
+        shape: GazeShape.arch,
+        eyes: GazeEyes.wide,
+        spacing: GazeSpacing.snug,
+        rotation: -3,
+        scale: 0.97,
+      ),
+    );
+  });
+
+  testWidgets('voice list renders distinct gender-colored Gaze icons', (
+    tester,
+  ) async {
+    final options = previewCoachPresentationCatalog.voices
+        .map(
+          (voice) => CoachVoiceOption(
+            id: voice.id,
+            name: voice.displayName,
+            description: voice.description,
+            gender: voice.gender,
+          ),
+        )
+        .toList(growable: false);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: SpeakUpTheme.light,
+        home: CoachVoiceSelectionPage(
+          options: options,
+          initialVoiceId: 'voice_ava',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final avatars = tester
+        .widgetList<CoachVoiceGazeAvatar>(find.byType(CoachVoiceGazeAvatar))
+        .toList(growable: false);
+    expect(avatars, hasLength(options.length));
+    expect(
+      avatars.map((avatar) => avatar.variant.signature).toSet(),
+      hasLength(options.length),
+    );
+
+    final maleAvatars = avatars.where((avatar) => avatar.gender == 'male');
+    final femaleAvatars = avatars.where((avatar) => avatar.gender == 'female');
+    expect(maleAvatars, isNotEmpty);
+    expect(femaleAvatars, isNotEmpty);
+    expect(
+      maleAvatars.every(
+        (avatar) =>
+            avatar.bodyColor == CoachVoiceGazeAvatar.maleBodyColor &&
+            avatar.backgroundColor == CoachVoiceGazeAvatar.maleBackgroundColor,
+      ),
+      isTrue,
+    );
+    expect(
+      femaleAvatars.every(
+        (avatar) =>
+            avatar.bodyColor == CoachVoiceGazeAvatar.femaleBodyColor &&
+            avatar.backgroundColor ==
+                CoachVoiceGazeAvatar.femaleBackgroundColor,
+      ),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## 功能描述

- 用本地矢量绘制的 DiceBear Gaze 风格图标替换音色列表中重复的均衡器图标。
- 每个音色根据 `voiceId` 获得稳定、不同的形状、眼睛、间距、旋转和颜色组合。
- Gaze 图标使用官方六色调色板，不表达性别。
- 在音色名称右侧增加圆角 `♀` / `♂` 符号，女声粉色、男声蓝色。
- 当前音色入口与选择列表共用同一套图标和性别符号。

## 实现思路

- 新增 `CoachVoiceGazeAvatar`，以稳定 FNV-1a 哈希把 `voiceId` 映射到 Gaze 的 11 种形状、11 种眼睛、5 种间距及官方调色板。
- 使用 Flutter `CustomPainter` 本地绘制，无第三方运行时依赖、无网络请求、无动画。
- 新增 `CoachVoiceGenderIcon`，复用 Material `male_rounded` / `female_rounded` 图标。
- 将目录中已有的结构化 `gender` 字段透传到 UI，不从姓名、描述或头像外观推断。

## 可复现测试

```bash
cd mobile
dart analyze lib/features/profile/coach_voice_gaze_avatar.dart lib/features/profile/coach_voice_selection_page.dart lib/features/profile/coach_presentation_page.dart test/profile/coach_voice_gaze_avatar_test.dart test/profile/coach_presentation_page_test.dart
flutter test --no-pub test/profile/coach_voice_gaze_avatar_test.dart test/profile/coach_presentation_page_test.dart
flutter test --no-pub
```

本地结果：

- 定向 Dart analyze：通过，无问题。
- 定向 Widget 测试：6 项通过。
- 全量 Flutter 测试：865 项通过。
- `SPEAKUP_DEV_PORT=18082 make dev-android`：staging Debug APK 构建、安装并启动成功。
- Android 真机 ANA AN00：首屏、下半列表、男/女性别符号、Gaze 多色图标、选中勾与滚动均通过视觉验证。
- `/health` 返回 `status: ok`，`/readyz` 返回 `status: ready`。

## 素材与授权

DiceBear Gaze，CC0 1.0：<https://www.dicebear.com/styles/gaze/>。

Closes #1098