### PR TITLE
fix(speech): 恢复新加坡生产 Fun-ASR 兼容

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,9 @@ QIANWEN_LIVE_TEST=0
 # 阿里云：ASR（千问）
 SPEECH_RECOGNITION_PROVIDER=qianwen
 QIANWEN_ASR_BASE_URL=https://dashscope.aliyuncs.com/api/v1
-QIANWEN_ASR_MODEL=qwen-audio-3.0-asr-flash-streaming
+QIANWEN_ASR_MODEL=fun-asr-realtime
 QIANWEN_ASR_TIMEOUT=150s
-QIANWEN_ASR_RECORDED_MODEL=qwen-audio-3.0-asr-flash
+QIANWEN_ASR_RECORDED_MODEL=fun-asr-flash-2026-06-15
 QIANWEN_ASR_RECORDED_TIMEOUT=150s
 
 # 阿里云：TTS（千问）

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -163,9 +163,9 @@ jobs:
           QIANWEN_SPEECH_FEEDBACK_MODEL: qwen-ci-readiness-not-invoked
           SPEECH_RECOGNITION_PROVIDER: qianwen
           QIANWEN_ASR_BASE_URL: https://dashscope.aliyuncs.com/api/v1
-          QIANWEN_ASR_MODEL: qwen-audio-3.0-asr-flash-streaming
+          QIANWEN_ASR_MODEL: fun-asr-realtime
           QIANWEN_ASR_TIMEOUT: 150s
-          QIANWEN_ASR_RECORDED_MODEL: qwen-audio-3.0-asr-flash
+          QIANWEN_ASR_RECORDED_MODEL: fun-asr-flash-2026-06-15
           QIANWEN_ASR_RECORDED_TIMEOUT: 150s
           SPEECH_SYNTHESIS_PROVIDER: qianwen
           QIANWEN_TTS_BASE_URL: https://dashscope.aliyuncs.com/api/v1

--- a/deploy/experiments/cn-backend/README.md
+++ b/deploy/experiments/cn-backend/README.md
@@ -228,9 +228,8 @@ China candidate changes and validates these groups together:
   - `SPEECH_RECOGNITION_PROVIDER=qianwen`;
   - `QIANWEN_ASR_BASE_URL`, `QIANWEN_ASR_MODEL`, `QIANWEN_ASR_TIMEOUT`,
     `QIANWEN_ASR_RECORDED_MODEL`, and `QIANWEN_ASR_RECORDED_TIMEOUT`.
-    The current Server requires `qwen-audio-3.0-asr-flash-streaming` with a
-    timeout of at least `150s`, and `qwen-audio-3.0-asr-flash` for recorded
-    audio.
+    The current Server requires `fun-asr-realtime` with a timeout of at least
+    `150s`, and `fun-asr-flash-2026-06-15` for recorded audio.
 - Qianwen speech synthesis:
   - `SPEECH_SYNTHESIS_PROVIDER=qianwen`;
   - `QIANWEN_TTS_BASE_URL`, `QIANWEN_TTS_MODEL`, `QIANWEN_TTS_VOICE`,

--- a/server/internal/platform/config/speech.go
+++ b/server/internal/platform/config/speech.go
@@ -11,8 +11,8 @@ import (
 const (
 	SpeechProviderQianwen = "qianwen"
 
-	qianwenRealtimeASRModel = "qwen-audio-3.0-asr-flash-streaming"
-	qianwenRecordedASRModel = "qwen-audio-3.0-asr-flash"
+	qianwenRealtimeASRModel = "fun-asr-realtime"
+	qianwenRecordedASRModel = "fun-asr-flash-2026-06-15"
 
 	defaultASRTimeout         = 150 * time.Second
 	minimumRealtimeASRTimeout = 150 * time.Second

--- a/server/internal/providers/qianwen/agent_voice.go
+++ b/server/internal/providers/qianwen/agent_voice.go
@@ -62,7 +62,7 @@ func NewAgentVoiceRecognizer(
 		return nil, err
 	}
 	agentRecognizer := &AgentVoiceRecognizer{recognizer: recognizer}
-	if isRealtimeASRModel(recognizer.model) {
+	if recognizer.model == "fun-asr-realtime" {
 		return &agentRealtimeVoiceRecognizer{
 			AgentVoiceRecognizer: agentRecognizer,
 		}, nil
@@ -151,7 +151,7 @@ func (recognizer *agentRealtimeVoiceRecognizer) TranscribePCMStream(
 ) (agentvoice.TranscriptionResult, error) {
 	if recognizer == nil || recognizer.AgentVoiceRecognizer == nil ||
 		recognizer.recognizer == nil || observer == nil ||
-		!isRealtimeASRModel(recognizer.recognizer.model) {
+		recognizer.recognizer.model != "fun-asr-realtime" {
 		return agentvoice.TranscriptionResult{}, agentvoice.NewSpeechError(
 			agentvoice.SpeechOperationTranscription,
 			agentvoice.ErrorConfiguration,

--- a/server/internal/providers/qianwen/practice_interaction.go
+++ b/server/internal/providers/qianwen/practice_interaction.go
@@ -33,9 +33,9 @@ func NewPracticeRecordedVoiceRecognizer(
 	if err != nil {
 		return nil, err
 	}
-	if model != recordedASRModel {
+	if model != "fun-asr-flash-2026-06-15" {
 		return nil, errors.New(
-			"Qianwen recorded Practice Voice requires " + recordedASRModel,
+			"Qianwen recorded Practice Voice requires fun-asr-flash-2026-06-15",
 		)
 	}
 	configuration.Model = model
@@ -90,7 +90,7 @@ func (recognizer *PracticeVoiceRecognizer) TranscribeStream(
 	observer practiceinteraction.TranscriptionObserver,
 ) (practiceinteraction.TranscriptionResult, error) {
 	if recognizer == nil || recognizer.recognizer == nil || observer == nil ||
-		!isRealtimeASRModel(recognizer.recognizer.model) {
+		recognizer.recognizer.model != "fun-asr-realtime" {
 		return practiceinteraction.TranscriptionResult{},
 			practiceinteraction.NewProviderError(
 				practiceinteraction.ProviderOperationTranscription,

--- a/server/internal/providers/qianwen/practice_interaction_test.go
+++ b/server/internal/providers/qianwen/practice_interaction_test.go
@@ -171,7 +171,7 @@ func TestPracticeVoiceObserverClassifiesCallbackFailureAsCancelled(t *testing.T)
 
 func TestPracticeVoiceStreamingRejectsNonRealtimeModel(t *testing.T) {
 	recognizer := &PracticeVoiceRecognizer{
-		recognizer: &speechRecognizer{model: "qwen-audio-3.0-asr-flash"},
+		recognizer: &speechRecognizer{model: "fun-asr-flash-2026-06-15"},
 	}
 	_, err := recognizer.TranscribeStream(
 		context.Background(),
@@ -187,20 +187,20 @@ func TestPracticeRecordedVoiceRecognizerRequiresFlashModel(t *testing.T) {
 	recorded, err := NewPracticeRecordedVoiceRecognizer(
 		ASRConfig{
 			BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-			Model:   "qwen-audio-3.0-asr-flash",
+			Model:   "fun-asr-flash-2026-06-15",
 			Timeout: time.Second,
 		},
 		"test-key",
 	)
 	if err != nil || recorded == nil || recorded.recognizer == nil ||
-		recorded.recognizer.model != "qwen-audio-3.0-asr-flash" {
+		recorded.recognizer.model != "fun-asr-flash-2026-06-15" {
 		t.Fatalf("recorded recognizer = %#v, %v", recorded, err)
 	}
 
 	_, err = NewPracticeRecordedVoiceRecognizer(
 		ASRConfig{
 			BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-			Model:   "qwen-audio-3.0-asr-flash-streaming",
+			Model:   "fun-asr-realtime",
 			Timeout: time.Second,
 		},
 		"test-key",

--- a/server/internal/providers/qianwen/speech_live_test.go
+++ b/server/internal/providers/qianwen/speech_live_test.go
@@ -61,7 +61,6 @@ func TestLiveSpeechRecognition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create Qianwen recognizer: %v", err)
 	}
-	startedAt := time.Now()
 	result, err := recognizer.Transcribe(
 		context.Background(),
 		protocol.TranscriptionRequest{Audio: audio},
@@ -76,7 +75,7 @@ func TestLiveSpeechRecognition(t *testing.T) {
 		"ASR success: provider=%s model=%s request_id=%s "+
 			"transcript_nonempty=%t transcript_characters=%d "+
 			"usage_audio_seconds=%d fixture_type=%s fixture_bytes=%d "+
-			"fixture_rate_hz=%d fixture_duration=%s total_latency=%s",
+			"fixture_rate_hz=%d fixture_duration=%s",
 		result.Provider,
 		result.Model,
 		result.ID,
@@ -87,56 +86,6 @@ func TestLiveSpeechRecognition(t *testing.T) {
 		audio.Size(),
 		audio.SampleRate(),
 		audio.Duration(),
-		time.Since(startedAt),
-	)
-}
-
-func TestLiveRecordedSpeechRecognition(t *testing.T) {
-	if os.Getenv("QIANWEN_ASR_LIVE_TEST") != "1" {
-		t.Skip(
-			"set QIANWEN_ASR_LIVE_TEST=1 and the ASR environment variables " +
-				"to run; the real request may incur charges",
-		)
-	}
-	audioPath := os.Getenv("QIANWEN_ASR_LIVE_TEST_AUDIO")
-	if audioPath == "" {
-		audioPath = defaultASRLiveFixture
-	}
-	audio := captureLiveASRFixture(t, audioPath)
-	defer audio.Close()
-
-	cfg, err := platformconfig.LoadSpeechRecognition()
-	if err != nil {
-		t.Fatalf("load speech recognition config: %v", err)
-	}
-	recognizer, err := newSpeechRecognizer(ASRConfig{
-		BaseURL: cfg.BaseURL,
-		Model:   cfg.RecordedModel,
-		Timeout: cfg.RecordedTimeout,
-	}, cfg.APIKey.Reveal())
-	if err != nil {
-		t.Fatalf("create recorded Qianwen recognizer: %v", err)
-	}
-	startedAt := time.Now()
-	result, err := recognizer.Transcribe(
-		context.Background(),
-		protocol.TranscriptionRequest{Audio: audio},
-	)
-	if err != nil {
-		t.Fatalf("live recorded Qianwen ASR failed: %s", safeLiveSpeechError(err))
-	}
-	if result.Transcript == "" {
-		t.Fatal("live recorded Qianwen ASR returned an empty transcript")
-	}
-	t.Logf(
-		"recorded ASR success: provider=%s model=%s request_id=%s "+
-			"transcript_characters=%d fixture_duration=%s total_latency=%s",
-		result.Provider,
-		result.Model,
-		result.ID,
-		utf8.RuneCountInString(result.Transcript),
-		audio.Duration(),
-		time.Since(startedAt),
 	)
 }
 

--- a/server/internal/providers/qianwen/speech_recognizer.go
+++ b/server/internal/providers/qianwen/speech_recognizer.go
@@ -20,11 +20,6 @@ import (
 
 const maxASRDataURLBytes = 10_000_000
 
-const (
-	realtimeASRModel = "qwen-audio-3.0-asr-flash-streaming"
-	recordedASRModel = "qwen-audio-3.0-asr-flash"
-)
-
 type ASRConfig struct {
 	BaseURL  string
 	Model    string
@@ -44,10 +39,10 @@ type speechRecognizer struct {
 
 func (recognizer *speechRecognizer) String() string {
 	if recognizer == nil {
-		return "QianwenASRRecognizer(<nil>)"
+		return "FunASRRecognizer(<nil>)"
 	}
 	return fmt.Sprintf(
-		"QianwenASRRecognizer(model=%q, timeout=%s, api_key=[REDACTED])",
+		"FunASRRecognizer(model=%q, timeout=%s, api_key=[REDACTED])",
 		recognizer.model,
 		recognizer.timeout,
 	)
@@ -85,10 +80,10 @@ func newRecognizerWithClient(
 		return nil, err
 	}
 	if config.Timeout <= 0 || config.Timeout > maxTimeout {
-		return nil, fmt.Errorf("Qianwen ASR timeout must be greater than zero and at most %s", maxTimeout)
+		return nil, fmt.Errorf("Fun-ASR timeout must be greater than zero and at most %s", maxTimeout)
 	}
 	if client == nil {
-		return nil, errors.New("Qianwen ASR HTTP client is required")
+		return nil, errors.New("Fun-ASR HTTP client is required")
 	}
 	return &speechRecognizer{
 		endpoint:   baseURL + multimodalGenerationPath,
@@ -105,7 +100,7 @@ func (recognizer *speechRecognizer) Transcribe(
 	ctx context.Context,
 	request protocol.TranscriptionRequest,
 ) (protocol.TranscriptionResult, error) {
-	if isRealtimeASRModel(recognizer.model) {
+	if recognizer.model == "fun-asr-realtime" {
 		return recognizer.transcribeRealtime(ctx, request, nil)
 	}
 	if ctx == nil {
@@ -148,7 +143,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			0,
 			"",
 			"",
-			errors.New("encoded audio exceeds the Qianwen ASR input limit"),
+			errors.New("encoded audio exceeds the Fun-ASR input limit"),
 		)
 	}
 
@@ -178,7 +173,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			0,
 			"",
 			"",
-			errors.New("encode Qianwen ASR request"),
+			errors.New("encode Fun-ASR request"),
 		)
 	}
 
@@ -197,7 +192,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			0,
 			"",
 			"",
-			errors.New("create Qianwen ASR request"),
+			errors.New("create Fun-ASR request"),
 		)
 	}
 	httpRequest.Header.Set(
@@ -221,7 +216,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			0,
 			"",
-			"Qianwen ASR returned a nil HTTP response",
+			"Fun-ASR returned a nil HTTP response",
 		)
 	}
 	if response.Body == nil {
@@ -229,7 +224,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			response.StatusCode,
 			response.Header.Get("X-Request-Id"),
-			"Qianwen ASR returned an HTTP response without a body",
+			"Fun-ASR returned an HTTP response without a body",
 		)
 	}
 	defer response.Body.Close()
@@ -245,7 +240,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			response.StatusCode,
 			response.Header.Get("X-Request-Id"),
-			"Qianwen ASR response exceeds the accepted limit",
+			"Fun-ASR response exceeds the accepted limit",
 		)
 	}
 	var completion asrResponse
@@ -254,7 +249,7 @@ func (recognizer *speechRecognizer) Transcribe(
 			protocol.SpeechOperationTranscription,
 			response.StatusCode,
 			response.Header.Get("X-Request-Id"),
-			"decode Qianwen ASR response",
+			"decode Fun-ASR response",
 		)
 	}
 	result, err := completion.result(recognizer.model)
@@ -274,7 +269,7 @@ func (recognizer *speechRecognizer) TranscribeStream(
 	request protocol.TranscriptionRequest,
 	observer protocol.TranscriptionObserver,
 ) (protocol.TranscriptionResult, error) {
-	if !isRealtimeASRModel(recognizer.model) || observer == nil {
+	if recognizer.model != "fun-asr-realtime" || observer == nil {
 		return recognizer.Transcribe(ctx, request)
 	}
 	return recognizer.transcribeRealtime(ctx, request, observer)
@@ -312,12 +307,7 @@ type asrParameters struct {
 type asrResponse struct {
 	RequestID string `json:"request_id"`
 	Output    struct {
-		Text   string `json:"text"`
-		Output struct {
-			Sentence struct {
-				Text string `json:"text"`
-			} `json:"sentence"`
-		} `json:"output"`
+		Text     string `json:"text"`
 		Sentence struct {
 			Text string `json:"text"`
 		} `json:"sentence"`
@@ -330,10 +320,10 @@ type asrResponse struct {
 func (response asrResponse) result(model string) (protocol.TranscriptionResult, error) {
 	requestID := sanitizeIdentifier(response.RequestID)
 	if requestID == "" {
-		return protocol.TranscriptionResult{}, errors.New("Qianwen ASR response has no valid request ID")
+		return protocol.TranscriptionResult{}, errors.New("Fun-ASR response has no valid request ID")
 	}
 	if response.Usage.Duration < 0 {
-		return protocol.TranscriptionResult{}, errors.New("Qianwen ASR response has invalid audio usage")
+		return protocol.TranscriptionResult{}, errors.New("Fun-ASR response has invalid audio usage")
 	}
 	text := strings.TrimSpace(response.Output.Text)
 	sentenceText := strings.TrimSpace(response.Output.Sentence.Text)
@@ -343,10 +333,7 @@ func (response asrResponse) result(model string) (protocol.TranscriptionResult, 
 		text = sentenceText
 	}
 	if text == "" {
-		text = strings.TrimSpace(response.Output.Output.Sentence.Text)
-	}
-	if text == "" {
-		return protocol.TranscriptionResult{}, errors.New("Qianwen ASR response has no transcript")
+		return protocol.TranscriptionResult{}, errors.New("Fun-ASR response has no transcript")
 	}
 	return protocol.TranscriptionResult{
 		ID:         requestID,
@@ -385,18 +372,10 @@ func readAudioSource(source platformmedia.AudioSource) ([]byte, error) {
 
 func normalizeASRModel(raw string) (string, error) {
 	model := strings.ToLower(strings.TrimSpace(raw))
-	if model != realtimeASRModel && model != recordedASRModel {
-		return "", fmt.Errorf(
-			"Qianwen ASR adapter only accepts %s or %s",
-			realtimeASRModel,
-			recordedASRModel,
-		)
+	if model != "fun-asr-realtime" && model != "fun-asr-flash-2026-06-15" {
+		return "", errors.New("Fun-ASR adapter only accepts fun-asr-realtime or fun-asr-flash-2026-06-15")
 	}
 	return model, nil
-}
-
-func isRealtimeASRModel(model string) bool {
-	return model == realtimeASRModel
 }
 
 func invalidSpeechResponse(

--- a/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_realtime_test.go
@@ -24,8 +24,8 @@ func TestAgentVoiceRecognizerExposesRealtimePCMCapabilityOnlyForRealtime(
 		model string
 		want  bool
 	}{
-		{model: "qwen-audio-3.0-asr-flash-streaming", want: true},
-		{model: "qwen-audio-3.0-asr-flash", want: false},
+		{model: "fun-asr-realtime", want: true},
+		{model: "fun-asr-flash-2026-06-15", want: false},
 	} {
 		t.Run(test.model, func(t *testing.T) {
 			recognizer, err := NewAgentVoiceRecognizer(ASRConfig{
@@ -86,7 +86,7 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 			return
 		}
 		if run.Header.Action != "run-task" ||
-			run.Payload.Model != "qwen-audio-3.0-asr-flash-streaming" ||
+			run.Payload.Model != "fun-asr-realtime" ||
 			run.Payload.Parameters.SampleRate != 16_000 {
 			t.Errorf("unexpected run-task: %#v", run)
 			return
@@ -177,7 +177,7 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 		t.Fatal("realtime recognition must not use HTTP generation")
 		return nil, nil
 	}), apiKey)
-	recognizer.model = "qwen-audio-3.0-asr-flash-streaming"
+	recognizer.model = "fun-asr-realtime"
 	recognizer.wsEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
 	observer := &recordingTranscriptionObserver{}
 	result, err := recognizer.TranscribeStream(
@@ -192,7 +192,7 @@ func TestRealtimeTranscribeUsesDocumentedWebSocketSequence(t *testing.T) {
 		t.Fatalf("validated source format = %q, want wav", format)
 	}
 	if result.Transcript != "I practice English for interviews." ||
-		result.Model != "qwen-audio-3.0-asr-flash-streaming" ||
+		result.Model != "fun-asr-realtime" ||
 		result.Usage.AudioSeconds != 4 {
 		t.Fatalf("result = %#v", result)
 	}
@@ -282,7 +282,7 @@ func TestRealtimeTranscribeClosesProviderConnectionOnCancellation(t *testing.T) 
 		t.Fatal("realtime recognition must not use HTTP generation")
 		return nil, nil
 	}), "test-realtime-key")
-	recognizer.model = "qwen-audio-3.0-asr-flash-streaming"
+	recognizer.model = "fun-asr-realtime"
 	recognizer.wsEndpoint = "ws" + strings.TrimPrefix(server.URL, "http")
 	ctx, cancel := context.WithCancel(context.Background())
 	result := make(chan error, 1)

--- a/server/internal/providers/qianwen/speech_recognizer_test.go
+++ b/server/internal/providers/qianwen/speech_recognizer_test.go
@@ -17,7 +17,7 @@ import (
 	protocol "github.com/1024XEngineer/XE3-ESL/server/internal/providers/qianwen/internal/protocol"
 )
 
-func TestTranscribeUsesDocumentedQwenAudioASRFlashContract(t *testing.T) {
+func TestTranscribeUsesDocumentedFunASRFlashContract(t *testing.T) {
 	t.Parallel()
 
 	const apiKey = "test-api-key"
@@ -53,7 +53,7 @@ func TestTranscribeUsesDocumentedQwenAudioASRFlashContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transcribe: %v", err)
 	}
-	if received.Model != "qwen-audio-3.0-asr-flash" ||
+	if received.Model != "fun-asr-flash-2026-06-15" ||
 		received.Parameters.Format != "wav" ||
 		received.Parameters.SampleRate != "16000" ||
 		len(received.Input.Messages) != 1 ||
@@ -68,7 +68,7 @@ func TestTranscribeUsesDocumentedQwenAudioASRFlashContract(t *testing.T) {
 	expected := protocol.TranscriptionResult{
 		ID:         "fun-asr-safe-1",
 		Provider:   providerName,
-		Model:      "qwen-audio-3.0-asr-flash",
+		Model:      "fun-asr-flash-2026-06-15",
 		Transcript: "I am preparing for an interview.",
 		Usage: protocol.SpeechUsage{
 			AudioSeconds: 4,
@@ -86,10 +86,6 @@ func TestTranscribeAcceptsDocumentedTranscriptLocations(t *testing.T) {
 		"top-level output text": `{
 			"output":{"text":"Hello from the top level."},
 			"request_id":"fun-asr-top"
-		}`,
-		"documented nested sentence text": `{
-			"output":{"output":{"sentence":{"text":"Hello from the nested sentence."}}},
-			"request_id":"qwen-audio-asr-sentence"
 		}`,
 		"documented sentence text": `{
 			"output":{"sentence":{"text":"Hello from the sentence."}},
@@ -256,7 +252,7 @@ func TestRecognizerTimeoutAndFormattingAreSafe(t *testing.T) {
 	})
 	recognizer, err := newRecognizerWithClient(ASRConfig{
 		BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-		Model:   "qwen-audio-3.0-asr-flash",
+		Model:   "fun-asr-flash-2026-06-15",
 		Timeout: 10 * time.Millisecond,
 	}, apiKey, blocking)
 	if err != nil {
@@ -302,7 +298,7 @@ func TestNewRecognizerRejectsUnsupportedModelAndEndpoint(t *testing.T) {
 
 	valid := ASRConfig{
 		BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-		Model:   "qwen-audio-3.0-asr-flash",
+		Model:   "fun-asr-flash-2026-06-15",
 		Timeout: time.Second,
 	}
 	tests := []struct {
@@ -336,7 +332,7 @@ func mustRecognizer(t *testing.T, client httpDoer, apiKey string) *speechRecogni
 	t.Helper()
 	recognizer, err := newRecognizerWithClient(ASRConfig{
 		BaseURL: "https://dashscope.aliyuncs.com/api/v1",
-		Model:   "qwen-audio-3.0-asr-flash",
+		Model:   "fun-asr-flash-2026-06-15",
 		Timeout: time.Second,
 	}, apiKey, client)
 	if err != nil {


### PR DESCRIPTION
## 功能描述

恢复当前新加坡生产环境使用的 Fun-ASR 模型与协议，使最新 `dev` 能使用已核验的生产配置启动并完成实时语音转写。

## 实现思路

- 精准撤销 #1078 中对 Qwen-Audio 3.0 ASR 的切换。
- 恢复 `fun-asr-realtime` 与 `fun-asr-flash-2026-06-15` 的配置校验、请求和响应解析。
- 保留后续数字人、报告、场景和 Agent 修复，不改生产环境。

## 可复现测试

- `cd server && go test -count=1 ./internal/platform/config ./internal/providers/qianwen`
- `cd server && go build ./cmd/server`
- 加载已核验的新加坡配置后：`QIANWEN_ASR_LIVE_TEST=1 go test -count=1 -run "^TestLiveSpeechRecognition$" -v ./internal/providers/qianwen`
  - 实测 `fun-asr-realtime` 成功返回非空转写，3.5 秒音频总请求约 1.28 秒。

Closes #1102