### PR TITLE
fix(mobile): 复用全局 Ambient 背景

### DIFF
--- a/mobile/lib/features/agent/conversation/conversation.dart
+++ b/mobile/lib/features/agent/conversation/conversation.dart
@@ -166,7 +166,6 @@ class ConversationPage extends StatefulWidget {
       backgroundColor: Colors.transparent,
       body: Stack(
         children: [
-          const Positioned.fill(child: _AgentBackground()),
           Positioned.fill(
             child: SafeArea(
               bottom: false,
@@ -758,15 +757,6 @@ final class _ConversationScrollAnchor {
   final int messageCount;
   final double pixels;
   final double maxScrollExtent;
-}
-
-class _AgentBackground extends StatelessWidget {
-  const _AgentBackground();
-
-  @override
-  Widget build(BuildContext context) {
-    return const SpeakUpAmbientBackground();
-  }
 }
 
 class _AgentTopBar extends StatelessWidget {

--- a/mobile/test/design/speak_up_design_test.dart
+++ b/mobile/test/design/speak_up_design_test.dart
@@ -34,13 +34,17 @@ void main() {
   testWidgets('ambient background matches the approved product gradient', (
     tester,
   ) async {
+    final backgroundKey = UniqueKey();
     await tester.pumpWidget(
-      const Directionality(
+      Directionality(
         textDirection: TextDirection.ltr,
-        child: SizedBox.expand(child: SpeakUpAmbientBackground()),
+        child: SizedBox.expand(
+          child: SpeakUpAmbientBackground(key: backgroundKey),
+        ),
       ),
     );
 
+    expect(find.byKey(backgroundKey), findsOneWidget);
     final box = tester.widget<DecoratedBox>(find.byType(DecoratedBox));
     final decoration = box.decoration as BoxDecoration;
     final gradient = decoration.gradient! as LinearGradient;

--- a/mobile/test/speak_up_app_test.dart
+++ b/mobile/test/speak_up_app_test.dart
@@ -214,13 +214,21 @@ void main() {
     await tester.pumpWidget(const SpeakUpApp.preview());
     final semantics = tester.ensureSemantics();
 
-    expect(find.byType(SpeakUpAmbientBackground), findsWidgets);
+    final ambientBackground = find.byType(SpeakUpAmbientBackground);
+    expect(ambientBackground, findsOneWidget);
+    final ambientBackgroundElement = tester.element(ambientBackground);
+
+    void expectStableAmbientBackground() {
+      expect(ambientBackground, findsOneWidget);
+      expect(tester.element(ambientBackground), same(ambientBackgroundElement));
+    }
 
     await _tapPrimaryDestination(
       tester,
       key: 'primary-tab-scenes',
       expectedPageKey: 'scenes-page',
     );
+    expectStableAmbientBackground();
     expect(find.text('Practice'), findsOneWidget);
     expect(
       find.descendant(
@@ -249,6 +257,7 @@ void main() {
       key: 'primary-tab-review',
       expectedPageKey: 'review-page',
     );
+    expectStableAmbientBackground();
     expect(find.text('Review'), findsOneWidget);
     expect(find.byKey(const Key('review-exit-button')), findsNothing);
     expect(find.byKey(const Key('primary-navigation')), findsOneWidget);
@@ -257,6 +266,7 @@ void main() {
       key: 'primary-tab-profile',
       expectedPageKey: 'profile-page',
     );
+    expectStableAmbientBackground();
     expect(find.byKey(const Key('profile-avatar')), findsOneWidget);
     expect(find.byKey(const Key('profile-display-name')), findsOneWidget);
     expect(
@@ -276,6 +286,7 @@ void main() {
       key: 'primary-tab-agent',
       expectedPageKey: 'agent-home-page',
     );
+    expectStableAmbientBackground();
     semantics.dispose();
   });
 


### PR DESCRIPTION
## 功能描述

- 修复首页与应用根层各绘制一份 Ambient 渐变的问题。
- 主导航切换时只保留 `MaterialApp.builder` 中的共享背景，页面视觉保持不变。

## 实现思路

- 删除会话首页冗余的 `_AgentBackground -> SpeakUpAmbientBackground` 局部层。
- 保留根层全局背景及聊天顶部/底部滚动遮罩。
- 将现有主导航测试从允许多个背景收紧为唯一实例，并验证四个 Tab 切换前后根背景 `Element` 身份不变。
- 未添加 `RepaintBoundary` 或缓存层；本次证据指向重复页面背景，额外合成层没有必要。

## 可复现测试

- `cd mobile && flutter test --no-pub test/speak_up_app_test.dart --plain-name "switches between every primary destination"`
- `make check-flutter`
  - Dart format 通过
  - Flutter analyze 通过
  - iOS Simulator AvatarKit stub 契约测试通过
  - Flutter 全量 866 项测试通过
  - Android 显式签名守卫测试通过
- `SPEAKUP_DEV_PORT=18082 IOS_SIMULATOR_ID=F726FD1C-12E1-4E8A-9741-F6FC98B4520D make dev-ios-simulator`
  - 真实本地后端运行，数字人明确禁用
  - iPhone 16 Pro / iOS 18.3 上切换 SpeakUp、训练、复盘、我的并返回首页，无白色断层或视觉异常
  - 用户已在模拟器确认问题消失

Closes #1107

关联：#1002、#1003