### PR TITLE
feat(observability): add user behavior dashboard

### DIFF
--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -18,8 +18,8 @@ The shared server remains protected by three scope rules:
 - Prometheus: 30-day/8-GB bounded retention.
 - Alertmanager: private SMTP configuration supplied by the server operator.
 - Grafana: provisioned Prometheus and restricted PostgreSQL data sources, with
-  separate system and Product Health dashboards. New users default to the
-  Simplified Chinese (`zh-Hans`) interface.
+  separate system, Product Health, and User Behavior dashboards. New users
+  default to the Simplified Chinese (`zh-Hans`) interface.
 - blackbox_exporter: Portal, API, and Android release HTTPS probes.
 - node_exporter: only the bounded SpeakUp textfile collector. It has no host
   root mount; the reviewed host-side exporter emits root disk and inode values.
@@ -55,8 +55,9 @@ The migration revokes `PUBLIC` access to every view.
 
 `configure-product-health-reader` provisions the login role
 `speakup_product_health_reader` after the migration is applied. It first revokes
-all table access, then grants `SELECT` on exactly those five views. The role is
-non-inheriting, read-only by default, connection-limited, and time-bounded.
+all table access, then grants `SELECT` on exactly the five Product Health views
+and seven User Behavior views. The role is non-inheriting, read-only by default,
+connection-limited, and time-bounded.
 Grafana uses that role only through the existing internal
 `xe3-speakup-production_database` Docker network. PostgreSQL receives no host
 or public port.
@@ -90,6 +91,42 @@ The deterministic migration integration fixture is the canonical
 Staging-compatible seed for reproducing and checking every first-version
 formula; it creates only an isolated test schema and is never loaded into
 Production.
+
+## User Behavior boundary
+
+Migration `000015_user_behavior_views` creates seven anonymous aggregates. The
+User Behavior dashboard reuses the restricted Product Health PostgreSQL
+datasource and reads only those views:
+
+- `user_behavior_daily_session_funnel`;
+- `user_behavior_daily_time_to_first_effective_turn`;
+- `user_behavior_daily_retention`;
+- `user_behavior_daily_repractice`;
+- `user_behavior_current_nonterminal_sessions`;
+- `user_behavior_daily_early_end`;
+- `user_behavior_daily_feature_usage`.
+
+The dashboard tells one product-improvement story in order: practice funnel,
+time to first effective answer, confirmed-answer retention, repractice and
+early-end behavior, non-terminal Session candidates, and feature usage. It
+never queries raw business tables or exposes a user, Session, Turn, Evaluation,
+content, or other identifier. Rates and percentiles remain `NULL` when the
+aggregate view has no valid denominator, and Grafana keeps No Data distinct
+from a measured zero.
+
+Feature panels require one fixed `feature_kind` and one fixed volume measure at
+a time. The default shows `PRACTICE_EXPERIENCE` and `SESSIONS`; even the largest
+closed feature dimension produces at most ten series instead of mixing every
+kind and measure in one chart.
+
+Current server facts can prove that Session Report generation was scheduled or
+became READY; they cannot prove that a user viewed the report or Turn Feedback.
+The User Behavior funnel exposes READY generation, labels it as generation, and
+lists viewing, screen paths, permission denial, and other client-only behavior
+as not observable. Likewise, an old non-terminal Session is a stale candidate,
+not proof that a user abandoned it. Adding those client facts requires a
+separately reviewed, allowlisted event contract; this dashboard does not infer
+them.
 
 ## Application metrics boundary
 
@@ -225,7 +262,8 @@ switching it so rollback selects an exact source. Then:
    ```
 
 9. Confirm every Prometheus target is up and the Product Health datasource can
-   query only its five views from a loopback Grafana session.
+   query only the five Product Health and seven User Behavior aggregate views
+   from a loopback Grafana session.
 10. After DNS/TLS validation, install `monitor-nginx.conf`, run
    `/usr/local/nginx/sbin/nginx -t`, and reload only after it succeeds.
 
@@ -305,10 +343,11 @@ are installed; do not commit those settings.
   curl --fail http://127.0.0.1:13000/api/health
   ```
 
-  Keep the Product Health role, views, and root-private PGPASSFILE in place.
-  They are additive and cannot read raw tables; Production rollback never runs
-  a down migration. Removing them belongs to a separately reviewed database
-  change, not an availability rollback.
+  Keep the Product Health reader role, the Product Health and User Behavior
+  views, and the root-private PGPASSFILE in place. They are additive and cannot
+  read raw tables; Production rollback never runs a down migration. Removing
+  them belongs to a separately reviewed database change, not an availability
+  rollback.
 - If the stack fails, keep its volumes and stop only the
   `xe3-speakup-observability` Compose project.
 - Restore the previous SpeakUp Compose files and recreate only those services if

--- a/deploy/observability/configure-product-health-reader
+++ b/deploy/observability/configure-product-health-reader
@@ -159,7 +159,14 @@ GRANT SELECT ON public.product_health_daily_practice_activity,
                 public.product_health_daily_session_outcomes,
                 public.product_health_daily_artifact_coverage,
                 public.product_health_daily_evaluation_health,
-                public.product_health_daily_scoreability
+                public.product_health_daily_scoreability,
+                public.user_behavior_daily_session_funnel,
+                public.user_behavior_daily_time_to_first_effective_turn,
+                public.user_behavior_daily_retention,
+                public.user_behavior_daily_repractice,
+                public.user_behavior_current_nonterminal_sessions,
+                public.user_behavior_daily_early_end,
+                public.user_behavior_daily_feature_usage
 TO speakup_product_health_reader;
 COMMIT;
 SQL

--- a/deploy/observability/grafana/dashboards/speakup-user-behavior.json
+++ b/deploy/observability/grafana/dashboards/speakup-user-behavior.json
@@ -1,0 +1,547 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Production 匿名聚合用户行为基线。所有日期与看板时区均为 UTC；No Data 表示当前没有可证明的样本，不等于 0。",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "panels": [],
+      "title": "练习漏斗",
+      "type": "row"
+    },
+    {
+      "description": "汇总所选时间范围内创建的练习 cohort，依次展示已开始、已确认首次有效回答、已完成，以及练后报告已生成 READY 的数量。报告 READY 不代表用户查看过报告；空范围保持 No Data。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 16, "x": 0, "y": 1},
+      "id": 2,
+      "options": {
+        "displayMode": "basic",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT sum(created_sessions)::double precision AS \"1 创建练习\",\n       sum(started_sessions)::double precision AS \"2 开始练习\",\n       sum(first_effective_confirmed_sessions)::double precision AS \"3 首次有效回答\",\n       sum(completed_sessions)::double precision AS \"4 完成练习\",\n       sum(ready_session_report_sessions)::double precision AS \"5 练后报告 READY\"\nFROM public.user_behavior_daily_session_funnel\nWHERE $__timeFilter(day_utc)",
+          "refId": "A"
+        }
+      ],
+      "title": "所选时段总漏斗",
+      "type": "bargauge"
+    },
+    {
+      "description": "开始率分母为已创建练习；首次有效回答率分母为已开始练习；完成率分母为已有首次有效回答的练习；报告 READY 率分母为已完成练习；提前结束率分母为已开始练习。分母为 0 时保持 No Data。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 1},
+      "id": 3,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time,\n       started_from_created_rate AS \"创建 → 开始\",\n       first_effective_from_started_rate AS \"开始 → 首次有效回答\",\n       completed_from_first_effective_rate AS \"首次有效回答 → 完成\",\n       ready_report_from_completed_rate AS \"完成 → 报告 READY\",\n       ended_early_from_started_rate AS \"开始 → 提前结束\"\nFROM public.user_behavior_daily_session_funnel\nWHERE $__timeFilter(day_utc)\nORDER BY day_utc",
+          "refId": "A"
+        }
+      ],
+      "title": "漏斗转化与提前结束率",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "id": 4,
+      "panels": [],
+      "title": "首次有效回答",
+      "type": "row"
+    },
+    {
+      "description": "ACCOUNT 按账户创建 UTC 日形成 cohort；SESSION 按练习创建 UTC 日形成 cohort。分别展示 cohort 到达首次有效回答的比例；无有效分母时保持 No Data。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 10},
+      "id": 5,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time, scope AS metric, reach_rate AS value\nFROM public.user_behavior_daily_time_to_first_effective_turn\nWHERE $__timeFilter(day_utc)\nORDER BY day_utc, scope",
+          "refId": "A"
+        }
+      ],
+      "title": "首次有效回答覆盖率",
+      "type": "timeseries"
+    },
+    {
+      "description": "仅统计已到达首次有效回答的 cohort：ACCOUNT 从账户创建计时，SESSION 从练习创建计时，分别展示耗时中位数和 P95；没有到达样本时保持 No Data。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 16, "x": 8, "y": 10},
+      "id": 6,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time,\n       max(p50_seconds) FILTER (WHERE scope = 'ACCOUNT') AS \"账户 P50\",\n       max(p95_seconds) FILTER (WHERE scope = 'ACCOUNT') AS \"账户 P95\",\n       max(p50_seconds) FILTER (WHERE scope = 'SESSION') AS \"练习 P50\",\n       max(p95_seconds) FILTER (WHERE scope = 'SESSION') AS \"练习 P95\"\nFROM public.user_behavior_daily_time_to_first_effective_turn\nWHERE $__timeFilter(day_utc)\nGROUP BY day_utc\nORDER BY day_utc",
+          "refId": "A"
+        }
+      ],
+      "title": "首次有效回答耗时 P50 / P95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18},
+      "id": 7,
+      "panels": [],
+      "title": "练习留存",
+      "type": "row"
+    },
+    {
+      "description": "按账户全历史首次有效回答 UTC 日形成 cohort，展示 cohort 人数以及在 D1、D7 再次确认任一回答的人数。尚未成熟的 cohort 保持 No Data。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 18,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 19},
+      "id": 8,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT cohort_day_utc AS time,\n       cohort_users AS \"首次有效回答账户\",\n       d1_returned_users AS \"D1 再次确认回答\",\n       d7_returned_users AS \"D7 再次确认回答\"\nFROM public.user_behavior_daily_retention\nWHERE $__timeFilter(cohort_day_utc)\nORDER BY cohort_day_utc",
+          "refId": "A"
+        }
+      ],
+      "title": "留存人数（按首次有效回答日）",
+      "type": "timeseries"
+    },
+    {
+      "description": "D1 与 D7 留存都要求账户在目标 UTC 日再次确认任一回答；尚未到达观察窗口的 cohort 为 No Data，不显示为 0%。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 19},
+      "id": 9,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT cohort_day_utc AS time,\n       d1_retention_rate AS \"D1 确认回答留存\",\n       d7_retention_rate AS \"D7 确认回答留存\"\nFROM public.user_behavior_daily_retention\nWHERE $__timeFilter(cohort_day_utc)\nORDER BY cohort_day_utc",
+          "refId": "A"
+        }
+      ],
+      "title": "D1 / D7 确认回答留存率",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 27},
+      "id": 10,
+      "panels": [],
+      "title": "重练、提前结束与未终态",
+      "type": "row"
+    },
+    {
+      "description": "展示创建的重练回答中已确认、失败和非终态超过 24 小时的数量。stale 是停滞候选，不代表用户明确放弃。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 18,
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 14, "x": 0, "y": 28},
+      "id": 11,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time,\n       created_retry_turns AS \"创建重练回答\",\n       confirmed_retry_turns AS \"确认重练回答\",\n       failed_retry_turns AS \"失败重练回答\",\n       stale_retry_turns AS \"停滞候选\"\nFROM public.user_behavior_daily_repractice\nWHERE $__timeFilter(day_utc)\nORDER BY day_utc",
+          "refId": "A"
+        }
+      ],
+      "title": "重练结果",
+      "type": "timeseries"
+    },
+    {
+      "description": "以当日创建的重练回答为分母；确认、失败和停滞候选分别统计。无重练样本时保持 No Data。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 10, "x": 14, "y": 28},
+      "id": 12,
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time,\n       confirmation_rate AS \"确认率\",\n       failure_rate AS \"失败率\",\n       stale_rate AS \"停滞候选率\"\nFROM public.user_behavior_daily_repractice\nWHERE $__timeFilter(day_utc)\nORDER BY day_utc",
+          "refId": "A"
+        }
+      ],
+      "title": "重练结果占比",
+      "type": "timeseries"
+    },
+    {
+      "description": "按提前结束前已经确认的有效回答数分层；5_PLUS 表示 5 个及以上。占比只在提前结束练习内计算。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 14, "x": 0, "y": 36},
+      "id": 13,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time, effective_turn_depth AS metric, ended_early_share AS value\nFROM public.user_behavior_daily_early_end\nWHERE $__timeFilter(day_utc)\nORDER BY day_utc, effective_turn_depth",
+          "refId": "A"
+        }
+      ],
+      "title": "提前结束深度",
+      "type": "timeseries"
+    },
+    {
+      "description": "当前仍处于非终态的练习，按状态与停滞时间桶聚合。它们只是需要调查的 stale candidates，不能直接解释为用户放弃。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {"align": "auto", "cellOptions": {"type": "auto"}, "inspect": false},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 10, "x": 14, "y": 36},
+      "id": 14,
+      "options": {"cellHeight": "sm", "showHeader": true},
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n    CASE session_status\n        WHEN 'STARTING' THEN '启动中'\n        WHEN 'IN_PROGRESS' THEN '进行中'\n        WHEN 'PAUSED' THEN '已暂停'\n        ELSE session_status\n    END AS \"练习状态\",\n    CASE staleness_bucket\n        WHEN 'UNDER_1H' THEN '< 1 小时'\n        WHEN '1H_TO_24H' THEN '1–24 小时'\n        WHEN '1D_TO_7D' THEN '1–7 天'\n        WHEN '7D_PLUS' THEN '≥ 7 天'\n        ELSE staleness_bucket\n    END AS \"停滞时长\",\n    sessions AS \"练习数\"\nFROM public.user_behavior_current_nonterminal_sessions\nORDER BY\n    CASE session_status\n        WHEN 'STARTING' THEN 1\n        WHEN 'IN_PROGRESS' THEN 2\n        WHEN 'PAUSED' THEN 3\n        ELSE 4\n    END,\n    CASE staleness_bucket\n        WHEN 'UNDER_1H' THEN 1\n        WHEN '1H_TO_24H' THEN 2\n        WHEN '1D_TO_7D' THEN 3\n        WHEN '7D_PLUS' THEN 4\n        ELSE 5\n    END",
+          "refId": "A"
+        }
+      ],
+      "title": "当前未终态练习（候选，不等于放弃）",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 44},
+      "id": 15,
+      "panels": [],
+      "title": "功能使用",
+      "type": "row"
+    },
+    {
+      "description": "使用顶部“功能维度”选择器，按已确认回答所在练习的功能值展示每日去重账户数。单次只展示一个闭集维度，避免系列混杂；不含用户标识。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 45},
+      "id": 16,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time,\n       feature_value AS metric,\n       active_users::double precision AS value\nFROM public.user_behavior_daily_feature_usage\nWHERE $__timeFilter(day_utc)\n  AND feature_kind = ${feature_kind:sqlstring}\nORDER BY day_utc, feature_value",
+          "refId": "A"
+        }
+      ],
+      "title": "功能使用用户（${feature_kind:text}）",
+      "type": "timeseries"
+    },
+    {
+      "description": "使用顶部选择器切换功能维度与行为量口径。SESSIONS 是每日去重练习数，CONFIRMED_TURNS 是每日已确认回答数；单次最多展示所选维度的 10 个闭集值。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 45},
+      "id": 17,
+      "options": {
+        "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "none"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "grafana-postgresql-datasource", "uid": "speakup-product-health-postgres"},
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT day_utc AS time,\n       feature_value AS metric,\n       CASE ${feature_metric:sqlstring}\n           WHEN 'SESSIONS' THEN sessions::double precision\n           WHEN 'CONFIRMED_TURNS' THEN confirmed_turns::double precision\n       END AS value\nFROM public.user_behavior_daily_feature_usage\nWHERE $__timeFilter(day_utc)\n  AND feature_kind = ${feature_kind:sqlstring}\nORDER BY day_utc, feature_value",
+          "refId": "A"
+        }
+      ],
+      "title": "功能使用行为量（${feature_metric:text}）",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 53},
+      "id": 18,
+      "panels": [],
+      "title": "数据边界",
+      "type": "row"
+    },
+    {
+      "description": "列出当前服务端事实无法回答的问题，避免路演或产品复盘时把缺失观测解释成用户行为。",
+      "gridPos": {"h": 7, "w": 24, "x": 0, "y": 54},
+      "id": 19,
+      "options": {
+        "content": "### 暂不可观测（不是 0）\n\n- **报告与逐轮反馈实际查看**：当前只能证明生成已调度或 READY，不能证明用户打开或阅读。\n- **页面路径与入口选择**：当前没有 App 端页面浏览、点击或路径事件。\n- **权限拒绝与前端中途退出**：服务端没有收到请求时无法识别。\n- **明确放弃**：未终态且停滞的练习只是 stale candidate，不能等同于用户放弃。\n\n如需回答这些问题，应另行设计严格白名单、无内容字段的客户端行为事件；本看板不从服务端事实猜测。No Data 表示尚无可证明样本，不等于测得 0。",
+        "mode": "markdown"
+      },
+      "title": "暂不可观测（不是 0）",
+      "type": "text"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 42,
+  "tags": ["speakup", "user-behavior", "production"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": true, "text": "练习体验", "value": "PRACTICE_EXPERIENCE"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "功能维度",
+        "multi": false,
+        "name": "feature_kind",
+        "options": [
+          {"selected": true, "text": "练习体验", "value": "PRACTICE_EXPERIENCE"},
+          {"selected": false, "text": "场景", "value": "SCENE_CATEGORY"},
+          {"selected": false, "text": "练习模式", "value": "PRACTICE_MODE"},
+          {"selected": false, "text": "交互方式", "value": "INTERACTION_MODE"}
+        ],
+        "query": "练习体验 : PRACTICE_EXPERIENCE,场景 : SCENE_CATEGORY,练习模式 : PRACTICE_MODE,交互方式 : INTERACTION_MODE",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {"selected": true, "text": "练习数", "value": "SESSIONS"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "行为量口径",
+        "multi": false,
+        "name": "feature_metric",
+        "options": [
+          {"selected": true, "text": "练习数", "value": "SESSIONS"},
+          {"selected": false, "text": "确认回答数", "value": "CONFIRMED_TURNS"}
+        ],
+        "query": "练习数 : SESSIONS,确认回答数 : CONFIRMED_TURNS",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {"from": "now-30d", "to": "now"},
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "SpeakUp 用户行为",
+  "uid": "speakup-user-behavior",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -16,6 +16,7 @@ readonly probe_workflow="$observability_directory/../../.github/workflows/produc
 readonly metrics_service="$observability_directory/xe3-speakup-observability-metrics.service"
 readonly metrics_environment_example="$observability_directory/observability-metrics.env.example"
 readonly product_health_dashboard="$observability_directory/grafana/dashboards/speakup-product-health.json"
+readonly user_behavior_dashboard="$observability_directory/grafana/dashboards/speakup-user-behavior.json"
 readonly product_health_datasource="$observability_directory/grafana/provisioning/datasources/product-health.yml"
 
 fail() {
@@ -463,6 +464,142 @@ jq --exit-status '
 ' "$product_health_dashboard" >/dev/null ||
   fail 'Product Health Grafana dashboard violates its anonymous SQL contract'
 
+jq --exit-status '
+  .uid == "speakup-user-behavior" and
+  .title == "SpeakUp 用户行为" and
+  (.description | contains("UTC")) and
+  (.description | contains("No Data")) and
+  .timezone == "utc" and
+  .editable == false and
+  .refresh == "5m" and
+  .time.from == "now-30d" and
+  ([.panels[].title] == [
+    "练习漏斗",
+    "所选时段总漏斗",
+    "漏斗转化与提前结束率",
+    "首次有效回答",
+    "首次有效回答覆盖率",
+    "首次有效回答耗时 P50 / P95",
+    "练习留存",
+    "留存人数（按首次有效回答日）",
+    "D1 / D7 确认回答留存率",
+    "重练、提前结束与未终态",
+    "重练结果",
+    "重练结果占比",
+    "提前结束深度",
+    "当前未终态练习（候选，不等于放弃）",
+    "功能使用",
+    "功能使用用户（${feature_kind:text}）",
+    "功能使用行为量（${feature_metric:text}）",
+    "数据边界",
+    "暂不可观测（不是 0）"
+  ]) and
+  ([.panels[] | select(.type != "row") |
+    (.description | type == "string" and length > 0)
+  ] | all) and
+  ([.panels[].targets[]? |
+    .datasource.uid == "speakup-product-health-postgres" and
+    .datasource.type == "grafana-postgresql-datasource"
+  ] | all) and
+  ([.panels[].targets[]?.rawSql // "" |
+    test("FROM public\\.user_behavior_(daily_session_funnel|daily_time_to_first_effective_turn|daily_retention|daily_repractice|current_nonterminal_sessions|daily_early_end|daily_feature_usage)\\b")
+  ] | all) and
+  ([.panels[].targets[]?.rawSql // "" |
+    test("JOIN[[:space:]]+public\\."; "i")
+  ] | any | not) and
+  ([.panels[].targets[]?.rawSql // "" |
+    test("FROM public\\.(users|practice_sessions|practice_turns|evaluations|evaluation_feedback_items)")
+  ] | any | not) and
+  ([.panels[].targets[]? |
+    select(.rawSql | contains("current_nonterminal_sessions") | not) |
+    (.rawSql | contains("$__timeFilter("))
+  ] | all) and
+  ([.panels[].targets[]? |
+    select(.rawSql | contains("current_nonterminal_sessions")) |
+    (.format == "table" and
+      (.rawSql | contains("$__timeFilter(") | not))
+  ] | all) and
+  (.panels[] | select(.id == 2) |
+    .type == "bargauge" and
+    .options.displayMode == "basic" and
+    .targets[0].format == "table" and
+    (.targets[0].rawSql | contains("sum(created_sessions)")) and
+    (.targets[0].rawSql | contains("sum(ready_session_report_sessions)"))
+  ) and
+  (.panels[] | select(.id == 14) | .targets[0].rawSql |
+    contains("WHEN '\''UNDER_1H'\'' THEN 1") and
+    contains("WHEN '\''1H_TO_24H'\'' THEN 2") and
+    contains("WHEN '\''1D_TO_7D'\'' THEN 3") and
+    contains("WHEN '\''7D_PLUS'\'' THEN 4")
+  ) and
+  ([.templating.list[].name] == ["feature_kind", "feature_metric"]) and
+  ([.templating.list[] | select(.name == "feature_kind") |
+    .options[].value
+  ] == [
+    "PRACTICE_EXPERIENCE",
+    "SCENE_CATEGORY",
+    "PRACTICE_MODE",
+    "INTERACTION_MODE"
+  ]) and
+  ([.templating.list[] | select(.name == "feature_metric") |
+    .options[].value
+  ] == ["SESSIONS", "CONFIRMED_TURNS"]) and
+  (.templating.list[] | select(.name == "feature_kind") |
+    .current == {
+      "selected": true,
+      "text": "练习体验",
+      "value": "PRACTICE_EXPERIENCE"
+    } and
+    .query == "练习体验 : PRACTICE_EXPERIENCE,场景 : SCENE_CATEGORY,练习模式 : PRACTICE_MODE,交互方式 : INTERACTION_MODE"
+  ) and
+  (.templating.list[] | select(.name == "feature_metric") |
+    .current == {
+      "selected": true,
+      "text": "练习数",
+      "value": "SESSIONS"
+    } and
+    .query == "练习数 : SESSIONS,确认回答数 : CONFIRMED_TURNS"
+  ) and
+  ([.templating.list[] |
+    .includeAll == false and .multi == false
+  ] | all) and
+  ([.panels[] | select(.id == 16 or .id == 17) |
+    .targets[0].rawSql |
+    contains("feature_kind = ${feature_kind:sqlstring}")
+  ] | all) and
+  (.panels[] | select(.id == 17) | .targets[0].rawSql |
+    contains("CASE ${feature_metric:sqlstring}")
+  ) and
+  ([.panels[].targets[]?.rawSql // ""] |
+    any(contains("user_behavior_daily_session_funnel"))) and
+  ([.panels[].targets[]?.rawSql // ""] |
+    any(contains("user_behavior_daily_time_to_first_effective_turn"))) and
+  ([.panels[].targets[]?.rawSql // ""] |
+    any(contains("user_behavior_daily_retention"))) and
+  ([.panels[].targets[]?.rawSql // ""] |
+    any(contains("user_behavior_daily_repractice"))) and
+  ([.panels[].targets[]?.rawSql // ""] |
+    any(contains("user_behavior_current_nonterminal_sessions"))) and
+  ([.panels[].targets[]?.rawSql // ""] |
+    any(contains("user_behavior_daily_early_end"))) and
+  ([.panels[].targets[]?.rawSql // ""] |
+    any(contains("user_behavior_daily_feature_usage"))) and
+  ([.. | strings] | any(test("COALESCE"; "i")) | not) and
+  ([.. | objects | select(has("spanNulls")) | .spanNulls == false] | all) and
+  ([.panels[] | select(.type == "timeseries") |
+    .fieldConfig.defaults.custom.showPoints == "auto"
+  ] | all) and
+  ([.. | objects | select(has("noValue")) | .noValue] |
+    any(. == "0" or . == 0) | not) and
+  ([.panels[] | select(.type == "text") | .options.content] |
+    any(contains("报告与逐轮反馈实际查看"))) and
+  ([.panels[] | select(.type == "text") | .options.content] |
+    any(contains("stale candidate"))) and
+  ([.panels[] | select(.type == "text") | .options.content] |
+    any(contains("No Data 表示尚无可证明样本，不等于测得 0")))
+' "$user_behavior_dashboard" >/dev/null ||
+  fail 'User Behavior Grafana dashboard violates its anonymous behavior contract'
+
 grep -Fxq '    uid: speakup-product-health-postgres' "$product_health_datasource" ||
   fail 'Product Health datasource UID is not fixed'
 grep -Fxq '    url: postgres:5432' "$product_health_datasource" ||
@@ -596,6 +733,19 @@ grep -Fq 'FROM pg_catalog.pg_auth_members AS membership' "$role_sql" ||
   fail 'Product Health reader does not reject role memberships'
 [[ $(grep -Fc 'public.product_health_daily_' "$role_sql") -eq 5 ]] ||
   fail 'Product Health reader grant is not the exact five-view set'
+[[ $(grep -Fc 'public.user_behavior_' "$role_sql") -eq 7 ]] ||
+  fail 'Product Health reader grant is not the exact seven-view behavior set'
+for behavior_view in \
+  user_behavior_daily_session_funnel \
+  user_behavior_daily_time_to_first_effective_turn \
+  user_behavior_daily_retention \
+  user_behavior_daily_repractice \
+  user_behavior_current_nonterminal_sessions \
+  user_behavior_daily_early_end \
+  user_behavior_daily_feature_usage; do
+  grep -Fq "public.$behavior_view" "$role_sql" ||
+    fail "Product Health reader does not grant $behavior_view"
+done
 ! grep -Eq 'GRANT SELECT ON public\.(users|practice_sessions|practice_turns|evaluations)' \
   "$role_sql" || fail 'Product Health reader grants a raw business table'
 

--- a/server/internal/platform/migration/migration_integration_test.go
+++ b/server/internal/platform/migration/migration_integration_test.go
@@ -77,6 +77,12 @@ func TestMigrationHistoryFreshUpDownUp(t *testing.T) {
 
 	changed, err = runner.DownOne()
 	if err != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, err)
+	}
+	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
+
+	changed, err = runner.DownOne()
+	if err != nil || !changed {
 		t.Fatalf("DownOne to v13 Lisa avatar asset = %t, %v", changed, err)
 	}
 	assertApplicationTableCount(t, admin, schema, len(cleanBaselineTables))
@@ -217,6 +223,9 @@ WHERE id = $1
 		1,
 	)
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, downErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v13 Lisa avatar asset = %t, %v", changed, downErr)
 	}
 	assertAvatarBinding(
@@ -279,6 +288,9 @@ func TestExpandedCoachVoiceMigrationSeedsCatalogAndSafelyRollsBackPreference(
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, downErr)
 	}
 
 	database, err := pgx.ConnectConfig(context.Background(), config)
@@ -358,6 +370,9 @@ func TestAgentRunQualifiedModelMigrationEnforcesDomainAndRollbackGuard(
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v13 Lisa avatar asset = %t, %v", changed, downErr)
@@ -448,6 +463,9 @@ WHERE id = $1
 		"23514",
 	)
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, downErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v13 Lisa avatar asset = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
@@ -489,6 +507,9 @@ func TestSceneSelectionSourceMigrationTransformsPlansAndPreservesSessions(
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v13 Lisa avatar asset = %t, %v", changed, downErr)
@@ -645,6 +666,9 @@ FROM practice_sessions WHERE session_id = $1
 	}
 
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("roll back v15 = %t, %v", changed, downErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("roll back v14 = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
@@ -703,6 +727,9 @@ func TestMigratedLegacyCatalogPlanCompletesThroughFormalReport(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v13 Lisa avatar asset = %t, %v", changed, downErr)
@@ -983,6 +1010,9 @@ func TestSceneSelectionSourceMigrationRejectsDownWithCustomPlan(t *testing.T) {
 	t.Cleanup(func() { _ = runner.Close() })
 	if changed, upErr := runner.Up(); upErr != nil || !changed {
 		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("DownOne to v14 expanded voice catalog = %t, %v", changed, downErr)
 	}
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("DownOne to v13 Lisa avatar asset = %t, %v", changed, downErr)

--- a/server/internal/platform/migration/product_health_migration_integration_test.go
+++ b/server/internal/platform/migration/product_health_migration_integration_test.go
@@ -43,6 +43,10 @@ func TestProductHealthViewsAreAnonymousAccurateAndReadOnly(t *testing.T) {
 	assertProductHealthReaderPrivileges(t, admin, database, schema)
 
 	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("user behavior DownOne = %t, %v", changed, downErr)
+	}
+	assertProductHealthViewSet(t, admin, schema)
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
 		t.Fatalf("expanded voice catalog DownOne = %t, %v", changed, downErr)
 	}
 	assertProductHealthViewSet(t, admin, schema)

--- a/server/internal/platform/migration/user_behavior_migration_integration_test.go
+++ b/server/internal/platform/migration/user_behavior_migration_integration_test.go
@@ -1,0 +1,803 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+var userBehaviorViews = []string{
+	"user_behavior_current_nonterminal_sessions",
+	"user_behavior_daily_early_end",
+	"user_behavior_daily_feature_usage",
+	"user_behavior_daily_repractice",
+	"user_behavior_daily_retention",
+	"user_behavior_daily_session_funnel",
+	"user_behavior_daily_time_to_first_effective_turn",
+}
+
+var userBehaviorIndexes = []string{
+	"user_behavior_confirmed_turns_day_idx",
+	"user_behavior_nonterminal_sessions_updated_idx",
+	"user_behavior_ready_session_reports_idx",
+	"user_behavior_sessions_created_day_idx",
+}
+
+func TestUserBehaviorViewsAreAnonymousAccurateAndReadOnly(t *testing.T) {
+	config, admin, schema := isolatedMigrationConfig(t)
+	runner, err := openConfig(config)
+	if err != nil {
+		t.Fatalf("open migration runner: %v", err)
+	}
+	t.Cleanup(func() { _ = runner.Close() })
+	if changed, upErr := runner.Up(); upErr != nil || !changed {
+		t.Fatalf("initial Up = %t, %v", changed, upErr)
+	}
+
+	config.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+	database, err := pgx.ConnectConfig(context.Background(), config)
+	if err != nil {
+		t.Fatalf("connect user behavior database: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close(context.Background()) })
+	if _, err := database.Exec(context.Background(), `
+ALTER TABLE evaluations DROP CONSTRAINT evaluations_source_key
+`); err != nil {
+		t.Fatalf("allow anomalous duplicate report fixture: %v", err)
+	}
+
+	baseDay := time.Now().UTC().Truncate(24 * time.Hour).Add(-10 * 24 * time.Hour)
+	now := time.Now().UTC()
+	seedUserBehaviorFacts(t, database, baseDay, now)
+
+	assertUserBehaviorDatabaseContract(t, admin, database, schema)
+	assertUserBehaviorFacts(t, database, baseDay)
+	assertUserBehaviorIndexesUsed(t, database, baseDay)
+	if _, err := database.Exec(context.Background(), `
+DELETE FROM evaluations
+WHERE id = '80000000-0000-4000-8000-000000001100';
+ALTER TABLE evaluations
+ADD CONSTRAINT evaluations_source_key UNIQUE (user_id, kind, source_id);
+`); err != nil {
+		t.Fatalf("restore evaluation source uniqueness: %v", err)
+	}
+	assertUserBehaviorReaderPrivileges(t, admin, database, schema)
+
+	if changed, downErr := runner.DownOne(); downErr != nil || !changed {
+		t.Fatalf("user behavior DownOne = %t, %v", changed, downErr)
+	}
+	assertUserBehaviorObjectCount(t, admin, schema, 0, 0)
+	if changed, upErr := runner.Up(); upErr != nil || !changed {
+		t.Fatalf("user behavior second Up = %t, %v", changed, upErr)
+	}
+	assertUserBehaviorDatabaseContract(t, admin, database, schema)
+}
+
+func seedUserBehaviorFacts(
+	t *testing.T,
+	database *pgx.Conn,
+	baseDay time.Time,
+	now time.Time,
+) {
+	t.Helper()
+	_, err := database.Exec(context.Background(), `
+INSERT INTO users (id, canonical_email, created_at, updated_at) VALUES
+('10000000-0000-4000-8000-000000001101', 'behavior-a@example.com', $1::timestamptz + interval '1 hour', $1::timestamptz + interval '1 hour'),
+('10000000-0000-4000-8000-000000001102', 'behavior-b@example.com', $1::timestamptz + interval '90 minutes', $1::timestamptz + interval '90 minutes'),
+('10000000-0000-4000-8000-000000001103', 'behavior-c@example.com', $2::timestamptz - interval '30 minutes', $2::timestamptz - interval '30 minutes'),
+('10000000-0000-4000-8000-000000001104', 'behavior-d@example.com', $1::timestamptz + interval '105 minutes', $1::timestamptz + interval '105 minutes');
+
+INSERT INTO practice_plans (
+    plan_id, user_id, preparation_snapshot, scene_selection, session_policy,
+    practice_objectives, practice_experience, status,
+    initial_client_request_id, initial_request_fingerprint,
+    created_at, updated_at
+) VALUES
+(
+    '30000000-0000-4000-8000-000000001101',
+    '10000000-0000-4000-8000-000000001101',
+    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[{}]'::jsonb,
+    'INTERVIEW', 'ready', 'behavior-plan-a-request',
+    decode(repeat('11', 32), 'hex'), $1::timestamptz + interval '1 hour', $1::timestamptz + interval '1 hour'
+),
+(
+    '30000000-0000-4000-8000-000000001102',
+    '10000000-0000-4000-8000-000000001102',
+    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[{}]'::jsonb,
+    'LEGACY_EXPERIENCE', 'ready', 'behavior-plan-b-request',
+    decode(repeat('12', 32), 'hex'), $1::timestamptz + interval '90 minutes', $1::timestamptz + interval '90 minutes'
+),
+(
+    '30000000-0000-4000-8000-000000001103',
+    '10000000-0000-4000-8000-000000001103',
+    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '[{}]'::jsonb,
+    'WORKPLACE', 'ready', 'behavior-plan-c-request',
+    decode(repeat('13', 32), 'hex'), $2::timestamptz - interval '30 minutes', $2::timestamptz - interval '30 minutes'
+);
+
+INSERT INTO practice_sessions (
+    session_id, user_id, plan_id, plan_version, practice_experience,
+    scene_category, practice_mode, evaluation_policy_ref, status,
+    effective_turns, plan_snapshot, participants, presentation_snapshot,
+    initial_client_request_id, initial_request_fingerprint,
+    started_at, ended_at, end_reason, created_at, updated_at
+) VALUES
+(
+    '40000000-0000-4000-8000-000000001101',
+    '10000000-0000-4000-8000-000000001101',
+    '30000000-0000-4000-8000-000000001101', 1,
+    'INTERVIEW', 'INTERVIEW_BEHAVIORAL', 'FOCUS', 'interview.v1',
+    'completed', 1, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-a1', decode(repeat('21', 32), 'hex'),
+    $1::timestamptz + interval '125 minutes', $1::timestamptz + interval '150 minutes', 'completed',
+    $1::timestamptz + interval '120 minutes', $1::timestamptz + interval '150 minutes'
+),
+(
+    '40000000-0000-4000-8000-000000001102',
+    '10000000-0000-4000-8000-000000001102',
+    '30000000-0000-4000-8000-000000001102', 1,
+    'LEGACY_EXPERIENCE', 'LEGACY_SCENE', 'LEGACY_MODE', 'legacy.v1',
+    'completed', 2, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-b1', decode(repeat('22', 32), 'hex'),
+    $1::timestamptz + interval '190 minutes', $1::timestamptz + interval '240 minutes', 'completed',
+    $1::timestamptz + interval '180 minutes', $1::timestamptz + interval '240 minutes'
+),
+(
+    '40000000-0000-4000-8000-000000001103',
+    '10000000-0000-4000-8000-000000001101',
+    '30000000-0000-4000-8000-000000001101', 1,
+    'IELTS_SPEAKING', 'IELTS_SPEAKING', 'PART_1', 'ielts.v1',
+    'ended_early', 1, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-a2', decode(repeat('23', 32), 'hex'),
+    $1::timestamptz + interval '1 day 125 minutes', $1::timestamptz + interval '1 day 140 minutes',
+    'user_ended', $1::timestamptz + interval '1 day 120 minutes',
+    $1::timestamptz + interval '1 day 140 minutes'
+),
+(
+    '40000000-0000-4000-8000-000000001104',
+    '10000000-0000-4000-8000-000000001102',
+    '30000000-0000-4000-8000-000000001102', 1,
+    'LEGACY_EXPERIENCE', 'LEGACY_SCENE', 'LEGACY_MODE', 'legacy.v1',
+    'ended_early', 6, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-b2', decode(repeat('24', 32), 'hex'),
+    $1::timestamptz + interval '1 day 185 minutes', $1::timestamptz + interval '1 day 200 minutes',
+    'user_ended', $1::timestamptz + interval '1 day 180 minutes',
+    $1::timestamptz + interval '1 day 200 minutes'
+),
+(
+    '40000000-0000-4000-8000-000000001105',
+    '10000000-0000-4000-8000-000000001101',
+    '30000000-0000-4000-8000-000000001101', 1,
+    'INTERVIEW', 'INTERVIEW_RECRUITER', 'FULL_SIMULATION', 'interview.v1',
+    'starting', 0, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-a-stale', decode(repeat('25', 32), 'hex'),
+    NULL, NULL, NULL, $1::timestamptz + interval '2 days', $1::timestamptz + interval '2 days'
+),
+(
+    '40000000-0000-4000-8000-000000001106',
+    '10000000-0000-4000-8000-000000001101',
+    '30000000-0000-4000-8000-000000001101', 1,
+    'LIFE_AND_TRAVEL', 'LIFE_TRAVEL', 'FOCUS', 'life.v1',
+    'completed', 1, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-a3', decode(repeat('26', 32), 'hex'),
+    $1::timestamptz + interval '7 days 125 minutes', $1::timestamptz + interval '7 days 150 minutes',
+    'completed', $1::timestamptz + interval '7 days 120 minutes',
+    $1::timestamptz + interval '7 days 150 minutes'
+),
+(
+    '40000000-0000-4000-8000-000000001107',
+    '10000000-0000-4000-8000-000000001102',
+    '30000000-0000-4000-8000-000000001102', 1,
+    'WORKPLACE', 'WORKPLACE_GENERAL', 'FOCUS', 'workplace.v1',
+    'in_progress', 0, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-b-recent', decode(repeat('27', 32), 'hex'),
+    $2::timestamptz - interval '150 minutes', NULL, NULL,
+    $2::timestamptz - interval '3 hours', $2::timestamptz - interval '2 hours'
+),
+(
+    '40000000-0000-4000-8000-000000001108',
+    '10000000-0000-4000-8000-000000001102',
+    '30000000-0000-4000-8000-000000001102', 1,
+    'WORKPLACE', 'WORKPLACE_GENERAL', 'FOCUS', 'workplace.v1',
+    'paused', 0, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-b-paused', decode(repeat('28', 32), 'hex'),
+    $2::timestamptz - interval '60 hours', NULL, NULL,
+    $2::timestamptz - interval '3 days', $2::timestamptz - interval '2 days'
+),
+(
+    '40000000-0000-4000-8000-000000001109',
+    '10000000-0000-4000-8000-000000001103',
+    '30000000-0000-4000-8000-000000001103', 1,
+    'WORKPLACE', 'WORKPLACE_GENERAL', 'FULL_SIMULATION', 'workplace.v1',
+    'in_progress', 1, '{}'::jsonb, '[{}]'::jsonb,
+    '{"schema_version":1,"avatar":{},"voice":{}}'::jsonb,
+    'behavior-session-c1', decode(repeat('29', 32), 'hex'),
+    $2::timestamptz - interval '15 minutes', NULL, NULL,
+    $2::timestamptz - interval '20 minutes', $2::timestamptz - interval '10 minutes'
+);
+
+INSERT INTO practice_questions (
+    question_id, session_id, objective_id, question_type, content,
+    speaker_participant_id, addressee_participant_ids, sequence,
+    created_at, updated_at
+) VALUES
+('50000000-0000-4000-8000-000000001101', '40000000-0000-4000-8000-000000001101', 'objective-a1', 'prompt', 'A1', 'coach', ARRAY['learner'], 1, $1::timestamptz + interval '125 minutes', $1::timestamptz + interval '125 minutes'),
+('50000000-0000-4000-8000-000000001102', '40000000-0000-4000-8000-000000001102', 'objective-b1', 'prompt', 'B1', 'coach', ARRAY['learner'], 1, $1::timestamptz + interval '182 minutes', $1::timestamptz + interval '182 minutes'),
+('50000000-0000-4000-8000-000000001110', '40000000-0000-4000-8000-000000001102', 'objective-b2', 'prompt', 'B2', 'coach', ARRAY['learner'], 2, $1::timestamptz + interval '195 minutes', $1::timestamptz + interval '195 minutes'),
+('50000000-0000-4000-8000-000000001103', '40000000-0000-4000-8000-000000001103', 'objective-a2', 'prompt', 'A2', 'coach', ARRAY['learner'], 1, $1::timestamptz + interval '1 day 125 minutes', $1::timestamptz + interval '1 day 125 minutes'),
+('50000000-0000-4000-8000-000000001106', '40000000-0000-4000-8000-000000001106', 'objective-a3', 'prompt', 'A3', 'coach', ARRAY['learner'], 1, $1::timestamptz + interval '7 days 125 minutes', $1::timestamptz + interval '7 days 125 minutes'),
+('50000000-0000-4000-8000-000000001109', '40000000-0000-4000-8000-000000001109', 'objective-c1', 'prompt', 'C1', 'coach', ARRAY['learner'], 1, $2::timestamptz - interval '15 minutes', $2::timestamptz - interval '15 minutes');
+
+INSERT INTO practice_turns (
+    turn_id, session_id, question_id, respondent_participant_id, sequence,
+    turn_kind, status, original_turn_id, client_request_id,
+    counts_toward_turn_limit, candidate_id, transcript_id, evidence_version,
+    transcript, interaction_mode, confirmed_at, created_at, updated_at
+) VALUES
+(
+    '60000000-0000-4000-8000-000000001101',
+    '40000000-0000-4000-8000-000000001101',
+    '50000000-0000-4000-8000-000000001101', 'learner', 1,
+    'EFFECTIVE', 'confirmed', NULL, NULL, true,
+    '70000000-0000-4000-8000-000000001101', 'behavior-transcript-a1', 1,
+    'private answer a1', 'TEXT', $1::timestamptz + interval '130 minutes',
+    $1::timestamptz + interval '126 minutes', $1::timestamptz + interval '130 minutes'
+),
+(
+    '60000000-0000-4000-8000-000000001102',
+    '40000000-0000-4000-8000-000000001101',
+    '50000000-0000-4000-8000-000000001101', 'learner', 2,
+    'RETRY', 'confirmed', '60000000-0000-4000-8000-000000001101',
+    'behavior-retry-confirmed', false,
+    '70000000-0000-4000-8000-000000001102', 'behavior-transcript-retry', 1,
+    'private retry answer', 'PUSH_TO_TALK', $1::timestamptz + interval '140 minutes',
+    $1::timestamptz + interval '135 minutes', $1::timestamptz + interval '140 minutes'
+),
+(
+    '60000000-0000-4000-8000-000000001103',
+    '40000000-0000-4000-8000-000000001101',
+    '50000000-0000-4000-8000-000000001101', 'learner', 3,
+    'RETRY', 'failed', '60000000-0000-4000-8000-000000001101',
+    'behavior-retry-failed', false, NULL, NULL, NULL, NULL, NULL, NULL,
+    $1::timestamptz + interval '141 minutes', $1::timestamptz + interval '142 minutes'
+),
+(
+    '60000000-0000-4000-8000-000000001104',
+    '40000000-0000-4000-8000-000000001101',
+    '50000000-0000-4000-8000-000000001101', 'learner', 4,
+    'RETRY', 'answering', '60000000-0000-4000-8000-000000001101',
+    'behavior-retry-stale', false, NULL, NULL, NULL, NULL, NULL, NULL,
+    $1::timestamptz + interval '143 minutes', $2::timestamptz - interval '2 days'
+),
+(
+    '60000000-0000-4000-8000-000000001105',
+    '40000000-0000-4000-8000-000000001102',
+    '50000000-0000-4000-8000-000000001102', 'learner', 1,
+    'EFFECTIVE', 'confirmed', NULL, NULL, true,
+    '70000000-0000-4000-8000-000000001105', 'behavior-transcript-b1', 1,
+    'private invalid-time answer', NULL, $1::timestamptz + interval '185 minutes',
+    $1::timestamptz + interval '182 minutes', $1::timestamptz + interval '185 minutes'
+),
+(
+    '60000000-0000-4000-8000-000000001110',
+    '40000000-0000-4000-8000-000000001102',
+    '50000000-0000-4000-8000-000000001110', 'learner', 2,
+    'EFFECTIVE', 'confirmed', NULL, NULL, true,
+    '70000000-0000-4000-8000-000000001110', 'behavior-transcript-b2', 1,
+    'private valid-time answer', NULL, $1::timestamptz + interval '200 minutes',
+    $1::timestamptz + interval '195 minutes', $1::timestamptz + interval '200 minutes'
+),
+(
+    '60000000-0000-4000-8000-000000001106',
+    '40000000-0000-4000-8000-000000001103',
+    '50000000-0000-4000-8000-000000001103', 'learner', 1,
+    'EFFECTIVE', 'confirmed', NULL, NULL, true,
+    '70000000-0000-4000-8000-000000001106', 'behavior-transcript-a2', 1,
+    'private answer a2', 'TEXT', $1::timestamptz + interval '1 day 130 minutes',
+    $1::timestamptz + interval '1 day 126 minutes', $1::timestamptz + interval '1 day 130 minutes'
+),
+(
+    '60000000-0000-4000-8000-000000001107',
+    '40000000-0000-4000-8000-000000001106',
+    '50000000-0000-4000-8000-000000001106', 'learner', 1,
+    'EFFECTIVE', 'confirmed', NULL, NULL, true,
+    '70000000-0000-4000-8000-000000001107', 'behavior-transcript-a3', 1,
+    'private answer a3', 'PUSH_TO_TALK', $1::timestamptz + interval '7 days 130 minutes',
+    $1::timestamptz + interval '7 days 126 minutes', $1::timestamptz + interval '7 days 130 minutes'
+),
+(
+    '60000000-0000-4000-8000-000000001109',
+    '40000000-0000-4000-8000-000000001109',
+    '50000000-0000-4000-8000-000000001109', 'learner', 1,
+    'EFFECTIVE', 'confirmed', NULL, NULL, true,
+    '70000000-0000-4000-8000-000000001109', 'behavior-transcript-c1', 1,
+    'private answer c1', 'TEXT', $2::timestamptz - interval '10 minutes',
+    $2::timestamptz - interval '12 minutes', $2::timestamptz - interval '10 minutes'
+);
+
+INSERT INTO evaluations (
+    id, user_id, kind, source_id, context_id, status, input_snapshot, input_hash,
+    config_lineage, config_hash, result, attempt_count,
+    created_at, updated_at, started_at, finished_at
+) VALUES
+(
+    '80000000-0000-4000-8000-000000001100',
+    '10000000-0000-4000-8000-000000001101', 'SESSION_REPORT',
+    '40000000-0000-4000-8000-000000001101',
+    '40000000-0000-4000-8000-000000001101', 'READY', '{}'::json,
+    decode(repeat('33', 32), 'hex'), '{}'::json,
+    decode(repeat('34', 32), 'hex'), '{}'::jsonb, 1,
+    $1::timestamptz + interval '130 minutes', $1::timestamptz + interval '140 minutes',
+    $1::timestamptz + interval '131 minutes', $1::timestamptz + interval '140 minutes'
+),
+(
+    '80000000-0000-4000-8000-000000001101',
+    '10000000-0000-4000-8000-000000001101', 'SESSION_REPORT',
+    '40000000-0000-4000-8000-000000001101',
+    '40000000-0000-4000-8000-000000001101', 'READY', '{}'::json,
+    decode(repeat('31', 32), 'hex'), '{}'::json,
+    decode(repeat('32', 32), 'hex'), '{}'::jsonb, 1,
+    $1::timestamptz + interval '151 minutes', $1::timestamptz + interval '160 minutes',
+    $1::timestamptz + interval '152 minutes', $1::timestamptz + interval '160 minutes'
+);
+`, baseDay, now)
+	if err != nil {
+		t.Fatalf("seed user behavior facts: %v", err)
+	}
+}
+
+func assertUserBehaviorDatabaseContract(
+	t *testing.T,
+	admin *pgx.Conn,
+	database *pgx.Conn,
+	schema string,
+) {
+	t.Helper()
+	rows, err := admin.Query(context.Background(), `
+SELECT table_name
+FROM information_schema.views
+WHERE table_schema = $1 AND table_name LIKE 'user_behavior_%'
+ORDER BY table_name
+`, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	views, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(views) != fmt.Sprint(userBehaviorViews) {
+		t.Fatalf("user behavior views = %v, want %v", views, userBehaviorViews)
+	}
+
+	rows, err = admin.Query(context.Background(), `
+SELECT indexname
+FROM pg_indexes
+WHERE schemaname = $1 AND indexname LIKE 'user_behavior_%'
+ORDER BY indexname
+`, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexes, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(indexes) != fmt.Sprint(userBehaviorIndexes) {
+		t.Fatalf("user behavior indexes = %v, want %v", indexes, userBehaviorIndexes)
+	}
+
+	var insecureViews int
+	if err := admin.QueryRow(context.Background(), `
+SELECT count(*)
+FROM pg_class AS relation
+JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+WHERE namespace.nspname = $1
+  AND relation.relname LIKE 'user_behavior_%'
+  AND relation.relkind = 'v'
+  AND NOT ('security_barrier=true' = ANY(relation.reloptions))
+`, schema).Scan(&insecureViews); err != nil {
+		t.Fatal(err)
+	}
+	if insecureViews != 0 {
+		t.Fatalf("user behavior views without security_barrier = %d", insecureViews)
+	}
+
+	rows, err = admin.Query(context.Background(), `
+SELECT table_name, column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = $1
+  AND table_name LIKE 'user_behavior_%'
+  AND (
+      data_type = 'uuid'
+      OR column_name ~ '(^|_)(user|account|session|turn|evaluation)_?id($|_)'
+      OR column_name ~ '(email|name|content|transcript|audio|prompt|feedback)'
+  )
+`, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsafeColumns, err := pgx.CollectRows(rows, pgx.RowToStructByPos[struct {
+		Table string
+		Name  string
+		Type  string
+	}])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unsafeColumns) != 0 {
+		t.Fatalf("unsafe user behavior columns = %#v", unsafeColumns)
+	}
+
+	var publicGrants int
+	if err := admin.QueryRow(context.Background(), `
+SELECT count(*)
+FROM information_schema.role_table_grants
+WHERE table_schema = $1
+  AND table_name LIKE 'user_behavior_%'
+  AND grantee = 'PUBLIC'
+`, schema).Scan(&publicGrants); err != nil {
+		t.Fatal(err)
+	}
+	if publicGrants != 0 {
+		t.Fatalf("PUBLIC user behavior grants = %d", publicGrants)
+	}
+
+	if _, err := database.Exec(context.Background(), "SET TIME ZONE 'Asia/Shanghai'"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = database.Exec(context.Background(), "SET TIME ZONE 'UTC'") }()
+	var day time.Time
+	if err := database.QueryRow(context.Background(), `
+SELECT min(day_utc) FROM user_behavior_daily_session_funnel
+`).Scan(&day); err != nil {
+		t.Fatal(err)
+	}
+	if day.UTC().Hour() != 0 {
+		t.Fatalf("UTC bucket = %s", day)
+	}
+}
+
+func assertUserBehaviorFacts(t *testing.T, database *pgx.Conn, baseDay time.Time) {
+	t.Helper()
+	var created, started, first, completed, ready, endedEarly int64
+	var startedRate, firstRate, completedRate, readyRate, earlyRate float64
+	if err := database.QueryRow(context.Background(), `
+SELECT created_sessions, started_sessions, first_effective_confirmed_sessions,
+       completed_sessions, ready_session_report_sessions, ended_early_sessions,
+       started_from_created_rate, first_effective_from_started_rate,
+       completed_from_first_effective_rate, ready_report_from_completed_rate,
+       ended_early_from_started_rate
+FROM user_behavior_daily_session_funnel
+WHERE day_utc = $1
+`, baseDay).Scan(&created, &started, &first, &completed, &ready, &endedEarly,
+		&startedRate, &firstRate, &completedRate, &readyRate, &earlyRate); err != nil {
+		t.Fatal(err)
+	}
+	if created != 2 || started != 2 || first != 2 || completed != 2 ||
+		ready != 1 || endedEarly != 0 || startedRate != 1 || firstRate != 1 ||
+		completedRate != 1 || readyRate != 0.5 || earlyRate != 0 {
+		t.Fatalf("funnel = %d %d %d %d %d %d %.2f %.2f %.2f %.2f %.2f",
+			created, started, first, completed, ready, endedEarly, startedRate,
+			firstRate, completedRate, readyRate, earlyRate)
+	}
+
+	var firstFromStarted, completedFromFirst, reportFromCompleted, earlyFromStarted *float64
+	if err := database.QueryRow(context.Background(), `
+SELECT first_effective_from_started_rate, completed_from_first_effective_rate,
+       ready_report_from_completed_rate, ended_early_from_started_rate
+FROM user_behavior_daily_session_funnel
+WHERE day_utc = $1::timestamptz + interval '2 days'
+`, baseDay).Scan(&firstFromStarted, &completedFromFirst, &reportFromCompleted,
+		&earlyFromStarted); err != nil {
+		t.Fatal(err)
+	}
+	if firstFromStarted != nil || completedFromFirst != nil ||
+		reportFromCompleted != nil || earlyFromStarted != nil {
+		t.Fatalf("zero-denominator funnel rates = %v %v %v %v",
+			firstFromStarted, completedFromFirst, reportFromCompleted, earlyFromStarted)
+	}
+
+	assertTTFV := func(scope string, eligible, reached int64, rate, p50, p95 float64) {
+		t.Helper()
+		var gotEligible, gotReached int64
+		var gotRate, gotP50, gotP95 float64
+		if err := database.QueryRow(context.Background(), `
+SELECT eligible_subjects, reached_subjects, reach_rate, p50_seconds, p95_seconds
+FROM user_behavior_daily_time_to_first_effective_turn
+WHERE day_utc = $1 AND scope = $2
+`, baseDay, scope).Scan(&gotEligible, &gotReached, &gotRate, &gotP50, &gotP95); err != nil {
+			t.Fatal(err)
+		}
+		if gotEligible != eligible || gotReached != reached ||
+			math.Abs(gotRate-rate) > 1e-12 || gotP50 != p50 || gotP95 != p95 {
+			t.Fatalf("%s TTFV = %d %d %.4f %.2f %.2f",
+				scope, gotEligible, gotReached, gotRate, gotP50, gotP95)
+		}
+	}
+	assertTTFV("ACCOUNT", 3, 2, 2.0/3.0, 5400, 6480)
+	assertTTFV("SESSION", 2, 2, 1, 900, 1170)
+
+	var cohortUsers int64
+	var d1Users, d7Users *int64
+	var d1Rate, d7Rate *float64
+	if err := database.QueryRow(context.Background(), `
+SELECT cohort_users, d1_returned_users, d1_retention_rate,
+       d7_returned_users, d7_retention_rate
+FROM user_behavior_daily_retention
+WHERE cohort_day_utc = $1
+`, baseDay).Scan(&cohortUsers, &d1Users, &d1Rate, &d7Users, &d7Rate); err != nil {
+		t.Fatal(err)
+	}
+	if cohortUsers != 2 || d1Users == nil || *d1Users != 1 ||
+		d1Rate == nil || *d1Rate != 0.5 || d7Users == nil || *d7Users != 1 ||
+		d7Rate == nil || *d7Rate != 0.5 {
+		t.Fatalf("mature retention = %d %v %v %v %v",
+			cohortUsers, d1Users, d1Rate, d7Users, d7Rate)
+	}
+	if err := database.QueryRow(context.Background(), `
+SELECT d1_returned_users, d1_retention_rate, d7_returned_users, d7_retention_rate
+FROM user_behavior_daily_retention
+ORDER BY cohort_day_utc DESC
+LIMIT 1
+`).Scan(&d1Users, &d1Rate, &d7Users, &d7Rate); err != nil {
+		t.Fatal(err)
+	}
+	if d1Users != nil || d1Rate != nil || d7Users != nil || d7Rate != nil {
+		t.Fatalf("immature retention = %v %v %v %v", d1Users, d1Rate, d7Users, d7Rate)
+	}
+
+	var retryCreated, retryConfirmed, retryFailed, retryStale int64
+	var retryConfirmedRate, retryFailedRate, retryStaleRate float64
+	if err := database.QueryRow(context.Background(), `
+SELECT created_retry_turns, confirmed_retry_turns, failed_retry_turns,
+       stale_retry_turns, confirmation_rate, failure_rate, stale_rate
+FROM user_behavior_daily_repractice
+WHERE day_utc = $1
+`, baseDay).Scan(&retryCreated, &retryConfirmed, &retryFailed, &retryStale,
+		&retryConfirmedRate, &retryFailedRate, &retryStaleRate); err != nil {
+		t.Fatal(err)
+	}
+	if retryCreated != 3 || retryConfirmed != 1 || retryFailed != 1 || retryStale != 1 ||
+		math.Abs(retryConfirmedRate-1.0/3.0) > 1e-12 ||
+		math.Abs(retryFailedRate-1.0/3.0) > 1e-12 ||
+		math.Abs(retryStaleRate-1.0/3.0) > 1e-12 {
+		t.Fatalf("repractice = %d %d %d %d %.4f %.4f %.4f",
+			retryCreated, retryConfirmed, retryFailed, retryStale,
+			retryConfirmedRate, retryFailedRate, retryStaleRate)
+	}
+
+	rows, err := database.Query(context.Background(), `
+SELECT effective_turn_depth, ended_early_sessions, ended_early_share
+FROM user_behavior_daily_early_end
+WHERE day_utc = $1::timestamptz + interval '1 day'
+ORDER BY effective_turn_depth
+`, baseDay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type earlyEnd struct {
+		Depth    string
+		Sessions int64
+		Share    float64
+	}
+	earlyEnds, err := pgx.CollectRows(rows, pgx.RowToStructByPos[earlyEnd])
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantEarlyEnds := []earlyEnd{{"1", 1, 0.5}, {"5_PLUS", 1, 0.5}}
+	if fmt.Sprint(earlyEnds) != fmt.Sprint(wantEarlyEnds) {
+		t.Fatalf("early ends = %#v, want %#v", earlyEnds, wantEarlyEnds)
+	}
+
+	rows, err = database.Query(context.Background(), `
+SELECT session_status, staleness_bucket, sessions
+FROM user_behavior_current_nonterminal_sessions
+ORDER BY session_status, staleness_bucket
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type nonterminal struct {
+		Status   string
+		Bucket   string
+		Sessions int64
+	}
+	nonterminals, err := pgx.CollectRows(rows, pgx.RowToStructByPos[nonterminal])
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNonterminals := []nonterminal{
+		{"IN_PROGRESS", "1H_TO_24H", 1},
+		{"IN_PROGRESS", "UNDER_1H", 1},
+		{"PAUSED", "1D_TO_7D", 1},
+		{"STARTING", "7D_PLUS", 1},
+	}
+	if fmt.Sprint(nonterminals) != fmt.Sprint(wantNonterminals) {
+		t.Fatalf("nonterminal sessions = %#v, want %#v", nonterminals, wantNonterminals)
+	}
+
+	var activeUsers, sessions, turns int64
+	if err := database.QueryRow(context.Background(), `
+SELECT active_users, sessions, confirmed_turns
+FROM user_behavior_daily_feature_usage
+WHERE day_utc = $1
+  AND feature_kind = 'PRACTICE_EXPERIENCE'
+  AND feature_value = 'INTERVIEW'
+`, baseDay).Scan(&activeUsers, &sessions, &turns); err != nil {
+		t.Fatal(err)
+	}
+	if activeUsers != 1 || sessions != 1 || turns != 2 {
+		t.Fatalf("known feature usage = %d %d %d", activeUsers, sessions, turns)
+	}
+	rows, err = database.Query(context.Background(), `
+SELECT feature_kind, active_users, sessions, confirmed_turns
+FROM user_behavior_daily_feature_usage
+WHERE day_utc = $1 AND feature_value = 'UNKNOWN'
+ORDER BY feature_kind
+`, baseDay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type unknownFeature struct {
+		Kind        string
+		ActiveUsers int64
+		Sessions    int64
+		Turns       int64
+	}
+	unknownFeatures, err := pgx.CollectRows(rows, pgx.RowToStructByPos[unknownFeature])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unknownFeatures) != 4 {
+		t.Fatalf("unknown feature rows = %#v", unknownFeatures)
+	}
+	for _, feature := range unknownFeatures {
+		if feature.ActiveUsers != 1 || feature.Sessions != 1 || feature.Turns != 2 {
+			t.Fatalf("unknown feature = %#v", feature)
+		}
+	}
+}
+
+func assertUserBehaviorReaderPrivileges(
+	t *testing.T,
+	admin *pgx.Conn,
+	database *pgx.Conn,
+	schema string,
+) {
+	t.Helper()
+	role := fmt.Sprintf("user_behavior_reader_test_%d", time.Now().UnixNano())
+	roleIdentifier := pgx.Identifier{role}.Sanitize()
+	schemaIdentifier := pgx.Identifier{schema}.Sanitize()
+	if _, err := admin.Exec(context.Background(), "CREATE ROLE "+roleIdentifier+" NOLOGIN"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = admin.Exec(context.Background(), "DROP ROLE IF EXISTS "+roleIdentifier)
+	})
+	if _, err := admin.Exec(context.Background(),
+		"GRANT USAGE ON SCHEMA "+schemaIdentifier+" TO "+roleIdentifier); err != nil {
+		t.Fatal(err)
+	}
+	for _, view := range userBehaviorViews {
+		qualified := pgx.Identifier{schema, view}.Sanitize()
+		if _, err := admin.Exec(context.Background(),
+			"GRANT SELECT ON "+qualified+" TO "+roleIdentifier); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := database.Exec(context.Background(), "SET ROLE "+roleIdentifier); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = database.Exec(context.Background(), "RESET ROLE") }()
+	qualifiedView := pgx.Identifier{schema, userBehaviorViews[0]}.Sanitize()
+	if _, err := database.Exec(context.Background(),
+		"SELECT count(*) FROM "+qualifiedView); err != nil {
+		t.Fatalf("reader SELECT aggregate view: %v", err)
+	}
+	qualifiedTable := pgx.Identifier{schema, "practice_sessions"}.Sanitize()
+	_, rawErr := database.Exec(context.Background(),
+		"SELECT count(*) FROM "+qualifiedTable)
+	if rawErr == nil || !strings.Contains(rawErr.Error(), "permission denied") {
+		t.Fatalf("reader raw SELECT error = %v", rawErr)
+	}
+}
+
+func assertUserBehaviorIndexesUsed(
+	t *testing.T,
+	database *pgx.Conn,
+	baseDay time.Time,
+) {
+	t.Helper()
+	if _, err := database.Exec(context.Background(), "SET enable_seqscan = off"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _, _ = database.Exec(context.Background(), "RESET enable_seqscan") }()
+
+	assertPlanUses := func(index, query string, arguments ...any) {
+		t.Helper()
+		rows, err := database.Query(
+			context.Background(),
+			"EXPLAIN (COSTS OFF) "+query,
+			arguments...,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		plan, err := pgx.CollectRows(rows, pgx.RowTo[string])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if joined := strings.Join(plan, "\n"); !strings.Contains(joined, index) {
+			t.Fatalf("plan does not use %s:\n%s", index, joined)
+		}
+	}
+
+	assertPlanUses(
+		"user_behavior_sessions_created_day_idx",
+		`SELECT * FROM user_behavior_daily_session_funnel
+         WHERE day_utc = $1`,
+		baseDay,
+	)
+	assertPlanUses(
+		"user_behavior_confirmed_turns_day_idx",
+		`SELECT count(*) FROM practice_turns
+         WHERE status = 'confirmed'
+           AND date_trunc('day', confirmed_at, 'UTC') = $1`,
+		baseDay,
+	)
+	assertPlanUses(
+		"user_behavior_ready_session_reports_idx",
+		`SELECT * FROM user_behavior_daily_session_funnel
+         WHERE day_utc = $1`,
+		baseDay,
+	)
+	assertPlanUses(
+		"user_behavior_nonterminal_sessions_updated_idx",
+		`SELECT * FROM user_behavior_current_nonterminal_sessions
+         WHERE staleness_bucket = '7D_PLUS'`,
+	)
+}
+
+func assertUserBehaviorObjectCount(
+	t *testing.T,
+	database *pgx.Conn,
+	schema string,
+	wantViews int,
+	wantIndexes int,
+) {
+	t.Helper()
+	var views, indexes int
+	if err := database.QueryRow(context.Background(), `
+SELECT count(*)
+FROM information_schema.views
+WHERE table_schema = $1 AND table_name LIKE 'user_behavior_%'
+`, schema).Scan(&views); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRow(context.Background(), `
+SELECT count(*)
+FROM pg_indexes
+WHERE schemaname = $1 AND indexname LIKE 'user_behavior_%'
+`, schema).Scan(&indexes); err != nil {
+		t.Fatal(err)
+	}
+	if views != wantViews || indexes != wantIndexes {
+		t.Fatalf("user behavior objects = %d views, %d indexes; want %d, %d",
+			views, indexes, wantViews, wantIndexes)
+	}
+}

--- a/server/migrations/000015_user_behavior_views.down.sql
+++ b/server/migrations/000015_user_behavior_views.down.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+DROP VIEW user_behavior_daily_feature_usage;
+DROP VIEW user_behavior_current_nonterminal_sessions;
+DROP VIEW user_behavior_daily_early_end;
+DROP VIEW user_behavior_daily_repractice;
+DROP VIEW user_behavior_daily_retention;
+DROP VIEW user_behavior_daily_time_to_first_effective_turn;
+DROP VIEW user_behavior_daily_session_funnel;
+
+DROP INDEX user_behavior_nonterminal_sessions_updated_idx;
+DROP INDEX user_behavior_ready_session_reports_idx;
+DROP INDEX user_behavior_confirmed_turns_day_idx;
+DROP INDEX user_behavior_sessions_created_day_idx;
+
+COMMIT;

--- a/server/migrations/000015_user_behavior_views.up.sql
+++ b/server/migrations/000015_user_behavior_views.up.sql
@@ -1,0 +1,471 @@
+BEGIN;
+
+CREATE INDEX user_behavior_sessions_created_day_idx
+    ON practice_sessions (date_trunc('day', created_at, 'UTC'));
+CREATE INDEX user_behavior_confirmed_turns_day_idx
+    ON practice_turns (date_trunc('day', confirmed_at, 'UTC'))
+    WHERE status = 'confirmed';
+CREATE INDEX user_behavior_ready_session_reports_idx
+    ON evaluations (source_id, context_id, user_id, finished_at)
+    WHERE kind = 'SESSION_REPORT' AND status = 'READY';
+CREATE INDEX user_behavior_nonterminal_sessions_updated_idx
+    ON practice_sessions (updated_at)
+    WHERE status IN ('starting', 'in_progress', 'paused');
+
+CREATE VIEW user_behavior_daily_session_funnel
+WITH (security_barrier = true) AS
+WITH session_events AS (
+    SELECT
+        session.created_at,
+        session.started_at,
+        session.status,
+        session.ended_at,
+        first_effective.confirmed_at AS first_effective_confirmed_at,
+        ready_report.finished_at AS ready_report_finished_at
+    FROM practice_sessions AS session
+    LEFT JOIN LATERAL (
+        SELECT min(turn.confirmed_at) AS confirmed_at
+        FROM practice_turns AS turn
+        WHERE turn.session_id = session.session_id
+          AND turn.status = 'confirmed'
+          AND turn.turn_kind = 'EFFECTIVE'
+          AND turn.confirmed_at >= session.started_at
+    ) AS first_effective ON true
+    LEFT JOIN LATERAL (
+        SELECT min(evaluation.finished_at) AS finished_at
+        FROM evaluations AS evaluation
+        WHERE evaluation.user_id = session.user_id
+          AND evaluation.kind = 'SESSION_REPORT'
+          AND evaluation.source_id = session.session_id
+          AND evaluation.context_id = session.session_id
+          AND evaluation.status = 'READY'
+          AND evaluation.finished_at >= session.ended_at
+    ) AS ready_report ON true
+), monotonic_steps AS (
+    SELECT
+        created_at,
+        started_at IS NOT NULL
+            AND started_at >= created_at AS reached_started,
+        started_at IS NOT NULL
+            AND started_at >= created_at
+            AND first_effective_confirmed_at >= started_at
+                AS reached_first_effective,
+        started_at IS NOT NULL
+            AND started_at >= created_at
+            AND first_effective_confirmed_at >= started_at
+            AND status = 'completed'
+            AND ended_at >= first_effective_confirmed_at
+                AS reached_completed,
+        started_at IS NOT NULL
+            AND started_at >= created_at
+            AND first_effective_confirmed_at >= started_at
+            AND status = 'completed'
+            AND ended_at >= first_effective_confirmed_at
+            AND ready_report_finished_at >= ended_at
+                AS reached_ready_report,
+        started_at IS NOT NULL
+            AND started_at >= created_at
+            AND status = 'ended_early'
+            AND ended_at >= started_at AS reached_ended_early
+    FROM session_events
+), daily AS (
+    SELECT
+        date_trunc('day', created_at, 'UTC') AS day_utc,
+        count(*)::bigint AS created_sessions,
+        count(*) FILTER (WHERE reached_started)::bigint AS started_sessions,
+        count(*) FILTER (WHERE reached_first_effective)::bigint
+            AS first_effective_confirmed_sessions,
+        count(*) FILTER (WHERE reached_completed)::bigint AS completed_sessions,
+        count(*) FILTER (WHERE reached_ready_report)::bigint
+            AS ready_session_report_sessions,
+        count(*) FILTER (WHERE reached_ended_early)::bigint
+            AS ended_early_sessions
+    FROM monotonic_steps
+    GROUP BY date_trunc('day', created_at, 'UTC')
+)
+SELECT
+    day_utc,
+    created_sessions,
+    started_sessions,
+    first_effective_confirmed_sessions,
+    completed_sessions,
+    ready_session_report_sessions,
+    ended_early_sessions,
+    started_sessions::double precision
+        / NULLIF(created_sessions, 0) AS started_from_created_rate,
+    first_effective_confirmed_sessions::double precision
+        / NULLIF(started_sessions, 0) AS first_effective_from_started_rate,
+    completed_sessions::double precision
+        / NULLIF(first_effective_confirmed_sessions, 0)
+            AS completed_from_first_effective_rate,
+    ready_session_report_sessions::double precision
+        / NULLIF(completed_sessions, 0) AS ready_report_from_completed_rate,
+    ended_early_sessions::double precision
+        / NULLIF(started_sessions, 0) AS ended_early_from_started_rate
+FROM daily;
+
+CREATE VIEW user_behavior_daily_time_to_first_effective_turn
+WITH (security_barrier = true) AS
+WITH valid_effective_turns AS (
+    SELECT
+        session.user_id,
+        session.session_id,
+        turn.confirmed_at
+    FROM practice_sessions AS session
+    JOIN practice_turns AS turn
+      ON turn.session_id = session.session_id
+     AND turn.status = 'confirmed'
+     AND turn.turn_kind = 'EFFECTIVE'
+     AND session.started_at IS NOT NULL
+     AND turn.confirmed_at >= session.started_at
+), account_first_turn AS (
+    SELECT user_id, min(confirmed_at) AS confirmed_at
+    FROM valid_effective_turns
+    GROUP BY user_id
+), account_daily AS (
+    SELECT
+        date_trunc('day', account.created_at, 'UTC') AS day_utc,
+        'ACCOUNT'::text AS scope,
+        count(*)::bigint AS eligible_subjects,
+        count(first_turn.confirmed_at) FILTER (
+            WHERE first_turn.confirmed_at >= account.created_at
+        )::bigint AS reached_subjects,
+        percentile_cont(0.50) WITHIN GROUP (
+            ORDER BY extract(
+                epoch FROM first_turn.confirmed_at - account.created_at
+            )::double precision
+        ) FILTER (
+            WHERE first_turn.confirmed_at >= account.created_at
+        ) AS p50_seconds,
+        percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY extract(
+                epoch FROM first_turn.confirmed_at - account.created_at
+            )::double precision
+        ) FILTER (
+            WHERE first_turn.confirmed_at >= account.created_at
+        ) AS p95_seconds
+    FROM users AS account
+    LEFT JOIN account_first_turn AS first_turn
+      ON first_turn.user_id = account.id
+    GROUP BY date_trunc('day', account.created_at, 'UTC')
+), session_first_turn AS (
+    SELECT session_id, min(confirmed_at) AS confirmed_at
+    FROM valid_effective_turns
+    GROUP BY session_id
+), session_daily AS (
+    SELECT
+        date_trunc('day', session.created_at, 'UTC') AS day_utc,
+        'SESSION'::text AS scope,
+        count(*)::bigint AS eligible_subjects,
+        count(first_turn.confirmed_at) FILTER (
+            WHERE first_turn.confirmed_at >= session.created_at
+        )::bigint AS reached_subjects,
+        percentile_cont(0.50) WITHIN GROUP (
+            ORDER BY extract(
+                epoch FROM first_turn.confirmed_at - session.created_at
+            )::double precision
+        ) FILTER (
+            WHERE first_turn.confirmed_at >= session.created_at
+        ) AS p50_seconds,
+        percentile_cont(0.95) WITHIN GROUP (
+            ORDER BY extract(
+                epoch FROM first_turn.confirmed_at - session.created_at
+            )::double precision
+        ) FILTER (
+            WHERE first_turn.confirmed_at >= session.created_at
+        ) AS p95_seconds
+    FROM practice_sessions AS session
+    LEFT JOIN session_first_turn AS first_turn
+      ON first_turn.session_id = session.session_id
+    GROUP BY date_trunc('day', session.created_at, 'UTC')
+), daily AS (
+    SELECT * FROM account_daily
+    UNION ALL
+    SELECT * FROM session_daily
+)
+SELECT
+    day_utc,
+    scope,
+    eligible_subjects,
+    reached_subjects,
+    reached_subjects::double precision
+        / NULLIF(eligible_subjects, 0) AS reach_rate,
+    p50_seconds,
+    p95_seconds
+FROM daily;
+
+CREATE VIEW user_behavior_daily_retention
+WITH (security_barrier = true) AS
+WITH first_effective_turn AS (
+    SELECT
+        session.user_id,
+        min(turn.confirmed_at) AS confirmed_at
+    FROM practice_sessions AS session
+    JOIN practice_turns AS turn
+      ON turn.session_id = session.session_id
+     AND turn.status = 'confirmed'
+     AND turn.turn_kind = 'EFFECTIVE'
+     AND session.started_at IS NOT NULL
+     AND turn.confirmed_at >= session.started_at
+    GROUP BY session.user_id
+), cohort AS (
+    SELECT
+        user_id,
+        date_trunc('day', confirmed_at, 'UTC') AS cohort_day_utc
+    FROM first_effective_turn
+), daily_activity AS (
+    SELECT DISTINCT
+        session.user_id,
+        date_trunc('day', turn.confirmed_at, 'UTC') AS activity_day_utc
+    FROM practice_sessions AS session
+    JOIN practice_turns AS turn
+      ON turn.session_id = session.session_id
+     AND turn.status = 'confirmed'
+), cohort_counts AS (
+    SELECT
+        cohort.cohort_day_utc,
+        count(DISTINCT cohort.user_id)::bigint AS cohort_users,
+        count(DISTINCT cohort.user_id) FILTER (
+            WHERE activity.activity_day_utc = cohort.cohort_day_utc
+                + interval '1 day'
+        )::bigint AS d1_returned_users,
+        count(DISTINCT cohort.user_id) FILTER (
+            WHERE activity.activity_day_utc = cohort.cohort_day_utc
+                + interval '7 days'
+        )::bigint AS d7_returned_users
+    FROM cohort
+    LEFT JOIN daily_activity AS activity
+      ON activity.user_id = cohort.user_id
+     AND activity.activity_day_utc IN (
+         cohort.cohort_day_utc + interval '1 day',
+         cohort.cohort_day_utc + interval '7 days'
+     )
+    GROUP BY cohort.cohort_day_utc
+)
+SELECT
+    cohort_day_utc,
+    cohort_users,
+    CASE
+        WHEN date_trunc('day', CURRENT_TIMESTAMP, 'UTC')
+            >= cohort_day_utc + interval '2 days'
+        THEN d1_returned_users
+        ELSE NULL
+    END AS d1_returned_users,
+    CASE
+        WHEN date_trunc('day', CURRENT_TIMESTAMP, 'UTC')
+            >= cohort_day_utc + interval '2 days'
+        THEN d1_returned_users::double precision / NULLIF(cohort_users, 0)
+        ELSE NULL
+    END AS d1_retention_rate,
+    CASE
+        WHEN date_trunc('day', CURRENT_TIMESTAMP, 'UTC')
+            >= cohort_day_utc + interval '8 days'
+        THEN d7_returned_users
+        ELSE NULL
+    END AS d7_returned_users,
+    CASE
+        WHEN date_trunc('day', CURRENT_TIMESTAMP, 'UTC')
+            >= cohort_day_utc + interval '8 days'
+        THEN d7_returned_users::double precision / NULLIF(cohort_users, 0)
+        ELSE NULL
+    END AS d7_retention_rate
+FROM cohort_counts;
+
+CREATE VIEW user_behavior_daily_repractice
+WITH (security_barrier = true) AS
+WITH daily AS (
+    SELECT
+        date_trunc('day', created_at, 'UTC') AS day_utc,
+        count(*)::bigint AS created_retry_turns,
+        count(*) FILTER (WHERE status = 'confirmed')::bigint
+            AS confirmed_retry_turns,
+        count(*) FILTER (WHERE status = 'failed')::bigint
+            AS failed_retry_turns,
+        count(*) FILTER (
+            WHERE status IN ('answering', 'transcribing', 'transcribed')
+              AND updated_at <= CURRENT_TIMESTAMP - interval '24 hours'
+        )::bigint AS stale_retry_turns
+    FROM practice_turns
+    WHERE turn_kind = 'RETRY'
+    GROUP BY date_trunc('day', created_at, 'UTC')
+)
+SELECT
+    day_utc,
+    created_retry_turns,
+    confirmed_retry_turns,
+    failed_retry_turns,
+    stale_retry_turns,
+    confirmed_retry_turns::double precision
+        / NULLIF(created_retry_turns, 0) AS confirmation_rate,
+    failed_retry_turns::double precision
+        / NULLIF(created_retry_turns, 0) AS failure_rate,
+    stale_retry_turns::double precision
+        / NULLIF(created_retry_turns, 0) AS stale_rate
+FROM daily;
+
+CREATE VIEW user_behavior_daily_early_end
+WITH (security_barrier = true) AS
+WITH bucketed AS (
+    SELECT
+        date_trunc('day', ended_at, 'UTC') AS day_utc,
+        CASE effective_turns
+            WHEN 0 THEN '0'
+            WHEN 1 THEN '1'
+            WHEN 2 THEN '2'
+            WHEN 3 THEN '3'
+            WHEN 4 THEN '4'
+            ELSE '5_PLUS'
+        END::text AS effective_turn_depth
+    FROM practice_sessions
+    WHERE status = 'ended_early'
+), daily AS (
+    SELECT
+        day_utc,
+        effective_turn_depth,
+        count(*)::bigint AS ended_early_sessions
+    FROM bucketed
+    GROUP BY day_utc, effective_turn_depth
+)
+SELECT
+    day_utc,
+    effective_turn_depth,
+    ended_early_sessions,
+    ended_early_sessions::double precision
+        / NULLIF(
+            sum(ended_early_sessions) OVER (PARTITION BY day_utc),
+            0
+        ) AS ended_early_share
+FROM daily;
+
+CREATE VIEW user_behavior_current_nonterminal_sessions
+WITH (security_barrier = true) AS
+SELECT
+    CASE status
+        WHEN 'starting' THEN 'STARTING'
+        WHEN 'in_progress' THEN 'IN_PROGRESS'
+        WHEN 'paused' THEN 'PAUSED'
+    END::text AS session_status,
+    CASE
+        WHEN updated_at > CURRENT_TIMESTAMP - interval '1 hour'
+            THEN 'UNDER_1H'
+        WHEN updated_at > CURRENT_TIMESTAMP - interval '24 hours'
+            THEN '1H_TO_24H'
+        WHEN updated_at > CURRENT_TIMESTAMP - interval '7 days'
+            THEN '1D_TO_7D'
+        ELSE '7D_PLUS'
+    END::text AS staleness_bucket,
+    count(*)::bigint AS sessions
+FROM practice_sessions
+WHERE status IN ('starting', 'in_progress', 'paused')
+GROUP BY
+    CASE status
+        WHEN 'starting' THEN 'STARTING'
+        WHEN 'in_progress' THEN 'IN_PROGRESS'
+        WHEN 'paused' THEN 'PAUSED'
+    END,
+    CASE
+        WHEN updated_at > CURRENT_TIMESTAMP - interval '1 hour'
+            THEN 'UNDER_1H'
+        WHEN updated_at > CURRENT_TIMESTAMP - interval '24 hours'
+            THEN '1H_TO_24H'
+        WHEN updated_at > CURRENT_TIMESTAMP - interval '7 days'
+            THEN '1D_TO_7D'
+        ELSE '7D_PLUS'
+    END;
+
+CREATE VIEW user_behavior_daily_feature_usage
+WITH (security_barrier = true) AS
+WITH confirmed_activity AS NOT MATERIALIZED (
+    SELECT
+        date_trunc('day', turn.confirmed_at, 'UTC') AS day_utc,
+        session.user_id,
+        session.session_id,
+        session.practice_experience,
+        session.scene_category,
+        session.practice_mode,
+        turn.interaction_mode
+    FROM practice_turns AS turn
+    JOIN practice_sessions AS session
+      ON session.session_id = turn.session_id
+    WHERE turn.status = 'confirmed'
+), feature_activity AS (
+    SELECT
+        day_utc,
+        user_id,
+        session_id,
+        'PRACTICE_EXPERIENCE'::text AS feature_kind,
+        CASE practice_experience
+            WHEN 'INTERVIEW' THEN 'INTERVIEW'
+            WHEN 'IELTS_SPEAKING' THEN 'IELTS_SPEAKING'
+            WHEN 'WORKPLACE' THEN 'WORKPLACE'
+            WHEN 'LIFE_AND_TRAVEL' THEN 'LIFE_AND_TRAVEL'
+            ELSE 'UNKNOWN'
+        END::text AS feature_value
+    FROM confirmed_activity
+    UNION ALL
+    SELECT
+        day_utc,
+        user_id,
+        session_id,
+        'SCENE_CATEGORY'::text,
+        CASE scene_category
+            WHEN 'INTERVIEW_RECRUITER' THEN 'INTERVIEW_RECRUITER'
+            WHEN 'INTERVIEW_BEHAVIORAL' THEN 'INTERVIEW_BEHAVIORAL'
+            WHEN 'INTERVIEW_PROFESSIONAL' THEN 'INTERVIEW_PROFESSIONAL'
+            WHEN 'INTERVIEW_HIRING_MANAGER' THEN 'INTERVIEW_HIRING_MANAGER'
+            WHEN 'INTERVIEW_CUSTOM' THEN 'INTERVIEW_CUSTOM'
+            WHEN 'IELTS_SPEAKING' THEN 'IELTS_SPEAKING'
+            WHEN 'WORKPLACE_GENERAL' THEN 'WORKPLACE_GENERAL'
+            WHEN 'LIFE_TRAVEL' THEN 'LIFE_TRAVEL'
+            WHEN 'LIFE_DAILY' THEN 'LIFE_DAILY'
+            ELSE 'UNKNOWN'
+        END::text
+    FROM confirmed_activity
+    UNION ALL
+    SELECT
+        day_utc,
+        user_id,
+        session_id,
+        'PRACTICE_MODE'::text,
+        CASE practice_mode
+            WHEN 'FULL_SIMULATION' THEN 'FULL_SIMULATION'
+            WHEN 'FOCUS' THEN 'FOCUS'
+            WHEN 'FULL_MOCK' THEN 'FULL_MOCK'
+            WHEN 'PART_1' THEN 'PART_1'
+            WHEN 'PART_2' THEN 'PART_2'
+            WHEN 'PART_3' THEN 'PART_3'
+            ELSE 'UNKNOWN'
+        END::text
+    FROM confirmed_activity
+    UNION ALL
+    SELECT
+        day_utc,
+        user_id,
+        session_id,
+        'INTERACTION_MODE'::text,
+        CASE interaction_mode
+            WHEN 'TEXT' THEN 'TEXT'
+            WHEN 'PUSH_TO_TALK' THEN 'PUSH_TO_TALK'
+            ELSE 'UNKNOWN'
+        END::text
+    FROM confirmed_activity
+)
+SELECT
+    day_utc,
+    feature_kind,
+    feature_value,
+    count(DISTINCT user_id)::bigint AS active_users,
+    count(DISTINCT session_id)::bigint AS sessions,
+    count(*)::bigint AS confirmed_turns
+FROM feature_activity
+GROUP BY day_utc, feature_kind, feature_value;
+
+REVOKE ALL ON user_behavior_daily_session_funnel FROM PUBLIC;
+REVOKE ALL ON user_behavior_daily_time_to_first_effective_turn FROM PUBLIC;
+REVOKE ALL ON user_behavior_daily_retention FROM PUBLIC;
+REVOKE ALL ON user_behavior_daily_repractice FROM PUBLIC;
+REVOKE ALL ON user_behavior_daily_early_end FROM PUBLIC;
+REVOKE ALL ON user_behavior_current_nonterminal_sessions FROM PUBLIC;
+REVOKE ALL ON user_behavior_daily_feature_usage FROM PUBLIC;
+
+COMMIT;

--- a/server/migrations/embed_test.go
+++ b/server/migrations/embed_test.go
@@ -62,6 +62,8 @@ func TestEveryMigrationPairIsEmbedded(t *testing.T) {
 		"000013_lisa_avatar_asset.up.sql",
 		"000014_expand_coach_voice_catalog.down.sql",
 		"000014_expand_coach_voice_catalog.up.sql",
+		"000015_user_behavior_views.down.sql",
+		"000015_user_behavior_views.up.sql",
 	}
 	slices.Sort(files)
 	if !slices.Equal(files, want) {
@@ -99,6 +101,8 @@ func TestMigrationsAreTransactional(t *testing.T) {
 		"000013_lisa_avatar_asset.down.sql",
 		"000014_expand_coach_voice_catalog.up.sql",
 		"000014_expand_coach_voice_catalog.down.sql",
+		"000015_user_behavior_views.up.sql",
+		"000015_user_behavior_views.down.sql",
 	} {
 		sql := readMigration(t, name)
 		if !strings.HasPrefix(sql, "BEGIN;") {


### PR DESCRIPTION
## 功能描述

- 建立 Production 匿名用户行为基线，覆盖练习漏斗、首次有效回答、D1/D7 留存、重练、提前结束、未终态与功能使用。
- 新增 Grafana「SpeakUp 用户行为」看板并复用受限 PostgreSQL datasource。
- 明确报告 READY 不等于查看，stale candidate 不等于放弃；客户端页面/点击/权限拒绝仍标为不可观测。

## 实现思路

- migration 15 创建 7 个 `security_barrier` 聚合视图和 4 个经 `EXPLAIN` 验证的索引，撤销 PUBLIC。
- Reader 仅获得 5 个 Product Health + 7 个 User Behavior 视图的 `SELECT`，原始表继续拒绝。
- Dashboard 默认 30 天 UTC、5 分钟刷新；用总漏斗、TTFV、留存、重练/提前结束和可筛选功能使用串联产品改进路径。
- `NULL` / No Data 不伪装为 0；所有维度闭集化并带 `UNKNOWN`。

## 测试方式

1. 使用隔离 PostgreSQL 18 执行：
   - `TEST_DATABASE_URL=<isolated-postgres-url> go test ./migrations ./internal/platform/migration -count=1`
   - `go test ./... -count=1`
   - `make check-go-vet`
2. 执行发布与可观测性契约：
   - `make check-observability`
   - `make check-staging-deploy`
   - `make check-production-deploy`
   - `make check-production-rehearsal`
3. 隔离 PostgreSQL 18 + Grafana 13.2.0 实际渲染验证通过：13 个区域正常显示，`场景` / `确认回答数` 筛选生效，无浏览器控制台、查询或权限错误；Reader 可查询 7 个聚合视图，原始 `practice_sessions` 被拒绝。
4. 注意：现有 rehearsal 仍只证明 7→9；真实 Production 9→15 已拆为发布阻断 Issue #1109。

## 数据边界

- 不采集或暴露用户 ID、Session / Turn / Evaluation ID、邮箱、音频、简历、问题、回答、转写或报告内容。
- 报告/逐轮反馈实际查看、页面路径、点击、权限拒绝和无请求退出仍不可观测，未从服务端事实推断。

## 相关 Issue / 备注

Closes #1106

Release-blocking follow-up: #1109

## AI 辅助说明

使用 AI 协助梳理指标口径、实现 SQL / Grafana 契约并执行隔离测试。人工复核了领域事实边界、权限白名单、迁移生命周期、Dashboard 查询与发布链路，确认能够解释全部代码和配置。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未作为设计/架构文档提交入库
- [x] 我能够解释本 PR 中的全部代码和配置
