### PR TITLE
[发布] 将 Production 数据库隔离升级演练更新为 schema 9→15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help:
 		'  make check-api      Validate OpenAPI, JSON Schema, and contract fixtures' \
 		'  make check-release-candidate  Validate release metadata and manifest tooling' \
 		'  make check-production-backup  Exercise PostgreSQL backup and isolated restore' \
-		'  make check-production-rehearsal  Validate the isolated schema 7 to 9 rehearsal' \
+		'  make check-production-rehearsal  Validate the isolated schema 9 to 15 rehearsal' \
 		'  make check-offline-release  Validate offline image build/load contracts' \
 		'  make check-android-download  Validate the public Android bundle and publish contract' \
 		'  make check-tls-lifecycle  Validate TLS issuance and renewal contracts' \

--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -295,7 +295,7 @@ smoke tests remain part of the higher-level release Workflow.
 
 ## Rehearse a schema upgrade without touching Production
 
-Before promoting a Release Candidate that advances schema 7 to schema 9, run
+Before promoting a Release Candidate that advances schema 9 to schema 15, run
 the isolated rehearsal with the finalized Production backup, the reviewed
 manifest, and both immutable Server image identities. The command is a dry-run
 unless `--execute` is present. When a distinct forward-hotfix image exists, add
@@ -321,20 +321,25 @@ output, repeat the exact command with `--execute`.
 Execution restores the dump into a uniquely named, labeled volume on an
 internal Docker network with no host ports or Production network attachment. It
 runs the manifest-pinned migration image with a finite PostgreSQL lock timeout,
-then verifies clean schema 9, the five product-health views, the IELTS
-evaluation constraint, candidate readiness, the old image's readiness-only
-boundary, rollback fail-closed behavior and a same-schema redeploy of the same
-candidate image. If a distinct forward image is supplied, that final step uses
-the forward image instead and records its OCI version and revision only after
-its migration preserves clean schema 9 and its Server passes readiness.
-The old image is **not** claimed to process schema-9 profiles correctly. Success
-or failure produces a mode `0600`, redacted receipt after owned-resource cleanup;
+then verifies clean schema 15 and the critical schema 10 through 14 presentation,
+model-ID, avatar-binding and voice-catalog contracts. It also verifies the exact
+five product-health and seven user-behavior views, their security barriers, the
+four user-behavior indexes, revoked PUBLIC privileges, the IELTS evaluation
+constraint, candidate readiness, the old image's readiness-only boundary,
+schema 15 to 9 rollback rejection and an idempotent same-schema migration. If a
+distinct forward image is supplied, that final step uses the forward image
+instead and records its OCI version and revision only after its migration
+preserves clean schema 15 and its Server passes readiness. The old image is
+**not** claimed to process schema-15 application data correctly. Success or
+failure produces a mode `0600`, redacted receipt after owned-resource cleanup;
 failure or interruption never removes unlabeled or differently labeled Docker
 resources.
 
-This repository test uses a synthetic schema-7 backup and local fixture images.
-It does not replace the required runtime evidence from the selected finalized
-Production backup and the actual immutable Release Candidate and previous image.
+This repository test uses a synthetic schema-9 backup, the real schema 10
+through 15 migrations and local fixture images. It does not replace the required
+runtime evidence from the selected finalized Production backup and the actual
+immutable Release Candidate and previous image. Retain the redacted mode `0600`
+receipt from that real rehearsal as release evidence before Production approval.
 Without `--forward-server-image`, the receipt explicitly records that no forward
 image was provided. If an incident later requires a distinct hotfix image, rerun
 the rehearsal with that immutable image before promoting it; the earlier

--- a/deploy/production/rehearse-schema-upgrade.sh
+++ b/deploy/production/rehearse-schema-upgrade.sh
@@ -12,8 +12,8 @@ readonly run_label='com.xengineer.speakup.production-rehearsal-run-id'
 readonly source_project='xe3-speakup-production'
 readonly source_service='postgres'
 readonly source_volume='xe3-speakup-postgres-data'
-readonly source_schema=7
-readonly target_schema=9
+readonly source_schema=9
+readonly target_schema=15
 readonly container_cpus='1.0'
 readonly container_memory='512m'
 readonly container_memory_bytes=536870912
@@ -62,10 +62,14 @@ forward_server_image_revision=''
 forward_hotfix_status='not_provided'
 schema_verified=false
 views_verified=false
+user_behavior_views_verified=false
+view_privileges_verified=false
+schema_10_14_contracts_verified=false
 constraint_verified=false
 candidate_readiness_verified=false
 previous_readiness_verified=false
 rollback_guard_verified=false
+idempotent_migration_verified=false
 same_schema_candidate_redeploy_verified=false
 
 usage() {
@@ -127,10 +131,15 @@ write_receipt() {
     --argjson total_duration_seconds "$total_duration_seconds" \
     --argjson schema_verified "$schema_verified" \
     --argjson views_verified "$views_verified" \
+    --argjson user_behavior_views_verified "$user_behavior_views_verified" \
+    --argjson view_privileges_verified "$view_privileges_verified" \
+    --argjson schema_10_14_contracts_verified \
+      "$schema_10_14_contracts_verified" \
     --argjson constraint_verified "$constraint_verified" \
     --argjson candidate_readiness_verified "$candidate_readiness_verified" \
     --argjson previous_readiness_verified "$previous_readiness_verified" \
     --argjson rollback_guard_verified "$rollback_guard_verified" \
+    --argjson idempotent_migration_verified "$idempotent_migration_verified" \
     --argjson same_schema_candidate_redeploy_verified \
       "$same_schema_candidate_redeploy_verified" \
     --argjson cleanup_verified "$cleanup_verified" '
@@ -169,11 +178,15 @@ write_receipt() {
         checks: {
           clean_target_schema: $schema_verified,
           product_health_views: $views_verified,
+          user_behavior_views: $user_behavior_views_verified,
+          view_public_privileges_revoked: $view_privileges_verified,
+          schema_10_14_contracts: $schema_10_14_contracts_verified,
           ielts_evaluation_constraint: $constraint_verified,
           candidate_readiness: $candidate_readiness_verified,
           previous_image_readiness_only: $previous_readiness_verified,
           previous_image_profile_processing: "not_verified",
-          schema7_rollback_guard: $rollback_guard_verified,
+          schema9_rollback_guard: $rollback_guard_verified,
+          idempotent_migration: $idempotent_migration_verified,
           same_schema_candidate_redeploy: $same_schema_candidate_redeploy_verified,
           forward_hotfix_image: $forward_hotfix_status,
           owned_resource_cleanup: $cleanup_verified
@@ -460,7 +473,7 @@ validate_backup_metadata() {
       (.size_bytes | type == "number" and floor == . and . > 0) and
       (.sha256 | type == "string" and test("^[a-f0-9]{64}$"))
     ' "$backup_directory/metadata.json" >/dev/null ||
-    fail 'backup metadata is invalid or is not a clean Production schema 7 backup'
+    fail 'backup metadata is invalid or is not a clean Production schema 9 backup'
 
   expected_checksum=$(jq --raw-output '.sha256' "$backup_directory/metadata.json")
   expected_size=$(jq --raw-output '.size_bytes' "$backup_directory/metadata.json")
@@ -734,7 +747,10 @@ run_migration() {
 }
 
 verify_target_database() {
-  local views barrier_count constraint_count expected_views actual_views
+  local barrier_count constraint_count expected_views actual_views
+  local expected_indexes actual_indexes public_grants object_count column_count
+  local expected_constraints actual_constraints lisa_binding_count voice_count
+  local expected_voice_contract voice_contract
 
   [[ "$(schema_state)" == "$target_schema" ]] ||
     fail "candidate migration did not produce clean schema $target_schema"
@@ -744,7 +760,7 @@ verify_target_database() {
     "SELECT c.relname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'product_health_daily_%' ORDER BY c.relname;") ||
     fail 'cannot inspect product health views'
   [[ "$actual_views" == "$expected_views" ]] ||
-    fail 'schema 9 does not contain exactly the five product health views'
+    fail 'schema 15 does not contain exactly the five product health views'
   barrier_count=$(database_query \
     "SELECT count(*) FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'product_health_daily_%' AND c.reloptions @> ARRAY['security_barrier=true'];") ||
     fail 'cannot inspect product health view security barriers'
@@ -752,11 +768,73 @@ verify_target_database() {
     fail 'product health views are missing security barriers'
   views_verified=true
 
+  expected_views=$'user_behavior_current_nonterminal_sessions\nuser_behavior_daily_early_end\nuser_behavior_daily_feature_usage\nuser_behavior_daily_repractice\nuser_behavior_daily_retention\nuser_behavior_daily_session_funnel\nuser_behavior_daily_time_to_first_effective_turn'
+  actual_views=$(database_query \
+    "SELECT c.relname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'user_behavior_%' ORDER BY c.relname;") ||
+    fail 'cannot inspect user behavior views'
+  [[ "$actual_views" == "$expected_views" ]] ||
+    fail 'schema 15 does not contain exactly the seven user behavior views'
+  # The rehearsal pins PostgreSQL 18, so its normalized catalog definitions are
+  # stable fingerprints for the table, expression, column order and predicate.
+  expected_indexes=$'user_behavior_confirmed_turns_day_idx|practice_turns|true|true|true|false|false|fb14f0584e55b8235b27df1d15cf882c|301680844dfdda6cb713fd00399e02f7\nuser_behavior_nonterminal_sessions_updated_idx|practice_sessions|true|true|true|false|false|abdea30dc6f0b8ab1bacc26725251cfa|2ed9267ac3e11681d5050bf454787b63\nuser_behavior_ready_session_reports_idx|evaluations|true|true|true|false|false|5bb3c9b107d1e1c16179cac640b8f45c|ff20ea3c635e1dec160eed2b0f5803b4\nuser_behavior_sessions_created_day_idx|practice_sessions|true|true|true|false|false|acdceda1390123c40b36a123f110b2b3|d41d8cd98f00b204e9800998ecf8427e'
+  actual_indexes=$(database_query \
+    "SELECT index_relation.relname || '|' || table_relation.relname || '|' || index_catalog.indisvalid::text || '|' || index_catalog.indisready::text || '|' || index_catalog.indislive::text || '|' || index_catalog.indisunique::text || '|' || index_catalog.indisprimary::text || '|' || md5(pg_catalog.pg_get_indexdef(index_catalog.indexrelid)) || '|' || md5(COALESCE(pg_catalog.pg_get_expr(index_catalog.indpred, index_catalog.indrelid), '')) FROM pg_catalog.pg_index index_catalog JOIN pg_catalog.pg_class index_relation ON index_relation.oid = index_catalog.indexrelid JOIN pg_catalog.pg_namespace index_namespace ON index_namespace.oid = index_relation.relnamespace JOIN pg_catalog.pg_class table_relation ON table_relation.oid = index_catalog.indrelid JOIN pg_catalog.pg_namespace table_namespace ON table_namespace.oid = table_relation.relnamespace WHERE index_namespace.nspname = 'public' AND table_namespace.nspname = 'public' AND index_relation.relname LIKE 'user_behavior_%' ORDER BY index_relation.relname;") ||
+    fail 'cannot inspect user behavior index contracts'
+  [[ "$actual_indexes" == "$expected_indexes" ]] ||
+    fail 'schema 15 user behavior index contracts are invalid'
+  barrier_count=$(database_query \
+    "SELECT count(*) FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'v' AND c.relname LIKE 'user_behavior_%' AND c.reloptions @> ARRAY['security_barrier=true'];") ||
+    fail 'cannot inspect user behavior view security barriers'
+  [[ "$barrier_count" == 7 ]] ||
+    fail 'user behavior views are missing security barriers'
+  user_behavior_views_verified=true
+
+  public_grants=$(database_query \
+    "SELECT count(*) FROM (SELECT 1 FROM pg_catalog.pg_class relation JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(relation.relacl, pg_catalog.acldefault('r', relation.relowner))) public_acl WHERE namespace.nspname = 'public' AND relation.relkind = 'v' AND relation.relname IN ('product_health_daily_artifact_coverage', 'product_health_daily_evaluation_health', 'product_health_daily_practice_activity', 'product_health_daily_scoreability', 'product_health_daily_session_outcomes', 'user_behavior_current_nonterminal_sessions', 'user_behavior_daily_early_end', 'user_behavior_daily_feature_usage', 'user_behavior_daily_repractice', 'user_behavior_daily_retention', 'user_behavior_daily_session_funnel', 'user_behavior_daily_time_to_first_effective_turn') AND public_acl.grantee = 0 UNION ALL SELECT 1 FROM pg_catalog.pg_class relation JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace JOIN pg_catalog.pg_attribute attribute ON attribute.attrelid = relation.oid AND attribute.attnum > 0 AND NOT attribute.attisdropped CROSS JOIN LATERAL pg_catalog.aclexplode(attribute.attacl) public_acl WHERE namespace.nspname = 'public' AND relation.relkind = 'v' AND relation.relname IN ('product_health_daily_artifact_coverage', 'product_health_daily_evaluation_health', 'product_health_daily_practice_activity', 'product_health_daily_scoreability', 'product_health_daily_session_outcomes', 'user_behavior_current_nonterminal_sessions', 'user_behavior_daily_early_end', 'user_behavior_daily_feature_usage', 'user_behavior_daily_repractice', 'user_behavior_daily_retention', 'user_behavior_daily_session_funnel', 'user_behavior_daily_time_to_first_effective_turn') AND public_acl.grantee = 0) public_privileges;") ||
+    fail 'cannot inspect aggregate view PUBLIC privileges'
+  [[ "$public_grants" == 0 ]] ||
+    fail 'aggregate views expose privileges to PUBLIC'
+  view_privileges_verified=true
+
+  object_count=$(database_query \
+    "SELECT count(*) FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname IN ('coach_avatar_options', 'coach_voice_options', 'user_coach_presentation_preferences');") ||
+    fail 'cannot inspect schema 10 presentation tables'
+  [[ "$object_count" == 3 ]] ||
+    fail 'schema 10 presentation tables are incomplete'
+  column_count=$(database_query \
+    "SELECT count(*) FROM information_schema.columns WHERE table_schema = 'public' AND is_nullable = 'NO' AND (table_name, column_name) IN (('coach_avatar_options', 'provider_profile'), ('coach_voice_options', 'provider_profile'), ('practice_sessions', 'presentation_snapshot'));") ||
+    fail 'cannot inspect schema 11 runtime columns'
+  [[ "$column_count" == 3 ]] ||
+    fail 'schema 11 presentation runtime columns are incomplete'
+  expected_constraints=$'agent_runs|agent_runs_json_shape_check|c|true|true|f36065a83bac4c34f381540b741436c7|context_snapshot,tool_trace,model_result,usage,error\nagent_runs|agent_runs_model_configuration_check|c|true|true|16e1e11905311b9291cd6b1bcd3d826c|model_configuration\ncoach_avatar_options|coach_avatar_options_provider_binding_unique|u|true|true|5a972ed789cab55701518859c17b8314|provider,provider_profile,provider_avatar_id,binding_version\ncoach_avatar_options|coach_avatar_options_text_check|c|true|true|cacaac8ec461b7e191450e21842629a0|display_name,description,preview_asset_key,provider,provider_profile,provider_avatar_id\ncoach_voice_options|coach_voice_options_provider_binding_unique|u|true|true|7d0360aaaa9eea1997007a99e59ec519|provider,provider_profile,provider_model,provider_voice_id,binding_version\ncoach_voice_options|coach_voice_options_text_check|c|true|true|ea842603d9d2550a2b262fa6458666b6|display_name,description,locale,gender,provider,provider_profile,provider_model,provider_voice_id\npractice_sessions|practice_sessions_presentation_snapshot_check|c|true|true|75db06017f1900ed528d74da92161732|presentation_snapshot'
+  actual_constraints=$(database_query \
+    "SELECT relation.relname || '|' || constraint_catalog.conname || '|' || constraint_catalog.contype::text || '|' || constraint_catalog.convalidated::text || '|' || constraint_catalog.conenforced::text || '|' || md5(pg_catalog.pg_get_constraintdef(constraint_catalog.oid, false)) || '|' || COALESCE((SELECT string_agg(attribute.attname, ',' ORDER BY key_column.key_position) FROM unnest(constraint_catalog.conkey) WITH ORDINALITY AS key_column(attnum, key_position) JOIN pg_catalog.pg_attribute attribute ON attribute.attrelid = constraint_catalog.conrelid AND attribute.attnum = key_column.attnum), '') FROM pg_catalog.pg_constraint constraint_catalog JOIN pg_catalog.pg_class relation ON relation.oid = constraint_catalog.conrelid JOIN pg_catalog.pg_namespace namespace ON namespace.oid = relation.relnamespace WHERE namespace.nspname = 'public' AND constraint_catalog.conname IN ('coach_avatar_options_text_check', 'coach_avatar_options_provider_binding_unique', 'coach_voice_options_text_check', 'coach_voice_options_provider_binding_unique', 'practice_sessions_presentation_snapshot_check', 'agent_runs_model_configuration_check', 'agent_runs_json_shape_check') ORDER BY relation.relname, constraint_catalog.conname;") ||
+    fail 'cannot inspect schema 10 to 12 constraint contracts'
+  [[ "$actual_constraints" == "$expected_constraints" ]] ||
+    fail 'schema 10 to 12 constraint contracts are invalid'
+  lisa_binding_count=$(database_query \
+    "SELECT count(*) FROM public.coach_avatar_options WHERE id = 'avatar_lisa' AND provider = 'spatialreal' AND provider_profile = 'spatialreal_default' AND provider_avatar_id = 'ca9c5c22-6dba-4b59-ae3b-d26066f8c017' AND binding_version = 2;") ||
+    fail 'cannot inspect schema 13 Lisa binding'
+  [[ "$lisa_binding_count" == 1 ]] ||
+    fail 'schema 13 Lisa binding is invalid'
+  voice_count=$(database_query \
+    "SELECT count(*) FROM public.coach_voice_options;") ||
+    fail 'cannot inspect schema 14 voice catalog'
+  [[ "$voice_count" == 9 ]] ||
+    fail 'schema 14 voice catalog size is invalid'
+  expected_voice_contract=$'voice_adrian|en|qianwen|qianwen_default|qwen-audio-3.0-tts-flash|qwen-audio-3.0-tts-flash-loongadriangao|1|true\nvoice_ivy|en|qianwen|qianwen_default|qwen-audio-3.0-tts-flash|qwen-audio-3.0-tts-flash-loongivyhu|1|true\nvoice_james|en|qianwen|qianwen_default|qwen-audio-3.0-tts-flash|qwen-audio-3.0-tts-flash-loongjameszhao|1|true\nvoice_luna|en|qianwen|qianwen_default|qwen-audio-3.0-tts-flash|qwen-audio-3.0-tts-flash-loonglunawang|1|true\nvoice_mary|en-GB|qianwen|qianwen_default|qwen-audio-3.0-tts-flash|loongmary|1|true\nvoice_nora|en|qianwen|qianwen_default|qwen-audio-3.0-tts-flash|qwen-audio-3.0-tts-flash-loongnorahu|1|true\nvoice_olivia|en|qianwen|qianwen_default|qwen-audio-3.0-tts-flash|qwen-audio-3.0-tts-flash-loongolivialin|1|true'
+  voice_contract=$(database_query \
+    "SELECT id || '|' || locale || '|' || provider || '|' || provider_profile || '|' || provider_model || '|' || provider_voice_id || '|' || binding_version::text || '|' || enabled::text FROM public.coach_voice_options WHERE id IN ('voice_adrian', 'voice_ivy', 'voice_james', 'voice_luna', 'voice_mary', 'voice_nora', 'voice_olivia') ORDER BY id;") ||
+    fail 'cannot inspect schema 14 voice bindings'
+  [[ "$voice_contract" == "$expected_voice_contract" ]] ||
+    fail 'schema 14 voice catalog is invalid'
+  schema_10_14_contracts_verified=true
+
   constraint_count=$(database_query \
     "SELECT count(*) FROM pg_catalog.pg_constraint c WHERE c.conrelid = 'public.evaluations'::regclass AND c.conname = 'evaluations_kind_check' AND c.contype = 'c' AND c.convalidated = true AND pg_get_expr(c.conbin, c.conrelid) ~ '^\\(kind = ANY \\(ARRAY\\[' AND (SELECT array_agg((match)[1] ORDER BY (match)[1]) FROM regexp_matches(pg_get_constraintdef(c.oid), '''([^'']+)''', 'g') AS match) = ARRAY['AGENT_MESSAGE_FEEDBACK', 'IELTS_PART1_PROFILE', 'IELTS_PART2_PROFILE', 'PRACTICE_TURN_FEEDBACK', 'SESSION_REPORT']::text[];") ||
     fail 'cannot inspect IELTS evaluation constraint'
   [[ "$constraint_count" == 1 ]] ||
-    fail 'schema 9 IELTS evaluation kind constraint is invalid'
+    fail 'schema 15 IELTS evaluation kind constraint is invalid'
   constraint_verified=true
 }
 
@@ -808,7 +886,7 @@ verify_rollback_guard() {
 
   if output=$("$production_manager" validate-rollback-schema \
     --current-schema "$target_schema" --target-schema "$source_schema" 2>&1); then
-    fail 'Production rollback guard allowed schema 9 to schema 7'
+    fail 'Production rollback guard allowed schema 15 to schema 9'
   fi
   [[ "$output" == *'rollback requires the current database schema to match the target release'* ]] ||
     fail 'Production rollback guard failed for an unexpected reason'
@@ -871,6 +949,7 @@ run_isolated_rehearsal() {
     forward_migration="xe3-speakup-prod-rehearsal-forward-migrate-$run_id"
     run_migration "$forward_migration" "$forward_server_image_id"
     verify_target_database
+    idempotent_migration_verified=true
     forward_server="xe3-speakup-prod-rehearsal-forward-$run_id"
     start_server_and_wait "$forward_server" "$forward_server_image_id"
     stop_server "$last_created_container_id"
@@ -881,6 +960,7 @@ run_isolated_rehearsal() {
     run_migration "$redeploy_migration" "$candidate_server_image_id"
     [[ "$(schema_state)" == "$target_schema" ]] ||
       fail 'same-schema candidate redeploy changed the clean target schema'
+    idempotent_migration_verified=true
     redeploy_server="xe3-speakup-prod-rehearsal-redeploy-$run_id"
     start_server_and_wait "$redeploy_server" "$candidate_server_image_id"
     stop_server "$last_created_container_id"

--- a/deploy/production/test-rehearsal.sh
+++ b/deploy/production/test-rehearsal.sh
@@ -174,6 +174,13 @@ remove_test_image() {
 
   for image_id in \
     "${forward_fixture_image_id:-}" \
+    "${invalid_voice_fixture_image_id:-}" \
+    "${invalid_schema_contract_fixture_image_id:-}" \
+    "${invalid_index_fixture_image_id:-}" \
+    "${public_user_grant_fixture_image_id:-}" \
+    "${migration_failure_fixture_image_id:-}" \
+    "${public_grant_fixture_image_id:-}" \
+    "${missing_barrier_fixture_image_id:-}" \
     "${negative_constraint_fixture_image_id:-}" \
     "${interrupt_fixture_image_id:-}" \
     "${invalid_constraint_fixture_image_id:-}" \
@@ -247,7 +254,7 @@ write_manifest() {
   "minimum_android_api": 24,
   "abis": ["arm64-v8a"],
   "apk_certificate_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
-  "database_schema_version": 9,
+  "database_schema_version": 15,
   "quality_run_url": "https://github.com/1024XEngineer/XE3-ESL/actions/runs/123456"
 }
 EOF
@@ -277,6 +284,13 @@ readonly fixture_smoke="$test_id-image-smoke"
 readonly previous_fixture_builder="$test_id-previous-image-builder"
 readonly forward_fixture_builder="$test_id-forward-image-builder"
 readonly missing_view_fixture_builder="$test_id-missing-view-image-builder"
+readonly missing_barrier_fixture_builder="$test_id-missing-barrier-image-builder"
+readonly public_grant_fixture_builder="$test_id-public-grant-image-builder"
+readonly public_user_grant_fixture_builder="$test_id-public-user-grant-image-builder"
+readonly invalid_index_fixture_builder="$test_id-invalid-index-image-builder"
+readonly invalid_schema_contract_fixture_builder="$test_id-invalid-schema-contract-image-builder"
+readonly invalid_voice_fixture_builder="$test_id-invalid-voice-image-builder"
+readonly migration_failure_fixture_builder="$test_id-migration-failure-image-builder"
 readonly missing_constraint_fixture_builder="$test_id-missing-constraint-image-builder"
 readonly invalid_constraint_fixture_builder="$test_id-invalid-constraint-image-builder"
 readonly negative_constraint_fixture_builder="$test_id-negative-constraint-image-builder"
@@ -285,6 +299,13 @@ readonly fixture_image="xe3-speakup-prod-rehearsal-fixture:$test_id"
 readonly previous_fixture_image="xe3-speakup-prod-rehearsal-previous-fixture:$test_id"
 readonly forward_fixture_image="xe3-speakup-prod-rehearsal-forward-fixture:$test_id"
 readonly missing_view_fixture_image="xe3-speakup-prod-rehearsal-missing-view:$test_id"
+readonly missing_barrier_fixture_image="xe3-speakup-prod-rehearsal-missing-barrier:$test_id"
+readonly public_grant_fixture_image="xe3-speakup-prod-rehearsal-public-grant:$test_id"
+readonly public_user_grant_fixture_image="xe3-speakup-prod-rehearsal-public-user-grant:$test_id"
+readonly invalid_index_fixture_image="xe3-speakup-prod-rehearsal-invalid-index:$test_id"
+readonly invalid_schema_contract_fixture_image="xe3-speakup-prod-rehearsal-invalid-schema-contract:$test_id"
+readonly invalid_voice_fixture_image="xe3-speakup-prod-rehearsal-invalid-voice:$test_id"
+readonly migration_failure_fixture_image="xe3-speakup-prod-rehearsal-migration-failure:$test_id"
 readonly missing_constraint_fixture_image="xe3-speakup-prod-rehearsal-missing-constraint:$test_id"
 readonly invalid_constraint_fixture_image="xe3-speakup-prod-rehearsal-invalid-constraint:$test_id"
 readonly negative_constraint_fixture_image="xe3-speakup-prod-rehearsal-negative-constraint:$test_id"
@@ -293,6 +314,13 @@ fixture_image_id=''
 previous_fixture_image_id=''
 forward_fixture_image_id=''
 missing_view_fixture_image_id=''
+missing_barrier_fixture_image_id=''
+public_grant_fixture_image_id=''
+public_user_grant_fixture_image_id=''
+invalid_index_fixture_image_id=''
+invalid_schema_contract_fixture_image_id=''
+invalid_voice_fixture_image_id=''
+migration_failure_fixture_image_id=''
 missing_constraint_fixture_image_id=''
 invalid_constraint_fixture_image_id=''
 negative_constraint_fixture_image_id=''
@@ -314,6 +342,13 @@ cleanup() {
   remove_test_container "$previous_fixture_builder" >/dev/null 2>&1 || status=1
   remove_test_container "$forward_fixture_builder" >/dev/null 2>&1 || status=1
   remove_test_container "$missing_view_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$missing_barrier_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$public_grant_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$public_user_grant_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$invalid_index_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$invalid_schema_contract_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$invalid_voice_fixture_builder" >/dev/null 2>&1 || status=1
+  remove_test_container "$migration_failure_fixture_builder" >/dev/null 2>&1 || status=1
   remove_test_container "$missing_constraint_fixture_builder" >/dev/null 2>&1 || status=1
   remove_test_container "$invalid_constraint_fixture_builder" >/dev/null 2>&1 || status=1
   remove_test_container "$negative_constraint_fixture_builder" >/dev/null 2>&1 || status=1
@@ -354,7 +389,7 @@ jq --null-input \
       postgres_version: "18.0",
       database_name: "speakup",
       database_user: "speakup",
-      schema_version: 7,
+      schema_version: 9,
       schema_dirty: false,
       size_bytes: $size_bytes,
       sha256: $sha256
@@ -430,7 +465,7 @@ dry_run_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" \
   --receipt "$receipt" \
   --lock-timeout-seconds 3)"
 [[ "$dry_run_output" == \
-  'backup_id=20260825T010203Z-predeploy version=0.1.6 source_schema=7 target_schema=9 forward_hotfix=not_provided dry_run=true docker_touched=false' ]] ||
+  'backup_id=20260825T010203Z-predeploy version=0.1.6 source_schema=9 target_schema=15 forward_hotfix=not_provided dry_run=true docker_touched=false' ]] ||
   fail 'dry-run returned an unexpected contract'
 [[ ! -e "$docker_marker" ]] || fail 'dry-run called Docker'
 [[ ! -e "$dump_hash_marker" ]] || fail 'dry-run read database.dump'
@@ -438,12 +473,12 @@ dry_run_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" \
 ! grep -Fq "$secret_value" <<<"$dry_run_output" ||
   fail 'dry-run exposed the server environment secret'
 
-jq '.database_schema_version = 8' "$manifest" >"$temporary_directory/schema8.json"
-chmod 0600 "$temporary_directory/schema8.json"
+jq '.database_schema_version = 14' "$manifest" >"$temporary_directory/schema14.json"
+chmod 0600 "$temporary_directory/schema14.json"
 expect_failure 'wrong target schema' env PATH="$wrapper_directory:$PATH" \
   "$rehearsal" \
     --backup "$backup_directory" \
-    --manifest "$temporary_directory/schema8.json" \
+    --manifest "$temporary_directory/schema14.json" \
     --previous-server-image "$previous_image" \
     --server-env-file "$server_environment" \
     --receipt "$receipt" \
@@ -454,7 +489,7 @@ invalid_manifest_receipt="$temporary_directory/invalid-manifest-receipt.json"
 expect_failure 'wrong target schema execute gate' env PATH="$wrapper_directory:$PATH" \
   "$rehearsal" --execute \
     --backup "$backup_directory" \
-    --manifest "$temporary_directory/schema8.json" \
+    --manifest "$temporary_directory/schema14.json" \
     --previous-server-image "$previous_image" \
     --server-env-file "$server_environment" \
     --receipt "$invalid_manifest_receipt" \
@@ -504,61 +539,87 @@ jq --exit-status '
   .environment == "isolated" and
   .status == "failed" and
   .failed_step == "backup_content_validation" and
-  .source_schema == 7 and .target_schema == 9 and
+  .source_schema == 9 and .target_schema == 15 and
   .checks.owned_resource_cleanup == true
 ' "$receipt" >/dev/null || fail 'failed execute receipt is incomplete'
 ! grep -Fq "$secret_value" "$receipt" || fail 'receipt exposed a server secret'
 ! grep -Fq "$backup_directory" "$receipt" || fail 'receipt exposed the backup path'
 
 [[ "$("$production_directory/manage.sh" validate-rollback-schema \
-  --current-schema 9 --target-schema 9)" == \
-  'current_schema=9 target_schema=9 rollback_allowed=true' ]] ||
+  --current-schema 15 --target-schema 15)" == \
+  'current_schema=15 target_schema=15 rollback_allowed=true' ]] ||
   fail 'Production rollback schema guard rejected an equal schema'
 expect_failure 'Production rollback schema guard mismatch' \
   "$production_directory/manage.sh" validate-rollback-schema \
-    --current-schema 9 --target-schema 7
+    --current-schema 15 --target-schema 9
 rm -f "$wrapper_directory/sha256sum" "$wrapper_directory/shasum"
 
 # The runtime fixture uses only the already-required PostgreSQL 18 image. Its
-# migration entrypoint applies the repository's real schema 8 and 9 SQL, while
+# migration entrypoint applies the repository's real schema 10 through 15 SQL,
+# while
 # its HTTP process exposes only a local readiness endpoint.
 fixture_directory="$temporary_directory/fixture-image"
 mkdir -m 0700 "$fixture_directory"
-cp "$production_directory/../../server/migrations/000008_product_health_views.up.sql" \
-  "$fixture_directory/000008.up.sql"
-cp "$production_directory/../../server/migrations/000009_ielts_incremental_profile.up.sql" \
-  "$fixture_directory/000009.up.sql"
+for migration in \
+  "$production_directory"/../../server/migrations/00001[0-5]*.up.sql; do
+  migration_version=${migration##*/}
+  migration_version=${migration_version%%_*}
+  cp "$migration" "$fixture_directory/$migration_version.up.sql"
+done
 cat >"$fixture_directory/speakup-migrate" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 [[ "${1:-}" == up ]] || exit 2
+[[ "${REHEARSAL_FIXTURE_FAULT:-}" != migration-failure ]] || exit 5
 sleep 2
 version="$(psql "$DATABASE_URL" --no-psqlrc --tuples-only --no-align --quiet \
   --set ON_ERROR_STOP=1 --command 'SELECT version FROM public.schema_migrations;')"
-case "$version" in
-  7)
-    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
-      --file /fixture/000008.up.sql >/dev/null
-    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
-      --command 'UPDATE public.schema_migrations SET version = 8;' >/dev/null
-    ;&
-  8)
-    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
-      --file /fixture/000009.up.sql >/dev/null
-    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
-      --command 'UPDATE public.schema_migrations SET version = 9;' >/dev/null
-    ;;
-  9)
-    ;;
-  *)
-    exit 3
-    ;;
-esac
+[[ "$version" =~ ^[0-9]+$ ]] && ((version >= 9 && version <= 15)) || exit 3
+for ((next_version = version + 1; next_version <= 15; next_version += 1)); do
+  migration_file=$(printf '/fixture/%06d.up.sql' "$next_version")
+  psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+    --file "$migration_file" >/dev/null
+  psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+    --command "UPDATE public.schema_migrations SET version = $next_version;" \
+    >/dev/null
+done
 case "${REHEARSAL_FIXTURE_FAULT:-}" in
   '' | server-unready) ;;
   missing-view)
     psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
-      --command 'DROP VIEW public.product_health_daily_scoreability;' >/dev/null
+      --command 'DROP VIEW public.user_behavior_daily_feature_usage;' >/dev/null
+    ;;
+  missing-barrier)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER VIEW public.user_behavior_daily_feature_usage SET (security_barrier = false);' \
+      >/dev/null
+    ;;
+  public-grant)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'GRANT SELECT (day_utc) ON public.product_health_daily_artifact_coverage TO PUBLIC;' \
+      >/dev/null
+    ;;
+  public-user-grant)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'GRANT SELECT ON public.user_behavior_daily_feature_usage TO PUBLIC;' \
+      >/dev/null
+    ;;
+  invalid-index)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'DROP INDEX public.user_behavior_nonterminal_sessions_updated_idx;' \
+      --command "CREATE INDEX user_behavior_nonterminal_sessions_updated_idx ON public.practice_sessions (created_at) WHERE status IN ('starting', 'in_progress', 'paused');" \
+      >/dev/null
+    ;;
+  invalid-schema-contract)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command 'ALTER TABLE public.practice_sessions DROP CONSTRAINT practice_sessions_presentation_snapshot_check;' \
+      --command 'ALTER TABLE public.practice_sessions ADD CONSTRAINT practice_sessions_presentation_snapshot_check CHECK (true);' \
+      >/dev/null
+    ;;
+  invalid-voice)
+    psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+      --command "UPDATE public.coach_voice_options SET provider_model = 'qwen-audio-3.0-tts-flash-bad' WHERE id = 'voice_mary';" \
+      >/dev/null
     ;;
   missing-constraint)
     psql "$DATABASE_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
@@ -713,6 +774,24 @@ create_fixture_variant() {
 
 missing_view_fixture_image_id=$(create_fixture_variant \
   missing-view "$missing_view_fixture_builder" "$missing_view_fixture_image")
+missing_barrier_fixture_image_id=$(create_fixture_variant \
+  missing-barrier "$missing_barrier_fixture_builder" \
+  "$missing_barrier_fixture_image")
+public_grant_fixture_image_id=$(create_fixture_variant \
+  public-grant "$public_grant_fixture_builder" "$public_grant_fixture_image")
+public_user_grant_fixture_image_id=$(create_fixture_variant \
+  public-user-grant "$public_user_grant_fixture_builder" \
+  "$public_user_grant_fixture_image")
+invalid_index_fixture_image_id=$(create_fixture_variant \
+  invalid-index "$invalid_index_fixture_builder" "$invalid_index_fixture_image")
+invalid_schema_contract_fixture_image_id=$(create_fixture_variant \
+  invalid-schema-contract "$invalid_schema_contract_fixture_builder" \
+  "$invalid_schema_contract_fixture_image")
+invalid_voice_fixture_image_id=$(create_fixture_variant \
+  invalid-voice "$invalid_voice_fixture_builder" "$invalid_voice_fixture_image")
+migration_failure_fixture_image_id=$(create_fixture_variant \
+  migration-failure "$migration_failure_fixture_builder" \
+  "$migration_failure_fixture_image")
 missing_constraint_fixture_image_id=$(create_fixture_variant \
   missing-constraint "$missing_constraint_fixture_builder" \
   "$missing_constraint_fixture_image")
@@ -741,7 +820,7 @@ docker container run \
   "$postgres_image" >/dev/null
 wait_for_postgres "$source_container"
 for migration in \
-  "$production_directory"/../../server/migrations/00000[1-7]*.up.sql; do
+  "$production_directory"/../../server/migrations/00000[1-9]*.up.sql; do
   docker container exec --interactive "$source_container" \
     psql --no-psqlrc --set ON_ERROR_STOP=1 \
       --username speakup --dbname speakup <"$migration" >/dev/null
@@ -750,7 +829,7 @@ docker container exec "$source_container" \
   psql --no-psqlrc --set ON_ERROR_STOP=1 \
     --username speakup --dbname speakup \
     --command 'CREATE TABLE public.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL);' \
-    --command 'INSERT INTO public.schema_migrations (version, dirty) VALUES (7, false);' \
+    --command 'INSERT INTO public.schema_migrations (version, dirty) VALUES (9, false);' \
     >/dev/null
 docker container exec "$source_container" \
   pg_dump --format custom --no-owner --no-privileges \
@@ -820,6 +899,29 @@ export TEST_DOCKER_COMMAND_LOG="$command_log"
 export TEST_INSPECT_ERROR_TARGET_FILE="$temporary_directory/inspect-error-target"
 export TEST_INSPECT_ERROR_INJECTED_FILE="$temporary_directory/inspect-error-injected"
 
+migration_failure_receipt="$temporary_directory/migration-failure-receipt.json"
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$migration_failure_fixture_image_id
+expect_failure 'candidate migration failure' env PATH="$wrapper_directory:$PATH" \
+  "$rehearsal" --execute \
+    --backup "$backup_directory" \
+    --manifest "$manifest" \
+    --previous-server-image "$previous_image" \
+    --server-env-file "$server_environment" \
+    --receipt "$migration_failure_receipt" \
+    --lock-timeout-seconds 2
+verify_failed_receipt "$migration_failure_receipt" migration
+jq --exit-status '
+  .source_schema == 9 and .target_schema == 15 and
+  .checks.clean_target_schema == false and
+  .checks.idempotent_migration == false
+' "$migration_failure_receipt" >/dev/null ||
+  fail 'migration failure receipt has wrong checks'
+migration_failure_run_id=$(jq --raw-output '.run_id' \
+  "$migration_failure_receipt")
+observed_rehearsal_runs+=("$migration_failure_run_id")
+assert_no_rehearsal_resources "$migration_failure_run_id"
+export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_image_id
+
 success_receipt="$temporary_directory/success-receipt.json"
 success_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" --execute \
   --backup "$backup_directory" \
@@ -835,14 +937,18 @@ observed_rehearsal_runs+=("$success_run_id")
   fail 'successful rehearsal returned an invalid contract'
 jq --exit-status '
   .status == "succeeded" and .failed_step == null and
-  .source_schema == 7 and .target_schema == 9 and
+  .source_schema == 9 and .target_schema == 15 and
   .checks.clean_target_schema == true and
   .checks.product_health_views == true and
+  .checks.user_behavior_views == true and
+  .checks.view_public_privileges_revoked == true and
+  .checks.schema_10_14_contracts == true and
   .checks.ielts_evaluation_constraint == true and
   .checks.candidate_readiness == true and
   .checks.previous_image_readiness_only == true and
   .checks.previous_image_profile_processing == "not_verified" and
-  .checks.schema7_rollback_guard == true and
+  .checks.schema9_rollback_guard == true and
+  .checks.idempotent_migration == true and
   .checks.same_schema_candidate_redeploy == false and
   .checks.forward_hotfix_image == "verified" and
   .forward_server_image == "ghcr.io/1024xengineer/xe3-esl-server@sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" and
@@ -882,7 +988,9 @@ while IFS= read -r create_command; do
 done < <(grep -E '^container create ' "$command_log")
 
 run_schema_fault_test() {
-  local fault=$1 fixture_id=$2 expected_views=$3
+  local fault=$1 fixture_id=$2 expected_product_views=$3
+  local expected_user_views=$4 expected_privileges=$5
+  local expected_schema_contracts=$6
   local fault_receipt="$temporary_directory/$fault-receipt.json"
   local fault_run_id
 
@@ -896,9 +1004,16 @@ run_schema_fault_test() {
       --receipt "$fault_receipt" \
       --lock-timeout-seconds 2
   verify_failed_receipt "$fault_receipt" schema_verification
-  jq --exit-status --argjson expected_views "$expected_views" '
+  jq --exit-status \
+    --argjson expected_product_views "$expected_product_views" \
+    --argjson expected_user_views "$expected_user_views" \
+    --argjson expected_privileges "$expected_privileges" \
+    --argjson expected_schema_contracts "$expected_schema_contracts" '
     .checks.clean_target_schema == true and
-    .checks.product_health_views == $expected_views and
+    .checks.product_health_views == $expected_product_views and
+    .checks.user_behavior_views == $expected_user_views and
+    .checks.view_public_privileges_revoked == $expected_privileges and
+    .checks.schema_10_14_contracts == $expected_schema_contracts and
     .checks.ielts_evaluation_constraint == false
   ' "$fault_receipt" >/dev/null || fail "$fault failure receipt has wrong checks"
   fault_run_id=$(jq --raw-output '.run_id' "$fault_receipt")
@@ -906,10 +1021,16 @@ run_schema_fault_test() {
   assert_no_rehearsal_resources "$fault_run_id"
 }
 
-run_schema_fault_test missing-view "$missing_view_fixture_image_id" false
-run_schema_fault_test missing-constraint "$missing_constraint_fixture_image_id" true
-run_schema_fault_test invalid-constraint "$invalid_constraint_fixture_image_id" true
-run_schema_fault_test negative-constraint "$negative_constraint_fixture_image_id" true
+run_schema_fault_test missing-view "$missing_view_fixture_image_id" true false false false
+run_schema_fault_test missing-barrier "$missing_barrier_fixture_image_id" true false false false
+run_schema_fault_test invalid-index "$invalid_index_fixture_image_id" true false false false
+run_schema_fault_test public-grant "$public_grant_fixture_image_id" true true false false
+run_schema_fault_test public-user-grant "$public_user_grant_fixture_image_id" true true false false
+run_schema_fault_test invalid-schema-contract "$invalid_schema_contract_fixture_image_id" true true true false
+run_schema_fault_test invalid-voice "$invalid_voice_fixture_image_id" true true true false
+run_schema_fault_test missing-constraint "$missing_constraint_fixture_image_id" true true true true
+run_schema_fault_test invalid-constraint "$invalid_constraint_fixture_image_id" true true true true
+run_schema_fault_test negative-constraint "$negative_constraint_fixture_image_id" true true true true
 export TEST_CANDIDATE_FIXTURE_IMAGE_ID=$fixture_image_id
 
 decoy_candidate_id=$(docker container run --detach --pull never \
@@ -943,21 +1064,21 @@ lock_database=$selected_background_container
 lock_run_id=$selected_background_run_id
 observed_rehearsal_runs+=("$lock_run_id")
 
-schema7_ready=false
+schema9_ready=false
 for ((attempt = 1; attempt <= 150; attempt += 1)); do
   if [[ "$(docker container exec --user postgres "$lock_database" \
     psql --no-psqlrc --tuples-only --no-align --quiet \
       --username speakup --dbname speakup \
-      --command "SELECT count(*) FROM public.schema_migrations WHERE version = 7 AND dirty = false AND to_regclass('public.evaluations') IS NOT NULL;" \
+      --command "SELECT count(*) FROM public.schema_migrations WHERE version = 9 AND dirty = false AND to_regclass('public.evaluations') IS NOT NULL;" \
       2>/dev/null || true)" == 1 ]]; then
-    schema7_ready=true
+    schema9_ready=true
     break
   fi
   sleep 0.1
 done
-[[ "$schema7_ready" == true ]] || {
+[[ "$schema9_ready" == true ]] || {
   wait "$rehearsal_pid" || true
-  fail 'lock-timeout rehearsal did not restore clean schema 7'
+  fail 'lock-timeout rehearsal did not restore clean schema 9'
 }
 
 verify_pid_rehearsal_container "$rehearsal_pid" db \


### PR DESCRIPTION
## 功能描述

- 将 Production 隔离升级演练从 schema 7→9 更新为本次发布所需的 9→15。
- 用真实 migrations 10–15 验证 Candidate readiness、幂等迁移、15→9 rollback guard、审计回执与资源清理。
- 精确验证 5 个 Product Health 与 7 个 User Behavior 视图及其安全契约。

## 实现思路

- 仅接受 clean schema 9 备份和声明 schema 15 的不可变 Candidate。
- 通过 PostgreSQL 18 system catalog 核对 12 个视图的 security barrier、表级/列级 PUBLIC ACL，4 个行为索引的对象/状态/定义/谓词，以及 schema 10–14 的关键约束、Lisa 绑定和 voice tuple。
- 增加 migration 失败、错误视图/barrier/ACL、错误索引、错误约束、错误 voice、锁超时、信号清理与幂等路径的故障注入。
- 保留 internal network、无宿主端口、资源上限、双标签清理和 mode 0600 脱敏 receipt 的 fail-closed 边界。

## 测试方式

1. `bash -n deploy/production/rehearse-schema-upgrade.sh deploy/production/test-rehearsal.sh`
2. `git diff --check`
3. `make check-production-rehearsal`，预期末行 `Production schema rehearsal tests passed`
4. `make check-production-deploy`，预期末行 `Production contract tests passed`
5. `make check-observability`，预期 contract 与 Nginx 均通过

上述命令均已通过；完整 rehearsal 约 6 分 19 秒，结束后无 rehearsal container/network/volume 残留。

## 相关 Issue / 备注

Related to #1109

真实 Production schema 9 备份必须在不可变 Candidate 生成后，用 Candidate/previous 精确 digest 再执行一次并保存 mode 0600 脱敏 receipt；因此本 PR 合入后仍保持 #1109 打开，直到发布审批前置证据完成。

## AI 辅助说明

AI 用于实现、故障矩阵扩展和两轮对抗式审查；针对 PUBLIC ACL、同名错误索引/约束及错误 voice tuple 的假阳性均已修复，并由独立复审确认通过。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 工程决策保留在 Issue，未新增架构文档
- [x] 变更范围已逐项审查，可解释其安全边界