### PR TITLE
[发布] 准备 v0.1.10 候选版本

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: speakup
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.9+10
+version: 0.1.10+11
 
 environment:
   sdk: ^3.12.2

--- a/portal/public/release-notes/android/index.zh-CN.json
+++ b/portal/public/release-notes/android/index.zh-CN.json
@@ -1,5 +1,5 @@
 {
   "release_notes_index_version": 1,
   "locale": "zh-CN",
-  "versions": ["0.1.9", "0.1.8", "0.1.7", "0.1.4"]
+  "versions": ["0.1.10", "0.1.9", "0.1.8", "0.1.7", "0.1.4"]
 }

--- a/portal/public/release-notes/android/v0.1.10.zh-CN.json
+++ b/portal/public/release-notes/android/v0.1.10.zh-CN.json
@@ -1,0 +1,24 @@
+{
+  "release_notes_version": 1,
+  "locale": "zh-CN",
+  "version": "0.1.10",
+  "published_at": "2026-08-28T13:22:15Z",
+  "changes": [
+    {
+      "type": "feature",
+      "text": "选择陪练音色时会自动试听并即时保存，切换后即可直接用于练习。"
+    },
+    {
+      "type": "fix",
+      "text": "修复录音停止后偶发卡住及语音识别异常的问题，提升连续练习的语音稳定性。"
+    },
+    {
+      "type": "improvement",
+      "text": "统一主导航页面的 Ambient 背景，切换首页、练习和个人页时视觉更连贯。"
+    },
+    {
+      "type": "improvement",
+      "text": "扩充英文陪练音色并完善音色图标、头像轮播与整卡选择体验，让陪练形象更易辨认和切换。"
+    }
+  ]
+}

--- a/portal/tests/android-release-notes.test.mjs
+++ b/portal/tests/android-release-notes.test.mjs
@@ -97,7 +97,13 @@ test("publishes an honest Android release history", () => {
   );
 
   assert.equal(parseAndroidReleaseNotesIndex(index), index);
-  assert.deepEqual(index.versions, ["0.1.9", "0.1.8", "0.1.7", "0.1.4"]);
+  assert.deepEqual(index.versions, [
+    "0.1.10",
+    "0.1.9",
+    "0.1.8",
+    "0.1.7",
+    "0.1.4",
+  ]);
   const currentRelease = {
     version: notes[0].version,
     published_at: notes[0].published_at,
@@ -107,6 +113,24 @@ test("publishes an honest Android release history", () => {
     notes,
   );
   assert.deepEqual(notes[0].changes, [
+    {
+      type: "feature",
+      text: "选择陪练音色时会自动试听并即时保存，切换后即可直接用于练习。",
+    },
+    {
+      type: "fix",
+      text: "修复录音停止后偶发卡住及语音识别异常的问题，提升连续练习的语音稳定性。",
+    },
+    {
+      type: "improvement",
+      text: "统一主导航页面的 Ambient 背景，切换首页、练习和个人页时视觉更连贯。",
+    },
+    {
+      type: "improvement",
+      text: "扩充英文陪练音色并完善音色图标、头像轮播与整卡选择体验，让陪练形象更易辨认和切换。",
+    },
+  ]);
+  assert.deepEqual(notes[1].changes, [
     {
       type: "feature",
       text: "新增“关于 SpeakUp”页面，可查看当前安装版本、检查更新、访问产品官网和开源许可。",
@@ -120,7 +144,7 @@ test("publishes an honest Android release history", () => {
       text: "优化产品官网首页展示，直接呈现练习与复盘流程，并简化客户端下载入口。",
     },
   ]);
-  assert.deepEqual(notes[1].changes, [
+  assert.deepEqual(notes[2].changes, [
     {
       type: "feature",
       text: "在日常、职场、面试和 IELTS 练习中增加逐句纠错、润色与原声播放。",
@@ -138,7 +162,7 @@ test("publishes an honest Android release history", () => {
       text: "优化 Android 底部导航选中状态、首页快捷入口布局和用户消息样式。",
     },
   ]);
-  assert.deepEqual(notes[2].changes, [
+  assert.deepEqual(notes[3].changes, [
     {
       type: "fix",
       text: "修复断网后实时语音无法再次录音的问题。",
@@ -156,7 +180,7 @@ test("publishes an honest Android release history", () => {
       text: "修复进入历史练习时可能自动触发新回复的问题。",
     },
   ]);
-  assert.deepEqual(notes[3], validLegacyNotes());
+  assert.deepEqual(notes[4], validLegacyNotes());
 });
 
 test("parses strict Android release notes and their ordered index", () => {


### PR DESCRIPTION
## 功能描述

- 将 Android 版本从 `0.1.9+10` 升级为 `0.1.10+11`，为下一次官方 Candidate 提供未使用过且单调递增的版本身份。
- 发布 v0.1.10 中文 Android 更新说明并更新有序索引。
- 更新精确发布历史测试，确保 Portal 不会展示未索引、乱序或与当前版本不一致的说明。

## 实现思路

- 版本号仅在 `mobile/pubspec.yaml` 更新，不修改依赖与 lockfile。
- 更新说明只包含用户可感知的移动端变化：音色自动试听/即时保存、录音恢复与语音稳定、全局 Ambient 背景、音色和头像选择改进。
- Monitor 属于内部发布链，不写入 Android 用户发布说明。

## 测试方式

1. `git diff --check`
2. `make check-release-candidate`，预期 42/42 通过
3. 在 `portal/` 运行 `npm run lint`
4. 在 `portal/` 运行 `npm test`，预期构建成功且 36/36 通过

上述命令均在最新 `upstream/dev@4c88836a` 基线上通过。

## 相关 Issue / 备注

Closes #1111

本 PR 合入后由单独的 `dev → main` Release PR 触发不可变 Candidate；不手工创建 Tag 或 Release。

## AI 辅助说明

AI 用于核对现有发布契约、整理用户可见说明和执行发布元数据/Portal 回归；变更仅 4 个版本与发布说明文件，已逐项审查。

## 提交前检查

- [x] 本 PR 只对应一个 Issue，不包含无关改动
- [x] 变更来自个人 Fork，没有在主仓直接创建开发分支
- [x] Commit 符合 Conventional Commits
- [x] 已提供可复现的测试步骤并完成本地验证
- [x] 未提交密钥、环境文件、缓存或构建产物
- [x] 未修改依赖或 lockfile
- [x] 变更范围已逐项审查