### PR TITLE
fix(production): 隔离 schema 演练外部 Provider

### DIFF
--- a/deploy/production/README.md
+++ b/deploy/production/README.md
@@ -335,6 +335,18 @@ failure produces a mode `0600`, redacted receipt after owned-resource cleanup;
 failure or interruption never removes unlabeled or differently labeled Docker
 resources.
 
+Server readiness loads the supplied environment through Docker's `--env-file`
+parser. The source file must use unique, canonical `KEY=value` lines, with only
+empty lines or column-one `#` comments. The rehearsal then explicitly disables
+object storage, Resume OCR, ISE credentials
+and all Docker-supported proxy variables. Together with the internal network,
+this prevents a restored job from reaching a real third-party service. The
+receipt records the `core_database_external_integrations_disabled` readiness
+profile and `production_provider_readiness=not_verified`: this proves core
+Server boot and database compatibility, not Production Provider availability.
+Staging UAT covers Staging business paths; exact Production Provider business
+calls require a separate authorized smoke or UAT.
+
 This repository test uses a synthetic schema-9 backup, the real schema 10
 through 15 migrations and local fixture images. It does not replace the required
 runtime evidence from the selected finalized Production backup and the actual

--- a/deploy/production/rehearse-schema-upgrade.sh
+++ b/deploy/production/rehearse-schema-upgrade.sh
@@ -20,12 +20,15 @@ readonly container_memory_bytes=536870912
 readonly container_pids_limit=256
 readonly container_log_max_size='10m'
 readonly container_log_max_file='3'
+readonly server_readiness_profile='core_database_external_integrations_disabled'
+readonly production_provider_readiness='not_verified'
 
 execute=false
 backup_directory=''
 manifest=''
-manifest_snapshot_directory=''
+input_snapshot_directory=''
 manifest_snapshot=''
+server_environment_snapshot=''
 previous_server_image=''
 forward_server_image=''
 validated_forward_server_image=''
@@ -122,6 +125,8 @@ write_receipt() {
     --arg forward_server_image_version "$forward_server_image_version" \
     --arg forward_server_image_revision "$forward_server_image_revision" \
     --arg forward_hotfix_status "$forward_hotfix_status" \
+    --arg server_readiness_profile "$server_readiness_profile" \
+    --arg production_provider_readiness "$production_provider_readiness" \
     --arg recorded_at "$recorded_at" \
     --argjson source_schema "$source_schema" \
     --argjson target_schema "$target_schema" \
@@ -169,6 +174,8 @@ write_receipt() {
         forward_server_image_revision:
           (if $forward_server_image_revision == "" then null
            else $forward_server_image_revision end),
+        server_readiness_profile: $server_readiness_profile,
+        production_provider_readiness: $production_provider_readiness,
         source_schema: $source_schema,
         target_schema: $target_schema,
         lock_timeout_seconds: $lock_timeout_seconds,
@@ -212,8 +219,13 @@ write_receipt() {
 cleanup_on_exit() {
   local status=$?
 
-  trap - EXIT INT HUP TERM
+  trap - EXIT
+  trap '' INT HUP TERM
   set +e
+  if ! cleanup_input_snapshots; then
+    status=1
+    phase='cleanup'
+  fi
   if [[ "$docker_touched" == true ]]; then
     if cleanup_owned_resources; then
       cleanup_verified=true
@@ -225,19 +237,16 @@ cleanup_on_exit() {
   elif [[ "$execute" == true ]]; then
     cleanup_verified=true
   fi
-  if ! cleanup_manifest_snapshot; then
-    status=1
-    phase='cleanup'
-  fi
   if ((started_at_seconds > 0)); then
     total_duration_seconds=$(( $(now_seconds) - started_at_seconds ))
   fi
   if [[ "$execute" == true && "$receipt_ready" == true ]]; then
     if ((status == 0)); then
       if write_receipt succeeded; then
-        printf 'backup_id=%s version=%s source_schema=%s target_schema=%s receipt=%s rehearsal=verified\n' \
+        printf 'backup_id=%s version=%s source_schema=%s target_schema=%s readiness_profile=%s production_provider_readiness=%s receipt=%s rehearsal=verified\n' \
           "$selected_backup_id" "$release_version" "$source_schema" \
-          "$target_schema" "$receipt"
+          "$target_schema" "$server_readiness_profile" \
+          "$production_provider_readiness" "$receipt"
       else
         status=1
       fi
@@ -248,23 +257,30 @@ cleanup_on_exit() {
   exit "$status"
 }
 
-cleanup_manifest_snapshot() {
+cleanup_input_snapshots() {
   local name
 
-  [[ -n "$manifest_snapshot_directory" ]] || return 0
-  name=${manifest_snapshot_directory##*/}
-  [[ "$name" == xe3-production-rehearsal-manifest.* &&
-    -d "$manifest_snapshot_directory" && ! -L "$manifest_snapshot_directory" &&
-    "$(path_owner "$manifest_snapshot_directory")" == "$EUID" ]] || return 1
+  [[ -n "$input_snapshot_directory" ]] || return 0
+  name=${input_snapshot_directory##*/}
+  [[ "$name" == xe3-production-rehearsal-inputs.* &&
+    -d "$input_snapshot_directory" && ! -L "$input_snapshot_directory" &&
+    "$(path_owner "$input_snapshot_directory")" == "$EUID" ]] || return 1
+  if [[ -e "$server_environment_snapshot" || -L "$server_environment_snapshot" ]]; then
+    [[ "$server_environment_snapshot" == "$input_snapshot_directory/server.env" &&
+      -f "$server_environment_snapshot" && ! -L "$server_environment_snapshot" &&
+      "$(path_owner "$server_environment_snapshot")" == "$EUID" ]] || return 1
+    rm -- "$server_environment_snapshot" || return 1
+  fi
   if [[ -e "$manifest_snapshot" || -L "$manifest_snapshot" ]]; then
-    [[ "$manifest_snapshot" == "$manifest_snapshot_directory/release-manifest.json" &&
+    [[ "$manifest_snapshot" == "$input_snapshot_directory/release-manifest.json" &&
       -f "$manifest_snapshot" && ! -L "$manifest_snapshot" &&
       "$(path_owner "$manifest_snapshot")" == "$EUID" ]] || return 1
     rm -- "$manifest_snapshot" || return 1
   fi
-  rmdir -- "$manifest_snapshot_directory" || return 1
-  manifest_snapshot_directory=''
+  rmdir -- "$input_snapshot_directory" || return 1
+  input_snapshot_directory=''
   manifest_snapshot=''
+  server_environment_snapshot=''
 }
 
 require_command() {
@@ -366,12 +382,12 @@ validate_manifest() {
 
   temporary_base=${TMPDIR:-/tmp}
   temporary_base=${temporary_base%/}
-  manifest_snapshot_directory=$(mktemp -d \
-    "$temporary_base/xe3-production-rehearsal-manifest.XXXXXX") ||
-    fail 'cannot create private manifest snapshot directory'
-  chmod 0700 "$manifest_snapshot_directory" ||
-    fail 'cannot protect manifest snapshot directory'
-  manifest_snapshot="$manifest_snapshot_directory/release-manifest.json"
+  input_snapshot_directory=$(mktemp -d \
+    "$temporary_base/xe3-production-rehearsal-inputs.XXXXXX") ||
+    fail 'cannot create private input snapshot directory'
+  chmod 0700 "$input_snapshot_directory" ||
+    fail 'cannot protect input snapshot directory'
+  manifest_snapshot="$input_snapshot_directory/release-manifest.json"
   cp "$manifest" "$manifest_snapshot" || fail 'cannot freeze release manifest snapshot'
   chmod 0600 "$manifest_snapshot" || fail 'cannot protect release manifest snapshot'
 
@@ -386,6 +402,59 @@ validate_manifest() {
   release_manifest_sha256=${BASH_REMATCH[4]}
   candidate_server_image="$server_repository@$(jq --raw-output \
     '.server_image_digest' "$manifest_snapshot")"
+}
+
+freeze_server_environment() {
+  server_environment_snapshot="$input_snapshot_directory/server.env"
+  awk '
+    BEGIN {
+      split("OSS_ENABLED RESUME_OCR_ENABLED APPID APIKey APISecret HTTP_PROXY HTTPS_PROXY FTP_PROXY ALL_PROXY NO_PROXY http_proxy https_proxy ftp_proxy all_proxy no_proxy DATABASE_URL SERVER_HOST SERVER_PORT METRICS_HOST", names)
+      for (position in names) {
+        controlled[names[position]] = 1
+      }
+    }
+    index($0, "\r") != 0 {
+      exit 2
+    }
+    $0 == "" || substr($0, 1, 1) == "#" {
+      print
+      next
+    }
+    $0 !~ /^[A-Za-z_][A-Za-z0-9_]*=/ {
+      exit 3
+    }
+    {
+      key = $0
+      sub(/=.*/, "", key)
+      if (++seen[key] != 1) {
+        exit 4
+      }
+      if (!(key in controlled)) {
+        print
+      }
+    }
+    END {
+      print "OSS_ENABLED=0"
+      print "RESUME_OCR_ENABLED=0"
+      print "APPID="
+      print "APIKey="
+      print "APISecret="
+      print "HTTP_PROXY="
+      print "HTTPS_PROXY="
+      print "FTP_PROXY="
+      print "ALL_PROXY="
+      print "NO_PROXY="
+      print "http_proxy="
+      print "https_proxy="
+      print "ftp_proxy="
+      print "all_proxy="
+      print "no_proxy="
+    }
+  ' "$server_environment" >"$server_environment_snapshot" ||
+    fail 'cannot freeze isolated Server environment'
+  chmod 0600 "$server_environment_snapshot" ||
+    fail 'cannot protect isolated Server environment'
+  require_private_file 'isolated Server environment' "$server_environment_snapshot"
 }
 
 validate_previous_server_image() {
@@ -853,13 +922,14 @@ start_server_and_wait() {
     --log-opt "max-file=$container_log_max_file" \
     --label "$resource_label=true" \
     --label "$run_label=$run_id" \
-    --env-file "$server_environment" \
+    --env-file "$server_environment_snapshot" \
     --env "DATABASE_URL=postgres://$selected_database_user@$postgres_container:5432/$selected_database?sslmode=disable" \
     --env SERVER_HOST=0.0.0.0 \
     --env SERVER_PORT=8080 \
     --env METRICS_HOST=127.0.0.1 \
     "$image_id") || fail 'cannot create isolated Server image'
   record_created_container "$name" "$created_id"
+  verify_server_environment_profile "$created_id"
   docker container start "$created_id" >/dev/null ||
     fail 'cannot start isolated Server image'
   for ((attempt = 1; attempt <= 60; attempt += 1)); do
@@ -874,6 +944,37 @@ start_server_and_wait() {
     sleep 1
   done
   fail 'isolated Server image did not pass readiness'
+}
+
+verify_server_environment_profile() {
+  local database_url
+
+  database_url="postgres://$selected_database_user@$postgres_container:5432/$selected_database?sslmode=disable"
+  docker container inspect "$1" | jq --exit-status \
+    --arg database_url "$database_url" '
+    def exact_env($key; $value):
+      [.[] | .Config.Env[]? | select(startswith($key + "="))] ==
+        [($key + "=" + $value)];
+    exact_env("OSS_ENABLED"; "0") and
+    exact_env("RESUME_OCR_ENABLED"; "0") and
+    exact_env("APPID"; "") and
+    exact_env("APIKey"; "") and
+    exact_env("APISecret"; "") and
+    exact_env("HTTP_PROXY"; "") and
+    exact_env("HTTPS_PROXY"; "") and
+    exact_env("FTP_PROXY"; "") and
+    exact_env("ALL_PROXY"; "") and
+    exact_env("NO_PROXY"; "") and
+    exact_env("http_proxy"; "") and
+    exact_env("https_proxy"; "") and
+    exact_env("ftp_proxy"; "") and
+    exact_env("all_proxy"; "") and
+    exact_env("no_proxy"; "") and
+    exact_env("DATABASE_URL"; $database_url) and
+    exact_env("SERVER_HOST"; "0.0.0.0") and
+    exact_env("SERVER_PORT"; "8080") and
+    exact_env("METRICS_HOST"; "127.0.0.1")
+  ' >/dev/null || fail 'isolated Server readiness profile is invalid'
 }
 
 stop_server() {
@@ -1144,6 +1245,9 @@ validate_inputs() {
   require_private_file 'server environment file' "$server_environment"
   phase='manifest_validation'
   validate_manifest
+  phase='environment_validation'
+  freeze_server_environment
+  phase='manifest_validation'
   validate_previous_server_image
   validate_forward_server_image
   phase='backup_metadata_validation'
@@ -1158,9 +1262,10 @@ main() {
   trap 'exit 130' INT HUP TERM
   validate_inputs
   if [[ "$execute" == false ]]; then
-    printf 'backup_id=%s version=%s source_schema=%s target_schema=%s forward_hotfix=%s dry_run=true docker_touched=false\n' \
+    printf 'backup_id=%s version=%s source_schema=%s target_schema=%s forward_hotfix=%s readiness_profile=%s production_provider_readiness=%s dry_run=true docker_touched=false\n' \
       "$selected_backup_id" "$release_version" "$source_schema" "$target_schema" \
-      "$forward_hotfix_status"
+      "$forward_hotfix_status" "$server_readiness_profile" \
+      "$production_provider_readiness"
     return
   fi
 

--- a/deploy/production/test-rehearsal.sh
+++ b/deploy/production/test-rehearsal.sh
@@ -54,6 +54,8 @@ verify_failed_receipt() {
     .operation == "production_schema_upgrade_rehearsal" and
     .environment == "isolated" and .status == "failed" and
     .failed_step == $expected_step and
+    .server_readiness_profile == "core_database_external_integrations_disabled" and
+    .production_provider_readiness == "not_verified" and
     .checks.owned_resource_cleanup == true
   ' "$selected_receipt" >/dev/null ||
     fail "$expected_step receipt is incomplete"
@@ -71,6 +73,9 @@ assert_no_rehearsal_resources() {
     >/dev/null 2>&1 || fail "$selected_run leaked its network"
   ! docker volume inspect "xe3-speakup-prod-rehearsal-$selected_run" \
     >/dev/null 2>&1 || fail "$selected_run leaked its volume"
+  [[ -z "$(find "$temporary_directory" -maxdepth 1 -type d \
+    -name 'xe3-production-rehearsal-inputs.*' -print -quit)" ]] ||
+    fail "$selected_run leaked a private input snapshot"
 }
 
 selected_background_container=''
@@ -265,6 +270,7 @@ temporary_base=${temporary_base%/}
 temporary_directory="$(realpath \
   "$(mktemp -d "$temporary_base/xe3-production-rehearsal-test.XXXXXX")")"
 readonly temporary_directory
+export TMPDIR="$temporary_directory"
 readonly backup_directory="$temporary_directory/20260825T010203Z-predeploy"
 readonly manifest="$temporary_directory/release-manifest.json"
 readonly server_environment="$temporary_directory/server.env"
@@ -367,6 +373,15 @@ trap cleanup EXIT INT TERM
 mkdir -m 0700 "$backup_directory" "$wrapper_directory"
 write_manifest
 printf 'DASHSCOPE_API_KEY=%s\n' "$secret_value" >"$server_environment"
+printf 'OSS_ENABLED=1\n' >>"$server_environment"
+printf 'RESUME_OCR_ENABLED=1\n' >>"$server_environment"
+printf 'APPID=%s\n' "$secret_value" >>"$server_environment"
+printf 'APIKey=%s\n' "$secret_value" >>"$server_environment"
+printf 'APISecret=%s\n' "$secret_value" >>"$server_environment"
+for key in HTTP_PROXY HTTPS_PROXY FTP_PROXY ALL_PROXY NO_PROXY \
+  http_proxy https_proxy ftp_proxy all_proxy no_proxy; do
+  printf '%s=%s\n' "$key" "$secret_value" >>"$server_environment"
+done
 printf 'PGDMP synthetic dry-run fixture\n' >"$dump"
 dump_sha256=$(sha256_file "$dump")
 dump_size=$(wc -c <"$dump" | tr -d '[:space:]')
@@ -465,8 +480,11 @@ dry_run_output="$(PATH="$wrapper_directory:$PATH" "$rehearsal" \
   --receipt "$receipt" \
   --lock-timeout-seconds 3)"
 [[ "$dry_run_output" == \
-  'backup_id=20260825T010203Z-predeploy version=0.1.6 source_schema=9 target_schema=15 forward_hotfix=not_provided dry_run=true docker_touched=false' ]] ||
+  'backup_id=20260825T010203Z-predeploy version=0.1.6 source_schema=9 target_schema=15 forward_hotfix=not_provided readiness_profile=core_database_external_integrations_disabled production_provider_readiness=not_verified dry_run=true docker_touched=false' ]] ||
   fail 'dry-run returned an unexpected contract'
+[[ -z "$(find "$temporary_directory" -maxdepth 1 -type d \
+  -name 'xe3-production-rehearsal-inputs.*' -print -quit)" ]] ||
+  fail 'dry-run leaked a private input snapshot'
 [[ ! -e "$docker_marker" ]] || fail 'dry-run called Docker'
 [[ ! -e "$dump_hash_marker" ]] || fail 'dry-run read database.dump'
 [[ ! -e "$receipt" ]] || fail 'dry-run wrote a receipt'
@@ -644,6 +662,18 @@ EOF
 cat >"$fixture_directory/speakup-server" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  [[ "${OSS_ENABLED:-}" == 0 && "${RESUME_OCR_ENABLED:-}" == 0 ]] || exit 6
+  for key in OSS_ENABLED RESUME_OCR_ENABLED APPID APIKey APISecret \
+    HTTP_PROXY HTTPS_PROXY FTP_PROXY ALL_PROXY NO_PROXY \
+    http_proxy https_proxy ftp_proxy all_proxy no_proxy; do
+    [[ "$(env | grep -c "^${key}=")" == 1 ]] || exit 8
+  done
+  for key in APPID APIKey APISecret HTTP_PROXY HTTPS_PROXY FTP_PROXY \
+    ALL_PROXY NO_PROXY http_proxy https_proxy ftp_proxy all_proxy no_proxy; do
+    [[ -v "$key" && -z "${!key}" ]] || exit 7
+  done
+fi
 if [[ "${REHEARSAL_FIXTURE_FAULT:-}" == server-unready ]]; then
   sleep 300
   exit 5
@@ -937,6 +967,8 @@ observed_rehearsal_runs+=("$success_run_id")
   fail 'successful rehearsal returned an invalid contract'
 jq --exit-status '
   .status == "succeeded" and .failed_step == null and
+  .server_readiness_profile == "core_database_external_integrations_disabled" and
+  .production_provider_readiness == "not_verified" and
   .source_schema == 9 and .target_schema == 15 and
   .checks.clean_target_schema == true and
   .checks.product_health_views == true and


### PR DESCRIPTION
## 功能描述

修复真实 Production schema 9→15 演练中 Candidate Server 在 `/readyz` 前退出的问题，同时保持演练对真实第三方服务零出网。

根因是 rehearsal 使用唯一 `--internal` 网络，而 Production env 开启对象存储后，Server 会在监听前执行远端 bucket preflight。旧实现因此把网络隔离误判成 Candidate 不可启动。

## 实现思路

- 从 mode 0400/0600 的 Production Server env 生成一次性 0700/0600 私有快照；
- 严格接受唯一、规范的 `KEY=value`，过滤脚本控制的 runtime key；
- 在快照中精确写入一次 `OSS_ENABLED=0`、`RESUME_OCR_ENABLED=0`、空 ISE credential，以及 Docker 支持的全部大小写 proxy key；
- 容器启动前用只返回布尔值的 `docker inspect` 校验 19 个 runtime key 各自唯一且值精确，不输出 `.Config.Env`；
- 退出时忽略后续信号，先删除含密钥快照，再清理 Docker 资源；
- receipt/stdout 显式记录 `core_database_external_integrations_disabled` 和 `production_provider_readiness=not_verified`，避免把 core Server+DB readiness 误读为完整 Production Provider 验证；
- Production compose、业务逻辑、migrations 与 internal/no-host-port 边界均不变。

Docker 官方说明 internal network 没有外部默认路由，且 Docker CLI 可自动注入 proxy 环境变量：
- https://docs.docker.com/reference/cli/docker/network/create/#network-internal-mode---internal
- https://docs.docker.com/engine/cli/proxy/

## 可复现测试

- `make check-production-rehearsal`：PASS
- `make check-production-deploy`：PASS
- `make check-observability`：PASS
- `bash -n deploy/production/rehearse-schema-upgrade.sh`：PASS
- `bash -n deploy/production/test-rehearsal.sh`：PASS
- `git diff --check`：PASS
- 真实 Production env 仅做格式布尔校验：`portable_env=valid`，未输出任何值

合入并重建不可变 Candidate 后，将使用同一份 restore-verified schema 9 backup 重跑真实演练并把 0600 脱敏成功回执附到 #1109。

Closes #1120
Related to #1109
Blocks #1112