### PR TITLE
fix(observability): provision Grafana reader credential

### DIFF
--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -64,8 +64,13 @@ or public port.
 
 This follows Grafana's recommendation to use a dedicated database user with
 only `SELECT` on the necessary views and PostgreSQL's separate `USAGE`/`SELECT`
-privilege model. The datasource supplies no password field: Grafana reads the
-official `PGPASSFILE` instead.
+privilege model. The PostgreSQL plugin process resolves its standard password
+file from the Grafana OS user's home, so Compose mounts the single scoped secret
+read-only at `/home/grafana/.pgpass`. The private-file validator enforces host
+UID `472` and mode `0600`, which the file-backed secret bind preserves. This
+does not rely on a `PGPASSFILE` environment variable crossing the plugin process
+boundary, and it does not persist the database password in Grafana
+`secureJsonData`.
 
 The first dashboard intentionally reports only facts the current schema can
 prove:

--- a/deploy/observability/compose.yaml
+++ b/deploy/observability/compose.yaml
@@ -82,10 +82,10 @@ services:
       GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
       GF_USERS_DEFAULT_LANGUAGE: zh-Hans
       OBSERVABILITY_PRODUCT_HEALTH_DATABASE: ${OBSERVABILITY_PRODUCT_HEALTH_DATABASE:?OBSERVABILITY_PRODUCT_HEALTH_DATABASE is required}
-      PGPASSFILE: /run/secrets/product_health_reader_pgpass
     secrets:
       - grafana_admin_password
-      - product_health_reader_pgpass
+      - source: product_health_reader_pgpass
+        target: /home/grafana/.pgpass
     ports:
       - "127.0.0.1:13000:3000"
     volumes:

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -315,11 +315,11 @@ jq --exit-status \
   .services.grafana.platform == "linux/amd64" and
   .services.grafana.environment.GF_AUTH_ANONYMOUS_ENABLED == "false" and
   .services.grafana.environment.GF_USERS_DEFAULT_LANGUAGE == "zh-Hans" and
-  .services.grafana.environment.PGPASSFILE == "/run/secrets/product_health_reader_pgpass" and
+  (.services.grafana.environment | has("PGPASSFILE") | not) and
   .services.grafana.environment.OBSERVABILITY_PRODUCT_HEALTH_DATABASE == "speakup" and
   ([.services.grafana.secrets[] |
     select(.source == "product_health_reader_pgpass" and
-      .target == "/run/secrets/product_health_reader_pgpass")
+      .target == "/home/grafana/.pgpass")
   ] | length) == 1 and
   .secrets.product_health_reader_pgpass.file ==
     $product_health_pgpass_file and


### PR DESCRIPTION
## 功能描述

修复 Grafana bundled PostgreSQL plugin 无法获得 `speakup_product_health_reader` 凭据、导致 Product Health / User Behavior 查询认证失败的问题。

Closes #1126

## 已验证根因

Grafana Server 容器环境虽然设置了 `PGPASSFILE`，但 bundled PostgreSQL plugin 子进程不继承该变量。插件使用的 pgx v5 会按运行用户的 home 查找标准 `.pgpass`；固定 Grafana UID 472 的 home 为 `/home/grafana`。

## 实现思路

- 保留现有 scoped PGPASSFILE 作为唯一私密凭据，不复制密码、不写普通环境变量，也不写入 Grafana `secureJsonData`。
- 移除无效且误导的 `PGPASSFILE` environment。
- 使用 Compose secret 长语法，将现有 `product_health_reader_pgpass` 只读挂载到 `/home/grafana/.pgpass`。
- 现有 private-file validator 继续在 host 侧强制 UID 472、mode 0600；Compose file-backed secret bind 保留这些权限。
- 契约测试固定校验 secret source、pgx 默认 home target、无 `PGPASSFILE` env，以及原有 host private-file 权限边界。
- README 同步记录 pgx 默认查找路径、权限边界与 force-recreate 流程。

官方依据：
- https://grafana.com/docs/grafana/latest/datasources/postgres/configure/
- https://github.com/jackc/pgx/blob/v5.7.5/pgpassfile/pgpass.go

## 可复现测试

```bash
make check-observability
```

已通过：

- Observability contract tests passed
- Observability Nginx configuration passed
- `docker compose config --format json` 精确解析 secret source 与 `/home/grafana/.pgpass` target
- private-file contract 继续要求 host PGPASSFILE 为 UID 472、mode 0600、单行 scoped entry

## 上线验收

合入后按 README 安装 `xe3-speakup-configure-product-health-reader`、配置 reader、验证 private files，并由 operator 一次性清除当前紧急 `secureJsonData.password` override，然后仅 force-recreate Grafana。随后验证 `secureJsonFields` 为空、datasource health、12 个 Dashboard query targets、全部筛选组合，以及 reader 仅可读取 12 个聚合视图且 raw table SELECT 仍被拒绝。
