### PR TITLE
fix(observability): mount Grafana pgpass in home

### DIFF
--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -66,7 +66,7 @@ This follows Grafana's recommendation to use a dedicated database user with
 only `SELECT` on the necessary views and PostgreSQL's separate `USAGE`/`SELECT`
 privilege model. The PostgreSQL plugin process resolves its standard password
 file from the Grafana OS user's home, so Compose mounts the single scoped secret
-read-only at `/home/grafana/.pgpass`. The private-file validator enforces host
+read-only at `/usr/share/grafana/.pgpass`. The private-file validator enforces host
 UID `472` and mode `0600`, which the file-backed secret bind preserves. This
 does not rely on a `PGPASSFILE` environment variable crossing the plugin process
 boundary, and it does not persist the database password in Grafana

--- a/deploy/observability/compose.yaml
+++ b/deploy/observability/compose.yaml
@@ -85,7 +85,7 @@ services:
     secrets:
       - grafana_admin_password
       - source: product_health_reader_pgpass
-        target: /home/grafana/.pgpass
+        target: /usr/share/grafana/.pgpass
     ports:
       - "127.0.0.1:13000:3000"
     volumes:

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -319,7 +319,7 @@ jq --exit-status \
   .services.grafana.environment.OBSERVABILITY_PRODUCT_HEALTH_DATABASE == "speakup" and
   ([.services.grafana.secrets[] |
     select(.source == "product_health_reader_pgpass" and
-      .target == "/home/grafana/.pgpass")
+      .target == "/usr/share/grafana/.pgpass")
   ] | length) == 1 and
   .secrets.product_health_reader_pgpass.file ==
     $product_health_pgpass_file and


### PR DESCRIPTION
## 功能描述

修复 PR #1128 Review 指出的 Grafana PostgreSQL reader 凭据挂载路径问题。

## 实现思路

Grafana `13.2.0` 官方镜像将 `GF_PATHS_HOME` 和 Grafana 用户 home 设置为 `/usr/share/grafana`，容器启动脚本也将 `HOME` 导出为该路径。将 scoped `product_health_reader_pgpass` secret 挂载到 `/usr/share/grafana/.pgpass`，使 PostgreSQL plugin 进程能够通过标准 home 路径读取凭据，同时不引入 `PGPASSFILE` 或 `secureJsonData.password`。

同步更新 Compose contract 和运维说明。

Follow-up to #1128; related to #1126.

## 可复现测试

- `make check-observability`
- `bash -n deploy/observability/test.sh deploy/observability/validate-private-files deploy/observability/configure-product-health-reader`
- `git diff --check`

## 变更范围

仅修改：

- `deploy/observability/compose.yaml`
- `deploy/observability/test.sh`
- `deploy/observability/README.md`
