### PR TITLE
revert(observability): revert PR #1128 credential promotion

### DIFF
--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -64,13 +64,8 @@ or public port.
 
 This follows Grafana's recommendation to use a dedicated database user with
 only `SELECT` on the necessary views and PostgreSQL's separate `USAGE`/`SELECT`
-privilege model. The PostgreSQL plugin process resolves its standard password
-file from the Grafana OS user's home, so Compose mounts the single scoped secret
-read-only at `/home/grafana/.pgpass`. The private-file validator enforces host
-UID `472` and mode `0600`, which the file-backed secret bind preserves. This
-does not rely on a `PGPASSFILE` environment variable crossing the plugin process
-boundary, and it does not persist the database password in Grafana
-`secureJsonData`.
+privilege model. The datasource supplies no password field: Grafana reads the
+official `PGPASSFILE` instead.
 
 The first dashboard intentionally reports only facts the current schema can
 prove:

--- a/deploy/observability/compose.yaml
+++ b/deploy/observability/compose.yaml
@@ -82,10 +82,10 @@ services:
       GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
       GF_USERS_DEFAULT_LANGUAGE: zh-Hans
       OBSERVABILITY_PRODUCT_HEALTH_DATABASE: ${OBSERVABILITY_PRODUCT_HEALTH_DATABASE:?OBSERVABILITY_PRODUCT_HEALTH_DATABASE is required}
+      PGPASSFILE: /run/secrets/product_health_reader_pgpass
     secrets:
       - grafana_admin_password
-      - source: product_health_reader_pgpass
-        target: /home/grafana/.pgpass
+      - product_health_reader_pgpass
     ports:
       - "127.0.0.1:13000:3000"
     volumes:

--- a/deploy/observability/test.sh
+++ b/deploy/observability/test.sh
@@ -315,11 +315,11 @@ jq --exit-status \
   .services.grafana.platform == "linux/amd64" and
   .services.grafana.environment.GF_AUTH_ANONYMOUS_ENABLED == "false" and
   .services.grafana.environment.GF_USERS_DEFAULT_LANGUAGE == "zh-Hans" and
-  (.services.grafana.environment | has("PGPASSFILE") | not) and
+  .services.grafana.environment.PGPASSFILE == "/run/secrets/product_health_reader_pgpass" and
   .services.grafana.environment.OBSERVABILITY_PRODUCT_HEALTH_DATABASE == "speakup" and
   ([.services.grafana.secrets[] |
     select(.source == "product_health_reader_pgpass" and
-      .target == "/home/grafana/.pgpass")
+      .target == "/run/secrets/product_health_reader_pgpass")
   ] | length) == 1 and
   .secrets.product_health_reader_pgpass.file ==
     $product_health_pgpass_file and


### PR DESCRIPTION
## 功能描述
撤回误合入 `main` 的 PR #1128 `chore(release): promote Monitor credential fix`，恢复 `main` 到该 PR 合入前的状态。`dev` 不受影响，后续正确挂载路径的修复 PR #1129 可独立评审和合入。

## 实现思路
对 merge commit `9b602509fe1e93e620c4bb93caff4b0dafaaf60f` 执行标准 `git revert -m 1`，生成可审计的反向提交，不改写 `main` 历史。仅回退以下 3 个 Observability 文件：

- `deploy/observability/README.md`
- `deploy/observability/compose.yaml`
- `deploy/observability/test.sh`

## 可复现测试

```bash
make check-observability
bash -n deploy/observability/test.sh deploy/observability/validate-private-files deploy/observability/configure-product-health-reader
git diff --check
```

本地结果：全部通过。

## 关联 Issue
Closes #1130

关联 PR：#1128、#1129。