### PR TITLE
fix(release): skip already released candidate runs

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
+      status: ${{ steps.release.outputs.status }}
       version: ${{ steps.release.outputs.version }}
       version_code: ${{ steps.release.outputs.version_code }}
       git_sha: ${{ steps.release.outputs.git_sha }}
@@ -65,8 +66,10 @@ jobs:
           node tools/release-candidate/metadata.mjs
           --candidate-sha "$GITHUB_SHA"
           --main-ref refs/remotes/origin/main
+          --existing-tag-policy skip
 
       - name: Record Candidate identity
+        if: steps.release.outputs.status == 'candidate'
         env:
           CANDIDATE_VERSION: ${{ steps.release.outputs.version }}
           CANDIDATE_VERSION_CODE: ${{ steps.release.outputs.version_code }}
@@ -81,9 +84,39 @@ jobs:
             printf -- '- Run: %s\n' "$CANDIDATE_RUN_URL"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Record already released Candidate skip
+        if: steps.release.outputs.status == 'already-released'
+        env:
+          CANDIDATE_SHA: ${{ steps.release.outputs.git_sha }}
+          CANDIDATE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          {
+            printf '## Release Candidate skipped\n\n'
+            printf -- '- Stable Tag already exists: `%s`\n' "$CANDIDATE_TAG"
+            printf -- '- Commit: `%s`\n' "$CANDIDATE_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload already released Candidate marker
+        if: steps.release.outputs.status == 'already-released'
+        run: |
+          printf 'status=already-released\ntag=%s\ncommit=%s\n' \
+            '${{ steps.release.outputs.tag }}' \
+            '${{ steps.release.outputs.git_sha }}' \
+            > "$RUNNER_TEMP/release-candidate-skipped.txt"
+
+      - name: Store already released Candidate marker
+        if: steps.release.outputs.status == 'already-released'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-candidate-skipped
+          path: ${{ runner.temp }}/release-candidate-skipped.txt
+          if-no-files-found: error
+          retention-days: 90
+
   quality:
     name: Full quality checks
     needs: metadata
+    if: needs.metadata.outputs.status == 'candidate'
     permissions:
       actions: read
       contents: read
@@ -92,6 +125,7 @@ jobs:
   database:
     name: Database checks
     needs: metadata
+    if: needs.metadata.outputs.status == 'candidate'
     permissions:
       contents: read
     uses: ./.github/workflows/database.yml
@@ -102,6 +136,7 @@ jobs:
       - metadata
       - quality
       - database
+    if: needs.metadata.outputs.status == 'candidate'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -175,6 +210,7 @@ jobs:
       - metadata
       - quality
       - database
+    if: needs.metadata.outputs.status == 'candidate'
     environment:
       name: android-release-signing
       deployment: false
@@ -317,6 +353,7 @@ jobs:
       - metadata
       - images
       - android
+    if: needs.metadata.outputs.status == 'candidate'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
+      status: ${{ steps.artifact.outputs.status }}
       candidate_run_id: ${{ steps.candidate.outputs.run_id }}
       candidate_sha: ${{ steps.candidate.outputs.sha }}
       android_artifact: ${{ steps.artifact.outputs.android_name }}
@@ -70,6 +71,13 @@ jobs:
                 per_page: 100,
               },
             );
+            const skipped = artifacts.find(
+              (artifact) => artifact.name === "release-candidate-skipped",
+            );
+            if (skipped) {
+              core.setOutput("status", "skipped");
+              return;
+            }
             const manifests = artifacts.filter(
               (artifact) =>
                 !artifact.expired &&
@@ -100,12 +108,14 @@ jobs:
               core.setFailed(`Candidate run ${runId} artifact versions differ.`);
               return;
             }
+            core.setOutput("status", "candidate");
             core.setOutput("name", manifests[0].name);
             core.setOutput("android_name", androidArtifacts[0].name);
 
   deploy:
     name: Deploy immutable Candidate to Staging
     needs: authorize
+    if: needs.authorize.outputs.status == 'candidate'
     environment:
       name: staging
       url: https://staging.speak-up.top

--- a/tools/release-candidate/metadata.mjs
+++ b/tools/release-candidate/metadata.mjs
@@ -13,6 +13,7 @@ const migrationPattern = /^server\/migrations\/(\d{6})_[^/]+\.up\.sql$/;
 const tagRemotePattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const gitShaPattern = /^[0-9a-f]{40}$/;
 const officialUpstreamUrl = "https://github.com/1024XEngineer/XE3-ESL.git";
+const existingTagPolicies = new Set(["reject", "skip"]);
 
 export function parseStableTag(tag) {
   const match = stableTagPattern.exec(tag);
@@ -341,7 +342,13 @@ export function collectCandidateMetadata({
   candidateSha,
   mainRef,
   tagRemote = "origin",
+  existingTagPolicy = "reject",
 }) {
+  if (!existingTagPolicies.has(existingTagPolicy)) {
+    throw new Error(
+      `existingTagPolicy must be one of: ${[...existingTagPolicies].join(", ")}`,
+    );
+  }
   if (!gitShaPattern.test(candidateSha)) {
     throw new Error("candidateSha must be a full lowercase Git commit SHA");
   }
@@ -365,6 +372,12 @@ export function collectCandidateMetadata({
   const parsedVersion = parseStableTag(expectedTag);
   validateVersionCode(current.versionCode, "Candidate");
   if (history.allStableTags.includes(expectedTag)) {
+    if (existingTagPolicy === "skip") {
+      return metadataForCommit(repoDir, candidateSha, current, {
+        status: "already-released",
+        tag: expectedTag,
+      });
+    }
     throw new Error(`Candidate stable Tag already exists: ${expectedTag}`);
   }
   const tagOnCandidate = history.releasesOnMain.find(
@@ -384,17 +397,27 @@ export function collectCandidateMetadata({
     history.historyOrder,
     { tag: expectedTag, commit: candidateSha, version: current },
   );
-  return metadataForCommit(repoDir, candidateSha, current);
+  return metadataForCommit(repoDir, candidateSha, current, {
+    status: "candidate",
+  });
 }
 
 function main() {
   const usage =
     "Usage: metadata.mjs (--tag <vX.Y.Z> | --candidate-sha <sha>) " +
     "--main-ref <ref> " +
-    "[--repo <path>] [--tag-remote <name>]";
+    "[--repo <path>] [--tag-remote <name>] " +
+    "[--existing-tag-policy <reject|skip>]";
   const arguments_ = readArguments(
     process.argv.slice(2),
-    ["tag", "candidate-sha", "main-ref", "repo", "tag-remote"],
+    [
+      "tag",
+      "candidate-sha",
+      "main-ref",
+      "repo",
+      "tag-remote",
+      "existing-tag-policy",
+    ],
     usage,
   );
   if (!arguments_["main-ref"]) {
@@ -402,6 +425,9 @@ function main() {
   }
   if (Boolean(arguments_.tag) === Boolean(arguments_["candidate-sha"])) {
     throw new Error("Exactly one of --tag or --candidate-sha is required");
+  }
+  if (arguments_.tag && arguments_["existing-tag-policy"] !== undefined) {
+    throw new Error("--existing-tag-policy requires --candidate-sha");
   }
   const common = {
     repoDir: path.resolve(arguments_.repo ?? "."),
@@ -413,6 +439,7 @@ function main() {
     : collectCandidateMetadata({
         ...common,
         candidateSha: arguments_["candidate-sha"],
+        existingTagPolicy: arguments_["existing-tag-policy"],
       });
   const output = Object.entries(metadata)
     .map(([key, value]) => `${key}=${value}`)

--- a/tools/release-candidate/release-candidate.test.mjs
+++ b/tools/release-candidate/release-candidate.test.mjs
@@ -448,6 +448,7 @@ test("accepts an untagged Candidate from the exact main checkout", () => {
       mainRef: "main",
     }),
     {
+      status: "candidate",
       version: "0.1.0",
       version_code: "1",
       git_sha: candidateSha,
@@ -455,6 +456,29 @@ test("accepts an untagged Candidate from the exact main checkout", () => {
     },
   );
   assert.equal(git(repo, "tag", "--list"), tagsBefore);
+});
+
+test("marks a Candidate as already released when its stable Tag exists", () => {
+  const repo = createRepository();
+  const candidateSha = git(repo, "rev-parse", "HEAD");
+  git(repo, "tag", "v0.1.0");
+
+  assert.deepEqual(
+    collectCandidateMetadata({
+      repoDir: repo,
+      candidateSha,
+      mainRef: "main",
+      existingTagPolicy: "skip",
+    }),
+    {
+      status: "already-released",
+      tag: "v0.1.0",
+      version: "0.1.0",
+      version_code: "1",
+      git_sha: candidateSha,
+      database_schema_version: "7",
+    },
+  );
 });
 
 test("accepts a Candidate newer than the complete stable release history", () => {
@@ -823,6 +847,9 @@ test("Release Candidate workflow is automatic, official-main-only, and Tag-free"
   assert.match(workflow, /refs\/heads\/main/);
   assert.match(workflow, /CANDIDATE_EVENT" != "push"/);
   assert.match(workflow, /--candidate-sha "\$GITHUB_SHA"/);
+  assert.match(workflow, /--existing-tag-policy skip/);
+  assert.match(workflow, /name: release-candidate-skipped/);
+  assert.match(workflow, /status == 'candidate'/);
   assert.doesNotMatch(workflow, /workflow_dispatch/);
   assert.doesNotMatch(workflow, /push:\n\s+tags:/);
   assert.doesNotMatch(workflow, /GITHUB_REF_NAME/);
@@ -880,6 +907,14 @@ test("Staging deploy accepts only a successful official Candidate artifact", () 
   assert.match(workflow, /https:\/\/staging-api\.speak-up\.top\/health/);
   assert.match(workflow, /staging-deployment-\$\{\{ github\.run_id \}\}/);
   assert.doesNotMatch(workflow, /deploy\/production/);
+});
+
+test("Staging deploy skips an already released Candidate run", () => {
+  const workflow = readFileSync(stagingDeployWorkflow, "utf8");
+  assert.match(workflow, /status: \$\{\{ steps\.artifact\.outputs\.status \}\}/);
+  assert.match(workflow, /release-candidate-skipped/);
+  assert.match(workflow, /core\.setOutput\("status", "skipped"\)/);
+  assert.match(workflow, /if: needs\.authorize\.outputs\.status == 'candidate'/);
 });
 
 test("rejects a release tag that is not contained in main", () => {


### PR DESCRIPTION
## 功能描述
修复 PR #1128 合入 `main` 后出现的 Release Candidate 红叉：当 main push 对应的稳定 Tag 已经存在时，将该次运行标记为 `already-released` 并成功结束，而不是把“禁止重复稳定版本”报告为失败。

## 实现思路
- 保留默认严格校验：直接调用候选元数据校验时，重复稳定 Tag 仍然失败。
- 为 Release Candidate workflow 增加显式 `--existing-tag-policy skip`，仅在候选 Tag 已存在时输出 `already-released` 状态。
- 已发布状态只记录摘要和 skip marker，不运行质量、数据库、OCI 镜像、Android APK 或 release manifest 任务。
- 更新 Staging workflow 识别 skip marker，避免成功的跳过运行被误当成可部署 Candidate。
- 补充 metadata、Release Candidate workflow 和 Staging workflow 契约测试。

## 可复现测试

```bash
make check-release-candidate
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/release-candidate.yml .github/workflows/staging-deploy.yml
git diff --check
```

本地结果：44 个 release-candidate 测试全部通过，Android release verifier 测试全部通过，两个 Workflow YAML 解析通过。

## 关联 Issue
Closes #1132

关联 PR：#1128。